### PR TITLE
Allow trailing commas in import and export statements

### DIFF
--- a/src/extra/ast.ts
+++ b/src/extra/ast.ts
@@ -710,7 +710,10 @@ export class ASTBuilder {
       sb.push(";\n");
     } else {
       let last = sb[sb.length - 1];
-      if (last.length && last.charCodeAt(last.length - 1) == CharCode.CLOSEBRACE) {
+      if (last.length && (
+          last.charCodeAt(last.length - 1) == CharCode.CLOSEBRACE ||
+          last.charCodeAt(last.length - 1) == CharCode.SEMICOLON)
+      ) {
         sb.push("\n");
       } else {
         sb.push(";\n");
@@ -892,11 +895,15 @@ export class ASTBuilder {
     var numMembers = members.length;
     if (numMembers) {
       sb.push("export {\n");
+      let indentLevel = ++this.indentLevel;
+      indent(sb, indentLevel);
       this.visitExportMember(node.members[0]);
       for (let i = 1; i < numMembers; ++i) {
         sb.push(",\n");
+        indent(sb, indentLevel);
         this.visitExportMember(node.members[i]);
       }
+      --this.indentLevel;
       sb.push("\n}");
     } else {
       sb.push("export {}");
@@ -906,6 +913,7 @@ export class ASTBuilder {
       sb.push(" from ");
       this.visitStringLiteralExpression(path);
     }
+    sb.push(";");
   }
 
   visitExpressionStatement(node: ExpressionStatement): void {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1878,18 +1878,20 @@ export class Parser extends DiagnosticEmitter {
 
     if (tn.skip(Token.OPENBRACE)) {
       let members = new Array<ExportMember>();
-      if (!tn.skip(Token.CLOSEBRACE)) {
-        do {
+      while (!tn.skip(Token.CLOSEBRACE)) {
           let member = this.parseExportMember(tn);
           if (!member) return null;
           members.push(member);
-        } while (tn.skip(Token.COMMA));
-        if (!tn.skip(Token.CLOSEBRACE)) {
-          this.error(
-            DiagnosticCode._0_expected,
-            tn.range(), "}"
-          );
-          return null;
+        if (!tn.skip(Token.COMMA)) {
+          if (tn.skip(Token.CLOSEBRACE)) {
+            break;
+          } else {
+            this.error(
+              DiagnosticCode._0_expected,
+              tn.range(), "}"
+            );
+            return null;
+          }
         }
       }
       let path: StringLiteralExpression | null = null;
@@ -1971,18 +1973,20 @@ export class Parser extends DiagnosticEmitter {
     var skipFrom = false;
     if (tn.skip(Token.OPENBRACE)) {
       members = new Array();
-      if (!tn.skip(Token.CLOSEBRACE)) {
-        do {
-          let member = this.parseImportDeclaration(tn);
-          if (!member) return null;
-          members.push(member);
-        } while (tn.skip(Token.COMMA));
-        if (!tn.skip(Token.CLOSEBRACE)) {
-          this.error(
-            DiagnosticCode._0_expected,
-            tn.range(), "}"
-          );
-          return null;
+      while (!tn.skip(Token.CLOSEBRACE)) {
+        let member = this.parseImportDeclaration(tn);
+        if (!member) return null;
+        members.push(member);
+        if (!tn.skip(Token.COMMA)) {
+          if (tn.skip(Token.CLOSEBRACE)) {
+            break;
+          } else {
+            this.error(
+              DiagnosticCode._0_expected,
+              tn.range(), "}"
+            );
+            return null;
+          }
         }
       }
     } else if (tn.skip(Token.ASTERISK)) {

--- a/tests/parser/trailing-commas.ts
+++ b/tests/parser/trailing-commas.ts
@@ -1,3 +1,8 @@
+import {
+  a,
+  b,
+} from "c";
+
 enum Foo {
   A,
   B,
@@ -31,3 +36,8 @@ export function compute(): i32 {
     2,
   );
 }
+
+export {
+  a,
+  b,
+};

--- a/tests/parser/trailing-commas.ts.fixture.ts
+++ b/tests/parser/trailing-commas.ts.fixture.ts
@@ -1,3 +1,7 @@
+import {
+  a,
+  b
+} from "c";
 enum Foo {
   A,
   B
@@ -11,3 +15,7 @@ export function compute(): i32 {
   parameterized<i8, i32>(0, 0);
   return add(1, 2);
 }
+export {
+  a,
+  b
+};


### PR DESCRIPTION
This uses the same strategy as #97 for two more cases in the parser.