### PR TITLE
Remove assert for comparator which prevent to constantly abort

### DIFF
--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -307,9 +307,6 @@ export class Array<T> {
   }
 
   sort(comparator: (a: T, b: T) => i32 = defaultComparator<T>()): this {
-    // TODO remove this when flow will allow trackcing null
-    assert(comparator); // The comparison function must be a function
-
     var length = this.length_;
     if (length <= 1) return this;
     var buffer = this.buffer_;

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -36,10 +36,10 @@
  (global $~lib/math/random_seeded (mut i32) (i32.const 0))
  (global $~lib/math/random_state0 (mut i64) (i64.const 0))
  (global $~lib/math/random_state1 (mut i64) (i64.const 0))
- (global $std/array/f32ArrayTyped (mut i32) (i32.const 408))
- (global $std/array/f64ArrayTyped (mut i32) (i32.const 616))
- (global $std/array/i32ArrayTyped (mut i32) (i32.const 792))
- (global $std/array/u32ArrayTyped (mut i32) (i32.const 872))
+ (global $std/array/f32Array (mut i32) (i32.const 408))
+ (global $std/array/f64Array (mut i32) (i32.const 616))
+ (global $std/array/i32Array (mut i32) (i32.const 792))
+ (global $std/array/u32Array (mut i32) (i32.const 872))
  (global $std/array/reversed0 (mut i32) (i32.const 928))
  (global $std/array/reversed1 (mut i32) (i32.const 952))
  (global $std/array/reversed2 (mut i32) (i32.const 976))
@@ -4839,20 +4839,6 @@
   (local $4 f32)
   (local $5 f32)
   (if
-   (i32.eqz
-    (get_local $1)
-   )
-   (block
-    (call $~lib/env/abort
-     (i32.const 0)
-     (i32.const 8)
-     (i32.const 311)
-     (i32.const 4)
-    )
-    (unreachable)
-   )
-  )
-  (if
    (i32.le_s
     (tee_local $3
      (i32.load offset=4
@@ -5671,20 +5657,6 @@
   (local $3 i32)
   (local $4 f64)
   (local $5 f64)
-  (if
-   (i32.eqz
-    (get_local $1)
-   )
-   (block
-    (call $~lib/env/abort
-     (i32.const 0)
-     (i32.const 8)
-     (i32.const 311)
-     (i32.const 4)
-    )
-    (unreachable)
-   )
-  )
   (if
    (i32.le_s
     (tee_local $3
@@ -6533,20 +6505,6 @@
   (local $3 i32)
   (local $4 i32)
   (if
-   (i32.eqz
-    (get_local $1)
-   )
-   (block
-    (call $~lib/env/abort
-     (i32.const 0)
-     (i32.const 8)
-     (i32.const 311)
-     (i32.const 4)
-    )
-    (unreachable)
-   )
-  )
-  (if
    (i32.le_s
     (tee_local $2
      (i32.load offset=4
@@ -7073,20 +7031,6 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (if
-   (i32.eqz
-    (get_local $1)
-   )
-   (block
-    (call $~lib/env/abort
-     (i32.const 0)
-     (i32.const 8)
-     (i32.const 311)
-     (i32.const 4)
-    )
-    (unreachable)
-   )
-  )
   (if
    (i32.le_s
     (tee_local $2
@@ -10871,14 +10815,14 @@
   )
   (drop
    (call $~lib/array/Array<f32>#sort|trampoline
-    (get_global $std/array/f32ArrayTyped)
+    (get_global $std/array/f32Array)
     (i32.const 0)
    )
   )
   (if
    (i32.eqz
     (call $std/array/isArraysEqual<f32>
-     (get_global $std/array/f32ArrayTyped)
+     (get_global $std/array/f32Array)
      (i32.const 480)
      (i32.const 0)
     )
@@ -10898,14 +10842,14 @@
   )
   (drop
    (call $~lib/array/Array<f64>#sort|trampoline
-    (get_global $std/array/f64ArrayTyped)
+    (get_global $std/array/f64Array)
     (i32.const 0)
    )
   )
   (if
    (i32.eqz
     (call $std/array/isArraysEqual<f64>
-     (get_global $std/array/f64ArrayTyped)
+     (get_global $std/array/f64Array)
      (i32.const 752)
      (i32.const 0)
     )
@@ -10925,14 +10869,14 @@
   )
   (drop
    (call $~lib/array/Array<i32>#sort|trampoline
-    (get_global $std/array/i32ArrayTyped)
+    (get_global $std/array/i32Array)
     (i32.const 0)
    )
   )
   (if
    (i32.eqz
     (call $std/array/isArraysEqual<i32>
-     (get_global $std/array/i32ArrayTyped)
+     (get_global $std/array/i32Array)
      (i32.const 832)
      (i32.const 0)
     )
@@ -10952,14 +10896,14 @@
   )
   (drop
    (call $~lib/array/Array<u32>#sort|trampoline
-    (get_global $std/array/u32ArrayTyped)
+    (get_global $std/array/u32Array)
     (i32.const 0)
    )
   )
   (if
    (i32.eqz
     (call $std/array/isArraysEqual<i32>
-     (get_global $std/array/u32ArrayTyped)
+     (get_global $std/array/u32Array)
      (i32.const 912)
      (i32.const 0)
     )

--- a/tests/compiler/std/array.ts
+++ b/tests/compiler/std/array.ts
@@ -614,21 +614,21 @@ function assertSortedDefault<T>(arr: Array<T>): void {
 
 // Tests for default comparator
 
-var f32ArrayTyped: f32[] = [1.0, NaN, -Infinity, 1.00000001, 0.0, -1.0, -2.0, +Infinity];
-f32ArrayTyped.sort();
-assert(isArraysEqual<f32>(f32ArrayTyped, [-Infinity, -2.0, -1.0, 0.0, 1.0, 1.00000001, Infinity, NaN]));
+var f32Array: f32[] = [1.0, NaN, -Infinity, 1.00000001, 0.0, -1.0, -2.0, +Infinity];
+f32Array.sort();
+assert(isArraysEqual<f32>(f32Array, [-Infinity, -2.0, -1.0, 0.0, 1.0, 1.00000001, Infinity, NaN]));
 
-var f64ArrayTyped: f64[] = [1.0, NaN, -Infinity, 1.000000000000001, 0.0, -1.0, -2.0, +Infinity];
-f64ArrayTyped.sort();
-assert(isArraysEqual<f64>(f64ArrayTyped, [-Infinity, -2.0, -1.0, 0.0, 1.0, 1.000000000000001, Infinity, NaN]));
+var f64Array: f64[] = [1.0, NaN, -Infinity, 1.000000000000001, 0.0, -1.0, -2.0, +Infinity];
+f64Array.sort();
+assert(isArraysEqual<f64>(f64Array, [-Infinity, -2.0, -1.0, 0.0, 1.0, 1.000000000000001, Infinity, NaN]));
 
-var i32ArrayTyped: i32[] = [1, -2, -1, 0, 2];
-i32ArrayTyped.sort();
-assert(isArraysEqual<i32>(i32ArrayTyped, [-2, -1, 0, 1, 2]));
+var i32Array: i32[] = [1, -2, -1, 0, 2];
+i32Array.sort();
+assert(isArraysEqual<i32>(i32Array, [-2, -1, 0, 1, 2]));
 
-var u32ArrayTyped: u32[] = [1, 4294967295, 4294967294, 0, 2];
-u32ArrayTyped.sort();
-assert(isArraysEqual<u32>(u32ArrayTyped, [0, 1, 2, 4294967294, 4294967295]));
+var u32Array: u32[] = [1, 4294967295, 4294967294, 0, 2];
+u32Array.sort();
+assert(isArraysEqual<u32>(u32Array, [0, 1, 2, 4294967294, 4294967295]));
 
 var reversed0: i32[] = [];
 var reversed1: i32[] = [1];

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -47,10 +47,10 @@
  (global $std/array/charset i32 (i32.const 168))
  (global $NaN f64 (f64.const nan:0x8000000000000))
  (global $Infinity f64 (f64.const inf))
- (global $std/array/f32ArrayTyped (mut i32) (i32.const 408))
- (global $std/array/f64ArrayTyped (mut i32) (i32.const 616))
- (global $std/array/i32ArrayTyped (mut i32) (i32.const 792))
- (global $std/array/u32ArrayTyped (mut i32) (i32.const 872))
+ (global $std/array/f32Array (mut i32) (i32.const 408))
+ (global $std/array/f64Array (mut i32) (i32.const 616))
+ (global $std/array/i32Array (mut i32) (i32.const 792))
+ (global $std/array/u32Array (mut i32) (i32.const 872))
  (global $std/array/reversed0 (mut i32) (i32.const 928))
  (global $std/array/reversed1 (mut i32) (i32.const 952))
  (global $std/array/reversed2 (mut i32) (i32.const 976))
@@ -6165,20 +6165,6 @@
   (local $4 i32)
   (local $5 f32)
   (local $6 f32)
-  (if
-   (i32.eqz
-    (get_local $1)
-   )
-   (block
-    (call $~lib/env/abort
-     (i32.const 0)
-     (i32.const 8)
-     (i32.const 311)
-     (i32.const 4)
-    )
-    (unreachable)
-   )
-  )
   (set_local $2
    (i32.load offset=4
     (get_local $0)
@@ -7249,20 +7235,6 @@
   (local $4 i32)
   (local $5 f64)
   (local $6 f64)
-  (if
-   (i32.eqz
-    (get_local $1)
-   )
-   (block
-    (call $~lib/env/abort
-     (i32.const 0)
-     (i32.const 8)
-     (i32.const 311)
-     (i32.const 4)
-    )
-    (unreachable)
-   )
-  )
   (set_local $2
    (i32.load offset=4
     (get_local $0)
@@ -8364,20 +8336,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (if
-   (i32.eqz
-    (get_local $1)
-   )
-   (block
-    (call $~lib/env/abort
-     (i32.const 0)
-     (i32.const 8)
-     (i32.const 311)
-     (i32.const 4)
-    )
-    (unreachable)
-   )
-  )
   (set_local $2
    (i32.load offset=4
     (get_local $0)
@@ -9367,20 +9325,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (if
-   (i32.eqz
-    (get_local $1)
-   )
-   (block
-    (call $~lib/env/abort
-     (i32.const 0)
-     (i32.const 8)
-     (i32.const 311)
-     (i32.const 4)
-    )
-    (unreachable)
-   )
-  )
   (set_local $2
    (i32.load offset=4
     (get_local $0)
@@ -10384,20 +10328,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (if
-   (i32.eqz
-    (get_local $1)
-   )
-   (block
-    (call $~lib/env/abort
-     (i32.const 0)
-     (i32.const 8)
-     (i32.const 311)
-     (i32.const 4)
-    )
-    (unreachable)
-   )
-  )
   (set_local $2
    (i32.load offset=4
     (get_local $0)
@@ -11004,20 +10934,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (if
-   (i32.eqz
-    (get_local $1)
-   )
-   (block
-    (call $~lib/env/abort
-     (i32.const 0)
-     (i32.const 8)
-     (i32.const 311)
-     (i32.const 4)
-    )
-    (unreachable)
-   )
-  )
   (set_local $2
    (i32.load offset=4
     (get_local $0)
@@ -11664,20 +11580,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (if
-   (i32.eqz
-    (get_local $1)
-   )
-   (block
-    (call $~lib/env/abort
-     (i32.const 0)
-     (i32.const 8)
-     (i32.const 311)
-     (i32.const 4)
-    )
-    (unreachable)
-   )
-  )
   (set_local $2
    (i32.load offset=4
     (get_local $0)
@@ -15995,7 +15897,7 @@
      (i32.const 0)
     )
     (call $~lib/array/Array<f32>#sort|trampoline
-     (get_global $std/array/f32ArrayTyped)
+     (get_global $std/array/f32Array)
      (i32.const 0)
     )
    )
@@ -16003,7 +15905,7 @@
   (if
    (i32.eqz
     (call $std/array/isArraysEqual<f32>
-     (get_global $std/array/f32ArrayTyped)
+     (get_global $std/array/f32Array)
      (i32.const 480)
      (i32.const 0)
     )
@@ -16024,7 +15926,7 @@
      (i32.const 0)
     )
     (call $~lib/array/Array<f64>#sort|trampoline
-     (get_global $std/array/f64ArrayTyped)
+     (get_global $std/array/f64Array)
      (i32.const 0)
     )
    )
@@ -16032,7 +15934,7 @@
   (if
    (i32.eqz
     (call $std/array/isArraysEqual<f64>
-     (get_global $std/array/f64ArrayTyped)
+     (get_global $std/array/f64Array)
      (i32.const 752)
      (i32.const 0)
     )
@@ -16053,7 +15955,7 @@
      (i32.const 0)
     )
     (call $~lib/array/Array<i32>#sort|trampoline
-     (get_global $std/array/i32ArrayTyped)
+     (get_global $std/array/i32Array)
      (i32.const 0)
     )
    )
@@ -16061,7 +15963,7 @@
   (if
    (i32.eqz
     (call $std/array/isArraysEqual<i32>
-     (get_global $std/array/i32ArrayTyped)
+     (get_global $std/array/i32Array)
      (i32.const 832)
      (i32.const 0)
     )
@@ -16082,7 +15984,7 @@
      (i32.const 0)
     )
     (call $~lib/array/Array<u32>#sort|trampoline
-     (get_global $std/array/u32ArrayTyped)
+     (get_global $std/array/u32Array)
      (i32.const 0)
     )
    )
@@ -16090,7 +15992,7 @@
   (if
    (i32.eqz
     (call $std/array/isArraysEqual<u32>
-     (get_global $std/array/u32ArrayTyped)
+     (get_global $std/array/u32Array)
      (i32.const 912)
      (i32.const 0)
     )


### PR DESCRIPTION
@dcodeIO It seems `assert(someFunctionRef)` always cause to abort. Not sure is it regression or not, but I remove `assert(comparator)` for now.