### PR TITLE
Support non-null assertion expression `x!`

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -118,7 +118,8 @@ export function nodeIsCallable(kind: NodeKind): bool {
     case NodeKind.IDENTIFIER:
     case NodeKind.CALL:
     case NodeKind.ELEMENTACCESS:
-    case NodeKind.PROPERTYACCESS: return true;
+    case NodeKind.PROPERTYACCESS:
+    case NodeKind.NON_NULL_ASSERTION: return true;
   }
   return false;
 }

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -39,6 +39,7 @@ export enum NodeKind {
   // expressions
   IDENTIFIER,
   ASSERTION,
+  NON_NULL_ASSERTION,
   BINARY,
   CALL,
   CLASS,
@@ -421,6 +422,16 @@ export abstract class Node {
     expr.expression = expression; expression.parent = expr;
     expr.typeArguments = typeArgs; if (typeArgs) setParent(typeArgs, expr);
     expr.arguments = args; setParent(args, expr);
+    return expr;
+  }
+
+  static createNonNullAssertionExpression(
+    expression: Expression,
+    range: Range
+  ): NonNullAssertionExpression {
+    var expr = new NonNullAssertionExpression();
+    expr.range = range;
+    expr.expression = expression;
     return expr;
   }
 
@@ -1372,6 +1383,11 @@ export class IntegerLiteralExpression extends LiteralExpression {
 /** Represents a `new` expression. Like a call but with its own kind. */
 export class NewExpression extends CallExpression {
   kind = NodeKind.NEW;
+}
+
+export class NonNullAssertionExpression extends Expression {
+  kind = NodeKind.NON_NULL_ASSERTION;
+  expression: Expression;
 }
 
 /** Represents a `null` expression. */

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -2680,7 +2680,7 @@ export class Compiler extends DiagnosticEmitter {
   }
 
   compileNonNullAssertionExpression(expression: NonNullAssertionExpression, contextualType: Type): ExpressionRef {
-    const res = this.compileExpressionRetainType(expression.expression, contextualType.asNullable(), WrapMode.NONE);
+    const res = this.compileExpressionRetainType(expression.expression, contextualType.asNullableIfPossible(), WrapMode.NONE);
     this.currentType = this.currentType.nonNullableType;
     return res;
   }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -2680,7 +2680,8 @@ export class Compiler extends DiagnosticEmitter {
   }
 
   compileNonNullAssertionExpression(expression: NonNullAssertionExpression, contextualType: Type): ExpressionRef {
-    const res = this.compileExpressionRetainType(expression.expression, contextualType.asNullableIfPossible(), WrapMode.NONE);
+    const inner = expression.expression;
+    const res = this.compileExpressionRetainType(inner, contextualType.asNullableIfPossible(), WrapMode.NONE);
     this.currentType = this.currentType.nonNullableType;
     return res;
   }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -132,6 +132,7 @@ import {
   LiteralExpression,
   LiteralKind,
   NewExpression,
+  NonNullAssertionExpression,
   ObjectLiteralExpression,
   ParenthesizedExpression,
   PropertyAccessExpression,
@@ -2422,6 +2423,10 @@ export class Compiler extends DiagnosticEmitter {
         expr = this.compileNewExpression(<NewExpression>expression, contextualType);
         break;
       }
+      case NodeKind.NON_NULL_ASSERTION: {
+        expr = this.compileNonNullAssertionExpression(<NonNullAssertionExpression>expression, contextualType);
+        break;
+      }
       case NodeKind.PARENTHESIZED: {
         expr = this.compileParenthesizedExpression(<ParenthesizedExpression>expression, contextualType);
         break;
@@ -2672,6 +2677,12 @@ export class Compiler extends DiagnosticEmitter {
     );
     if (!toType) return this.module.createUnreachable();
     return this.compileExpression(expression.expression, toType, ConversionKind.EXPLICIT, WrapMode.NONE);
+  }
+
+  compileNonNullAssertionExpression(expression: NonNullAssertionExpression, contextualType: Type): ExpressionRef {
+    const res = this.compileExpressionRetainType(expression.expression, contextualType.asNullable(), WrapMode.NONE);
+    this.currentType = this.currentType.nonNullableType;
+    return res;
   }
 
   private f32ModInstance: Function | null = null;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3339,6 +3339,10 @@ export class Parser extends DiagnosticEmitter {
           );
           break;
         }
+        case Token.EXCLAMATION: {
+          expr = Node.createNonNullAssertionExpression(expr, tn.range(startPos, tn.pos));
+          break;
+        }
         // TernaryExpression
         case Token.QUESTION: {
           let ifThen = this.parseExpression(tn);
@@ -3597,7 +3601,8 @@ function determinePrecedence(kind: Token): Precedence {
     case Token.MINUS_MINUS: return Precedence.UNARY_POSTFIX;
     case Token.DOT:
     case Token.NEW:
-    case Token.OPENBRACKET: return Precedence.MEMBERACCESS;
+    case Token.OPENBRACKET:
+    case Token.EXCLAMATION: return Precedence.MEMBERACCESS;
   }
   return Precedence.NONE;
 }

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -560,8 +560,10 @@ export class Resolver extends DiagnosticEmitter {
         }
         return null;
       }
-      case NodeKind.NON_NULL_ASSERTION:
-        return this.resolveExpression((<NonNullAssertionExpression> expression).expression, contextualFunction, reportMode);
+      case NodeKind.NON_NULL_ASSERTION: {
+        const inner = (<NonNullAssertionExpression> expression).expression;
+        return this.resolveExpression(inner, contextualFunction, reportMode);
+      }
       case NodeKind.BINARY: { // TODO: string concatenation, mostly
         throw new Error("not implemented");
       }

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -44,7 +44,8 @@ import {
   LiteralKind,
   ParenthesizedExpression,
   AssertionExpression,
-  Expression
+  Expression,
+  NonNullAssertionExpression
 } from "./ast";
 
 import {
@@ -559,6 +560,8 @@ export class Resolver extends DiagnosticEmitter {
         }
         return null;
       }
+      case NodeKind.NON_NULL_ASSERTION:
+        return this.resolveExpression((<NonNullAssertionExpression> expression).expression, contextualFunction, reportMode);
       case NodeKind.BINARY: { // TODO: string concatenation, mostly
         throw new Error("not implemented");
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,6 +190,11 @@ export class Type {
     return this.cachedNullableType;
   }
 
+  // TODO: GH#233 support nullable primitives, then just use `asNullable()`
+  asNullableIfPossible(): Type {
+    return this.is(TypeFlags.REFERENCE) ? this.asNullable() : this;
+  }
+
   /** Tests if a value of this type is assignable to a target of the specified type. */
   isAssignableTo(target: Type, signednessIsRelevant: bool = false): bool {
     var currentClass: Class | null;

--- a/tests/compiler/nonNullAssertion.ts
+++ b/tests/compiler/nonNullAssertion.ts
@@ -1,0 +1,3 @@
+export function test(n: Error | null): Error {
+  return n!;
+}

--- a/tests/compiler/nonNullAssertion.ts
+++ b/tests/compiler/nonNullAssertion.ts
@@ -5,7 +5,18 @@ export function test(n: Error | null): Error {
 class Foo {
   boo: i32;
   arr: Array<i32 | null>;
+  f: (() => i32 | null) | null;
 }
 export function test2(foo: Foo | null): i32 {
-  return foo!.boo + foo!.arr![0]!;
+  let f = foo!.f; // Test as lone call expression in addition to member access call expression
+  let arr = foo!.arr;
+  return foo!.boo + foo!.arr![0]! + foo!.f!()! + f!()! + arr![0]!;
+}
+
+// Without this there is a compiler error, see GH#237
+export function useTest2(): void {
+  let foo = new Foo();
+  foo.boo = 0;
+  foo.arr = [];
+  foo.f = (): i32 => 1;
 }

--- a/tests/compiler/nonNullAssertion.ts
+++ b/tests/compiler/nonNullAssertion.ts
@@ -1,3 +1,11 @@
 export function test(n: Error | null): Error {
   return n!;
 }
+
+class Foo {
+  boo: i32;
+  arr: Array<i32 | null>;
+}
+export function test2(foo: Foo | null): i32 {
+  return foo!.boo + foo!.arr![0]!;
+}

--- a/tests/compiler/nonNullAssertion.untouched.wat
+++ b/tests/compiler/nonNullAssertion.untouched.wat
@@ -1,15 +1,24 @@
 (module
  (type $ii (func (param i32) (result i32)))
  (type $iii (func (param i32 i32) (result i32)))
+ (type $i (func (result i32)))
+ (type $v (func))
  (global $~lib/internal/allocator/AL_BITS i32 (i32.const 3))
  (global $~lib/internal/allocator/AL_SIZE i32 (i32.const 8))
  (global $~lib/internal/allocator/AL_MASK i32 (i32.const 7))
  (global $~lib/internal/arraybuffer/HEADER_SIZE i32 (i32.const 8))
- (global $HEAP_BASE i32 (i32.const 8))
- (memory $0 0)
+ (global $~argc (mut i32) (i32.const 0))
+ (global $HEAP_BASE i32 (i32.const 24))
+ (table 1 1 anyfunc)
+ (elem (i32.const 0) $nonNullAssertion/useTest2~anonymous|0)
+ (memory $0 1)
+ (data (i32.const 8) "\00\00\00\00\00\00\00\00")
+ (data (i32.const 16) "\08\00\00\00\00\00\00\00")
  (export "memory" (memory $0))
+ (export "table" (table $0))
  (export "test" (func $nonNullAssertion/test))
  (export "test2" (func $nonNullAssertion/test2))
+ (export "useTest2" (func $nonNullAssertion/useTest2))
  (func $nonNullAssertion/test (; 0 ;) (type $ii) (param $0 i32) (result i32)
   (get_local $0)
  )
@@ -45,16 +54,99 @@
   )
  )
  (func $nonNullAssertion/test2 (; 2 ;) (type $ii) (param $0 i32) (result i32)
-  (i32.add
-   (i32.load
+  (local $1 i32)
+  (local $2 i32)
+  (set_local $1
+   (i32.load offset=8
     (get_local $0)
    )
-   (call $~lib/array/Array<i32>#__get
-    (i32.load offset=4
-     (get_local $0)
+  )
+  (set_local $2
+   (i32.load offset=4
+    (get_local $0)
+   )
+  )
+  (i32.add
+   (i32.add
+    (i32.add
+     (i32.add
+      (i32.load
+       (get_local $0)
+      )
+      (call $~lib/array/Array<i32>#__get
+       (i32.load offset=4
+        (get_local $0)
+       )
+       (i32.const 0)
+      )
+     )
+     (block (result i32)
+      (set_global $~argc
+       (i32.const 0)
+      )
+      (call_indirect (type $i)
+       (i32.load offset=8
+        (get_local $0)
+       )
+      )
+     )
     )
+    (block (result i32)
+     (set_global $~argc
+      (i32.const 0)
+     )
+     (call_indirect (type $i)
+      (get_local $1)
+     )
+    )
+   )
+   (call $~lib/array/Array<i32>#__get
+    (get_local $2)
     (i32.const 0)
    )
+  )
+ )
+ (func $~lib/memory/memory.allocate (; 3 ;) (type $ii) (param $0 i32) (result i32)
+  (unreachable)
+ )
+ (func $nonNullAssertion/useTest2~anonymous|0 (; 4 ;) (type $i) (result i32)
+  (i32.const 1)
+ )
+ (func $nonNullAssertion/useTest2 (; 5 ;) (type $v)
+  (local $0 i32)
+  (set_local $0
+   (block (result i32)
+    (set_local $0
+     (call $~lib/memory/memory.allocate
+      (i32.const 12)
+     )
+    )
+    (i32.store
+     (get_local $0)
+     (i32.const 0)
+    )
+    (i32.store offset=4
+     (get_local $0)
+     (i32.const 0)
+    )
+    (i32.store offset=8
+     (get_local $0)
+     (i32.const 0)
+    )
+    (get_local $0)
+   )
+  )
+  (i32.store
+   (get_local $0)
+   (i32.const 0)
+  )
+  (i32.store offset=4
+   (get_local $0)
+   (i32.const 16)
+  )
+  (i32.store offset=8
+   (get_local $0)
+   (i32.const 0)
   )
  )
 )

--- a/tests/compiler/nonNullAssertion.untouched.wat
+++ b/tests/compiler/nonNullAssertion.untouched.wat
@@ -1,0 +1,10 @@
+(module
+ (type $ii (func (param i32) (result i32)))
+ (global $HEAP_BASE i32 (i32.const 8))
+ (memory $0 0)
+ (export "memory" (memory $0))
+ (export "test" (func $nonNullAssertion/test))
+ (func $nonNullAssertion/test (; 0 ;) (type $ii) (param $0 i32) (result i32)
+  (get_local $0)
+ )
+)

--- a/tests/compiler/nonNullAssertion.untouched.wat
+++ b/tests/compiler/nonNullAssertion.untouched.wat
@@ -1,10 +1,60 @@
 (module
  (type $ii (func (param i32) (result i32)))
+ (type $iii (func (param i32 i32) (result i32)))
+ (global $~lib/internal/allocator/AL_BITS i32 (i32.const 3))
+ (global $~lib/internal/allocator/AL_SIZE i32 (i32.const 8))
+ (global $~lib/internal/allocator/AL_MASK i32 (i32.const 7))
+ (global $~lib/internal/arraybuffer/HEADER_SIZE i32 (i32.const 8))
  (global $HEAP_BASE i32 (i32.const 8))
  (memory $0 0)
  (export "memory" (memory $0))
  (export "test" (func $nonNullAssertion/test))
+ (export "test2" (func $nonNullAssertion/test2))
  (func $nonNullAssertion/test (; 0 ;) (type $ii) (param $0 i32) (result i32)
   (get_local $0)
+ )
+ (func $~lib/array/Array<i32>#__get (; 1 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (set_local $2
+   (i32.load
+    (get_local $0)
+   )
+  )
+  (if (result i32)
+   (i32.lt_u
+    (get_local $1)
+    (i32.shr_u
+     (i32.load
+      (get_local $2)
+     )
+     (i32.const 2)
+    )
+   )
+   (block $~lib/internal/arraybuffer/loadUnsafe<i32,i32>|inlined.0 (result i32)
+    (i32.load offset=8
+     (i32.add
+      (get_local $2)
+      (i32.shl
+       (get_local $1)
+       (i32.const 2)
+      )
+     )
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $nonNullAssertion/test2 (; 2 ;) (type $ii) (param $0 i32) (result i32)
+  (i32.add
+   (i32.load
+    (get_local $0)
+   )
+   (call $~lib/array/Array<i32>#__get
+    (i32.load offset=4
+     (get_local $0)
+    )
+    (i32.const 0)
+   )
+  )
  )
 )


### PR DESCRIPTION
Adds support for TypeScript's `x!` non-null assertion expression. If `x` is of type `T | null`, this is equivalent to `<T> x`.
(Documentation: See "Type guards and type assertions" at in the TypeScript [handbook](https://www.typescriptlang.org/docs/handbook/advanced-types.html))

This does not come with a runtime check for consistency with type assertions. See #234.