### PR TITLE
Add min normalized positive value for decimals

### DIFF
--- a/std/assembly.d.ts
+++ b/std/assembly.d.ts
@@ -107,6 +107,8 @@ declare namespace f32 {
   export const MIN_SAFE_INTEGER: f32;
   /** Largest safely representable integer value. */
   export const MAX_SAFE_INTEGER: f32;
+  /** Smallest normalized positive value */
+  export const MIN_NORMAL_VALUE: f32;
   /** Difference between 1 and the smallest representable value greater than 1. */
   export const EPSILON: f32;
 }
@@ -119,6 +121,8 @@ declare namespace f64 {
   export const MIN_SAFE_INTEGER: f64;
   /** Largest safely representable integer value. */
   export const MAX_SAFE_INTEGER: f64;
+  /** Smallest normalized positive value */
+  export const MIN_NORMAL_VALUE: f64;
   /** Difference between 1 and the smallest representable value greater than 1. */
   export const EPSILON: f64;
 }

--- a/std/assembly.d.ts
+++ b/std/assembly.d.ts
@@ -103,12 +103,12 @@ declare function f32(value: i8 | i16 | i32 | i64 | isize | u8 | u16 | u32 | u64 
 declare namespace f32 {
   export const MIN_VALUE: f32;
   export const MAX_VALUE: f32;
+  /** Smallest normalized positive value */
+  export const MIN_POSITIVE_VALUE: f32;
   /** Smallest safely representable integer value. */
   export const MIN_SAFE_INTEGER: f32;
   /** Largest safely representable integer value. */
   export const MAX_SAFE_INTEGER: f32;
-  /** Smallest normalized positive value */
-  export const MIN_NORMAL_VALUE: f32;
   /** Difference between 1 and the smallest representable value greater than 1. */
   export const EPSILON: f32;
 }
@@ -117,12 +117,12 @@ declare function f64(value: i8 | i16 | i32 | i64 | isize | u8 | u16 | u32 | u64 
 declare namespace f64 {
   export const MIN_VALUE: f64;
   export const MAX_VALUE: f64;
+  /** Smallest normalized positive value */
+  export const MIN_POSITIVE_VALUE: f64;
   /** Smallest safely representable integer value. */
   export const MIN_SAFE_INTEGER: f64;
   /** Largest safely representable integer value. */
   export const MAX_SAFE_INTEGER: f64;
-  /** Smallest normalized positive value */
-  export const MIN_NORMAL_VALUE: f64;
   /** Difference between 1 and the smallest representable value greater than 1. */
   export const EPSILON: f64;
 }

--- a/std/assembly/builtins.ts
+++ b/std/assembly/builtins.ts
@@ -216,6 +216,7 @@ namespace f32 {
   export const MAX_VALUE: f32 = 3.40282347e+38;
   export const MIN_SAFE_INTEGER: f32 = -16777215;
   export const MAX_SAFE_INTEGER: f32 = 16777215;
+  export const MIN_NORMAL_VALUE: f32 = 1.175494351e-38;
   export const EPSILON: f32 = 1.19209290e-07;
 }
 export { f32 };
@@ -227,6 +228,7 @@ namespace f64 {
   export const MAX_VALUE: f64 = 1.7976931348623157e+308;
   export const MIN_SAFE_INTEGER: f64 = -9007199254740991;
   export const MAX_SAFE_INTEGER: f64 = 9007199254740991;
+  export const MIN_NORMAL_VALUE: f64 = 2.2250738585072014e-308;
   export const EPSILON: f64 = 2.2204460492503131e-16;
 }
 export{ f64 };

--- a/std/assembly/builtins.ts
+++ b/std/assembly/builtins.ts
@@ -214,9 +214,9 @@ declare function f32(value: void): f32;
 namespace f32 {
   export const MIN_VALUE: f32 = -3.40282347e+38;
   export const MAX_VALUE: f32 = 3.40282347e+38;
+  export const MIN_POSITIVE_VALUE: f32 = 1.175494351e-38;
   export const MIN_SAFE_INTEGER: f32 = -16777215;
   export const MAX_SAFE_INTEGER: f32 = 16777215;
-  export const MIN_NORMAL_VALUE: f32 = 1.175494351e-38;
   export const EPSILON: f32 = 1.19209290e-07;
 }
 export { f32 };
@@ -226,9 +226,9 @@ declare function f64(value: void): f64;
 namespace f64 {
   export const MIN_VALUE: f64 = -1.7976931348623157e+308;
   export const MAX_VALUE: f64 = 1.7976931348623157e+308;
+  export const MIN_POSITIVE_VALUE: f64 = 2.2250738585072014e-308;
   export const MIN_SAFE_INTEGER: f64 = -9007199254740991;
   export const MAX_SAFE_INTEGER: f64 = 9007199254740991;
-  export const MIN_NORMAL_VALUE: f64 = 2.2250738585072014e-308;
   export const EPSILON: f64 = 2.2204460492503131e-16;
 }
 export{ f64 };

--- a/std/portable.d.ts
+++ b/std/portable.d.ts
@@ -83,20 +83,28 @@ declare namespace bool {
 /** Converts any other numeric value to a 32-bit float. */
 declare function f32(value: i8 | i16 | i32 | isize | u8 | u16 | u32 | usize | bool | f32 | f64): f32;
 declare namespace f32 {
+  export const MIN_VALUE: f32;
+  export const MAX_VALUE: f32;
   /** Smallest safely representable integer value. */
   export const MIN_SAFE_INTEGER: f32;
   /** Largest safely representable integer value. */
   export const MAX_SAFE_INTEGER: f32;
+  /** Smallest normalized positive value */
+  export const MIN_NORMAL_VALUE: f32;
   /** Difference between 1 and the smallest representable value greater than 1. */
   export const EPSILON: f32;
 }
 /** Converts any other numeric value to a 64-bit float. */
 declare function f64(value: i8 | i16 | i32 | isize | u8 | u16 | u32 | usize | bool | f32 | f64): f64;
 declare namespace f64 {
+  export const MIN_VALUE: f64;
+  export const MAX_VALUE: f64;
   /** Smallest safely representable integer value. */
   export const MIN_SAFE_INTEGER: f64;
   /** Largest safely representable integer value. */
   export const MAX_SAFE_INTEGER: f64;
+  /** Smallest normalized positive value */
+  export const MIN_NORMAL_VALUE: f64;
   /** Difference between 1 and the smallest representable value greater than 1. */
   export const EPSILON: f64;
 }

--- a/std/portable.d.ts
+++ b/std/portable.d.ts
@@ -85,12 +85,12 @@ declare function f32(value: i8 | i16 | i32 | isize | u8 | u16 | u32 | usize | bo
 declare namespace f32 {
   export const MIN_VALUE: f32;
   export const MAX_VALUE: f32;
+  /** Smallest normalized positive value */
+  export const MIN_POSITIVE_VALUE: f32;
   /** Smallest safely representable integer value. */
   export const MIN_SAFE_INTEGER: f32;
   /** Largest safely representable integer value. */
   export const MAX_SAFE_INTEGER: f32;
-  /** Smallest normalized positive value */
-  export const MIN_NORMAL_VALUE: f32;
   /** Difference between 1 and the smallest representable value greater than 1. */
   export const EPSILON: f32;
 }
@@ -99,12 +99,12 @@ declare function f64(value: i8 | i16 | i32 | isize | u8 | u16 | u32 | usize | bo
 declare namespace f64 {
   export const MIN_VALUE: f64;
   export const MAX_VALUE: f64;
+  /** Smallest normalized positive value */
+  export const MIN_POSITIVE_VALUE: f64;
   /** Smallest safely representable integer value. */
   export const MIN_SAFE_INTEGER: f64;
   /** Largest safely representable integer value. */
   export const MAX_SAFE_INTEGER: f64;
-  /** Smallest normalized positive value */
-  export const MIN_NORMAL_VALUE: f64;
   /** Difference between 1 and the smallest representable value greater than 1. */
   export const EPSILON: f64;
 }

--- a/std/portable.js
+++ b/std/portable.js
@@ -56,9 +56,9 @@ Object.defineProperties(
 , {
   "MIN_VALUE": { value: Math.fround(-3.40282347e+38), writable: false },
   "MAX_VALUE": { value: Math.fround(3.40282347e+38), writable: false },
+  "MIN_POSITIVE_VALUE": { value: Math.fround(1.175494351e-38), writable: false },
   "MIN_SAFE_INTEGER": { value: -16777215, writable: false },
   "MAX_SAFE_INTEGER": { value: 16777215, writable: false },
-  "MIN_NORMAL_VALUE": { value: Math.fround(1.175494351e-38), writable: false },
   "EPSILON": { value: Math.fround(1.19209290e-07), writable: false }
 });
 
@@ -67,9 +67,9 @@ Object.defineProperties(
 , {
   "MIN_VALUE": { value: -1.7976931348623157e+308, writable: false },
   "MAX_VALUE": { value: 1.7976931348623157e+308, writable: false },
+  "MIN_POSITIVE_VALUE": { value: 2.2250738585072014e-308 , writable: false },
   "MIN_SAFE_INTEGER": { value: -9007199254740991, writable: false },
   "MAX_SAFE_INTEGER": { value: 9007199254740991, writable: false },
-  "MIN_NORMAL_VALUE": { value: 2.2250738585072014e-308 , writable: false },
   "EPSILON": { value: 2.2204460492503131e-16, writable: false }
 });
 

--- a/std/portable.js
+++ b/std/portable.js
@@ -58,7 +58,7 @@ Object.defineProperties(
   "MAX_VALUE": { value: Math.fround(3.40282347e+38), writable: false },
   "MIN_SAFE_INTEGER": { value: -16777215, writable: false },
   "MAX_SAFE_INTEGER": { value: 16777215, writable: false },
-  "MIN_NORMAL_VALUE": { value: 1.175494351e-38 , writable: false },
+  "MIN_NORMAL_VALUE": { value: Math.fround(1.175494351e-38), writable: false },
   "EPSILON": { value: Math.fround(1.19209290e-07), writable: false }
 });
 

--- a/std/portable.js
+++ b/std/portable.js
@@ -58,6 +58,7 @@ Object.defineProperties(
   "MAX_VALUE": { value: Math.fround(3.40282347e+38), writable: false },
   "MIN_SAFE_INTEGER": { value: -16777215, writable: false },
   "MAX_SAFE_INTEGER": { value: 16777215, writable: false },
+  "MIN_NORMAL_VALUE": { value: 1.175494351e-38 , writable: false },
   "EPSILON": { value: Math.fround(1.19209290e-07), writable: false }
 });
 
@@ -68,6 +69,7 @@ Object.defineProperties(
   "MAX_VALUE": { value: 1.7976931348623157e+308, writable: false },
   "MIN_SAFE_INTEGER": { value: -9007199254740991, writable: false },
   "MAX_SAFE_INTEGER": { value: 9007199254740991, writable: false },
+  "MIN_NORMAL_VALUE": { value: 2.2250738585072014e-308 , writable: false },
   "EPSILON": { value: 2.2204460492503131e-16, writable: false }
 });
 


### PR DESCRIPTION
### Also
- Add min & max values for decimals in portable defs.

### Motivation:
Java:  https://docs.oracle.com/javase/7/docs/api/java/lang/Double.html#MIN_NORMAL
Swift: https://developer.apple.com/documentation/swift/double/1849547-leastnormalmagnitude
Rust:  https://rust-num.github.io/num/num_traits/float/trait.Float.html#tymethod.min_positive_value

and etc