### PR TITLE
 Avoid some npm issues 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 notifications:
   email: false
 before_install: npm i -g npm@latest
-install: npm config set progress=false && npm i
+install: npm config set progress=false && npm i --no-audit
 cache:
   directories:
   - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 notifications:
   email: false
-before_install: npm i -g npm@latest
+before_install: npm i -g npm@latest --no-audit
 install: npm config set progress=false && npm i --no-audit
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: node_js
 notifications:
   email: false
+before_install: npm i -g npm@latest
+install: npm config set progress=false && npm i
+cache:
+  directories:
+  - node_modules
 stages:
 - name: check-pr
   if: type = pull_request


### PR DESCRIPTION
This ditches audits and `npm ci`, and caches `node_modules`. While there are certainly reasons not to do that, it speeds up builds significantly and appears to be less error prone in general.