### PR TITLE
Add a more helpful error message when you haven't defined an allocator

### DIFF
--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -2718,7 +2718,11 @@ export function compileAllocate(
   var allocatePrototype = program.elementsLookup.get(allocateInternalName);
   if (!allocatePrototype) {
     program.error(
-      DiagnosticCode.Cannot_allocate_memory_unless_an_allocator_is_defined_Please_define_an_allocator_e_g_by_importing_allocator_arena_or_allocator_tlsf,
+      DiagnosticCode.Cannot_find_name_0,
+      reportNode.range, allocateInternalName
+    );
+    program.info(
+      DiagnosticCode.An_allocator_must_be_declared_to_allocate_memory_Try_importing_allocator_arena_or_allocator_tlsf,
       reportNode.range
     );
     return module.createUnreachable();

--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -2718,8 +2718,8 @@ export function compileAllocate(
   var allocatePrototype = program.elementsLookup.get(allocateInternalName);
   if (!allocatePrototype) {
     program.error(
-      DiagnosticCode.Cannot_find_name_0,
-      reportNode.range, allocateInternalName
+      DiagnosticCode.Cannot_allocate_memory_unless_an_allocator_is_defined_Please_define_an_allocator_e_g_by_importing_allocator_arena_or_allocator_tlsf,
+      reportNode.range
     );
     return module.createUnreachable();
   }

--- a/src/diagnosticMessages.generated.ts
+++ b/src/diagnosticMessages.generated.ts
@@ -23,6 +23,7 @@ export enum DiagnosticCode {
   Class_0_is_sealed_and_cannot_be_extended = 211,
   Decorator_0_is_not_valid_here = 212,
   Duplicate_decorator = 213,
+  Cannot_allocate_memory_unless_an_allocator_is_defined_Please_define_an_allocator_e_g_by_importing_allocator_arena_or_allocator_tlsf = 214,
   Unterminated_string_literal = 1002,
   Identifier_expected = 1003,
   _0_expected = 1005,
@@ -131,6 +132,7 @@ export function diagnosticCodeToString(code: DiagnosticCode): string {
     case 211: return "Class '{0}' is sealed and cannot be extended.";
     case 212: return "Decorator '{0}' is not valid here.";
     case 213: return "Duplicate decorator.";
+    case 214: return "Cannot allocate memory unless an allocator is defined. Please define an allocator e.g. by importing allocator/arena or allocator/tlsf.";
     case 1002: return "Unterminated string literal.";
     case 1003: return "Identifier expected.";
     case 1005: return "'{0}' expected.";

--- a/src/diagnosticMessages.generated.ts
+++ b/src/diagnosticMessages.generated.ts
@@ -23,7 +23,7 @@ export enum DiagnosticCode {
   Class_0_is_sealed_and_cannot_be_extended = 211,
   Decorator_0_is_not_valid_here = 212,
   Duplicate_decorator = 213,
-  Cannot_allocate_memory_unless_an_allocator_is_defined_Please_define_an_allocator_e_g_by_importing_allocator_arena_or_allocator_tlsf = 214,
+  An_allocator_must_be_declared_to_allocate_memory_Try_importing_allocator_arena_or_allocator_tlsf = 214,
   Unterminated_string_literal = 1002,
   Identifier_expected = 1003,
   _0_expected = 1005,
@@ -132,7 +132,7 @@ export function diagnosticCodeToString(code: DiagnosticCode): string {
     case 211: return "Class '{0}' is sealed and cannot be extended.";
     case 212: return "Decorator '{0}' is not valid here.";
     case 213: return "Duplicate decorator.";
-    case 214: return "Cannot allocate memory unless an allocator is defined. Please define an allocator e.g. by importing allocator/arena or allocator/tlsf.";
+    case 214: return "An allocator must be declared to allocate memory. Try importing allocator/arena or allocator/tlsf.";
     case 1002: return "Unterminated string literal.";
     case 1003: return "Identifier expected.";
     case 1005: return "'{0}' expected.";

--- a/src/diagnosticMessages.json
+++ b/src/diagnosticMessages.json
@@ -15,7 +15,7 @@
   "Class '{0}' is sealed and cannot be extended.": 211,
   "Decorator '{0}' is not valid here.": 212,
   "Duplicate decorator.": 213,
-  "Cannot allocate memory unless an allocator is defined. Please define an allocator e.g. by importing allocator/arena or allocator/tlsf.": 214,
+  "An allocator must be declared to allocate memory. Try importing allocator/arena or allocator/tlsf.": 214,
 
   "Unterminated string literal.": 1002,
   "Identifier expected.": 1003,

--- a/src/diagnosticMessages.json
+++ b/src/diagnosticMessages.json
@@ -15,6 +15,7 @@
   "Class '{0}' is sealed and cannot be extended.": 211,
   "Decorator '{0}' is not valid here.": 212,
   "Duplicate decorator.": 213,
+  "Cannot allocate memory unless an allocator is defined. Please define an allocator e.g. by importing allocator/arena or allocator/tlsf.": 214,
 
   "Unterminated string literal.": 1002,
   "Identifier expected.": 1003,

--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -40,23 +40,16 @@ if (args._.length) {
   }
 }
 
-const EXPECT_ERRORS_PREFIX = '// Expect errors: ';
+const EXPECT_ERROR_PREFIX = '// Expect error:';
 
-// Returns an array of error codes to expect, or null if compilation should succeed.
+// Returns an array of error strings to expect, or null if compilation should succeed.
 function getExpectedErrors(filePath) {
-  const firstLine = fs.readFileSync(filePath).toString().split('\n')[0];
-  if (!firstLine) {
+  const lines = fs.readFileSync(filePath).toString().split('\n');
+  const expectErrorLines = lines.filter(line => line.startsWith(EXPECT_ERROR_PREFIX));
+  if (expectErrorLines.length === 0) {
     return null;
   }
-  if (firstLine.startsWith(EXPECT_ERRORS_PREFIX)) {
-    const errors = firstLine.slice(EXPECT_ERRORS_PREFIX.length).trim().split(', ');
-    if (errors.length === 0) {
-      return null;
-    }
-    return errors;
-  } else {
-    return null;
-  }
+  return expectErrorLines.map(line => line.slice(EXPECT_ERROR_PREFIX.length).trim());
 }
 
 // TODO: asc's callback is synchronous here. This might change.
@@ -91,7 +84,7 @@ tests.forEach(filename => {
       const stderrString = stderr.toString();
       for (const expectedError of expectedErrors) {
         if (!stderrString.includes(expectedError)) {
-          console.log(`Expected error ${expectedError} was not in the error output.`);
+          console.log(`Expected error "${expectedError}" was not in the error output.`);
           console.log("- " + chalk.red("error check ERROR"));
           failedTests.push(basename);
           console.log();

--- a/tests/compiler/new-without-allocator.ts
+++ b/tests/compiler/new-without-allocator.ts
@@ -1,0 +1,7 @@
+// Expect errors: AS214
+class A {}
+
+export function test(): i32 {
+  var a = new A();
+  return 3;
+}

--- a/tests/compiler/new-without-allocator.ts
+++ b/tests/compiler/new-without-allocator.ts
@@ -1,4 +1,5 @@
-// Expect errors: AS214
+// Expect error: TS2304: Cannot find name 'allocate_memory'.
+// Expect error: AS214: An allocator must be declared to allocate memory. Try importing allocator/arena or allocator/tlsf.
 class A {}
 
 export function test(): i32 {


### PR DESCRIPTION
This tripped me up, and it looks like others have run into it as well, so it
seems like a good idea to have a custom error message.

I also added a system for writing tests that assert that certain error codes are
triggered so that I could test this.