### PR TITLE
Fix crash when assigning to bool class fields

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -7,6 +7,7 @@ under the licensing terms detailed in LICENSE:
 * Max Graey <maxgraey@gmail.com>
 * Igor Sbitnev <PinkaminaDianePie@gmail.com>
 * Norton Wang <me@nortonwang.com>
+* Alan Pierce <alangpierce@gmail.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -4411,7 +4411,7 @@ export class Compiler extends DiagnosticEmitter {
           return module.createBlock(null, [
             module.createSetLocal(tempLocalIndex, valueWithCorrectType),
             module.createStore(
-              type.size >> 3,
+              type.byteSize,
               thisExpr,
               module.createGetLocal(tempLocalIndex, nativeType),
               nativeType,
@@ -4421,7 +4421,7 @@ export class Compiler extends DiagnosticEmitter {
           ], nativeType);
         } else {
           return module.createStore(
-            type.size >> 3,
+            type.byteSize,
             thisExpr,
             valueWithCorrectType,
             nativeType,

--- a/tests/compiler/class-with-boolean-field.optimized.wat
+++ b/tests/compiler/class-with-boolean-field.optimized.wat
@@ -1,0 +1,16 @@
+(module
+ (type $i (func (result i32)))
+ (memory $0 1)
+ (export "test" (func $class-with-boolean-field/test))
+ (export "memory" (memory $0))
+ (func $class-with-boolean-field/test (; 0 ;) (type $i) (result i32)
+  (local $0 i32)
+  (i32.store8
+   (get_local $0)
+   (i32.const 1)
+  )
+  (i32.load8_u
+   (get_local $0)
+  )
+ )
+)

--- a/tests/compiler/class-with-boolean-field.ts
+++ b/tests/compiler/class-with-boolean-field.ts
@@ -1,0 +1,9 @@
+class A {
+  boolValue: bool;
+}
+
+export function test(): bool {
+  let a: A;
+  a.boolValue = true;
+  return a.boolValue;
+}

--- a/tests/compiler/class-with-boolean-field.untouched.wat
+++ b/tests/compiler/class-with-boolean-field.untouched.wat
@@ -1,0 +1,20 @@
+(module
+ (type $i (func (result i32)))
+ (global $HEAP_BASE i32 (i32.const 4))
+ (memory $0 1)
+ (export "test" (func $class-with-boolean-field/test))
+ (export "memory" (memory $0))
+ (func $class-with-boolean-field/test (; 0 ;) (type $i) (result i32)
+  (local $0 i32)
+  (nop)
+  (i32.store8
+   (get_local $0)
+   (i32.const 1)
+  )
+  (return
+   (i32.load8_u
+    (get_local $0)
+   )
+  )
+ )
+)


### PR DESCRIPTION
Fixes #94

With `Type.bool`, size is 1, so dividing by 8 isn't the right way to convert to
byteSize. Instead, we need to use the `byteSize` property that does the proper
ceiling division.

I left out the allocation from the test so that the resulting wat files are
easier to read.