### PR TITLE
Add the packaging metadata to build the assemblyscript snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: assemblyscript
+version: git
+summary: A TypeScript to WebAssembly compiler.
+description: |
+  AssemblyScript compiles strictly typed TypeScript to WebAssembly using Binaryen.
+  It generates minimal WebAssembly modules.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: devmode # use 'strict' once you have the right plugs and slots
+
+apps:
+  asc:
+    command: asc
+
+parts:
+  assemblyscript:
+    source: .
+    plugin: nodejs


### PR DESCRIPTION
This package will let you publish the latest assemblyscript in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and Linux distributions. You just have to go to https://build.snapcraft.io and enable the automated continuous delivery.