### PR TITLE
Remove unnecessary 'queuedImports.splice()' calls

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -8,6 +8,7 @@ under the licensing terms detailed in LICENSE:
 * Igor Sbitnev <PinkaminaDianePie@gmail.com>
 * Norton Wang <me@nortonwang.com>
 * Alan Pierce <alangpierce@gmail.com>
+* Andy Hanson <andy.pj.hanson@gmail.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/src/program.ts
+++ b/src/program.ts
@@ -490,18 +490,15 @@ export class Program extends DiagnosticEmitter {
     }
 
     // queued imports should be resolvable now through traversing exports and queued exports
-    for (let i = 0; i < queuedImports.length;) {
-      let queuedImport = queuedImports[i];
+    for (const queuedImport of queuedImports) {
       let declaration = queuedImport.declaration;
       if (declaration) { // named
         let element = this.tryLocateImport(queuedImport.externalName, queuedExports);
         if (element) {
           this.elementsLookup.set(queuedImport.localName, element);
-          queuedImports.splice(i, 1);
         } else {
           if (element = this.tryLocateImport(queuedImport.externalNameAlt, queuedExports)) {
             this.elementsLookup.set(queuedImport.localName, element);
-            queuedImports.splice(i, 1);
           } else {
             this.error(
               DiagnosticCode.Module_0_has_no_exported_member_1,
@@ -509,21 +506,17 @@ export class Program extends DiagnosticEmitter {
               (<ImportStatement>declaration.parent).path.value,
               declaration.externalName.text
             );
-            ++i;
           }
         }
       } else { // filespace
         let element = this.elementsLookup.get(queuedImport.externalName);
         if (element) {
           this.elementsLookup.set(queuedImport.localName, element);
-          queuedImports.splice(i, 1);
         } else {
           if (element = this.elementsLookup.get(queuedImport.externalNameAlt)) {
             this.elementsLookup.set(queuedImport.localName, element);
-            queuedImports.splice(i, 1);
           } else {
             assert(false); // already reported by the parser not finding the file
-            ++i;
           }
         }
       }


### PR DESCRIPTION
I noticed that `queuedImports` is never looked at again after this loop. Since `queuedImports.splice(i, 1)` is equivalent to `i++` if we don't care about the state of `queuedImports` after the loop, we can just convert this to an ordinary `for-of` loop.
As of this PR, `queuedImports` is only referenced twice: once to write to in `initializeImports`, and once to loop over here.