### PR TITLE
Don't add default aliases if --noLib is set to avoid "element not found errors.

### DIFF
--- a/cli/asc.js
+++ b/cli/asc.js
@@ -411,11 +411,13 @@ exports.main = function main(argv, options, callback) {
   assemblyscript.setSourceMap(compilerOptions, args.sourceMap != null);
   assemblyscript.setOptimizeLevelHints(compilerOptions, optimizeLevel, shrinkLevel);
 
-  // Initialize default aliases
-  assemblyscript.setGlobalAlias(compilerOptions, "Math", "NativeMath");
-  assemblyscript.setGlobalAlias(compilerOptions, "Mathf", "NativeMathf");
-  assemblyscript.setGlobalAlias(compilerOptions, "abort", "~lib/env/abort");
-  assemblyscript.setGlobalAlias(compilerOptions, "trace", "~lib/env/trace");
+  if (!args.noLib) {
+    // Initialize default aliases
+    assemblyscript.setGlobalAlias(compilerOptions, "Math", "NativeMath");
+    assemblyscript.setGlobalAlias(compilerOptions, "Mathf", "NativeMathf");
+    assemblyscript.setGlobalAlias(compilerOptions, "abort", "~lib/env/abort");
+    assemblyscript.setGlobalAlias(compilerOptions, "trace", "~lib/env/trace");
+  }
 
   // Add or override aliases if specified
   if (args.use) {


### PR DESCRIPTION
Running with `--noLib` currently always fails. This is because the default global aliases that are always added aren't available with the --noLib flag, and a recently added check throws an exception. This change stops adding default global aliases if `--noLib` is specified, avoiding the error.

Example of error this fixed:

```
> @assemblyscript/i64@1.0.0 asbuild:untouched C:\src\assemblyscript\examples\i64-polyfill
> asc assembly/i64.ts -t build/untouched.wat -b build/untouched.wasm --validate --sourceMap --measure --noLib

ERROR: element not found: NativeMath
    at t.initialize (C:\src\assemblyscript\dist\assemblyscript.js:1:66981)
    at t.compile (C:\src\assemblyscript\dist\assemblyscript.js:1:175610)
    at Object.t.compileProgram (C:\src\assemblyscript\dist\assemblyscript.js:1:357909)
    at stats.compileTime.measure (C:\src\assemblyscript\cli\asc.js:450:33)
    at measure (C:\src\assemblyscript\cli\asc.js:806:3)
    at C:\src\assemblyscript\cli\asc.js:449:28
    at Object.main (C:\src\assemblyscript\cli\asc.js:455:5)
    at Object.<anonymous> (C:\src\assemblyscript\bin\asc:3:60)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
```