### PR TITLE
Rename Uint64Array to BigInt64Array. Add BigInt stub for portable

### DIFF
--- a/std/assembly.d.ts
+++ b/std/assembly.d.ts
@@ -353,9 +353,9 @@ declare class Int32Array extends TypedArray<i32> {}
 /** An array of 32-bit unsigned integers. */
 declare class Uint32Array extends TypedArray<u32> {}
 /** An array of twos-complement 64-bit signed integers. */
-declare class Int64Array extends TypedArray<i64> {}
+declare class BigInt64Array extends TypedArray<i64> {}
 /** An array of 64-bit unsigned integers. */
-declare class Uint64Array extends TypedArray<u64> {}
+declare class BigUint64Array extends TypedArray<u64> {}
 /** An array of 32-bit floating point numbers. */
 declare class Float32Array extends TypedArray<f32> {}
 /** An array of 64-bit floating point numbers. */

--- a/std/assembly/typedarray.ts
+++ b/std/assembly/typedarray.ts
@@ -68,19 +68,19 @@ export class Uint32Array extends TypedArray<u32,u32> {
   }
 }
 
-export class Int64Array extends TypedArray<i64,i64> {
+export class BigInt64Array extends TypedArray<i64,i64> {
   static readonly BYTES_PER_ELEMENT: usize = sizeof<i64>();
 
-  subarray(begin: i32 = 0, end: i32 = 0x7fffffff): Int64Array {
-    return changetype<Int64Array>(super.subarray(begin, end));
+  subarray(begin: i32 = 0, end: i32 = 0x7fffffff): BigInt64Array {
+    return changetype<BigInt64Array>(super.subarray(begin, end));
   }
 }
 
-export class Uint64Array extends TypedArray<u64,u64> {
+export class BigUint64Array extends TypedArray<u64,u64> {
   static readonly BYTES_PER_ELEMENT: usize = sizeof<u64>();
 
-  subarray(begin: i32 = 0, end: i32 = 0x7fffffff): Uint64Array {
-    return changetype<Uint64Array>(super.subarray(begin, end));
+  subarray(begin: i32 = 0, end: i32 = 0x7fffffff): BigUint64Array {
+    return changetype<BigUint64Array>(super.subarray(begin, end));
   }
 }
 

--- a/std/portable.d.ts
+++ b/std/portable.d.ts
@@ -14,13 +14,18 @@
 
 // Portable types
 
+// TODO temprary stub until this issue not resolved: https://github.com/Microsoft/TypeScript/issues/15096
+declare type BigInt = number;
+
 declare type i8 = number;
 declare type i16 = number;
 declare type i32 = number;
+declare type i64 = BigInt;
 declare type isize = number;
 declare type u8 = number;
 declare type u16 = number;
 declare type u32 = number;
+declare type u64 = BigInt;
 declare type bool = boolean;
 declare type usize = number;
 declare type f32 = number;
@@ -263,6 +268,8 @@ declare class Int16Array extends Array<i16> {}
 declare class Int32Array extends Array<i32> {}
 declare class Float32Array extends Array<f32> {}
 declare class Float64Array extends Array<f64> {}
+declare class BigInt64Array extends Array<i64> {}
+declare class BigUint64Array extends Array<u64> {}
 
 declare class String {
 

--- a/tests/compiler/std/typedarray.ts
+++ b/tests/compiler/std/typedarray.ts
@@ -5,8 +5,8 @@ assert(Int16Array.BYTES_PER_ELEMENT == 2);
 assert(Uint16Array.BYTES_PER_ELEMENT == 2);
 assert(Int32Array.BYTES_PER_ELEMENT == 4);
 assert(Uint32Array.BYTES_PER_ELEMENT == 4);
-assert(Int64Array.BYTES_PER_ELEMENT == 8);
-assert(Uint64Array.BYTES_PER_ELEMENT == 8);
+assert(BigInt64Array.BYTES_PER_ELEMENT == 8);
+assert(BigUint64Array.BYTES_PER_ELEMENT == 8);
 assert(Float32Array.BYTES_PER_ELEMENT == 4);
 assert(Float64Array.BYTES_PER_ELEMENT == 8);
 
@@ -49,14 +49,14 @@ function testInstantiate(len: i32): void {
   assert(u32a.byteLength == len * Uint32Array.BYTES_PER_ELEMENT);
   assert(u32a.length == len);
 
-  var i64a = new Int64Array(len);
+  var i64a = new BigInt64Array(len);
   assert(i64a.byteOffset == 0);
-  assert(i64a.byteLength == len * Int64Array.BYTES_PER_ELEMENT);
+  assert(i64a.byteLength == len * BigInt64Array.BYTES_PER_ELEMENT);
   assert(i64a.length == len);
 
-  var u64a = new Uint64Array(len);
+  var u64a = new BigUint64Array(len);
   assert(u64a.byteOffset == 0);
-  assert(u64a.byteLength == len * Uint64Array.BYTES_PER_ELEMENT);
+  assert(u64a.byteLength == len * BigUint64Array.BYTES_PER_ELEMENT);
   assert(u64a.length == len);
 
   var f32a = new Float32Array(len);


### PR DESCRIPTION
BigInt now landed in V8 6.6 and 6.7 (without extra flag). So I propose adopt some long integers stuffs for this feature.

Proposal spec detail: https://github.com/tc39/proposal-bigint