### PR TITLE
Improve error message for accessing method like a field

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -6749,6 +6749,13 @@ export class Compiler extends DiagnosticEmitter {
           return module.createUnreachable();
         }
       }
+      case ElementKind.FUNCTION_PROTOTYPE: {
+        this.error(
+          DiagnosticCode.Cannot_access_method_0_without_calling_it_as_it_requires_this_to_be_set,
+          propertyAccess.range, (<FunctionPrototype>target).simpleName
+        );
+        return module.createUnreachable();
+      }
     }
     this.error(
       DiagnosticCode.Operation_not_supported,

--- a/src/diagnosticMessages.generated.ts
+++ b/src/diagnosticMessages.generated.ts
@@ -28,6 +28,7 @@ export enum DiagnosticCode {
   Optional_parameter_must_have_an_initializer = 215,
   Constructor_of_class_0_must_not_require_any_arguments = 216,
   Function_0_cannot_be_inlined_into_itself = 217,
+  Cannot_access_method_0_without_calling_it_as_it_requires_this_to_be_set = 218,
   Unterminated_string_literal = 1002,
   Identifier_expected = 1003,
   _0_expected = 1005,
@@ -147,6 +148,7 @@ export function diagnosticCodeToString(code: DiagnosticCode): string {
     case 215: return "Optional parameter must have an initializer.";
     case 216: return "Constructor of class '{0}' must not require any arguments.";
     case 217: return "Function '{0}' cannot be inlined into itself.";
+    case 218: return "Cannot access method '{0}' without calling it as it requires 'this' to be set.";
     case 1002: return "Unterminated string literal.";
     case 1003: return "Identifier expected.";
     case 1005: return "'{0}' expected.";

--- a/src/diagnosticMessages.json
+++ b/src/diagnosticMessages.json
@@ -20,6 +20,7 @@
   "Optional parameter must have an initializer.": 215,
   "Constructor of class '{0}' must not require any arguments.": 216,
   "Function '{0}' cannot be inlined into itself.": 217,
+  "Cannot access method '{0}' without calling it as it requires 'this' to be set.": 218,
 
   "Unterminated string literal.": 1002,
   "Identifier expected.": 1003,


### PR DESCRIPTION
For this code:
```ts
class C {
  m(): i32 {
    return 0;
  }
}

export function test(): i32 {
  let c = new C();
  let m = c.m;
  return m();
}
```

Previously the error message would just be "Operation not supported".
Now it will be: "Cannot access method 'm' without calling it as it requires 'this' to be set.".

Does not include a test as I don't think there's currently a way to test modules that shouldn't compile -- is there an issue open for supporting that kind of test?