### PR TITLE
array.includes method

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -5,6 +5,7 @@ under the licensing terms detailed in LICENSE.
 
 * Daniel Wirtz <dcode@dcode.io>
 * Max Graey <maxgraey@gmail.com>
+* Igor Sbitnev <PinkaminaDianePie@gmail.com>
 
 ================================================================================
 

--- a/std/assembly.d.ts
+++ b/std/assembly.d.ts
@@ -224,6 +224,7 @@ declare class Array<T> {
   length: i32;
   /** Constructs a new array. */
   constructor(capacity?: i32);
+  includes(searchElement: T, fromIndex?: i32): bool;
   indexOf(searchElement: T, fromIndex?: i32): i32;
   lastIndexOf(searchElement: T, fromIndex?: i32): i32;
   push(element: T): void;

--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -58,9 +58,34 @@ export class Array<T> {
     store<T>(this.__memory + <usize>index * sizeof<T>(), value);
   }
 
-  indexOf(searchElement: T, fromIndex: i32 = 0): i32 {
+  includes(searchElement: T, fromIndex: i32 = 0): bool {
+    if (this.__length == 0 || fromIndex >= this.__length) {
+      return false;
+    }
     if (fromIndex < 0) {
       fromIndex = this.__length + fromIndex;
+      if (fromIndex < 0) {
+        fromIndex = 0;
+      }
+    }
+    while (<u32>fromIndex < <u32>this.__length) {
+      if (load<T>(this.__memory + <usize>fromIndex * sizeof<T>()) == searchElement) {
+        return true;
+      }
+      ++fromIndex;
+    }
+    return false;
+  }
+
+  indexOf(searchElement: T, fromIndex: i32 = 0): i32 {
+    if (this.__length == 0 || fromIndex >= this.__length) {
+      return -1;
+    }
+    if (fromIndex < 0) {
+      fromIndex = this.__length + fromIndex;
+      if (fromIndex < 0) {
+        fromIndex = 0;
+      }
     }
     while (<u32>fromIndex < <u32>this.__length) {
       if (load<T>(this.__memory + <usize>fromIndex * sizeof<T>()) == searchElement) {
@@ -71,7 +96,10 @@ export class Array<T> {
     return -1;
   }
 
-  lastIndexOf(searchElement: T, fromIndex: i32 = 0): i32 {
+  lastIndexOf(searchElement: T, fromIndex: i32 = this.__length): i32 {
+    if (this.__length == 0) {
+      return -1;
+    }
     if (fromIndex < 0) {
       fromIndex = this.__length + fromIndex;
     } else if (fromIndex >= this.__length) {

--- a/std/portable.d.ts
+++ b/std/portable.d.ts
@@ -169,6 +169,7 @@ declare class Array<T> {
   [key: number]: T;
   length: i32;
   constructor(capacity?: i32);
+  includes(searchElement: T, fromIndex?: i32): bool;
   indexOf(searchElement: T, fromIndex?: i32): i32;
   lastIndexOf(searchElement: T, fromIndex?: i32): i32;
   push(element: T): void;

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -12,6 +12,7 @@
  (global "$(lib)/allocator/arena/offset" (mut i32) (i32.const 0))
  (global $std/array/arr (mut i32) (i32.const 0))
  (global $std/array/i (mut i32) (i32.const 0))
+ (global $std/array/includes (mut i32) (i32.const 0))
  (global $HEAP_BASE i32 (i32.const 64))
  (memory $0 1)
  (data (i32.const 4) "\0c\00\00\00s\00t\00d\00/\00a\00r\00r\00a\00y\00.\00t\00s")
@@ -2182,7 +2183,7 @@
       (call $abort
        (i32.const 0)
        (i32.const 32)
-       (i32.const 128)
+       (i32.const 156)
        (i32.const 6)
       )
       (unreachable)
@@ -2750,17 +2751,50 @@
   (get_local $0)
  )
  (func "$(lib)/array/Array#indexOf" (; 14 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (if
+   (i32.and
+    (if (result i32)
+     (tee_local $3
+      (i32.eqz
+       (i32.load offset=8
+        (get_local $0)
+       )
+      )
+     )
+     (get_local $3)
+     (i32.ge_s
+      (get_local $2)
+      (i32.load offset=8
+       (get_local $0)
+      )
+     )
+    )
+    (i32.const 1)
+   )
+   (return
+    (i32.const -1)
+   )
+  )
   (if
    (i32.lt_s
     (get_local $2)
     (i32.const 0)
    )
-   (set_local $2
-    (i32.add
-     (i32.load offset=8
-      (get_local $0)
+   (if
+    (i32.lt_s
+     (tee_local $2
+      (i32.add
+       (i32.load offset=8
+        (get_local $0)
+       )
+       (get_local $2)
+      )
      )
-     (get_local $2)
+     (i32.const 0)
+    )
+    (set_local $2
+     (i32.const 0)
     )
    )
   )
@@ -2824,7 +2858,115 @@
    (get_local $2)
   )
  )
- (func "$(lib)/array/Array#splice" (; 16 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func "$(lib)/array/Array#includes" (; 16 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (if
+   (i32.and
+    (if (result i32)
+     (tee_local $3
+      (i32.eqz
+       (i32.load offset=8
+        (get_local $0)
+       )
+      )
+     )
+     (get_local $3)
+     (i32.ge_s
+      (get_local $2)
+      (i32.load offset=8
+       (get_local $0)
+      )
+     )
+    )
+    (i32.const 1)
+   )
+   (return
+    (i32.const 0)
+   )
+  )
+  (if
+   (i32.lt_s
+    (get_local $2)
+    (i32.const 0)
+   )
+   (if
+    (i32.lt_s
+     (tee_local $2
+      (i32.add
+       (i32.load offset=8
+        (get_local $0)
+       )
+       (get_local $2)
+      )
+     )
+     (i32.const 0)
+    )
+    (set_local $2
+     (i32.const 0)
+    )
+   )
+  )
+  (loop $continue|0
+   (if
+    (i32.lt_u
+     (get_local $2)
+     (i32.load offset=8
+      (get_local $0)
+     )
+    )
+    (block
+     (if
+      (i32.eq
+       (i32.load
+        (i32.add
+         (i32.load
+          (get_local $0)
+         )
+         (i32.shl
+          (get_local $2)
+          (i32.const 2)
+         )
+        )
+       )
+       (get_local $1)
+      )
+      (return
+       (i32.const 1)
+      )
+     )
+     (set_local $2
+      (i32.add
+       (get_local $2)
+       (i32.const 1)
+      )
+     )
+     (br $continue|0)
+    )
+   )
+  )
+  (i32.const 0)
+ )
+ (func "$(lib)/array/Array#includes|trampoline" (; 17 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+  (block $N=1
+   (block $N=0
+    (block $N=invalid
+     (br_table $N=0 $N=1 $N=invalid
+      (get_local $3)
+     )
+    )
+    (unreachable)
+   )
+   (set_local $2
+    (i32.const 0)
+   )
+  )
+  (call "$(lib)/array/Array#includes"
+   (get_local $0)
+   (get_local $1)
+   (get_local $2)
+  )
+ )
+ (func "$(lib)/array/Array#splice" (; 18 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (if
    (i32.lt_s
     (get_local $2)
@@ -2925,7 +3067,7 @@
    )
   )
  )
- (func $start (; 17 ;) (type $v)
+ (func $start (; 19 ;) (type $v)
   (set_global "$(lib)/allocator/arena/offset"
    (i32.and
     (i32.add
@@ -3874,6 +4016,18 @@
     (unreachable)
    )
   )
+  (drop
+   (call "$(lib)/array/Array#push"
+    (get_global $std/array/arr)
+    (i32.const 43)
+   )
+  )
+  (drop
+   (call "$(lib)/array/Array#push"
+    (get_global $std/array/arr)
+    (i32.const 44)
+   )
+  )
   (set_global $std/array/i
    (call "$(lib)/array/Array#indexOf|trampoline"
     (get_global $std/array/arr)
@@ -3888,7 +4042,7 @@
     (call $abort
      (i32.const 0)
      (i32.const 4)
-     (i32.const 89)
+     (i32.const 92)
      (i32.const 0)
     )
     (unreachable)
@@ -3911,7 +4065,7 @@
     (call $abort
      (i32.const 0)
      (i32.const 4)
-     (i32.const 93)
+     (i32.const 96)
      (i32.const 0)
     )
     (unreachable)
@@ -3934,7 +4088,378 @@
     (call $abort
      (i32.const 0)
      (i32.const 4)
-     (i32.const 97)
+     (i32.const 100)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/i
+   (call "$(lib)/array/Array#indexOf"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const 100)
+   )
+  )
+  (if
+   (i32.ne
+    (get_global $std/array/i)
+    (i32.const -1)
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 104)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/i
+   (call "$(lib)/array/Array#indexOf"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const -100)
+   )
+  )
+  (if
+   (i32.ne
+    (get_global $std/array/i)
+    (i32.const 1)
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 108)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/i
+   (call "$(lib)/array/Array#indexOf"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const -2)
+   )
+  )
+  (if
+   (i32.ne
+    (get_global $std/array/i)
+    (i32.const 3)
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 112)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/i
+   (call "$(lib)/array/Array#indexOf"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const -4)
+   )
+  )
+  (if
+   (i32.ne
+    (get_global $std/array/i)
+    (i32.const 1)
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 116)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/i
+   (call "$(lib)/array/Array#indexOf"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const 0)
+   )
+  )
+  (if
+   (i32.ne
+    (get_global $std/array/i)
+    (i32.const 1)
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 120)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/i
+   (call "$(lib)/array/Array#indexOf"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const 1)
+   )
+  )
+  (if
+   (i32.ne
+    (get_global $std/array/i)
+    (i32.const 1)
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 124)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/i
+   (call "$(lib)/array/Array#indexOf"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const 2)
+   )
+  )
+  (if
+   (i32.ne
+    (get_global $std/array/i)
+    (i32.const 3)
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 128)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/includes
+   (call "$(lib)/array/Array#includes|trampoline"
+    (get_global $std/array/arr)
+    (i32.const 44)
+    (i32.const 0)
+    (i32.const 0)
+   )
+  )
+  (if
+   (i32.ne
+    (get_global $std/array/includes)
+    (i32.const 1)
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 132)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/includes
+   (call "$(lib)/array/Array#includes|trampoline"
+    (get_global $std/array/arr)
+    (i32.const 42)
+    (i32.const 0)
+    (i32.const 0)
+   )
+  )
+  (if
+   (i32.ne
+    (get_global $std/array/includes)
+    (i32.const 1)
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 136)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/includes
+   (call "$(lib)/array/Array#includes|trampoline"
+    (get_global $std/array/arr)
+    (i32.const 45)
+    (i32.const 0)
+    (i32.const 0)
+   )
+  )
+  (if
+   (get_global $std/array/includes)
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 140)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/includes
+   (call "$(lib)/array/Array#includes"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const 100)
+   )
+  )
+  (if
+   (get_global $std/array/includes)
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 144)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/includes
+   (call "$(lib)/array/Array#includes"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const -100)
+   )
+  )
+  (if
+   (i32.ne
+    (get_global $std/array/includes)
+    (i32.const 1)
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 148)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/includes
+   (call "$(lib)/array/Array#includes"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const -2)
+   )
+  )
+  (if
+   (i32.ne
+    (get_global $std/array/includes)
+    (i32.const 1)
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 152)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/includes
+   (call "$(lib)/array/Array#includes"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const -4)
+   )
+  )
+  (if
+   (i32.ne
+    (get_global $std/array/includes)
+    (i32.const 1)
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 156)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/includes
+   (call "$(lib)/array/Array#includes"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const 0)
+   )
+  )
+  (if
+   (i32.ne
+    (get_global $std/array/includes)
+    (i32.const 1)
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 160)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/includes
+   (call "$(lib)/array/Array#includes"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const 1)
+   )
+  )
+  (if
+   (i32.ne
+    (get_global $std/array/includes)
+    (i32.const 1)
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 164)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/includes
+   (call "$(lib)/array/Array#includes"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const 2)
+   )
+  )
+  (if
+   (i32.ne
+    (get_global $std/array/includes)
+    (i32.const 1)
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 168)
      (i32.const 0)
     )
     (unreachable)
@@ -3950,13 +4475,13 @@
     (call "$(lib)/array/Array#get:length"
      (get_global $std/array/arr)
     )
-    (i32.const 2)
+    (i32.const 4)
    )
    (block
     (call $abort
      (i32.const 0)
      (i32.const 4)
-     (i32.const 101)
+     (i32.const 172)
      (i32.const 0)
     )
     (unreachable)
@@ -3973,7 +4498,7 @@
     (call $abort
      (i32.const 0)
      (i32.const 4)
-     (i32.const 102)
+     (i32.const 173)
      (i32.const 0)
     )
     (unreachable)
@@ -3991,7 +4516,7 @@
     (call $abort
      (i32.const 0)
      (i32.const 4)
-     (i32.const 103)
+     (i32.const 174)
      (i32.const 0)
     )
     (unreachable)
@@ -4009,7 +4534,7 @@
     (call $abort
      (i32.const 0)
      (i32.const 4)
-     (i32.const 104)
+     (i32.const 175)
      (i32.const 0)
     )
     (unreachable)

--- a/tests/compiler/std/array.ts
+++ b/tests/compiler/std/array.ts
@@ -84,6 +84,9 @@ assert(arr[0] == 44);
 assert(arr[1] == 43);
 assert(arr[2] == 42);
 
+arr.push(43);
+arr.push(44);
+
 i = arr.indexOf(44);
 
 assert(i == 0);
@@ -96,9 +99,77 @@ i = arr.indexOf(45);
 
 assert(i == - 1);
 
+i = arr.indexOf(43, 100);
+
+assert(i == - 1);
+
+i = arr.indexOf(43, -100);
+
+assert(i == 1);
+
+i = arr.indexOf(43, -2);
+
+assert(i == 3);
+
+i = arr.indexOf(43, -4);
+
+assert(i == 1);
+
+i = arr.indexOf(43, 0);
+
+assert(i == 1);
+
+i = arr.indexOf(43, 1);
+
+assert(i == 1);
+
+i = arr.indexOf(43, 2);
+
+assert(i == 3);
+
+var includes = arr.includes(44);
+
+assert(includes == true);
+
+includes = arr.includes(42);
+
+assert(includes == true);
+
+includes = arr.includes(45);
+
+assert(includes == false);
+
+includes = arr.includes(43, 100);
+
+assert(includes == false);
+
+includes = arr.includes(43, -100);
+
+assert(includes == true);
+
+includes = arr.includes(43, -2);
+
+assert(includes == true);
+
+includes = arr.includes(43, -4);
+
+assert(includes == true);
+
+includes = arr.includes(43, 0);
+
+assert(includes == true);
+
+includes = arr.includes(43, 1);
+
+assert(includes == true);
+
+includes = arr.includes(43, 2);
+
+assert(includes == true);
+
 arr.splice(1, 1);
 
-assert(arr.length == 2);
+assert(arr.length == 4);
 assert(arr.__capacity == 8);
 assert(arr[0] == 44);
 assert(arr[1] == 42);

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -16,6 +16,7 @@
  (global "$(lib)/allocator/arena/offset" (mut i32) (i32.const 0))
  (global $std/array/arr (mut i32) (i32.const 0))
  (global $std/array/i (mut i32) (i32.const 0))
+ (global $std/array/includes (mut i32) (i32.const 0))
  (global $HEAP_BASE i32 (i32.const 64))
  (memory $0 1)
  (data (i32.const 4) "\0c\00\00\00s\00t\00d\00/\00a\00r\00r\00a\00y\00.\00t\00s\00")
@@ -2484,7 +2485,7 @@
       (call $abort
        (i32.const 0)
        (i32.const 32)
-       (i32.const 128)
+       (i32.const 156)
        (i32.const 6)
       )
       (unreachable)
@@ -3088,17 +3089,54 @@
   )
  )
  (func "$(lib)/array/Array#indexOf" (; 14 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (if
+   (i32.and
+    (if (result i32)
+     (tee_local $3
+      (i32.eq
+       (i32.load offset=8
+        (get_local $0)
+       )
+       (i32.const 0)
+      )
+     )
+     (get_local $3)
+     (i32.ge_s
+      (get_local $2)
+      (i32.load offset=8
+       (get_local $0)
+      )
+     )
+    )
+    (i32.const 1)
+   )
+   (return
+    (i32.const -1)
+   )
+  )
   (if
    (i32.lt_s
     (get_local $2)
     (i32.const 0)
    )
-   (set_local $2
-    (i32.add
-     (i32.load offset=8
-      (get_local $0)
+   (block
+    (set_local $2
+     (i32.add
+      (i32.load offset=8
+       (get_local $0)
+      )
+      (get_local $2)
      )
-     (get_local $2)
+    )
+    (if
+     (i32.lt_s
+      (get_local $2)
+      (i32.const 0)
+     )
+     (set_local $2
+      (i32.const 0)
+     )
     )
    )
   )
@@ -3168,7 +3206,125 @@
    (get_local $2)
   )
  )
- (func "$(lib)/array/Array#splice" (; 16 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func "$(lib)/array/Array#includes" (; 16 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (if
+   (i32.and
+    (if (result i32)
+     (tee_local $3
+      (i32.eq
+       (i32.load offset=8
+        (get_local $0)
+       )
+       (i32.const 0)
+      )
+     )
+     (get_local $3)
+     (i32.ge_s
+      (get_local $2)
+      (i32.load offset=8
+       (get_local $0)
+      )
+     )
+    )
+    (i32.const 1)
+   )
+   (return
+    (i32.const 0)
+   )
+  )
+  (if
+   (i32.lt_s
+    (get_local $2)
+    (i32.const 0)
+   )
+   (block
+    (set_local $2
+     (i32.add
+      (i32.load offset=8
+       (get_local $0)
+      )
+      (get_local $2)
+     )
+    )
+    (if
+     (i32.lt_s
+      (get_local $2)
+      (i32.const 0)
+     )
+     (set_local $2
+      (i32.const 0)
+     )
+    )
+   )
+  )
+  (block $break|0
+   (loop $continue|0
+    (if
+     (i32.lt_u
+      (get_local $2)
+      (i32.load offset=8
+       (get_local $0)
+      )
+     )
+     (block
+      (block
+       (if
+        (i32.eq
+         (i32.load
+          (i32.add
+           (i32.load
+            (get_local $0)
+           )
+           (i32.mul
+            (get_local $2)
+            (i32.const 4)
+           )
+          )
+         )
+         (get_local $1)
+        )
+        (return
+         (i32.const 1)
+        )
+       )
+       (set_local $2
+        (i32.add
+         (get_local $2)
+         (i32.const 1)
+        )
+       )
+      )
+      (br $continue|0)
+     )
+    )
+   )
+  )
+  (return
+   (i32.const 0)
+  )
+ )
+ (func "$(lib)/array/Array#includes|trampoline" (; 17 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+  (block $N=1
+   (block $N=0
+    (block $N=invalid
+     (br_table $N=0 $N=1 $N=invalid
+      (get_local $3)
+     )
+    )
+    (unreachable)
+   )
+   (set_local $2
+    (i32.const 0)
+   )
+  )
+  (call "$(lib)/array/Array#includes"
+   (get_local $0)
+   (get_local $1)
+   (get_local $2)
+  )
+ )
+ (func "$(lib)/array/Array#splice" (; 18 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (if
@@ -3277,7 +3433,7 @@
    )
   )
  )
- (func $start (; 17 ;) (type $v)
+ (func $start (; 19 ;) (type $v)
   (set_global "$(lib)/allocator/arena/offset"
    (i32.and
     (i32.add
@@ -4346,6 +4502,18 @@
     (unreachable)
    )
   )
+  (drop
+   (call "$(lib)/array/Array#push"
+    (get_global $std/array/arr)
+    (i32.const 43)
+   )
+  )
+  (drop
+   (call "$(lib)/array/Array#push"
+    (get_global $std/array/arr)
+    (i32.const 44)
+   )
+  )
   (set_global $std/array/i
    (call "$(lib)/array/Array#indexOf|trampoline"
     (get_global $std/array/arr)
@@ -4365,7 +4533,7 @@
     (call $abort
      (i32.const 0)
      (i32.const 4)
-     (i32.const 89)
+     (i32.const 92)
      (i32.const 0)
     )
     (unreachable)
@@ -4390,7 +4558,7 @@
     (call $abort
      (i32.const 0)
      (i32.const 4)
-     (i32.const 93)
+     (i32.const 96)
      (i32.const 0)
     )
     (unreachable)
@@ -4415,7 +4583,418 @@
     (call $abort
      (i32.const 0)
      (i32.const 4)
-     (i32.const 97)
+     (i32.const 100)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/i
+   (call "$(lib)/array/Array#indexOf"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const 100)
+   )
+  )
+  (if
+   (i32.eqz
+    (i32.eq
+     (get_global $std/array/i)
+     (i32.const -1)
+    )
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 104)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/i
+   (call "$(lib)/array/Array#indexOf"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const -100)
+   )
+  )
+  (if
+   (i32.eqz
+    (i32.eq
+     (get_global $std/array/i)
+     (i32.const 1)
+    )
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 108)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/i
+   (call "$(lib)/array/Array#indexOf"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const -2)
+   )
+  )
+  (if
+   (i32.eqz
+    (i32.eq
+     (get_global $std/array/i)
+     (i32.const 3)
+    )
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 112)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/i
+   (call "$(lib)/array/Array#indexOf"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const -4)
+   )
+  )
+  (if
+   (i32.eqz
+    (i32.eq
+     (get_global $std/array/i)
+     (i32.const 1)
+    )
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 116)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/i
+   (call "$(lib)/array/Array#indexOf"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const 0)
+   )
+  )
+  (if
+   (i32.eqz
+    (i32.eq
+     (get_global $std/array/i)
+     (i32.const 1)
+    )
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 120)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/i
+   (call "$(lib)/array/Array#indexOf"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const 1)
+   )
+  )
+  (if
+   (i32.eqz
+    (i32.eq
+     (get_global $std/array/i)
+     (i32.const 1)
+    )
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 124)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/i
+   (call "$(lib)/array/Array#indexOf"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const 2)
+   )
+  )
+  (if
+   (i32.eqz
+    (i32.eq
+     (get_global $std/array/i)
+     (i32.const 3)
+    )
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 128)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/includes
+   (call "$(lib)/array/Array#includes|trampoline"
+    (get_global $std/array/arr)
+    (i32.const 44)
+    (i32.const 0)
+    (i32.const 0)
+   )
+  )
+  (if
+   (i32.eqz
+    (i32.eq
+     (get_global $std/array/includes)
+     (i32.const 1)
+    )
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 132)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/includes
+   (call "$(lib)/array/Array#includes|trampoline"
+    (get_global $std/array/arr)
+    (i32.const 42)
+    (i32.const 0)
+    (i32.const 0)
+   )
+  )
+  (if
+   (i32.eqz
+    (i32.eq
+     (get_global $std/array/includes)
+     (i32.const 1)
+    )
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 136)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/includes
+   (call "$(lib)/array/Array#includes|trampoline"
+    (get_global $std/array/arr)
+    (i32.const 45)
+    (i32.const 0)
+    (i32.const 0)
+   )
+  )
+  (if
+   (i32.eqz
+    (i32.eq
+     (get_global $std/array/includes)
+     (i32.const 0)
+    )
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 140)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/includes
+   (call "$(lib)/array/Array#includes"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const 100)
+   )
+  )
+  (if
+   (i32.eqz
+    (i32.eq
+     (get_global $std/array/includes)
+     (i32.const 0)
+    )
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 144)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/includes
+   (call "$(lib)/array/Array#includes"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const -100)
+   )
+  )
+  (if
+   (i32.eqz
+    (i32.eq
+     (get_global $std/array/includes)
+     (i32.const 1)
+    )
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 148)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/includes
+   (call "$(lib)/array/Array#includes"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const -2)
+   )
+  )
+  (if
+   (i32.eqz
+    (i32.eq
+     (get_global $std/array/includes)
+     (i32.const 1)
+    )
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 152)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/includes
+   (call "$(lib)/array/Array#includes"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const -4)
+   )
+  )
+  (if
+   (i32.eqz
+    (i32.eq
+     (get_global $std/array/includes)
+     (i32.const 1)
+    )
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 156)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/includes
+   (call "$(lib)/array/Array#includes"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const 0)
+   )
+  )
+  (if
+   (i32.eqz
+    (i32.eq
+     (get_global $std/array/includes)
+     (i32.const 1)
+    )
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 160)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/includes
+   (call "$(lib)/array/Array#includes"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const 1)
+   )
+  )
+  (if
+   (i32.eqz
+    (i32.eq
+     (get_global $std/array/includes)
+     (i32.const 1)
+    )
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 164)
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+  )
+  (set_global $std/array/includes
+   (call "$(lib)/array/Array#includes"
+    (get_global $std/array/arr)
+    (i32.const 43)
+    (i32.const 2)
+   )
+  )
+  (if
+   (i32.eqz
+    (i32.eq
+     (get_global $std/array/includes)
+     (i32.const 1)
+    )
+   )
+   (block
+    (call $abort
+     (i32.const 0)
+     (i32.const 4)
+     (i32.const 168)
      (i32.const 0)
     )
     (unreachable)
@@ -4432,14 +5011,14 @@
      (call "$(lib)/array/Array#get:length"
       (get_global $std/array/arr)
      )
-     (i32.const 2)
+     (i32.const 4)
     )
    )
    (block
     (call $abort
      (i32.const 0)
      (i32.const 4)
-     (i32.const 101)
+     (i32.const 172)
      (i32.const 0)
     )
     (unreachable)
@@ -4458,7 +5037,7 @@
     (call $abort
      (i32.const 0)
      (i32.const 4)
-     (i32.const 102)
+     (i32.const 173)
      (i32.const 0)
     )
     (unreachable)
@@ -4478,7 +5057,7 @@
     (call $abort
      (i32.const 0)
      (i32.const 4)
-     (i32.const 103)
+     (i32.const 174)
      (i32.const 0)
     )
     (unreachable)
@@ -4498,7 +5077,7 @@
     (call $abort
      (i32.const 0)
      (i32.const 4)
-     (i32.const 104)
+     (i32.const 175)
      (i32.const 0)
     )
     (unreachable)


### PR DESCRIPTION
Implemented `array.includes` method, improved spec compatibility for `array.indexOf`, added few missing tests.

`array.includes` was created as a new method, without using `indexOf` just because by spec they work slightly differently, especially for floats, so they can became different in the future.