### PR TITLE
fix: added missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@protobufjs/utf8": "^1.1.0",
     "binaryen": "48.0.0-nightly.20180627",
+    "glob": "^7.1.2",
     "long": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
It looks like it was removed in this PR https://github.com/AssemblyScript/assemblyscript/commit/5ca5df3dc7d17c23ae59f2323b415c598d7d69a0 - but it is still needed at runtime.

Found while testing https://github.com/ColinEberhardt/wasm-mandelbrot/pull/3