### PR TITLE
Added error message when using --noLib and not importing any builtins at all

### DIFF
--- a/src/program.ts
+++ b/src/program.ts
@@ -620,7 +620,7 @@ export class Program extends DiagnosticEmitter {
 
     // register 'start'
     {
-      let element = assert(this.elementsLookup.get("start"));
+      let element = assert(this.elementsLookup.get("start"), "builtin \"start\" missing. Try adding: import \"builtins\"");
       assert(element.kind == ElementKind.FUNCTION_PROTOTYPE);
       this.startFunction = <FunctionPrototype>element;
     }


### PR DESCRIPTION
When you compile with `--noLib` and you don't import anything, the compiler gets confused because the required builtin function `start` is not available. It wasn't really clear to me if that needed to be addressed, but it seemed like making the error more clear about how to fix the problem would be a good start.

Seems like it should also say so if compilation fails, instead of saying "Cannot read property 'setOptimizeLevel' of undefined", but this change doesn't address that.

New first line of error output:
```
ERROR: AssertionError: builtin "start" missing. Try adding: import "builtins"
```

Existing error output:

```
ERROR: AssertionError: assertion failed
    at assert (C:\src\assemblyscript\std\portable\index.js:172:9)
    at Program.initialize (C:\src\assemblyscript\src\program.ts:623:21)
    at Compiler.compile (C:\src\assemblyscript\src\compiler.ts:320:13)
    at Object.compileProgram (C:\src\assemblyscript\src\index.ts:150:41)
    at stats.compileTime.measure (C:\src\assemblyscript\cli\asc.js:453:33)
    at measure (C:\src\assemblyscript\cli\asc.js:809:3)
    at C:\src\assemblyscript\cli\asc.js:452:28
    at Object.main (C:\src\assemblyscript\cli\asc.js:458:5)
    at Object.<anonymous> (C:\src\assemblyscript\bin\asc:3:60)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
C:\src\assemblyscript\node_modules\binaryen\index.js:5
if(n){var da,ea;a.read=function(b,e){var c=q(b);c||(da||(da=require("fs")),ea||(ea=require("path")),b=ea.normalize(b),c=da.readFileSync(b));return e?c:c.toString()};a.readBinary=function(b){b=a.read(b,!0);b.buffer||(b=new Uint8Array(b));assert(b.buffer);return b};1<process.argv.length&&(a.thisProgram=process.argv[1].replace(/\\/g,"/"));a.arguments=process.argv.slice(2);process.on("uncaughtException",function(b){if(!(b instanceof fa))throw b;});process.on("unhandledRejection",function(){process.exit(1)});



                                      ^

TypeError: Cannot read property 'setOptimizeLevel' of undefined
    at Object.main (C:\src\assemblyscript\cli\asc.js:495:10)
    at Object.<anonymous> (C:\src\assemblyscript\bin\asc:3:60)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
    at startup (internal/bootstrap/node.js:236:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:560:3)
```