### PR TITLE
Improve Math#sign

### DIFF
--- a/std/assembly/math.ts
+++ b/std/assembly/math.ts
@@ -1042,7 +1042,8 @@ export namespace NativeMath {
 
   @inline
   export function sign(x: f64): f64 {
-    return x > 0 ? 1 : x < 0 ? -1 : x;
+    // return x > 0 ? 1 : x < 0 ? -1 : x;
+    return builtin_abs<f64>(x) > 0 ? builtin_copysign<f64>(1, x) : x;
   }
 
   export function sin(x: f64): f64 { // TODO
@@ -2096,7 +2097,8 @@ export namespace NativeMathf {
 
   @inline
   export function sign(x: f32): f32 {
-    return x > 0 ? 1 : x < 0 ? -1 : x;
+    // return x > 0 ? 1 : x < 0 ? -1 : x;
+    return builtin_abs<f32>(x) > 0 ? builtin_copysign<f32>(1, x) : x;
   }
 
   export function sin(x: f32): f32 { // TODO

--- a/tests/compiler/std/libm.optimized.wat
+++ b/tests/compiler/std/libm.optimized.wat
@@ -5719,19 +5719,17 @@
  (func $std/libm/sign (; 50 ;) (type $FF) (param $0 f64) (result f64)
   (local $1 f64)
   (select
-   (f64.const 1)
-   (select
-    (f64.const -1)
+   (f64.copysign
+    (f64.const 1)
     (tee_local $1
      (get_local $0)
     )
-    (f64.lt
-     (get_local $1)
-     (f64.const 0)
-    )
    )
+   (get_local $1)
    (f64.gt
-    (get_local $1)
+    (f64.abs
+     (get_local $1)
+    )
     (f64.const 0)
    )
   )

--- a/tests/compiler/std/libm.untouched.wat
+++ b/tests/compiler/std/libm.untouched.wat
@@ -6839,18 +6839,16 @@
     (br $~lib/math/NativeMath.sign|inlined.0
      (if (result f64)
       (f64.gt
-       (get_local $1)
+       (f64.abs
+        (get_local $1)
+       )
        (f64.const 0)
       )
-      (f64.const 1)
-      (if (result f64)
-       (f64.lt
-        (get_local $1)
-        (f64.const 0)
-       )
-       (f64.const -1)
+      (f64.copysign
+       (f64.const 1)
        (get_local $1)
       )
+      (get_local $1)
      )
     )
    )

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -12474,19 +12474,17 @@
     (tee_local $4
      (call $std/math/check<f64>
       (select
-       (f64.const 1)
-       (select
-        (f64.const -1)
+       (f64.copysign
+        (f64.const 1)
         (tee_local $5
          (get_local $0)
         )
-        (f64.lt
-         (get_local $5)
-         (f64.const 0)
-        )
        )
+       (get_local $5)
        (f64.gt
-        (get_local $5)
+        (f64.abs
+         (get_local $5)
+        )
         (f64.const 0)
        )
       )
@@ -12518,19 +12516,17 @@
   (local $4 f32)
   (call $std/math/check<f32>
    (select
-    (f32.const 1)
-    (select
-     (f32.const -1)
+    (f32.copysign
+     (f32.const 1)
      (tee_local $4
       (get_local $0)
      )
-     (f32.lt
-      (get_local $4)
-      (f32.const 0)
-     )
     )
+    (get_local $4)
     (f32.gt
-     (get_local $4)
+     (f32.abs
+      (get_local $4)
+     )
      (f32.const 0)
     )
    )

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -14859,18 +14859,16 @@
         (br $~lib/math/NativeMath.sign|inlined.0
          (if (result f64)
           (f64.gt
-           (get_local $4)
+           (f64.abs
+            (get_local $4)
+           )
            (f64.const 0)
           )
-          (f64.const 1)
-          (if (result f64)
-           (f64.lt
-            (get_local $4)
-            (f64.const 0)
-           )
-           (f64.const -1)
+          (f64.copysign
+           (f64.const 1)
            (get_local $4)
           )
+          (get_local $4)
          )
         )
        )
@@ -14912,18 +14910,16 @@
      (br $~lib/math/NativeMathf.sign|inlined.0
       (if (result f32)
        (f32.gt
-        (get_local $4)
+        (f32.abs
+         (get_local $4)
+        )
         (f32.const 0)
        )
-       (f32.const 1)
-       (if (result f32)
-        (f32.lt
-         (get_local $4)
-         (f32.const 0)
-        )
-        (f32.const -1)
+       (f32.copysign
+        (f32.const 1)
         (get_local $4)
        )
+       (get_local $4)
       )
      )
     )


### PR DESCRIPTION
+ new version produce less branchless machine code.
+ less comparision instructions
+ smaller wasm size (129 bytes vs 112 bytes)