### PR TITLE
ModuleExport#identifier never used, so just use Element directly

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -8,6 +8,7 @@ under the licensing terms detailed in LICENSE:
 * Igor Sbitnev <PinkaminaDianePie@gmail.com>
 * Norton Wang <me@nortonwang.com>
 * Alan Pierce <alangpierce@gmail.com>
+* Andy Hanson <andy.pj.hanson@gmail.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -408,7 +408,7 @@ export class Compiler extends DiagnosticEmitter {
 
     // set up module exports
     for (let [name, moduleExport] of program.moduleLevelExports) {
-      this.makeModuleExport(name, moduleExport.element);
+      this.makeModuleExport(name, moduleExport);
     }
 
     // set up gc

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -56,7 +56,7 @@ abstract class ExportsWalker {
   walk(): void {
     for (let moduleExport of this.program.moduleLevelExports.values()) {
       // FIXME: doesn't honor the actual externally visible name
-      this.visitElement(moduleExport.element);
+      this.visitElement(moduleExport);
     }
     var todo = this.todo;
     for (let i = 0; i < todo.length; ) this.visitElement(todo[i]);


### PR DESCRIPTION
Noticed that this class was only used for a single member; so it makes more sense to just use that member directly and remove the class. (And it looks like that would have been the only place where Program exposed AST nodes.)