### PR TITLE
Allow keywords in named import/export syntax

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1930,7 +1930,7 @@ export class Parser extends DiagnosticEmitter {
       let identifier = Node.createIdentifierExpression(tn.readIdentifier(), tn.range());
       let asIdentifier: IdentifierExpression | null = null;
       if (tn.skip(Token.AS)) {
-        if (tn.skip(Token.IDENTIFIER)) {
+        if (tn.skipIdentifierName()) {
           asIdentifier = Node.createIdentifierExpression(tn.readIdentifier(), tn.range());
         } else {
           this.error(
@@ -2044,7 +2044,7 @@ export class Parser extends DiagnosticEmitter {
 
     // before: Identifier ('as' Identifier)?
 
-    if (tn.skip(Token.IDENTIFIER)) {
+    if (tn.skipIdentifierName()) {
       let identifier = Node.createIdentifierExpression(tn.readIdentifier(), tn.range());
       let asIdentifier: IdentifierExpression | null = null;
       if (tn.skip(Token.AS)) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -580,7 +580,7 @@ export class Parser extends DiagnosticEmitter {
             this.tryParseSignatureIsSignature = false;
             return null;
           }
-        } else if (tn.skip(Token.IDENTIFIER)) {
+        } else if (tn.skipIdentifier()) {
           let name = Node.createIdentifierExpression(tn.readIdentifier(), tn.range(tn.tokenPos, tn.pos));
           if (tn.skip(Token.QUESTION)) {
             isSignature = true;
@@ -679,11 +679,11 @@ export class Parser extends DiagnosticEmitter {
     // at '@': Identifier ('.' Identifier)* '(' Arguments
 
     var startPos = tn.tokenPos;
-    if (tn.skip(Token.IDENTIFIER)) {
+    if (tn.skipIdentifier()) {
       let name = tn.readIdentifier();
       let expression: Expression = Node.createIdentifierExpression(name, tn.range(startPos, tn.pos));
       while (tn.skip(Token.DOT)) {
-        if (tn.skip(Token.IDENTIFIER)) {
+        if (tn.skipIdentifier()) {
           name = tn.readIdentifier();
           expression = Node.createPropertyAccessExpression(
             expression,
@@ -745,7 +745,7 @@ export class Parser extends DiagnosticEmitter {
 
     // before: Identifier (':' Type)? ('=' Expression)?
 
-    if (!tn.skip(Token.IDENTIFIER)) {
+    if (!tn.skipIdentifier()) {
       this.error(
         DiagnosticCode.Identifier_expected,
         tn.range()
@@ -854,7 +854,7 @@ export class Parser extends DiagnosticEmitter {
 
     // before: Identifier ('=' Expression)?
 
-    if (!tn.skip(Token.IDENTIFIER)) {
+    if (!tn.skipIdentifier()) {
       this.error(
         DiagnosticCode.Identifier_expected,
         tn.range()
@@ -1082,7 +1082,7 @@ export class Parser extends DiagnosticEmitter {
       }
       isRest = true;
     }
-    if (tn.skip(Token.IDENTIFIER)) {
+    if (tn.skipIdentifier()) {
       if (!isRest) startRange = tn.range();
       let identifier = Node.createIdentifierExpression(tn.readIdentifier(), tn.range());
       let type: CommonTypeNode | null = null;
@@ -1155,7 +1155,7 @@ export class Parser extends DiagnosticEmitter {
     //  '{' Statement* '}'
     //  ';'?
 
-    if (!tn.skip(Token.IDENTIFIER)) {
+    if (!tn.skipIdentifier()) {
       this.error(
         DiagnosticCode.Identifier_expected,
         tn.range(tn.pos)
@@ -1282,7 +1282,7 @@ export class Parser extends DiagnosticEmitter {
     //  Statement
 
     if (tn.token == Token.FUNCTION) {
-      if (tn.skip(Token.IDENTIFIER)) {
+      if (tn.skipIdentifier()) {
         name = Node.createIdentifierExpression(tn.readIdentifier(), tn.range());
       } else { // empty name
         name = Node.createEmptyIdentifierExpression(tn.range(tn.pos));
@@ -1398,7 +1398,7 @@ export class Parser extends DiagnosticEmitter {
 
     var isInterface = tn.token == Token.INTERFACE;
 
-    if (!tn.skip(Token.IDENTIFIER)) {
+    if (!tn.skipIdentifier()) {
       this.error(
         DiagnosticCode.Identifier_expected,
         tn.range()
@@ -1618,7 +1618,7 @@ export class Parser extends DiagnosticEmitter {
       }
     }
 
-    if (!isConstructor && !tn.skip(Token.IDENTIFIER)) {
+    if (!isConstructor && !tn.skipIdentifier()) {
       this.error(
         DiagnosticCode.Identifier_expected,
         tn.range()
@@ -1834,7 +1834,7 @@ export class Parser extends DiagnosticEmitter {
 
     // at 'namespace': Identifier '{' (Variable | Function)* '}'
 
-    if (tn.skip(Token.IDENTIFIER)) {
+    if (tn.skipIdentifier()) {
       let identifier = Node.createIdentifierExpression(tn.readIdentifier(), tn.range());
       if (tn.skip(Token.OPENBRACE)) {
         let members = new Array<Statement>();
@@ -1927,7 +1927,7 @@ export class Parser extends DiagnosticEmitter {
 
     // before: Identifier ('as' Identifier)?
 
-    if (tn.skip(Token.IDENTIFIER)) {
+    if (tn.skipIdentifier()) {
       let identifier = Node.createIdentifierExpression(tn.readIdentifier(), tn.range());
       let asIdentifier: IdentifierExpression | null = null;
       if (tn.skip(Token.AS)) {
@@ -1987,7 +1987,7 @@ export class Parser extends DiagnosticEmitter {
       }
     } else if (tn.skip(Token.ASTERISK)) {
       if (tn.skip(Token.AS)) {
-        if (tn.skip(Token.IDENTIFIER)) {
+        if (tn.skipIdentifier()) {
           namespaceName = Node.createIdentifierExpression(tn.readIdentifier(), tn.range());
         } else {
           this.error(
@@ -2049,7 +2049,7 @@ export class Parser extends DiagnosticEmitter {
       let identifier = Node.createIdentifierExpression(tn.readIdentifier(), tn.range());
       let asIdentifier: IdentifierExpression | null = null;
       if (tn.skip(Token.AS)) {
-        if (tn.skip(Token.IDENTIFIER)) {
+        if (tn.skipIdentifier()) {
           asIdentifier = Node.createIdentifierExpression(tn.readIdentifier(), tn.range());
         } else {
           this.error(
@@ -2082,10 +2082,10 @@ export class Parser extends DiagnosticEmitter {
 
     // at 'export' 'import': Identifier ('=' Identifier)? ';'?
 
-    if (tn.skip(Token.IDENTIFIER)) {
+    if (tn.skipIdentifier()) {
       let asIdentifier = Node.createIdentifierExpression(tn.readIdentifier(), tn.range());
       if (tn.skip(Token.EQUALS)) {
-        if (tn.skip(Token.IDENTIFIER)) {
+        if (tn.skipIdentifier()) {
           let identifier = Node.createIdentifierExpression(tn.readIdentifier(), tn.range());
           let ret = Node.createExportImportStatement(identifier, asIdentifier, tn.range(startPos, tn.pos));
           tn.skip(Token.SEMICOLON);
@@ -2579,7 +2579,7 @@ export class Parser extends DiagnosticEmitter {
           );
           return null;
         }
-        if (!tn.skip(Token.IDENTIFIER)) {
+        if (!tn.skipIdentifier()) {
           this.error(
             DiagnosticCode.Identifier_expected,
             tn.range()
@@ -2657,7 +2657,7 @@ export class Parser extends DiagnosticEmitter {
 
     // at 'type': Identifier ('<' TypeParameters '>')? '=' Type ';'?
 
-    if (tn.skip(Token.IDENTIFIER)) {
+    if (tn.skipIdentifier()) {
       let name = Node.createIdentifierExpression(tn.readIdentifier(), tn.range());
       let typeParameters: TypeParameterNode[] | null = null;
       if (tn.skip(Token.LESSTHAN)) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -14,7 +14,8 @@ import {
   Tokenizer,
   Token,
   Range,
-  CommentHandler
+  CommentHandler,
+  IdentifierHandling
 } from "./tokenizer";
 
 import {
@@ -1565,7 +1566,7 @@ export class Parser extends DiagnosticEmitter {
     var setStart: i32 = 0;
     var setEnd: i32 = 0;
     if (tn.skip(Token.GET)) {
-      if (tn.peek(true, true) == Token.IDENTIFIER && !tn.nextTokenOnNewLine) {
+      if (tn.peek(true, IdentifierHandling.PREFER) == Token.IDENTIFIER && !tn.nextTokenOnNewLine) {
         flags |= CommonFlags.GET;
         isGetter = true;
         setStart = tn.tokenPos;
@@ -1580,7 +1581,7 @@ export class Parser extends DiagnosticEmitter {
         tn.reset(state);
       }
     } else if (tn.skip(Token.SET)) {
-      if (tn.peek(true, true) == Token.IDENTIFIER && !tn.nextTokenOnNewLine) {
+      if (tn.peek(true, IdentifierHandling.PREFER) == Token.IDENTIFIER && !tn.nextTokenOnNewLine) {
         flags |= CommonFlags.SET | CommonFlags.SET;
         isSetter = true;
         setStart = tn.tokenPos;
@@ -2242,7 +2243,7 @@ export class Parser extends DiagnosticEmitter {
 
     var identifier: IdentifierExpression | null = null;
     if (tn.peek(true) == Token.IDENTIFIER && !tn.nextTokenOnNewLine) {
-      tn.next(true);
+      tn.next(IdentifierHandling.PREFER);
       identifier = Node.createIdentifierExpression(tn.readIdentifier(), tn.range());
     }
     var ret = Node.createBreakStatement(identifier, tn.range());
@@ -2258,7 +2259,7 @@ export class Parser extends DiagnosticEmitter {
 
     var identifier: IdentifierExpression | null = null;
     if (tn.peek(true) == Token.IDENTIFIER && !tn.nextTokenOnNewLine) {
-      tn.next(true);
+      tn.next(IdentifierHandling.PREFER);
       identifier = Node.createIdentifierExpression(tn.readIdentifier(), tn.range());
     }
     var ret = Node.createContinueStatement(identifier, tn.range());
@@ -2744,7 +2745,7 @@ export class Parser extends DiagnosticEmitter {
     tn: Tokenizer
   ): Expression | null {
 
-    var token = tn.next(true);
+    var token = tn.next(IdentifierHandling.PREFER);
     var startPos = tn.tokenPos;
     var expr: Expression | null = null;
 
@@ -2821,7 +2822,7 @@ export class Parser extends DiagnosticEmitter {
         let state = tn.mark();
         let again = true;
         do {
-          switch (tn.next(true)) {
+          switch (tn.next(IdentifierHandling.PREFER)) {
 
             // function expression
             case Token.DOT_DOT_DOT: {

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -972,7 +972,15 @@ export class Tokenizer extends DiagnosticEmitter {
     return this.nextToken;
   }
 
-  skip(token: Token): bool {
+  skipIdentifier(): bool {
+    return this.skip(Token.IDENTIFIER, IdentifierHandling.PREFER);
+  }
+
+  skipIdentifierName(): bool {
+    return this.skip(Token.IDENTIFIER, IdentifierHandling.ALWAYS);
+  }
+
+  skip(token: Token, identifierHandling: IdentifierHandling = IdentifierHandling.DEFAULT): bool {
     var posBefore = this.pos;
     var tokenBefore = this.token;
     var tokenPosBefore = this.tokenPos;
@@ -983,31 +991,8 @@ export class Tokenizer extends DiagnosticEmitter {
         break;
       }
     }
-    this.token = this.unsafeNext(
-      token == Token.IDENTIFIER ? IdentifierHandling.PREFER : IdentifierHandling.DEFAULT,
-      maxCompoundLength
-    );
+    this.token = this.unsafeNext(identifierHandling, maxCompoundLength);
     if (this.token == token) {
-      this.nextToken = -1;
-      return true;
-    } else {
-      this.pos = posBefore;
-      this.token = tokenBefore;
-      this.tokenPos = tokenPosBefore;
-      return false;
-    }
-  }
-
-  /**
-   * Skip any name token, whether or not it is a keyword.
-   */
-  skipIdentifierName(): bool {
-    var posBefore = this.pos;
-    var tokenBefore = this.token;
-    var tokenPosBefore = this.tokenPos;
-    var maxCompoundLength = i32.MAX_VALUE;
-    this.token = this.unsafeNext(IdentifierHandling.ALWAYS, maxCompoundLength);
-    if (this.token == Token.IDENTIFIER) {
       this.nextToken = -1;
       return true;
     } else {

--- a/tests/compiler/named-export-default.optimized.wat
+++ b/tests/compiler/named-export-default.optimized.wat
@@ -1,0 +1,9 @@
+(module
+ (type $i (func (result i32)))
+ (memory $0 1)
+ (export "default" (func $named-export-default/get3))
+ (export "memory" (memory $0))
+ (func $named-export-default/get3 (; 0 ;) (type $i) (result i32)
+  (i32.const 3)
+ )
+)

--- a/tests/compiler/named-export-default.ts
+++ b/tests/compiler/named-export-default.ts
@@ -1,0 +1,5 @@
+function get3(): i32 {
+  return 3;
+}
+
+export {get3 as default};

--- a/tests/compiler/named-export-default.untouched.wat
+++ b/tests/compiler/named-export-default.untouched.wat
@@ -1,0 +1,12 @@
+(module
+ (type $i (func (result i32)))
+ (global $HEAP_BASE i32 (i32.const 4))
+ (memory $0 1)
+ (export "default" (func $named-export-default/get3))
+ (export "memory" (memory $0))
+ (func $named-export-default/get3 (; 0 ;) (type $i) (result i32)
+  (return
+   (i32.const 3)
+  )
+ )
+)

--- a/tests/compiler/named-import-default.optimized.wat
+++ b/tests/compiler/named-import-default.optimized.wat
@@ -1,0 +1,12 @@
+(module
+ (type $i (func (result i32)))
+ (memory $0 1)
+ (export "getValue" (func $named-import-default/getValue))
+ (export "memory" (memory $0))
+ (func $named-export-default/get3 (; 0 ;) (type $i) (result i32)
+  (i32.const 3)
+ )
+ (func $named-import-default/getValue (; 1 ;) (type $i) (result i32)
+  (call $named-export-default/get3)
+ )
+)

--- a/tests/compiler/named-import-default.ts
+++ b/tests/compiler/named-import-default.ts
@@ -1,0 +1,7 @@
+import {
+  default as get3
+} from "./named-export-default";
+
+export function getValue(): i32 {
+  return get3();
+}

--- a/tests/compiler/named-import-default.untouched.wat
+++ b/tests/compiler/named-import-default.untouched.wat
@@ -1,0 +1,17 @@
+(module
+ (type $i (func (result i32)))
+ (global $HEAP_BASE i32 (i32.const 4))
+ (memory $0 1)
+ (export "getValue" (func $named-import-default/getValue))
+ (export "memory" (memory $0))
+ (func $named-export-default/get3 (; 0 ;) (type $i) (result i32)
+  (return
+   (i32.const 3)
+  )
+ )
+ (func $named-import-default/getValue (; 1 ;) (type $i) (result i32)
+  (return
+   (call $named-export-default/get3)
+  )
+ )
+)


### PR DESCRIPTION
Progress toward #98

See the imports and exports grammar from the spec:
https://www.ecma-international.org/ecma-262/8.0/index.html#sec-imports
https://www.ecma-international.org/ecma-262/8.0/index.html#sec-exports

In particular, ImportSpecifier and ExportSpecifier use IdentifierName to
identify the import/export name rather than the more restrictive ImportedBinding
(or just Identifier). That means any keyword is allowed.

There are (at least) three contexts to think about in JS identifier parsing:
* In most contexts, identifiers like variable names can be any name except a
  reserved word.
* Some keywords, like "as", are normally not keywords but have special
  keyword-like meaning in specific situations. Acorn and Babel call these
  "contextual keywords", and `tokenIsAlsoIdentifier` and `preferIdentifier` in
  AssemblyScript appear to handle that case.
* In some contexts, like object keys and named imports/exports, any name is
  allowed, even keywords.

This change adds that third case in order to handle imports/exports. I added a
`forceIdentifier` flag that tells the tokenizer that any identifier name should
be treated as a plain identifier, then used it in the import and export cases.