### PR TITLE
%TypedArray%.prototype.map and %TypedArray%.prototype.reduce/reduceRight test cleanup with Uint8ClampedArray changes

### DIFF
--- a/std/assembly/internal/typedarray.ts
+++ b/std/assembly/internal/typedarray.ts
@@ -177,3 +177,18 @@ export function REDUCE_RIGHT<TArray extends TypedArray<T>, T, TRet>(
   }
   return initialValue;
 }
+
+@inline
+export function MAP<TArray extends TypedArray<T>, T>(
+  array: TArray,
+  callbackfn: (value: T, index: i32, self: TArray) => T,
+): TArray {
+  var length: i32 = array.length;
+  var result = instantiate<TArray>(length);
+  var i: i32 = 0;
+  while (i < length) {
+    unchecked(result[i] = callbackfn(array[i], i, <TArray>array));
+    ++i;
+  }
+  return result;
+}

--- a/std/assembly/typedarray.ts
+++ b/std/assembly/typedarray.ts
@@ -41,8 +41,8 @@ export class Int8Array extends TypedArray<i8> {
     return REDUCE_RIGHT<Int8Array, i8, T>(this, callbackfn, initialValue);
   }
 
-  map(callbackfn: (value: i8, index: i32, self: this) => i8): this {
-    return MAP<this, i8>(this, callbackfn);
+  map(callbackfn: (value: i8, index: i32, self: Int8Array) => i8): Int8Array {
+    return MAP<Int8Array, i8>(this, callbackfn);
   }
 }
 
@@ -75,8 +75,8 @@ export class Uint8Array extends TypedArray<u8> {
     return REDUCE_RIGHT<Uint8Array, u8, T>(this, callbackfn, initialValue);
   }
 
-  map(callbackfn: (value: u8, index: i32, self: this) => u8): this {
-    return MAP<this, u8>(this, callbackfn);
+  map(callbackfn: (value: u8, index: i32, self: Uint8Array) => u8): Uint8Array {
+    return MAP<Uint8Array, u8>(this, callbackfn);
   }
 }
 
@@ -91,6 +91,10 @@ export class Uint8ClampedArray extends Uint8Array {
   @inline @operator("{}=")
   protected __unchecked_set(index: i32, value: i32): void {
     super.__unchecked_set(index, max(min(value, 255), 0));
+  }
+
+  map(callbackfn: (value: u8, index: i32, self: Uint8ClampedArray) => u8): Uint8ClampedArray {
+    return MAP<Uint8ClampedArray, u8>(this, callbackfn);
   }
 }
 
@@ -123,8 +127,8 @@ export class Int16Array extends TypedArray<i16> {
     return REDUCE_RIGHT<Int16Array, i16, T>(this, callbackfn, initialValue);
   }
 
-  map(callbackfn: (value: i16, index: i32, self: this) => i16): this {
-    return MAP<this, i16>(this, callbackfn);
+  map(callbackfn: (value: i16, index: i32, self: Int16Array) => i16): Int16Array {
+    return MAP<Int16Array, i16>(this, callbackfn);
   }
 }
 
@@ -157,8 +161,8 @@ export class Uint16Array extends TypedArray<u16> {
     return REDUCE_RIGHT<Uint16Array, u16, T>(this, callbackfn, initialValue);
   }
 
-  map(callbackfn: (value: u16, index: i32, self: this) => u16): this {
-    return MAP<this, u16>(this, callbackfn);
+  map(callbackfn: (value: u16, index: i32, self: Uint16Array) => u16): Uint16Array {
+    return MAP<Uint16Array, u16>(this, callbackfn);
   }
 }
 
@@ -191,8 +195,8 @@ export class Int32Array extends TypedArray<i32> {
     return REDUCE_RIGHT<Int32Array, i32, T>(this, callbackfn, initialValue);
   }
 
-  map(callbackfn: (value: i32, index: i32, self: this) => i32): this {
-    return MAP<this, i32>(this, callbackfn);
+  map(callbackfn: (value: i32, index: i32, self: Int32Array) => i32): Int32Array {
+    return MAP<Int32Array, i32>(this, callbackfn);
   }
 }
 
@@ -225,8 +229,8 @@ export class Uint32Array extends TypedArray<u32> {
     return REDUCE_RIGHT<Uint32Array, u32, T>(this, callbackfn, initialValue);
   }
 
-  map(callbackfn: (value: u32, index: i32, self: this) => u32): this {
-    return MAP<this, u32>(this, callbackfn);
+  map(callbackfn: (value: u32, index: i32, self: Uint32Array) => u32): Uint32Array {
+    return MAP<Uint32Array, u32>(this, callbackfn);
   }
 }
 
@@ -259,8 +263,8 @@ export class Int64Array extends TypedArray<i64> {
     return REDUCE_RIGHT<Int64Array, i64, T>(this, callbackfn, initialValue);
   }
 
-  map(callbackfn: (value: i64, index: i32, self: this) => i64): this {
-    return MAP<this, i64>(this, callbackfn);
+  map(callbackfn: (value: i64, index: i32, self: Int64Array) => i64): Int64Array {
+    return MAP<Int64Array, i64>(this, callbackfn);
   }
 }
 
@@ -293,8 +297,8 @@ export class Uint64Array extends TypedArray<u64> {
     return REDUCE_RIGHT<Uint64Array, u64, T>(this, callbackfn, initialValue);
   }
 
-  map(callbackfn: (value: u64, index: i32, self: this) => u64): this {
-    return MAP<this, u64>(this, callbackfn);
+  map(callbackfn: (value: u64, index: i32, self: Uint64Array) => u64): Uint64Array {
+    return MAP<Uint64Array, u64>(this, callbackfn);
   }
 }
 
@@ -327,8 +331,8 @@ export class Float32Array extends TypedArray<f32> {
     return REDUCE_RIGHT<Float32Array, f32, T>(this, callbackfn, initialValue);
   }
 
-  map(callbackfn: (value: f32, index: i32, self: this) => f32): this {
-    return MAP<this, f32>(this, callbackfn);
+  map(callbackfn: (value: f32, index: i32, self: Float32Array) => f32): Float32Array {
+    return MAP<Float32Array, f32>(this, callbackfn);
   }
 }
 
@@ -361,7 +365,7 @@ export class Float64Array extends TypedArray<f64> {
     return REDUCE_RIGHT<Float64Array, f64, T>(this, callbackfn, initialValue);
   }
 
-  map(callbackfn: (value: f64, index: i32, self: this) => f64): this {
-    return MAP<this, f64>(this, callbackfn);
+  map(callbackfn: (value: f64, index: i32, self: Float64Array) => f64): Float64Array {
+    return MAP<Float64Array, f64>(this, callbackfn);
   }
 }

--- a/std/assembly/typedarray.ts
+++ b/std/assembly/typedarray.ts
@@ -93,6 +93,14 @@ export class Uint8ClampedArray extends Uint8Array {
     super.__unchecked_set(index, max(min(value, 255), 0));
   }
 
+  fill(value: u32, start: i32 = 0, end: i32 = i32.MAX_VALUE): Uint8ClampedArray {
+    return <Uint8ClampedArray>super.fill(value, start, end);
+  }
+
+  sort(comparator: (a: u8, b: u8) => i32 = defaultComparator<u8>()): Uint8ClampedArray {
+    return <Uint8ClampedArray>super.sort(comparator);
+  }
+
   map(callbackfn: (value: u8, index: i32, self: Uint8ClampedArray) => u8): Uint8ClampedArray {
     return MAP<Uint8ClampedArray, u8>(this, callbackfn);
   }

--- a/std/assembly/typedarray.ts
+++ b/std/assembly/typedarray.ts
@@ -94,11 +94,15 @@ export class Uint8ClampedArray extends Uint8Array {
   }
 
   fill(value: u32, start: i32 = 0, end: i32 = i32.MAX_VALUE): Uint8ClampedArray {
-    return <Uint8ClampedArray>super.fill(value, start, end);
+    return changetype<Uint8ClampedArray>(super.fill(value, start, end));
   }
 
   sort(comparator: (a: u8, b: u8) => i32 = defaultComparator<u8>()): Uint8ClampedArray {
-    return <Uint8ClampedArray>super.sort(comparator);
+    return changetype<Uint8ClampedArray>(super.sort(comparator));
+  }
+
+  subarray(begin: i32 = 0, end: i32 = 0x7fffffff): Uint8ClampedArray {
+    return SUBARRAY<Uint8ClampedArray, u8>(this, begin, end);
   }
 
   map(callbackfn: (value: u8, index: i32, self: Uint8ClampedArray) => u8): Uint8ClampedArray {

--- a/std/assembly/typedarray.ts
+++ b/std/assembly/typedarray.ts
@@ -94,11 +94,11 @@ export class Uint8ClampedArray extends Uint8Array {
   }
 
   fill(value: u32, start: i32 = 0, end: i32 = i32.MAX_VALUE): Uint8ClampedArray {
-    return changetype<Uint8ClampedArray>(super.fill(value, start, end));
+    return changetype<Uint8ClampedArray>(super.fill(value, start, end)); // safe because '.fill' reuses 'this'
   }
 
   sort(comparator: (a: u8, b: u8) => i32 = defaultComparator<u8>()): Uint8ClampedArray {
-    return changetype<Uint8ClampedArray>(super.sort(comparator));
+    return changetype<Uint8ClampedArray>(super.sort(comparator)); // safe because '.sort' reuses 'this'
   }
 
   subarray(begin: i32 = 0, end: i32 = 0x7fffffff): Uint8ClampedArray {

--- a/std/assembly/typedarray.ts
+++ b/std/assembly/typedarray.ts
@@ -4,7 +4,8 @@ import {
   SORT,
   SUBARRAY,
   REDUCE,
-  REDUCE_RIGHT
+  REDUCE_RIGHT,
+  MAP,
 } from "./internal/typedarray";
 
 import {
@@ -39,6 +40,10 @@ export class Int8Array extends TypedArray<i8> {
   ): T {
     return REDUCE_RIGHT<Int8Array, i8, T>(this, callbackfn, initialValue);
   }
+
+  map(callbackfn: (value: i8, index: i32, self: this) => i8): this {
+    return MAP<this, i8>(this, callbackfn);
+  }
 }
 
 export class Uint8Array extends TypedArray<u8> {
@@ -68,6 +73,10 @@ export class Uint8Array extends TypedArray<u8> {
     initialValue: T,
   ): T {
     return REDUCE_RIGHT<Uint8Array, u8, T>(this, callbackfn, initialValue);
+  }
+
+  map(callbackfn: (value: u8, index: i32, self: this) => u8): this {
+    return MAP<this, u8>(this, callbackfn);
   }
 }
 
@@ -113,6 +122,10 @@ export class Int16Array extends TypedArray<i16> {
   ): T {
     return REDUCE_RIGHT<Int16Array, i16, T>(this, callbackfn, initialValue);
   }
+
+  map(callbackfn: (value: i16, index: i32, self: this) => i16): this {
+    return MAP<this, i16>(this, callbackfn);
+  }
 }
 
 export class Uint16Array extends TypedArray<u16> {
@@ -142,6 +155,10 @@ export class Uint16Array extends TypedArray<u16> {
     initialValue: T,
   ): T {
     return REDUCE_RIGHT<Uint16Array, u16, T>(this, callbackfn, initialValue);
+  }
+
+  map(callbackfn: (value: u16, index: i32, self: this) => u16): this {
+    return MAP<this, u16>(this, callbackfn);
   }
 }
 
@@ -173,6 +190,10 @@ export class Int32Array extends TypedArray<i32> {
   ): T {
     return REDUCE_RIGHT<Int32Array, i32, T>(this, callbackfn, initialValue);
   }
+
+  map(callbackfn: (value: i32, index: i32, self: this) => i32): this {
+    return MAP<this, i32>(this, callbackfn);
+  }
 }
 
 export class Uint32Array extends TypedArray<u32> {
@@ -202,6 +223,10 @@ export class Uint32Array extends TypedArray<u32> {
     initialValue: T,
   ): T {
     return REDUCE_RIGHT<Uint32Array, u32, T>(this, callbackfn, initialValue);
+  }
+
+  map(callbackfn: (value: u32, index: i32, self: this) => u32): this {
+    return MAP<this, u32>(this, callbackfn);
   }
 }
 
@@ -233,6 +258,10 @@ export class Int64Array extends TypedArray<i64> {
   ): T {
     return REDUCE_RIGHT<Int64Array, i64, T>(this, callbackfn, initialValue);
   }
+
+  map(callbackfn: (value: i64, index: i32, self: this) => i64): this {
+    return MAP<this, i64>(this, callbackfn);
+  }
 }
 
 export class Uint64Array extends TypedArray<u64> {
@@ -262,6 +291,10 @@ export class Uint64Array extends TypedArray<u64> {
     initialValue: T,
   ): T {
     return REDUCE_RIGHT<Uint64Array, u64, T>(this, callbackfn, initialValue);
+  }
+
+  map(callbackfn: (value: u64, index: i32, self: this) => u64): this {
+    return MAP<this, u64>(this, callbackfn);
   }
 }
 
@@ -293,6 +326,10 @@ export class Float32Array extends TypedArray<f32> {
   ): T {
     return REDUCE_RIGHT<Float32Array, f32, T>(this, callbackfn, initialValue);
   }
+
+  map(callbackfn: (value: f32, index: i32, self: this) => f32): this {
+    return MAP<this, f32>(this, callbackfn);
+  }
 }
 
 export class Float64Array extends TypedArray<f64> {
@@ -322,5 +359,9 @@ export class Float64Array extends TypedArray<f64> {
     initialValue: T,
   ): T {
     return REDUCE_RIGHT<Float64Array, f64, T>(this, callbackfn, initialValue);
+  }
+
+  map(callbackfn: (value: f64, index: i32, self: this) => f64): this {
+    return MAP<this, f64>(this, callbackfn);
   }
 }

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -3753,19 +3753,19 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Uint8Array#map (; 78 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#map (; 78 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
   get_local $0
   i32.load offset=8
-  tee_local $4
+  tee_local $3
   call $~lib/internal/typedarray/TypedArray<i8>#constructor
-  set_local $3
+  set_local $2
   loop $continue|0
-   get_local $2
-   get_local $4
+   get_local $1
+   get_local $3
    i32.lt_s
    if
     i32.const 3
@@ -3774,43 +3774,43 @@
     i32.load offset=4
     get_local $0
     i32.load
-    get_local $2
+    get_local $1
     i32.add
     i32.add
     i32.load8_u offset=8
-    get_local $2
-    get_local $0
     get_local $1
+    get_local $0
+    i32.const 25
     call_indirect (type $iiii)
     i32.const 255
     i32.and
-    set_local $5
-    get_local $3
-    i32.load offset=4
-    get_local $3
-    i32.load
+    set_local $4
     get_local $2
+    i32.load offset=4
+    get_local $2
+    i32.load
+    get_local $1
     i32.add
     i32.add
-    get_local $5
+    get_local $4
     i32.store8 offset=8
-    get_local $3
-    i32.load offset=4
-    get_local $3
-    i32.load
     get_local $2
+    i32.load offset=4
+    get_local $2
+    i32.load
+    get_local $1
     i32.add
     i32.add
     i32.load8_u offset=8
     drop
-    get_local $2
+    get_local $1
     i32.const 1
     i32.add
-    set_local $2
+    set_local $1
     br $continue|0
    end
   end
-  get_local $3
+  get_local $2
  )
  (func $std/typedarray/testArrayMap<Uint8Array,u8> (; 79 ;) (type $v)
   (local $0 i32)
@@ -3829,7 +3829,6 @@
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<u8>#__set
   get_local $0
-  i32.const 25
   call $~lib/typedarray/Uint8Array#map
   tee_local $0
   i32.const 0
@@ -3877,7 +3876,77 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8> (; 80 ;) (type $v)
+ (func $~lib/typedarray/Uint8ClampedArray#map (; 80 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  get_local $0
+  i32.load offset=8
+  tee_local $4
+  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  set_local $2
+  loop $continue|0
+   get_local $1
+   get_local $4
+   i32.lt_s
+   if
+    i32.const 3
+    set_global $~argc
+    get_local $0
+    i32.load offset=4
+    get_local $0
+    i32.load
+    get_local $1
+    i32.add
+    i32.add
+    i32.load8_u offset=8
+    get_local $1
+    get_local $0
+    i32.const 26
+    call_indirect (type $iiii)
+    i32.const 255
+    i32.and
+    tee_local $3
+    i32.const 255
+    get_local $3
+    i32.const 255
+    i32.lt_s
+    select
+    set_local $3
+    get_local $2
+    i32.load offset=4
+    get_local $2
+    i32.load
+    get_local $1
+    i32.add
+    i32.add
+    get_local $3
+    i32.const 0
+    get_local $3
+    i32.const 0
+    i32.gt_s
+    select
+    i32.store8 offset=8
+    get_local $2
+    i32.load offset=4
+    get_local $2
+    i32.load
+    get_local $1
+    i32.add
+    i32.add
+    i32.load8_u offset=8
+    drop
+    get_local $1
+    i32.const 1
+    i32.add
+    set_local $1
+    br $continue|0
+   end
+  end
+  get_local $2
+ )
+ (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8> (; 81 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i8>#constructor
@@ -3894,8 +3963,7 @@
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#__set
   get_local $0
-  i32.const 26
-  call $~lib/typedarray/Uint8Array#map
+  call $~lib/typedarray/Uint8ClampedArray#map
   tee_local $0
   i32.const 0
   call $~lib/internal/typedarray/TypedArray<u8>#__get
@@ -3942,7 +4010,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Int16Array#map (; 81 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#map (; 82 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4011,7 +4079,7 @@
   end
   get_local $2
  )
- (func $~lib/internal/typedarray/TypedArray<i16>#__get (; 82 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<i16>#__get (; 83 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   get_local $1
   get_local $0
   i32.load offset=8
@@ -4037,7 +4105,7 @@
   i32.add
   i32.load16_s offset=8
  )
- (func $std/typedarray/testArrayMap<Int16Array,i16> (; 83 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int16Array,i16> (; 84 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i16>#constructor
@@ -4101,7 +4169,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Uint16Array#map (; 84 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#map (; 85 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4168,7 +4236,7 @@
   end
   get_local $2
  )
- (func $~lib/internal/typedarray/TypedArray<u16>#__get (; 85 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<u16>#__get (; 86 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   get_local $1
   get_local $0
   i32.load offset=8
@@ -4194,7 +4262,7 @@
   i32.add
   i32.load16_u offset=8
  )
- (func $std/typedarray/testArrayMap<Uint16Array,u16> (; 86 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint16Array,u16> (; 87 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i16>#constructor
@@ -4258,7 +4326,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Int32Array#map (; 87 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#map (; 88 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4323,7 +4391,7 @@
   end
   get_local $3
  )
- (func $std/typedarray/testArrayMap<Int32Array,i32> (; 88 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int32Array,i32> (; 89 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i32>#constructor
@@ -4382,7 +4450,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint32Array,u32> (; 89 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint32Array,u32> (; 90 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i32>#constructor
@@ -4441,12 +4509,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 (; 90 ;) (type $IiiI) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+ (func $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 (; 91 ;) (type $IiiI) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
   get_local $0
   get_local $0
   i64.mul
  )
- (func $~lib/typedarray/Int64Array#map (; 91 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#map (; 92 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4511,7 +4579,7 @@
   end
   get_local $3
  )
- (func $~lib/internal/typedarray/TypedArray<i64>#__get (; 92 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/internal/typedarray/TypedArray<i64>#__get (; 93 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
   get_local $1
   get_local $0
   i32.load offset=8
@@ -4537,7 +4605,7 @@
   i32.add
   i64.load offset=8
  )
- (func $std/typedarray/testArrayMap<Int64Array,i64> (; 93 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int64Array,i64> (; 94 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i64>#constructor
@@ -4596,7 +4664,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint64Array,u64> (; 94 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint64Array,u64> (; 95 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i64>#constructor
@@ -4655,12 +4723,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|33 (; 95 ;) (type $fiif) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
+ (func $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|33 (; 96 ;) (type $fiif) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
   get_local $0
   get_local $0
   f32.mul
  )
- (func $~lib/typedarray/Float32Array#map (; 96 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#map (; 97 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4725,7 +4793,7 @@
   end
   get_local $2
  )
- (func $~lib/internal/typedarray/TypedArray<f32>#__get (; 97 ;) (type $iif) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/internal/typedarray/TypedArray<f32>#__get (; 98 ;) (type $iif) (param $0 i32) (param $1 i32) (result f32)
   get_local $1
   get_local $0
   i32.load offset=8
@@ -4751,7 +4819,7 @@
   i32.add
   f32.load offset=8
  )
- (func $std/typedarray/testArrayMap<Float32Array,f32> (; 98 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Float32Array,f32> (; 99 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i32>#constructor
@@ -4809,12 +4877,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|34 (; 99 ;) (type $FiiF) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
+ (func $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|34 (; 100 ;) (type $FiiF) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
   get_local $0
   get_local $0
   f64.mul
  )
- (func $~lib/typedarray/Float64Array#map (; 100 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#map (; 101 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4879,7 +4947,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/testArrayMap<Float64Array,f64> (; 101 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Float64Array,f64> (; 102 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i64>#constructor
@@ -4937,7 +5005,7 @@
    unreachable
   end
  )
- (func $start (; 102 ;) (type $v)
+ (func $start (; 103 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 624
@@ -5891,7 +5959,7 @@
   call $std/typedarray/testArrayMap<Float32Array,f32>
   call $std/typedarray/testArrayMap<Float64Array,f64>
  )
- (func $null (; 103 ;) (type $v)
+ (func $null (; 104 ;) (type $v)
   nop
  )
 )

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -4,6 +4,7 @@
  (type $iii (func (param i32 i32) (result i32)))
  (type $ii (func (param i32) (result i32)))
  (type $iiiv (func (param i32 i32 i32)))
+ (type $iiii (func (param i32 i32 i32) (result i32)))
  (type $iiFv (func (param i32 i32 f64)))
  (type $FFi (func (param f64 f64) (result i32)))
  (type $iiF (func (param i32 i32) (result f64)))
@@ -11,9 +12,14 @@
  (type $v (func))
  (type $iiIv (func (param i32 i32 i64)))
  (type $IIiiI (func (param i64 i64 i32 i32) (result i64)))
+ (type $iiI (func (param i32 i32) (result i64)))
  (type $iifv (func (param i32 i32 f32)))
  (type $ffiif (func (param f32 f32 i32 i32) (result f32)))
+ (type $iif (func (param i32 i32) (result f32)))
  (type $FFiiF (func (param f64 f64 i32 i32) (result f64)))
+ (type $IiiI (func (param i64 i32 i32) (result i64)))
+ (type $fiif (func (param f32 i32 i32) (result f32)))
+ (type $FiiF (func (param f64 i32 i32) (result f64)))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
@@ -54,8 +60,8 @@
  (data (i32.const 584) "\14\00\00\00\00\00\00\00\01")
  (data (i32.const 608) "\02")
  (data (i32.const 616) "H\02\00\00\05")
- (table $0 24 anyfunc)
- (elem (i32.const 0) $null $~lib/typedarray/Float64Array#sort|trampoline~anonymous|1 $std/typedarray/reduceInt8ArrayTest~anonymous|2 $std/typedarray/reduceInt8ArrayTest~anonymous|2 $std/typedarray/reduceInt8ArrayTest~anonymous|2 $std/typedarray/reduceInt8ArrayTest~anonymous|2 $std/typedarray/reduceInt8ArrayTest~anonymous|2 $std/typedarray/reduceInt8ArrayTest~anonymous|2 $std/typedarray/reduceInt8ArrayTest~anonymous|2 $std/typedarray/reduceInt64ArrayTest~anonymous|9 $std/typedarray/reduceInt64ArrayTest~anonymous|9 $std/typedarray/reduceFloat32ArrayTest~anonymous|11 $std/typedarray/reduceFloat64ArrayTest~anonymous|12 $std/typedarray/reduceInt8ArrayTest~anonymous|2 $std/typedarray/reduceInt8ArrayTest~anonymous|2 $std/typedarray/reduceInt8ArrayTest~anonymous|2 $std/typedarray/reduceInt8ArrayTest~anonymous|2 $std/typedarray/reduceInt8ArrayTest~anonymous|2 $std/typedarray/reduceInt8ArrayTest~anonymous|2 $std/typedarray/reduceInt8ArrayTest~anonymous|2 $std/typedarray/reduceInt64ArrayTest~anonymous|9 $std/typedarray/reduceInt64ArrayTest~anonymous|9 $std/typedarray/reduceFloat32ArrayTest~anonymous|11 $std/typedarray/reduceFloat64ArrayTest~anonymous|12)
+ (table $0 35 anyfunc)
+ (elem (i32.const 0) $null $~lib/typedarray/Float64Array#sort|trampoline~anonymous|1 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 $std/typedarray/testReduce<Float32Array,f32>~anonymous|11 $std/typedarray/testReduce<Float64Array,f64>~anonymous|12 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 $std/typedarray/testReduce<Float32Array,f32>~anonymous|11 $std/typedarray/testReduce<Float64Array,f64>~anonymous|12 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|33 $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|34)
  (global $~lib/allocator/arena/startOffset (mut i32) (i32.const 0))
  (global $~lib/allocator/arena/offset (mut i32) (i32.const 0))
  (global $std/typedarray/arr (mut i32) (i32.const 0))
@@ -2198,7 +2204,7 @@
   get_local $3
   call $~lib/typedarray/Int32Array#fill
  )
- (func $std/typedarray/reduceInt8ArrayTest~anonymous|2 (; 30 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 (; 30 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
@@ -2240,7 +2246,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceInt8ArrayTest (; 32 ;) (type $v)
+ (func $std/typedarray/testReduce<Int8Array,i8> (; 32 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i8>#constructor
@@ -2265,7 +2271,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 251
+   i32.const 252
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -2308,7 +2314,7 @@
   end
   get_local $3
  )
- (func $std/typedarray/reduceUint8ArrayTest (; 34 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint8Array,u8> (; 34 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i8>#constructor
@@ -2334,13 +2340,13 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 266
+   i32.const 252
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $std/typedarray/reduceUint8ClampedArrayTest (; 35 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint8ClampedArray,u8> (; 35 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i8>#constructor
@@ -2366,7 +2372,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 281
+   i32.const 252
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -2440,7 +2446,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceInt16ArrayTest (; 38 ;) (type $v)
+ (func $std/typedarray/testReduce<Int16Array,i16> (; 38 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i16>#constructor
@@ -2465,7 +2471,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 296
+   i32.const 252
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -2512,7 +2518,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceUint16ArrayTest (; 40 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint16Array,u16> (; 40 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i16>#constructor
@@ -2537,7 +2543,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 311
+   i32.const 252
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -2584,7 +2590,7 @@
   end
   get_local $3
  )
- (func $std/typedarray/reduceInt32ArrayTest (; 42 ;) (type $v)
+ (func $std/typedarray/testReduce<Int32Array,i32> (; 42 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i32>#constructor
@@ -2608,13 +2614,13 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 326
+   i32.const 252
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $std/typedarray/reduceUint32ArrayTest (; 43 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint32Array,u32> (; 43 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i32>#constructor
@@ -2638,7 +2644,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 341
+   i32.const 252
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -2671,7 +2677,7 @@
   get_local $2
   i64.store offset=8
  )
- (func $std/typedarray/reduceInt64ArrayTest~anonymous|9 (; 45 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 (; 45 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   get_local $0
   get_local $1
   i64.add
@@ -2717,7 +2723,7 @@
   end
   get_local $3
  )
- (func $std/typedarray/reduceInt64ArrayTest (; 47 ;) (type $v)
+ (func $std/typedarray/testReduce<Int64Array,i64> (; 47 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i64>#constructor
@@ -2741,13 +2747,13 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 356
+   i32.const 252
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $std/typedarray/reduceUint64ArrayTest (; 48 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint64Array,u64> (; 48 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i64>#constructor
@@ -2771,7 +2777,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 371
+   i32.const 252
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -2804,7 +2810,7 @@
   get_local $2
   f32.store offset=8
  )
- (func $std/typedarray/reduceFloat32ArrayTest~anonymous|11 (; 50 ;) (type $ffiif) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
+ (func $std/typedarray/testReduce<Float32Array,f32>~anonymous|11 (; 50 ;) (type $ffiif) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
   get_local $0
   get_local $1
   f32.add
@@ -2850,7 +2856,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceFloat32ArrayTest (; 52 ;) (type $v)
+ (func $std/typedarray/testReduce<Float32Array,f32> (; 52 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i32>#constructor
@@ -2873,13 +2879,13 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 386
+   i32.const 252
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $std/typedarray/reduceFloat64ArrayTest~anonymous|12 (; 53 ;) (type $FFiiF) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
+ (func $std/typedarray/testReduce<Float64Array,f64>~anonymous|12 (; 53 ;) (type $FFiiF) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
   get_local $0
   get_local $1
   f64.add
@@ -2925,7 +2931,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceFloat64ArrayTest (; 55 ;) (type $v)
+ (func $std/typedarray/testReduce<Float64Array,f64> (; 55 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i64>#constructor
@@ -2948,7 +2954,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 401
+   i32.const 252
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -2992,7 +2998,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceRightInt8ArrayTest (; 57 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int8Array,i8> (; 57 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i8>#constructor
@@ -3017,7 +3023,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 439
+   i32.const 279
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -3061,7 +3067,7 @@
   end
   get_local $3
  )
- (func $std/typedarray/reduceRightUint8ArrayTest (; 59 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint8Array,u8> (; 59 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i8>#constructor
@@ -3087,13 +3093,13 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 454
+   i32.const 279
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $std/typedarray/reduceRightUint8ClampedArrayTest (; 60 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8> (; 60 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i8>#constructor
@@ -3119,7 +3125,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 469
+   i32.const 279
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -3167,7 +3173,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceRightInt16ArrayTest (; 62 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int16Array,i16> (; 62 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i16>#constructor
@@ -3192,7 +3198,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 484
+   i32.const 279
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -3240,7 +3246,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceRightUint16ArrayTest (; 64 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint16Array,u16> (; 64 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i16>#constructor
@@ -3265,7 +3271,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 499
+   i32.const 279
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -3313,7 +3319,7 @@
   end
   get_local $3
  )
- (func $std/typedarray/reduceRightInt32ArrayTest (; 66 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int32Array,i32> (; 66 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i32>#constructor
@@ -3337,13 +3343,13 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 514
+   i32.const 279
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $std/typedarray/reduceRightUint32ArrayTest (; 67 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint32Array,u32> (; 67 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i32>#constructor
@@ -3367,7 +3373,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 529
+   i32.const 279
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -3415,7 +3421,7 @@
   end
   get_local $3
  )
- (func $std/typedarray/reduceRightInt64ArrayTest (; 69 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int64Array,i64> (; 69 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i64>#constructor
@@ -3439,13 +3445,13 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 544
+   i32.const 279
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $std/typedarray/reduceRightUint64ArrayTest (; 70 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint64Array,u64> (; 70 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i64>#constructor
@@ -3469,7 +3475,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 559
+   i32.const 279
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -3517,7 +3523,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceRightFloat32ArrayTest (; 72 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Float32Array,f32> (; 72 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i32>#constructor
@@ -3540,7 +3546,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 574
+   i32.const 279
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -3588,7 +3594,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceRightFloat64ArrayTest (; 74 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Float64Array,f64> (; 74 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i64>#constructor
@@ -3611,13 +3617,1327 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 589
+   i32.const 279
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $start (; 75 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 (; 75 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  get_local $0
+  i32.mul
+ )
+ (func $~lib/typedarray/Int8Array#map (; 76 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  get_local $0
+  i32.load offset=8
+  tee_local $3
+  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  set_local $2
+  loop $continue|0
+   get_local $1
+   get_local $3
+   i32.lt_s
+   if
+    i32.const 3
+    set_global $~argc
+    get_local $0
+    i32.load offset=4
+    get_local $0
+    i32.load
+    get_local $1
+    i32.add
+    i32.add
+    i32.load8_s offset=8
+    get_local $1
+    get_local $0
+    i32.const 24
+    call_indirect (type $iiii)
+    i32.const 24
+    i32.shl
+    i32.const 24
+    i32.shr_s
+    set_local $4
+    get_local $2
+    i32.load offset=4
+    get_local $2
+    i32.load
+    get_local $1
+    i32.add
+    i32.add
+    get_local $4
+    i32.store8 offset=8
+    get_local $2
+    i32.load offset=4
+    get_local $2
+    i32.load
+    get_local $1
+    i32.add
+    i32.add
+    i32.load8_s offset=8
+    drop
+    get_local $1
+    i32.const 1
+    i32.add
+    set_local $1
+    br $continue|0
+   end
+  end
+  get_local $2
+ )
+ (func $std/typedarray/testArrayMap<Int8Array,i8> (; 77 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  call $~lib/typedarray/Int8Array#map
+  tee_local $0
+  i32.const 0
+  call $~lib/internal/typedarray/TypedArray<i8>#__get
+  i32.const 255
+  i32.and
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 306
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<i8>#__get
+  i32.const 255
+  i32.and
+  i32.const 4
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 307
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i8>#__get
+  i32.const 255
+  i32.and
+  i32.const 9
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 308
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $~lib/typedarray/Uint8Array#map (; 78 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  get_local $0
+  i32.load offset=8
+  tee_local $4
+  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  set_local $3
+  loop $continue|0
+   get_local $2
+   get_local $4
+   i32.lt_s
+   if
+    i32.const 3
+    set_global $~argc
+    get_local $0
+    i32.load offset=4
+    get_local $0
+    i32.load
+    get_local $2
+    i32.add
+    i32.add
+    i32.load8_u offset=8
+    get_local $2
+    get_local $0
+    get_local $1
+    call_indirect (type $iiii)
+    i32.const 255
+    i32.and
+    set_local $5
+    get_local $3
+    i32.load offset=4
+    get_local $3
+    i32.load
+    get_local $2
+    i32.add
+    i32.add
+    get_local $5
+    i32.store8 offset=8
+    get_local $3
+    i32.load offset=4
+    get_local $3
+    i32.load
+    get_local $2
+    i32.add
+    i32.add
+    i32.load8_u offset=8
+    drop
+    get_local $2
+    i32.const 1
+    i32.add
+    set_local $2
+    br $continue|0
+   end
+  end
+  get_local $3
+ )
+ (func $std/typedarray/testArrayMap<Uint8Array,u8> (; 79 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 25
+  call $~lib/typedarray/Uint8Array#map
+  tee_local $0
+  i32.const 0
+  call $~lib/internal/typedarray/TypedArray<u8>#__get
+  i32.const 255
+  i32.and
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 306
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<u8>#__get
+  i32.const 255
+  i32.and
+  i32.const 4
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 307
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u8>#__get
+  i32.const 255
+  i32.and
+  i32.const 9
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 308
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8> (; 80 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/typedarray/Uint8ClampedArray#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/typedarray/Uint8ClampedArray#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/typedarray/Uint8ClampedArray#__set
+  get_local $0
+  i32.const 26
+  call $~lib/typedarray/Uint8Array#map
+  tee_local $0
+  i32.const 0
+  call $~lib/internal/typedarray/TypedArray<u8>#__get
+  i32.const 255
+  i32.and
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 306
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<u8>#__get
+  i32.const 255
+  i32.and
+  i32.const 4
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 307
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u8>#__get
+  i32.const 255
+  i32.and
+  i32.const 9
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 308
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $~lib/typedarray/Int16Array#map (; 81 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  get_local $0
+  i32.load offset=8
+  i32.const 1
+  i32.shr_u
+  tee_local $3
+  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  set_local $2
+  loop $continue|0
+   get_local $1
+   get_local $3
+   i32.lt_s
+   if
+    i32.const 3
+    set_global $~argc
+    get_local $0
+    i32.load offset=4
+    get_local $0
+    i32.load
+    get_local $1
+    i32.const 1
+    i32.shl
+    i32.add
+    i32.add
+    i32.load16_s offset=8
+    get_local $1
+    get_local $0
+    i32.const 27
+    call_indirect (type $iiii)
+    i32.const 16
+    i32.shl
+    i32.const 16
+    i32.shr_s
+    set_local $4
+    get_local $2
+    i32.load offset=4
+    get_local $2
+    i32.load
+    get_local $1
+    i32.const 1
+    i32.shl
+    i32.add
+    i32.add
+    get_local $4
+    i32.store16 offset=8
+    get_local $2
+    i32.load offset=4
+    get_local $2
+    i32.load
+    get_local $1
+    i32.const 1
+    i32.shl
+    i32.add
+    i32.add
+    i32.load16_s offset=8
+    drop
+    get_local $1
+    i32.const 1
+    i32.add
+    set_local $1
+    br $continue|0
+   end
+  end
+  get_local $2
+ )
+ (func $~lib/internal/typedarray/TypedArray<i16>#__get (; 82 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  get_local $1
+  get_local $0
+  i32.load offset=8
+  i32.const 1
+  i32.shr_u
+  i32.ge_u
+  if
+   i32.const 0
+   i32.const 48
+   i32.const 40
+   i32.const 63
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.load offset=4
+  get_local $0
+  i32.load
+  get_local $1
+  i32.const 1
+  i32.shl
+  i32.add
+  i32.add
+  i32.load16_s offset=8
+ )
+ (func $std/typedarray/testArrayMap<Int16Array,i16> (; 83 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  call $~lib/typedarray/Int16Array#map
+  tee_local $0
+  i32.const 0
+  call $~lib/internal/typedarray/TypedArray<i16>#__get
+  i32.const 65535
+  i32.and
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 306
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<i16>#__get
+  i32.const 65535
+  i32.and
+  i32.const 4
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 307
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i16>#__get
+  i32.const 65535
+  i32.and
+  i32.const 9
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 308
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $~lib/typedarray/Uint16Array#map (; 84 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  get_local $0
+  i32.load offset=8
+  i32.const 1
+  i32.shr_u
+  tee_local $3
+  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  set_local $2
+  loop $continue|0
+   get_local $1
+   get_local $3
+   i32.lt_s
+   if
+    i32.const 3
+    set_global $~argc
+    get_local $0
+    i32.load offset=4
+    get_local $0
+    i32.load
+    get_local $1
+    i32.const 1
+    i32.shl
+    i32.add
+    i32.add
+    i32.load16_u offset=8
+    get_local $1
+    get_local $0
+    i32.const 28
+    call_indirect (type $iiii)
+    i32.const 65535
+    i32.and
+    set_local $4
+    get_local $2
+    i32.load offset=4
+    get_local $2
+    i32.load
+    get_local $1
+    i32.const 1
+    i32.shl
+    i32.add
+    i32.add
+    get_local $4
+    i32.store16 offset=8
+    get_local $2
+    i32.load offset=4
+    get_local $2
+    i32.load
+    get_local $1
+    i32.const 1
+    i32.shl
+    i32.add
+    i32.add
+    i32.load16_u offset=8
+    drop
+    get_local $1
+    i32.const 1
+    i32.add
+    set_local $1
+    br $continue|0
+   end
+  end
+  get_local $2
+ )
+ (func $~lib/internal/typedarray/TypedArray<u16>#__get (; 85 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  get_local $1
+  get_local $0
+  i32.load offset=8
+  i32.const 1
+  i32.shr_u
+  i32.ge_u
+  if
+   i32.const 0
+   i32.const 48
+   i32.const 40
+   i32.const 63
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.load offset=4
+  get_local $0
+  i32.load
+  get_local $1
+  i32.const 1
+  i32.shl
+  i32.add
+  i32.add
+  i32.load16_u offset=8
+ )
+ (func $std/typedarray/testArrayMap<Uint16Array,u16> (; 86 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  call $~lib/typedarray/Uint16Array#map
+  tee_local $0
+  i32.const 0
+  call $~lib/internal/typedarray/TypedArray<u16>#__get
+  i32.const 65535
+  i32.and
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 306
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<u16>#__get
+  i32.const 65535
+  i32.and
+  i32.const 4
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 307
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u16>#__get
+  i32.const 65535
+  i32.and
+  i32.const 9
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 308
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $~lib/typedarray/Int32Array#map (; 87 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  get_local $0
+  i32.load offset=8
+  i32.const 2
+  i32.shr_u
+  tee_local $4
+  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  set_local $3
+  loop $continue|0
+   get_local $2
+   get_local $4
+   i32.lt_s
+   if
+    i32.const 3
+    set_global $~argc
+    get_local $0
+    i32.load offset=4
+    get_local $0
+    i32.load
+    get_local $2
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.add
+    i32.load offset=8
+    get_local $2
+    get_local $0
+    get_local $1
+    call_indirect (type $iiii)
+    set_local $5
+    get_local $3
+    i32.load offset=4
+    get_local $3
+    i32.load
+    get_local $2
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.add
+    get_local $5
+    i32.store offset=8
+    get_local $3
+    i32.load offset=4
+    get_local $3
+    i32.load
+    get_local $2
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.add
+    i32.load offset=8
+    drop
+    get_local $2
+    i32.const 1
+    i32.add
+    set_local $2
+    br $continue|0
+   end
+  end
+  get_local $3
+ )
+ (func $std/typedarray/testArrayMap<Int32Array,i32> (; 88 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 29
+  call $~lib/typedarray/Int32Array#map
+  tee_local $0
+  i32.const 0
+  call $~lib/internal/typedarray/TypedArray<i32>#__get
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 306
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<i32>#__get
+  i32.const 4
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 307
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i32>#__get
+  i32.const 9
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 308
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayMap<Uint32Array,u32> (; 89 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 30
+  call $~lib/typedarray/Int32Array#map
+  tee_local $0
+  i32.const 0
+  call $~lib/internal/typedarray/TypedArray<i32>#__get
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 306
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<i32>#__get
+  i32.const 4
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 307
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i32>#__get
+  i32.const 9
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 308
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 (; 90 ;) (type $IiiI) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+  get_local $0
+  get_local $0
+  i64.mul
+ )
+ (func $~lib/typedarray/Int64Array#map (; 91 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i64)
+  get_local $0
+  i32.load offset=8
+  i32.const 3
+  i32.shr_u
+  tee_local $4
+  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  set_local $3
+  loop $continue|0
+   get_local $2
+   get_local $4
+   i32.lt_s
+   if
+    i32.const 3
+    set_global $~argc
+    get_local $0
+    i32.load offset=4
+    get_local $0
+    i32.load
+    get_local $2
+    i32.const 3
+    i32.shl
+    i32.add
+    i32.add
+    i64.load offset=8
+    get_local $2
+    get_local $0
+    get_local $1
+    call_indirect (type $IiiI)
+    set_local $5
+    get_local $3
+    i32.load offset=4
+    get_local $3
+    i32.load
+    get_local $2
+    i32.const 3
+    i32.shl
+    i32.add
+    i32.add
+    get_local $5
+    i64.store offset=8
+    get_local $3
+    i32.load offset=4
+    get_local $3
+    i32.load
+    get_local $2
+    i32.const 3
+    i32.shl
+    i32.add
+    i32.add
+    i64.load offset=8
+    drop
+    get_local $2
+    i32.const 1
+    i32.add
+    set_local $2
+    br $continue|0
+   end
+  end
+  get_local $3
+ )
+ (func $~lib/internal/typedarray/TypedArray<i64>#__get (; 92 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
+  get_local $1
+  get_local $0
+  i32.load offset=8
+  i32.const 3
+  i32.shr_u
+  i32.ge_u
+  if
+   i32.const 0
+   i32.const 48
+   i32.const 40
+   i32.const 63
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.load offset=4
+  get_local $0
+  i32.load
+  get_local $1
+  i32.const 3
+  i32.shl
+  i32.add
+  i32.add
+  i64.load offset=8
+ )
+ (func $std/typedarray/testArrayMap<Int64Array,i64> (; 93 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  tee_local $0
+  i32.const 0
+  i64.const 1
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 1
+  i64.const 2
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 2
+  i64.const 3
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 31
+  call $~lib/typedarray/Int64Array#map
+  tee_local $0
+  i32.const 0
+  call $~lib/internal/typedarray/TypedArray<i64>#__get
+  i64.const 1
+  i64.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 306
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<i64>#__get
+  i64.const 4
+  i64.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 307
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i64>#__get
+  i64.const 9
+  i64.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 308
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayMap<Uint64Array,u64> (; 94 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  tee_local $0
+  i32.const 0
+  i64.const 1
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 1
+  i64.const 2
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 2
+  i64.const 3
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 32
+  call $~lib/typedarray/Int64Array#map
+  tee_local $0
+  i32.const 0
+  call $~lib/internal/typedarray/TypedArray<i64>#__get
+  i64.const 1
+  i64.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 306
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<i64>#__get
+  i64.const 4
+  i64.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 307
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i64>#__get
+  i64.const 9
+  i64.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 308
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|33 (; 95 ;) (type $fiif) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
+  get_local $0
+  get_local $0
+  f32.mul
+ )
+ (func $~lib/typedarray/Float32Array#map (; 96 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 f32)
+  get_local $0
+  i32.load offset=8
+  i32.const 2
+  i32.shr_u
+  tee_local $3
+  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  set_local $2
+  loop $continue|0
+   get_local $1
+   get_local $3
+   i32.lt_s
+   if
+    i32.const 3
+    set_global $~argc
+    get_local $0
+    i32.load offset=4
+    get_local $0
+    i32.load
+    get_local $1
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.add
+    f32.load offset=8
+    get_local $1
+    get_local $0
+    i32.const 33
+    call_indirect (type $fiif)
+    set_local $4
+    get_local $2
+    i32.load offset=4
+    get_local $2
+    i32.load
+    get_local $1
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.add
+    get_local $4
+    f32.store offset=8
+    get_local $2
+    i32.load offset=4
+    get_local $2
+    i32.load
+    get_local $1
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.add
+    f32.load offset=8
+    drop
+    get_local $1
+    i32.const 1
+    i32.add
+    set_local $1
+    br $continue|0
+   end
+  end
+  get_local $2
+ )
+ (func $~lib/internal/typedarray/TypedArray<f32>#__get (; 97 ;) (type $iif) (param $0 i32) (param $1 i32) (result f32)
+  get_local $1
+  get_local $0
+  i32.load offset=8
+  i32.const 2
+  i32.shr_u
+  i32.ge_u
+  if
+   i32.const 0
+   i32.const 48
+   i32.const 40
+   i32.const 63
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.load offset=4
+  get_local $0
+  i32.load
+  get_local $1
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.add
+  f32.load offset=8
+ )
+ (func $std/typedarray/testArrayMap<Float32Array,f32> (; 98 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  tee_local $0
+  i32.const 0
+  f32.const 1
+  call $~lib/internal/typedarray/TypedArray<f32>#__set
+  get_local $0
+  i32.const 1
+  f32.const 2
+  call $~lib/internal/typedarray/TypedArray<f32>#__set
+  get_local $0
+  i32.const 2
+  f32.const 3
+  call $~lib/internal/typedarray/TypedArray<f32>#__set
+  get_local $0
+  call $~lib/typedarray/Float32Array#map
+  tee_local $0
+  i32.const 0
+  call $~lib/internal/typedarray/TypedArray<f32>#__get
+  f32.const 1
+  f32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 306
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<f32>#__get
+  f32.const 4
+  f32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 307
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<f32>#__get
+  f32.const 9
+  f32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 308
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|34 (; 99 ;) (type $FiiF) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
+  get_local $0
+  get_local $0
+  f64.mul
+ )
+ (func $~lib/typedarray/Float64Array#map (; 100 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 f64)
+  get_local $0
+  i32.load offset=8
+  i32.const 3
+  i32.shr_u
+  tee_local $3
+  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  set_local $2
+  loop $continue|0
+   get_local $1
+   get_local $3
+   i32.lt_s
+   if
+    i32.const 3
+    set_global $~argc
+    get_local $0
+    i32.load offset=4
+    get_local $0
+    i32.load
+    get_local $1
+    i32.const 3
+    i32.shl
+    i32.add
+    i32.add
+    f64.load offset=8
+    get_local $1
+    get_local $0
+    i32.const 34
+    call_indirect (type $FiiF)
+    set_local $4
+    get_local $2
+    i32.load offset=4
+    get_local $2
+    i32.load
+    get_local $1
+    i32.const 3
+    i32.shl
+    i32.add
+    i32.add
+    get_local $4
+    f64.store offset=8
+    get_local $2
+    i32.load offset=4
+    get_local $2
+    i32.load
+    get_local $1
+    i32.const 3
+    i32.shl
+    i32.add
+    i32.add
+    f64.load offset=8
+    drop
+    get_local $1
+    i32.const 1
+    i32.add
+    set_local $1
+    br $continue|0
+   end
+  end
+  get_local $2
+ )
+ (func $std/typedarray/testArrayMap<Float64Array,f64> (; 101 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  tee_local $0
+  i32.const 0
+  f64.const 1
+  call $~lib/internal/typedarray/TypedArray<f64>#__set
+  get_local $0
+  i32.const 1
+  f64.const 2
+  call $~lib/internal/typedarray/TypedArray<f64>#__set
+  get_local $0
+  i32.const 2
+  f64.const 3
+  call $~lib/internal/typedarray/TypedArray<f64>#__set
+  get_local $0
+  call $~lib/typedarray/Float64Array#map
+  tee_local $0
+  i32.const 0
+  call $~lib/internal/typedarray/TypedArray<f64>#__get
+  f64.const 1
+  f64.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 306
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<f64>#__get
+  f64.const 4
+  f64.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 307
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<f64>#__get
+  f64.const 9
+  f64.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 308
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $start (; 102 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 624
@@ -4537,30 +5857,41 @@
    call $~lib/env/abort
    unreachable
   end
-  call $std/typedarray/reduceInt8ArrayTest
-  call $std/typedarray/reduceUint8ArrayTest
-  call $std/typedarray/reduceUint8ClampedArrayTest
-  call $std/typedarray/reduceInt16ArrayTest
-  call $std/typedarray/reduceUint16ArrayTest
-  call $std/typedarray/reduceInt32ArrayTest
-  call $std/typedarray/reduceUint32ArrayTest
-  call $std/typedarray/reduceInt64ArrayTest
-  call $std/typedarray/reduceUint64ArrayTest
-  call $std/typedarray/reduceFloat32ArrayTest
-  call $std/typedarray/reduceFloat64ArrayTest
-  call $std/typedarray/reduceRightInt8ArrayTest
-  call $std/typedarray/reduceRightUint8ArrayTest
-  call $std/typedarray/reduceRightUint8ClampedArrayTest
-  call $std/typedarray/reduceRightInt16ArrayTest
-  call $std/typedarray/reduceRightUint16ArrayTest
-  call $std/typedarray/reduceRightInt32ArrayTest
-  call $std/typedarray/reduceRightUint32ArrayTest
-  call $std/typedarray/reduceRightInt64ArrayTest
-  call $std/typedarray/reduceRightUint64ArrayTest
-  call $std/typedarray/reduceRightFloat32ArrayTest
-  call $std/typedarray/reduceRightFloat64ArrayTest
+  call $std/typedarray/testReduce<Int8Array,i8>
+  call $std/typedarray/testReduce<Uint8Array,u8>
+  call $std/typedarray/testReduce<Uint8ClampedArray,u8>
+  call $std/typedarray/testReduce<Int16Array,i16>
+  call $std/typedarray/testReduce<Uint16Array,u16>
+  call $std/typedarray/testReduce<Int32Array,i32>
+  call $std/typedarray/testReduce<Uint32Array,u32>
+  call $std/typedarray/testReduce<Int64Array,i64>
+  call $std/typedarray/testReduce<Uint64Array,u64>
+  call $std/typedarray/testReduce<Float32Array,f32>
+  call $std/typedarray/testReduce<Float64Array,f64>
+  call $std/typedarray/testReduceRight<Int8Array,i8>
+  call $std/typedarray/testReduceRight<Uint8Array,u8>
+  call $std/typedarray/testReduceRight<Uint8ClampedArray,u8>
+  call $std/typedarray/testReduceRight<Int16Array,i16>
+  call $std/typedarray/testReduceRight<Uint16Array,u16>
+  call $std/typedarray/testReduceRight<Int32Array,i32>
+  call $std/typedarray/testReduceRight<Uint32Array,u32>
+  call $std/typedarray/testReduceRight<Int64Array,i64>
+  call $std/typedarray/testReduceRight<Uint64Array,u64>
+  call $std/typedarray/testReduceRight<Float32Array,f32>
+  call $std/typedarray/testReduceRight<Float64Array,f64>
+  call $std/typedarray/testArrayMap<Int8Array,i8>
+  call $std/typedarray/testArrayMap<Uint8Array,u8>
+  call $std/typedarray/testArrayMap<Uint8ClampedArray,u8>
+  call $std/typedarray/testArrayMap<Int16Array,i16>
+  call $std/typedarray/testArrayMap<Uint16Array,u16>
+  call $std/typedarray/testArrayMap<Int32Array,i32>
+  call $std/typedarray/testArrayMap<Uint32Array,u32>
+  call $std/typedarray/testArrayMap<Int64Array,i64>
+  call $std/typedarray/testArrayMap<Uint64Array,u64>
+  call $std/typedarray/testArrayMap<Float32Array,f32>
+  call $std/typedarray/testArrayMap<Float64Array,f64>
  )
- (func $null (; 76 ;) (type $v)
+ (func $null (; 103 ;) (type $v)
   nop
  )
 )

--- a/tests/compiler/std/typedarray.ts
+++ b/tests/compiler/std/typedarray.ts
@@ -227,8 +227,8 @@ assert(multisubarr3.byteLength === 3);
 
 /**
  * Reduce test suite:
- * Each function is designed to test a simple sum reduction. In each test it initialized the tested
- * typedarray, and sets the values manually. Then it calls `TypedArray.prototype.reduce` with a
+ * The reduce test is designed to test a simple sum reduction. In each test it instantiates the
+ * tested typedarray, and sets the values manually. Then it calls `TypedArray.prototype.reduce` with a
  * single sum arrow function reduction. For each reduction, it verifies the `self` parameter is the
  * instantiated array, the index is the correct index, and it increments the testIndex variable.
  * Finally, it asserts the value is 6.
@@ -236,367 +236,86 @@ assert(multisubarr3.byteLength === 3);
  * TODO: When function closure support is added, remove the function comments to fully verify the
  * tests work.
  */
-function reduceInt8ArrayTest(): void {
-  var array: Int8Array = new Int8Array(3);
-  array[0] = 1;
-  array[1] = 2;
-  array[2] = 3;
-  // var testindex: i32 = 0;
-  var result = array.reduce<i8>((acc: i8, val: i8, index: i32, self: Int8Array): i8 => {
-    // assert(testindex == index);
-    // assert(array == self);
-    // ++testindex;
-    return acc + val;
-  }, 0);
-  assert(result == 6);
-}
 
-function reduceUint8ArrayTest(): void {
-  var array: Uint8Array = new Uint8Array(3);
-  array[0] = 1;
-  array[1] = 2;
-  array[2] = 3;
-  // var testindex: i32 = 0;
-  var result = array.reduce<u8>((acc: u8, val: u8, index: i32, self: Uint8Array): u8 => {
-    // assert(testindex == index);
-    // assert(array == self);
-    // ++testindex;
-    return acc + val;
-  }, 0);
-  assert(result == 6);
-}
-
-function reduceUint8ClampedArrayTest(): void {
-  var array: Uint8ClampedArray = new Uint8ClampedArray(3);
-  array[0] = 1;
-  array[1] = 2;
-  array[2] = 3;
-  // var testindex: i32 = 0;
-  var result = array.reduce<u8>((acc: u8, val: u8, index: i32, self: Uint8ClampedArray): u8 => {
-    // assert(testindex == index);
-    // assert(array == self);
-    // ++testindex;
-    return acc + val;
-  }, 0);
-  assert(result == 6);
-}
-
-function reduceInt16ArrayTest(): void {
-  var array: Int16Array = new Int16Array(3);
-  array[0] = 1;
-  array[1] = 2;
-  array[2] = 3;
-  // var testindex: i32 = 0;
-  var result = array.reduce<i16>((acc: i16, val: i16, index: i32, self: Int16Array): i16 => {
-    // assert(testindex == index);
-    // assert(array == self);
-    // ++testindex;
-    return acc + val;
-  }, 0);
-  assert(result == 6);
-}
-
-function reduceUint16ArrayTest(): void {
-  var array: Uint16Array = new Uint16Array(3);
-  array[0] = 1;
-  array[1] = 2;
-  array[2] = 3;
-  // var testindex: i32 = 0;
-  var result = array.reduce<u16>((acc: u16, val: u16, index: i32, self: Uint16Array): u16 => {
-    // assert(testindex == index);
-    // assert(array == self);
-    // ++testindex;
-    return acc + val;
-  }, 0);
-  assert(result == 6);
-}
-
-function reduceInt32ArrayTest(): void {
-  var array: Int32Array = new Int32Array(3);
-  array[0] = 1;
-  array[1] = 2;
-  array[2] = 3;
-  // var testindex: i32 = 0;
-  var result = array.reduce<i32>((acc: i32, val: i32, index: i32, self: Int32Array): i32 => {
-    // assert(testindex == index);
-    // assert(array == self);
-    // ++testindex;
-    return acc + val;
-  }, 0);
-  assert(result == 6);
-}
-
-function reduceUint32ArrayTest(): void {
-  var array: Uint32Array = new Uint32Array(3);
-  array[0] = 1;
-  array[1] = 2;
-  array[2] = 3;
-  // var testindex: i32 = 0;
-  var result = array.reduce<u32>((acc: u32, val: u32, index: i32, self: Uint32Array): u32 => {
-    // assert(testindex == index);
-    // assert(array == self);
-    // ++testindex;
-    return acc + val;
-  }, 0);
-  assert(result == 6);
-}
-
-function reduceInt64ArrayTest(): void {
-  var array: Int64Array = new Int64Array(3);
-  array[0] = 1;
-  array[1] = 2;
-  array[2] = 3;
-  // var testindex: i32 = 0;
-  var result = array.reduce<i64>((acc: i64, val: i64, index: i32, self: Int64Array): i64 => {
-    // assert(testindex == index);
-    // assert(array == self);
-    // ++testindex;
-    return acc + val;
-  }, 0);
-  assert(result == 6);
-}
-
-function reduceUint64ArrayTest(): void {
-  var array: Uint64Array = new Uint64Array(3);
-  array[0] = 1;
-  array[1] = 2;
-  array[2] = 3;
-  // var testindex: i32 = 0;
-  var result = array.reduce<u64>((acc: u64, val: u64, index: i32, self: Uint64Array): u64 => {
-    // assert(testindex == index);
-    // assert(array == self);
-    // ++testindex;
-    return acc + val;
-  }, 0);
-  assert(result == 6);
-}
-
-function reduceFloat32ArrayTest(): void {
-  var array: Float32Array = new Float32Array(3);
-  array[0] = 1;
-  array[1] = 2;
-  array[2] = 3;
-  // var testindex: i32 = 0;
-  var result = array.reduce<f32>((acc: f32, val: f32, index: i32, self: Float32Array): f32 => {
-    // assert(testindex == index);
-    // assert(array == self);
-    // ++testindex;
-    return acc + val;
-  }, 0);
-  assert(result == 6);
-}
-
-function reduceFloat64ArrayTest(): void {
-  var array: Float64Array = new Float64Array(3);
-  array[0] = 1;
-  array[1] = 2;
-  array[2] = 3;
-  // var testindex: i32 = 0;
-  var result = array.reduce<f64>((acc: f64, val: f64, index: i32, self: Float64Array): f64 => {
-    // assert(testindex == index);
-    // assert(array == self);
-    // ++testindex;
-    return acc + val;
-  }, 0);
-  assert(result == 6);
-}
-
-reduceInt8ArrayTest();
-reduceUint8ArrayTest();
-reduceUint8ClampedArrayTest();
-reduceInt16ArrayTest();
-reduceUint16ArrayTest();
-reduceInt32ArrayTest();
-reduceUint32ArrayTest();
-reduceInt64ArrayTest();
-reduceUint64ArrayTest();
-reduceFloat32ArrayTest();
-reduceFloat64ArrayTest();
-
-/**
- * ReduceRight test suite:
- * Each function is designed to test a simple sum reduction. In each test it initialized the tested
- * typedarray, and sets the values manually. Then it calls `TypedArray.prototype.reduceRight` with a
- * single sum arrow function reduction. For each reduction, it verifies the `self` parameter is the
- * instantiated array, the index is the correct index, and it increments the testIndex variable.
- * Finally, it asserts the value is 6.
- *
- * TODO: When function closure support is added, remove the function comments to fully verify the
- * tests work.
- */
-function reduceRightInt8ArrayTest(): void {
-  var array: Int8Array = new Int8Array(3);
-  array[0] = 1;
-  array[1] = 2;
-  array[2] = 3;
+function testReduce<ArrayType, T>(): void {
+  var array: ArrayType = instantiate<ArrayType>(3);
+  array[0] = <T>1;
+  array[1] = <T>2;
+  array[2] = <T>3;
   // var testindex: i32 = 2;
-  var result = array.reduceRight<i8>((acc: i8, val: i8, index: i32, self: Int8Array): i8 => {
+  var result = array.reduce<T>((acc: T, val: T, index: i32, self: ArrayType): T => {
     // assert(testindex == index);
     // assert(array == self);
     // --testindex;
     return acc + val;
   }, 0);
-  assert(result == 6);
+  assert(result == <T>6);
 }
 
-function reduceRightUint8ArrayTest(): void {
-  var array: Uint8Array = new Uint8Array(3);
-  array[0] = 1;
-  array[1] = 2;
-  array[2] = 3;
+testReduce<Int8Array, i8>();
+testReduce<Uint8Array, u8>();
+testReduce<Uint8ClampedArray, u8>();
+testReduce<Int16Array, i16>();
+testReduce<Uint16Array, u16>();
+testReduce<Int32Array, i32>();
+testReduce<Uint32Array, u32>();
+testReduce<Int64Array, i64>();
+testReduce<Uint64Array, u64>();
+testReduce<Float32Array, f32>();
+testReduce<Float64Array, f64>();
+
+function testReduceRight<ArrayType, T>(): void {
+  var array: ArrayType = instantiate<ArrayType>(3);
+  array[0] = <T>1;
+  array[1] = <T>2;
+  array[2] = <T>3;
   // var testindex: i32 = 2;
-  var result = array.reduceRight<u8>((acc: u8, val: u8, index: i32, self: Uint8Array): u8 => {
+  var result = array.reduceRight<T>((acc: T, val: T, index: i32, self: ArrayType): T => {
     // assert(testindex == index);
     // assert(array == self);
     // --testindex;
     return acc + val;
   }, 0);
-  assert(result == 6);
+  assert(result == <T>6);
 }
 
-function reduceRightUint8ClampedArrayTest(): void {
-  var array: Uint8ClampedArray = new Uint8ClampedArray(3);
-  array[0] = 1;
-  array[1] = 2;
-  array[2] = 3;
-  // var testindex: i32 = 2;
-  var result = array.reduceRight<u8>((acc: u8, val: u8, index: i32, self: Uint8ClampedArray): u8 => {
-    // assert(testindex == index);
-    // assert(array == self);
-    // --testindex;
-    return acc + val;
-  }, 0);
-  assert(result == 6);
+testReduceRight<Int8Array, i8>();
+testReduceRight<Uint8Array, u8>();
+testReduceRight<Uint8ClampedArray, u8>();
+testReduceRight<Int16Array, i16>();
+testReduceRight<Uint16Array, u16>();
+testReduceRight<Int32Array, i32>();
+testReduceRight<Uint32Array, u32>();
+testReduceRight<Int64Array, i64>();
+testReduceRight<Uint64Array, u64>();
+testReduceRight<Float32Array, f32>();
+testReduceRight<Float64Array, f64>();
+
+function testArrayMap<ArrayType, T>(): void {
+  var source: ArrayType = instantiate<ArrayType>(3);
+  source[0] = <T>1;
+  source[1] = <T>2;
+  source[2] = <T>3;
+  // var testIndex: i32 = 0;
+  var result = source.map((value: T, index: i32, self: ArrayType): T => {
+    // assert(self == source);
+    // assert(testIndex == testIndex);
+    // testIndex++;
+    return value * value;
+  });
+  assert(result[0] == <T>1);
+  assert(result[1] == <T>4);
+  assert(result[2] == <T>9);
 }
 
-function reduceRightInt16ArrayTest(): void {
-  var array: Int16Array = new Int16Array(3);
-  array[0] = 1;
-  array[1] = 2;
-  array[2] = 3;
-  // var testindex: i32 = 2;
-  var result = array.reduceRight<i16>((acc: i16, val: i16, index: i32, self: Int16Array): i16 => {
-    // assert(testindex == index);
-    // assert(array == self);
-    // --testindex;
-    return acc + val;
-  }, 0);
-  assert(result == 6);
-}
-
-function reduceRightUint16ArrayTest(): void {
-  var array: Uint16Array = new Uint16Array(3);
-  array[0] = 1;
-  array[1] = 2;
-  array[2] = 3;
-  // var testindex: i32 = 2;
-  var result = array.reduceRight<u16>((acc: u16, val: u16, index: i32, self: Uint16Array): u16 => {
-    // assert(testindex == index);
-    // assert(array == self);
-    // --testindex;
-    return acc + val;
-  }, 0);
-  assert(result == 6);
-}
-
-function reduceRightInt32ArrayTest(): void {
-  var array: Int32Array = new Int32Array(3);
-  array[0] = 1;
-  array[1] = 2;
-  array[2] = 3;
-  // var testindex: i32 = 2;
-  var result = array.reduceRight<i32>((acc: i32, val: i32, index: i32, self: Int32Array): i32 => {
-    // assert(testindex == index);
-    // assert(array == self);
-    // --testindex;
-    return acc + val;
-  }, 0);
-  assert(result == 6);
-}
-
-function reduceRightUint32ArrayTest(): void {
-  var array: Uint32Array = new Uint32Array(3);
-  array[0] = 1;
-  array[1] = 2;
-  array[2] = 3;
-  // var testindex: i32 = 2;
-  var result = array.reduceRight<u32>((acc: u32, val: u32, index: i32, self: Uint32Array): u32 => {
-    // assert(testindex == index);
-    // assert(array == self);
-    // --testindex;
-    return acc + val;
-  }, 0);
-  assert(result == 6);
-}
-
-function reduceRightInt64ArrayTest(): void {
-  var array: Int64Array = new Int64Array(3);
-  array[0] = 1;
-  array[1] = 2;
-  array[2] = 3;
-  // var testindex: i32 = 2;
-  var result = array.reduceRight<i64>((acc: i64, val: i64, index: i32, self: Int64Array): i64 => {
-    // assert(testindex == index);
-    // assert(array == self);
-    // --testindex;
-    return acc + val;
-  }, 0);
-  assert(result == 6);
-}
-
-function reduceRightUint64ArrayTest(): void {
-  var array: Uint64Array = new Uint64Array(3);
-  array[0] = 1;
-  array[1] = 2;
-  array[2] = 3;
-  // var testindex: i32 = 2;
-  var result = array.reduceRight<u64>((acc: u64, val: u64, index: i32, self: Uint64Array): u64 => {
-    // assert(testindex == index);
-    // assert(array == self);
-    // --testindex;
-    return acc + val;
-  }, 0);
-  assert(result == 6);
-}
-
-function reduceRightFloat32ArrayTest(): void {
-  var array: Float32Array = new Float32Array(3);
-  array[0] = 1;
-  array[1] = 2;
-  array[2] = 3;
-  // var testindex: i32 = 2;
-  var result = array.reduceRight<f32>((acc: f32, val: f32, index: i32, self: Float32Array): f32 => {
-    // assert(testindex == index);
-    // assert(array == self);
-    // --testindex;
-    return acc + val;
-  }, 0);
-  assert(result == 6);
-}
-
-function reduceRightFloat64ArrayTest(): void {
-  var array: Float64Array = new Float64Array(3);
-  array[0] = 1;
-  array[1] = 2;
-  array[2] = 3;
-  // var testindex: i32 = 2;
-  var result = array.reduceRight<f64>((acc: f64, val: f64, index: i32, self: Float64Array): f64 => {
-    // assert(testindex == index);
-    // assert(array == self);
-    // --testindex;
-    return acc + val;
-  }, 0);
-  assert(result == 6);
-}
-
-reduceRightInt8ArrayTest();
-reduceRightUint8ArrayTest();
-reduceRightUint8ClampedArrayTest();
-reduceRightInt16ArrayTest();
-reduceRightUint16ArrayTest();
-reduceRightInt32ArrayTest();
-reduceRightUint32ArrayTest();
-reduceRightInt64ArrayTest();
-reduceRightUint64ArrayTest();
-reduceRightFloat32ArrayTest();
-reduceRightFloat64ArrayTest();
+testArrayMap<Int8Array, i8>();
+testArrayMap<Uint8Array, u8>();
+testArrayMap<Uint8ClampedArray, u8>();
+testArrayMap<Int16Array, i16>();
+testArrayMap<Uint16Array, u16>();
+testArrayMap<Int32Array, i32>();
+testArrayMap<Uint32Array, u32>();
+testArrayMap<Int64Array, i64>();
+testArrayMap<Uint64Array, u64>();
+testArrayMap<Float32Array, f32>();
+testArrayMap<Float64Array, f64>();

--- a/tests/compiler/std/typedarray.ts
+++ b/tests/compiler/std/typedarray.ts
@@ -291,7 +291,7 @@ testReduceRight<Uint64Array, u64>();
 testReduceRight<Float32Array, f32>();
 testReduceRight<Float64Array, f64>();
 
-function testArrayMap<ArrayType, T>(): void {
+function testArrayMap<ArrayType extends TypedArray<T>, T>(): void {
   var source: ArrayType = instantiate<ArrayType>(3);
   source[0] = <T>1;
   source[1] = <T>2;

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -5913,7 +5913,106 @@
   get_local $0
   i32.mul
  )
- (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8> (; 132 ;) (type $v)
+ (func $~lib/typedarray/Uint8ClampedArray#__unchecked_set (; 132 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  get_local $2
+  tee_local $3
+  i32.const 255
+  tee_local $4
+  get_local $3
+  get_local $4
+  i32.lt_s
+  select
+  tee_local $3
+  i32.const 0
+  tee_local $4
+  get_local $3
+  get_local $4
+  i32.gt_s
+  select
+  set_local $3
+  block
+   get_local $0
+   i32.load
+   set_local $4
+   get_local $0
+   i32.load offset=4
+   set_local $5
+   get_local $4
+   get_local $1
+   i32.const 0
+   i32.shl
+   i32.add
+   get_local $5
+   i32.add
+   get_local $3
+   i32.store8 offset=8
+  end
+ )
+ (func $~lib/typedarray/Uint8ClampedArray#map (; 133 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  block $~lib/internal/typedarray/TypedArray<u8>#get:length|inlined.5 (result i32)
+   get_local $0
+   i32.load offset=8
+   i32.const 0
+   i32.shr_u
+  end
+  set_local $2
+  i32.const 0
+  get_local $2
+  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  set_local $3
+  i32.const 0
+  set_local $4
+  block $break|0
+   loop $continue|0
+    get_local $4
+    get_local $2
+    i32.lt_s
+    if
+     block
+      block (result i32)
+       get_local $3
+       tee_local $5
+       get_local $4
+       tee_local $6
+       block (result i32)
+        i32.const 3
+        set_global $~argc
+        get_local $0
+        get_local $4
+        call $~lib/internal/typedarray/TypedArray<u8>#__unchecked_get
+        get_local $4
+        get_local $0
+        get_local $1
+        call_indirect (type $iiii)
+       end
+       i32.const 255
+       i32.and
+       call $~lib/typedarray/Uint8ClampedArray#__unchecked_set
+       get_local $5
+       get_local $6
+       call $~lib/internal/typedarray/TypedArray<u8>#__unchecked_get
+      end
+      drop
+      get_local $4
+      i32.const 1
+      i32.add
+      set_local $4
+     end
+     br $continue|0
+    end
+   end
+  end
+  get_local $3
+ )
+ (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8> (; 134 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -5934,7 +6033,7 @@
   call $~lib/typedarray/Uint8ClampedArray#__set
   get_local $0
   i32.const 26
-  call $~lib/typedarray/Uint8Array#map
+  call $~lib/typedarray/Uint8ClampedArray#map
   set_local $1
   get_local $1
   i32.const 0
@@ -5985,12 +6084,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int16Array,i16>~anonymous|27 (; 133 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Int16Array,i16>~anonymous|27 (; 135 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   get_local $0
   i32.mul
  )
- (func $~lib/internal/typedarray/TypedArray<i16>#__unchecked_set (; 134 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<i16>#__unchecked_set (; 136 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   get_local $0
@@ -6009,7 +6108,7 @@
   get_local $2
   i32.store16 offset=8
  )
- (func $~lib/typedarray/Int16Array#map (; 135 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#map (; 137 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6072,7 +6171,7 @@
   end
   get_local $3
  )
- (func $~lib/internal/typedarray/TypedArray<i16>#__get (; 136 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<i16>#__get (; 138 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   get_local $1
@@ -6106,7 +6205,7 @@
    i32.load16_s offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Int16Array,i16> (; 137 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int16Array,i16> (; 139 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -6184,12 +6283,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint16Array,u16>~anonymous|28 (; 138 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Uint16Array,u16>~anonymous|28 (; 140 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   get_local $0
   i32.mul
  )
- (func $~lib/internal/typedarray/TypedArray<u16>#__unchecked_set (; 139 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<u16>#__unchecked_set (; 141 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   get_local $0
@@ -6208,7 +6307,7 @@
   get_local $2
   i32.store16 offset=8
  )
- (func $~lib/typedarray/Uint16Array#map (; 140 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#map (; 142 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6269,7 +6368,7 @@
   end
   get_local $3
  )
- (func $~lib/internal/typedarray/TypedArray<u16>#__get (; 141 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<u16>#__get (; 143 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   get_local $1
@@ -6303,7 +6402,7 @@
    i32.load16_u offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Uint16Array,u16> (; 142 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint16Array,u16> (; 144 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -6375,12 +6474,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int32Array,i32>~anonymous|29 (; 143 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Int32Array,i32>~anonymous|29 (; 145 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   get_local $0
   i32.mul
  )
- (func $~lib/internal/typedarray/TypedArray<i32>#__unchecked_set (; 144 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<i32>#__unchecked_set (; 146 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   get_local $0
@@ -6399,7 +6498,7 @@
   get_local $2
   i32.store offset=8
  )
- (func $~lib/typedarray/Int32Array#map (; 145 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#map (; 147 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6458,7 +6557,7 @@
   end
   get_local $3
  )
- (func $std/typedarray/testArrayMap<Int32Array,i32> (; 146 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int32Array,i32> (; 148 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -6524,12 +6623,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint32Array,u32>~anonymous|30 (; 147 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Uint32Array,u32>~anonymous|30 (; 149 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   get_local $0
   i32.mul
  )
- (func $~lib/internal/typedarray/TypedArray<u32>#__unchecked_set (; 148 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<u32>#__unchecked_set (; 150 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   get_local $0
@@ -6548,7 +6647,7 @@
   get_local $2
   i32.store offset=8
  )
- (func $~lib/typedarray/Uint32Array#map (; 149 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#map (; 151 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6607,7 +6706,7 @@
   end
   get_local $3
  )
- (func $~lib/internal/typedarray/TypedArray<u32>#__get (; 150 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<u32>#__get (; 152 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   get_local $1
@@ -6641,7 +6740,7 @@
    i32.load offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Uint32Array,u32> (; 151 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint32Array,u32> (; 153 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -6707,12 +6806,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 (; 152 ;) (type $IiiI) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+ (func $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 (; 154 ;) (type $IiiI) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
   get_local $0
   get_local $0
   i64.mul
  )
- (func $~lib/internal/typedarray/TypedArray<i64>#__unchecked_set (; 153 ;) (type $iiIv) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/internal/typedarray/TypedArray<i64>#__unchecked_set (; 155 ;) (type $iiIv) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local $4 i32)
   get_local $0
@@ -6731,7 +6830,7 @@
   get_local $2
   i64.store offset=8
  )
- (func $~lib/typedarray/Int64Array#map (; 154 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#map (; 156 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6790,7 +6889,7 @@
   end
   get_local $3
  )
- (func $~lib/internal/typedarray/TypedArray<i64>#__get (; 155 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/internal/typedarray/TypedArray<i64>#__get (; 157 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local $3 i32)
   get_local $1
@@ -6824,7 +6923,7 @@
    i64.load offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Int64Array,i64> (; 156 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int64Array,i64> (; 158 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -6890,12 +6989,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint64Array,u64>~anonymous|32 (; 157 ;) (type $IiiI) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+ (func $std/typedarray/testArrayMap<Uint64Array,u64>~anonymous|32 (; 159 ;) (type $IiiI) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
   get_local $0
   get_local $0
   i64.mul
  )
- (func $~lib/internal/typedarray/TypedArray<u64>#__unchecked_set (; 158 ;) (type $iiIv) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/internal/typedarray/TypedArray<u64>#__unchecked_set (; 160 ;) (type $iiIv) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local $4 i32)
   get_local $0
@@ -6914,7 +7013,7 @@
   get_local $2
   i64.store offset=8
  )
- (func $~lib/typedarray/Uint64Array#map (; 159 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#map (; 161 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6973,7 +7072,7 @@
   end
   get_local $3
  )
- (func $~lib/internal/typedarray/TypedArray<u64>#__get (; 160 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/internal/typedarray/TypedArray<u64>#__get (; 162 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local $3 i32)
   get_local $1
@@ -7007,7 +7106,7 @@
    i64.load offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Uint64Array,u64> (; 161 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint64Array,u64> (; 163 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -7073,12 +7172,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|33 (; 162 ;) (type $fiif) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
+ (func $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|33 (; 164 ;) (type $fiif) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
   get_local $0
   get_local $0
   f32.mul
  )
- (func $~lib/internal/typedarray/TypedArray<f32>#__unchecked_set (; 163 ;) (type $iifv) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/internal/typedarray/TypedArray<f32>#__unchecked_set (; 165 ;) (type $iifv) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (local $4 i32)
   get_local $0
@@ -7097,7 +7196,7 @@
   get_local $2
   f32.store offset=8
  )
- (func $~lib/typedarray/Float32Array#map (; 164 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#map (; 166 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7156,7 +7255,7 @@
   end
   get_local $3
  )
- (func $~lib/internal/typedarray/TypedArray<f32>#__get (; 165 ;) (type $iif) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/internal/typedarray/TypedArray<f32>#__get (; 167 ;) (type $iif) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (local $3 i32)
   get_local $1
@@ -7190,7 +7289,7 @@
    f32.load offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Float32Array,f32> (; 166 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Float32Array,f32> (; 168 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -7256,12 +7355,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|34 (; 167 ;) (type $FiiF) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
+ (func $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|34 (; 169 ;) (type $FiiF) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
   get_local $0
   get_local $0
   f64.mul
  )
- (func $~lib/internal/typedarray/TypedArray<f64>#__unchecked_set (; 168 ;) (type $iiFv) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/internal/typedarray/TypedArray<f64>#__unchecked_set (; 170 ;) (type $iiFv) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (local $4 i32)
   get_local $0
@@ -7280,7 +7379,7 @@
   get_local $2
   f64.store offset=8
  )
- (func $~lib/typedarray/Float64Array#map (; 169 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#map (; 171 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7339,7 +7438,7 @@
   end
   get_local $3
  )
- (func $std/typedarray/testArrayMap<Float64Array,f64> (; 170 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Float64Array,f64> (; 172 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -7405,7 +7504,7 @@
    unreachable
   end
  )
- (func $start (; 171 ;) (type $v)
+ (func $start (; 173 ;) (type $v)
   (local $0 i32)
   get_global $~lib/typedarray/Int8Array.BYTES_PER_ELEMENT
   i32.const 1
@@ -8618,6 +8717,6 @@
   call $std/typedarray/testArrayMap<Float32Array,f32>
   call $std/typedarray/testArrayMap<Float64Array,f64>
  )
- (func $null (; 172 ;) (type $v)
+ (func $null (; 174 ;) (type $v)
  )
 )

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -20,6 +20,9 @@
  (type $iif (func (param i32 i32) (result f32)))
  (type $FFiiF (func (param f64 f64 i32 i32) (result f64)))
  (type $iiFF (func (param i32 i32 f64) (result f64)))
+ (type $IiiI (func (param i64 i32 i32) (result i64)))
+ (type $fiif (func (param f32 i32 i32) (result f32)))
+ (type $FiiF (func (param f64 i32 i32) (result f64)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\11\00\00\00s\00t\00d\00/\00t\00y\00p\00e\00d\00a\00r\00r\00a\00y\00.\00t\00s\00")
@@ -53,8 +56,8 @@
  (data (i32.const 576) " \02\00\00\03\00\00\00")
  (data (i32.const 584) "\14\00\00\00\00\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\00\00\00\00")
  (data (i32.const 616) "H\02\00\00\05\00\00\00")
- (table $0 24 anyfunc)
- (elem (i32.const 0) $null $~lib/typedarray/Float64Array#sort|trampoline~anonymous|1 $std/typedarray/reduceInt8ArrayTest~anonymous|2 $std/typedarray/reduceUint8ArrayTest~anonymous|3 $std/typedarray/reduceUint8ClampedArrayTest~anonymous|4 $std/typedarray/reduceInt16ArrayTest~anonymous|5 $std/typedarray/reduceUint16ArrayTest~anonymous|6 $std/typedarray/reduceInt32ArrayTest~anonymous|7 $std/typedarray/reduceUint32ArrayTest~anonymous|8 $std/typedarray/reduceInt64ArrayTest~anonymous|9 $std/typedarray/reduceUint64ArrayTest~anonymous|10 $std/typedarray/reduceFloat32ArrayTest~anonymous|11 $std/typedarray/reduceFloat64ArrayTest~anonymous|12 $std/typedarray/reduceRightInt8ArrayTest~anonymous|13 $std/typedarray/reduceRightUint8ArrayTest~anonymous|14 $std/typedarray/reduceRightUint8ClampedArrayTest~anonymous|15 $std/typedarray/reduceRightInt16ArrayTest~anonymous|16 $std/typedarray/reduceRightUint16ArrayTest~anonymous|17 $std/typedarray/reduceRightInt32ArrayTest~anonymous|18 $std/typedarray/reduceRightUint32ArrayTest~anonymous|19 $std/typedarray/reduceRightInt64ArrayTest~anonymous|20 $std/typedarray/reduceRightUint64ArrayTest~anonymous|21 $std/typedarray/reduceRightFloat32ArrayTest~anonymous|22 $std/typedarray/reduceRightFloat64ArrayTest~anonymous|23)
+ (table $0 35 anyfunc)
+ (elem (i32.const 0) $null $~lib/typedarray/Float64Array#sort|trampoline~anonymous|1 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Uint8Array,u8>~anonymous|3 $std/typedarray/testReduce<Uint8ClampedArray,u8>~anonymous|4 $std/typedarray/testReduce<Int16Array,i16>~anonymous|5 $std/typedarray/testReduce<Uint16Array,u16>~anonymous|6 $std/typedarray/testReduce<Int32Array,i32>~anonymous|7 $std/typedarray/testReduce<Uint32Array,u32>~anonymous|8 $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 $std/typedarray/testReduce<Uint64Array,u64>~anonymous|10 $std/typedarray/testReduce<Float32Array,f32>~anonymous|11 $std/typedarray/testReduce<Float64Array,f64>~anonymous|12 $std/typedarray/testReduceRight<Int8Array,i8>~anonymous|13 $std/typedarray/testReduceRight<Uint8Array,u8>~anonymous|14 $std/typedarray/testReduceRight<Uint8ClampedArray,u8>~anonymous|15 $std/typedarray/testReduceRight<Int16Array,i16>~anonymous|16 $std/typedarray/testReduceRight<Uint16Array,u16>~anonymous|17 $std/typedarray/testReduceRight<Int32Array,i32>~anonymous|18 $std/typedarray/testReduceRight<Uint32Array,u32>~anonymous|19 $std/typedarray/testReduceRight<Int64Array,i64>~anonymous|20 $std/typedarray/testReduceRight<Uint64Array,u64>~anonymous|21 $std/typedarray/testReduceRight<Float32Array,f32>~anonymous|22 $std/typedarray/testReduceRight<Float64Array,f64>~anonymous|23 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Uint8Array,u8>~anonymous|25 $std/typedarray/testArrayMap<Uint8ClampedArray,u8>~anonymous|26 $std/typedarray/testArrayMap<Int16Array,i16>~anonymous|27 $std/typedarray/testArrayMap<Uint16Array,u16>~anonymous|28 $std/typedarray/testArrayMap<Int32Array,i32>~anonymous|29 $std/typedarray/testArrayMap<Uint32Array,u32>~anonymous|30 $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 $std/typedarray/testArrayMap<Uint64Array,u64>~anonymous|32 $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|33 $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|34)
  (global $~lib/typedarray/Int8Array.BYTES_PER_ELEMENT i32 (i32.const 1))
  (global $~lib/typedarray/Uint8Array.BYTES_PER_ELEMENT i32 (i32.const 1))
  (global $~lib/typedarray/Uint8ClampedArray.BYTES_PER_ELEMENT i32 (i32.const 1))
@@ -3373,7 +3376,7 @@
   get_local $3
   call $~lib/typedarray/Int32Array#fill
  )
- (func $std/typedarray/reduceInt8ArrayTest~anonymous|2 (; 43 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 (; 43 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
@@ -3439,7 +3442,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceInt8ArrayTest (; 46 ;) (type $v)
+ (func $std/typedarray/testReduce<Int8Array,i8> (; 46 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -3474,13 +3477,13 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 251
+   i32.const 252
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $std/typedarray/reduceUint8ArrayTest~anonymous|3 (; 47 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Uint8Array,u8>~anonymous|3 (; 47 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
@@ -3546,7 +3549,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceUint8ArrayTest (; 50 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint8Array,u8> (; 50 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -3579,18 +3582,18 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 266
+   i32.const 252
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $std/typedarray/reduceUint8ClampedArrayTest~anonymous|4 (; 51 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Uint8ClampedArray,u8>~anonymous|4 (; 51 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $std/typedarray/reduceUint8ClampedArrayTest (; 52 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint8ClampedArray,u8> (; 52 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -3623,7 +3626,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 281
+   i32.const 252
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -3662,7 +3665,7 @@
   get_local $2
   i32.store16 offset=8
  )
- (func $std/typedarray/reduceInt16ArrayTest~anonymous|5 (; 54 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Int16Array,i16>~anonymous|5 (; 54 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
@@ -3728,7 +3731,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceInt16ArrayTest (; 57 ;) (type $v)
+ (func $std/typedarray/testReduce<Int16Array,i16> (; 57 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -3763,7 +3766,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 296
+   i32.const 252
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -3802,7 +3805,7 @@
   get_local $2
   i32.store16 offset=8
  )
- (func $std/typedarray/reduceUint16ArrayTest~anonymous|6 (; 59 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Uint16Array,u16>~anonymous|6 (; 59 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
@@ -3868,7 +3871,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceUint16ArrayTest (; 62 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint16Array,u16> (; 62 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -3901,13 +3904,13 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 311
+   i32.const 252
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $std/typedarray/reduceInt32ArrayTest~anonymous|7 (; 63 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Int32Array,i32>~anonymous|7 (; 63 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
@@ -3973,7 +3976,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceInt32ArrayTest (; 66 ;) (type $v)
+ (func $std/typedarray/testReduce<Int32Array,i32> (; 66 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4004,7 +4007,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 326
+   i32.const 252
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -4043,7 +4046,7 @@
   get_local $2
   i32.store offset=8
  )
- (func $std/typedarray/reduceUint32ArrayTest~anonymous|8 (; 68 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Uint32Array,u32>~anonymous|8 (; 68 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
@@ -4109,7 +4112,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceUint32ArrayTest (; 71 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint32Array,u32> (; 71 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4140,7 +4143,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 341
+   i32.const 252
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -4179,7 +4182,7 @@
   get_local $2
   i64.store offset=8
  )
- (func $std/typedarray/reduceInt64ArrayTest~anonymous|9 (; 73 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 (; 73 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   get_local $0
   get_local $1
   i64.add
@@ -4245,7 +4248,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceInt64ArrayTest (; 76 ;) (type $v)
+ (func $std/typedarray/testReduce<Int64Array,i64> (; 76 ;) (type $v)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -4276,7 +4279,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 356
+   i32.const 252
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -4315,7 +4318,7 @@
   get_local $2
   i64.store offset=8
  )
- (func $std/typedarray/reduceUint64ArrayTest~anonymous|10 (; 78 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduce<Uint64Array,u64>~anonymous|10 (; 78 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   get_local $0
   get_local $1
   i64.add
@@ -4381,7 +4384,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceUint64ArrayTest (; 81 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint64Array,u64> (; 81 ;) (type $v)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -4412,7 +4415,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 371
+   i32.const 252
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -4451,7 +4454,7 @@
   get_local $2
   f32.store offset=8
  )
- (func $std/typedarray/reduceFloat32ArrayTest~anonymous|11 (; 83 ;) (type $ffiif) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
+ (func $std/typedarray/testReduce<Float32Array,f32>~anonymous|11 (; 83 ;) (type $ffiif) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
   get_local $0
   get_local $1
   f32.add
@@ -4517,7 +4520,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceFloat32ArrayTest (; 86 ;) (type $v)
+ (func $std/typedarray/testReduce<Float32Array,f32> (; 86 ;) (type $v)
   (local $0 i32)
   (local $1 f32)
   i32.const 0
@@ -4548,13 +4551,13 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 386
+   i32.const 252
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $std/typedarray/reduceFloat64ArrayTest~anonymous|12 (; 87 ;) (type $FFiiF) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
+ (func $std/typedarray/testReduce<Float64Array,f64>~anonymous|12 (; 87 ;) (type $FFiiF) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
   get_local $0
   get_local $1
   f64.add
@@ -4620,7 +4623,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceFloat64ArrayTest (; 90 ;) (type $v)
+ (func $std/typedarray/testReduce<Float64Array,f64> (; 90 ;) (type $v)
   (local $0 i32)
   (local $1 f64)
   i32.const 0
@@ -4651,13 +4654,13 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 401
+   i32.const 252
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $std/typedarray/reduceRightInt8ArrayTest~anonymous|13 (; 91 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Int8Array,i8>~anonymous|13 (; 91 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
@@ -4707,7 +4710,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceRightInt8ArrayTest (; 93 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int8Array,i8> (; 93 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4742,13 +4745,13 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 439
+   i32.const 279
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $std/typedarray/reduceRightUint8ArrayTest~anonymous|14 (; 94 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Uint8Array,u8>~anonymous|14 (; 94 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
@@ -4798,7 +4801,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceRightUint8ArrayTest (; 96 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint8Array,u8> (; 96 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4831,18 +4834,18 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 454
+   i32.const 279
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $std/typedarray/reduceRightUint8ClampedArrayTest~anonymous|15 (; 97 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8>~anonymous|15 (; 97 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $std/typedarray/reduceRightUint8ClampedArrayTest (; 98 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8> (; 98 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4875,13 +4878,13 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 469
+   i32.const 279
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $std/typedarray/reduceRightInt16ArrayTest~anonymous|16 (; 99 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Int16Array,i16>~anonymous|16 (; 99 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
@@ -4931,7 +4934,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceRightInt16ArrayTest (; 101 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int16Array,i16> (; 101 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4966,13 +4969,13 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 484
+   i32.const 279
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $std/typedarray/reduceRightUint16ArrayTest~anonymous|17 (; 102 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Uint16Array,u16>~anonymous|17 (; 102 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
@@ -5022,7 +5025,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceRightUint16ArrayTest (; 104 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint16Array,u16> (; 104 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -5055,13 +5058,13 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 499
+   i32.const 279
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $std/typedarray/reduceRightInt32ArrayTest~anonymous|18 (; 105 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Int32Array,i32>~anonymous|18 (; 105 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
@@ -5111,7 +5114,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceRightInt32ArrayTest (; 107 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int32Array,i32> (; 107 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -5142,13 +5145,13 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 514
+   i32.const 279
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $std/typedarray/reduceRightUint32ArrayTest~anonymous|19 (; 108 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Uint32Array,u32>~anonymous|19 (; 108 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
@@ -5198,7 +5201,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceRightUint32ArrayTest (; 110 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint32Array,u32> (; 110 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -5229,13 +5232,13 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 529
+   i32.const 279
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $std/typedarray/reduceRightInt64ArrayTest~anonymous|20 (; 111 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduceRight<Int64Array,i64>~anonymous|20 (; 111 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   get_local $0
   get_local $1
   i64.add
@@ -5285,7 +5288,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceRightInt64ArrayTest (; 113 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int64Array,i64> (; 113 ;) (type $v)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -5316,13 +5319,13 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 544
+   i32.const 279
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $std/typedarray/reduceRightUint64ArrayTest~anonymous|21 (; 114 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduceRight<Uint64Array,u64>~anonymous|21 (; 114 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   get_local $0
   get_local $1
   i64.add
@@ -5372,7 +5375,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceRightUint64ArrayTest (; 116 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint64Array,u64> (; 116 ;) (type $v)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -5403,13 +5406,13 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 559
+   i32.const 279
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $std/typedarray/reduceRightFloat32ArrayTest~anonymous|22 (; 117 ;) (type $ffiif) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
+ (func $std/typedarray/testReduceRight<Float32Array,f32>~anonymous|22 (; 117 ;) (type $ffiif) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
   get_local $0
   get_local $1
   f32.add
@@ -5459,7 +5462,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceRightFloat32ArrayTest (; 119 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Float32Array,f32> (; 119 ;) (type $v)
   (local $0 i32)
   (local $1 f32)
   i32.const 0
@@ -5490,13 +5493,13 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 574
+   i32.const 279
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $std/typedarray/reduceRightFloat64ArrayTest~anonymous|23 (; 120 ;) (type $FFiiF) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
+ (func $std/typedarray/testReduceRight<Float64Array,f64>~anonymous|23 (; 120 ;) (type $FFiiF) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
   get_local $0
   get_local $1
   f64.add
@@ -5546,7 +5549,7 @@
   end
   get_local $2
  )
- (func $std/typedarray/reduceRightFloat64ArrayTest (; 122 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Float64Array,f64> (; 122 ;) (type $v)
   (local $0 i32)
   (local $1 f64)
   i32.const 0
@@ -5577,13 +5580,1832 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 589
+   i32.const 279
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $start (; 123 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 (; 123 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  get_local $0
+  i32.mul
+ )
+ (func $~lib/internal/typedarray/TypedArray<i8>#__unchecked_set (; 124 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
+  get_local $3
+  get_local $1
+  i32.const 0
+  i32.shl
+  i32.add
+  get_local $4
+  i32.add
+  get_local $2
+  i32.store8 offset=8
+ )
+ (func $~lib/typedarray/Int8Array#map (; 125 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  block $~lib/internal/typedarray/TypedArray<i8>#get:length|inlined.12 (result i32)
+   get_local $0
+   i32.load offset=8
+   i32.const 0
+   i32.shr_u
+  end
+  set_local $2
+  i32.const 0
+  get_local $2
+  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  set_local $3
+  i32.const 0
+  set_local $4
+  block $break|0
+   loop $continue|0
+    get_local $4
+    get_local $2
+    i32.lt_s
+    if
+     block
+      block (result i32)
+       get_local $3
+       tee_local $5
+       get_local $4
+       tee_local $6
+       block (result i32)
+        i32.const 3
+        set_global $~argc
+        get_local $0
+        get_local $4
+        call $~lib/internal/typedarray/TypedArray<i8>#__unchecked_get
+        get_local $4
+        get_local $0
+        get_local $1
+        call_indirect (type $iiii)
+       end
+       i32.const 24
+       i32.shl
+       i32.const 24
+       i32.shr_s
+       call $~lib/internal/typedarray/TypedArray<i8>#__unchecked_set
+       get_local $5
+       get_local $6
+       call $~lib/internal/typedarray/TypedArray<i8>#__unchecked_get
+      end
+      drop
+      get_local $4
+      i32.const 1
+      i32.add
+      set_local $4
+     end
+     br $continue|0
+    end
+   end
+  end
+  get_local $3
+ )
+ (func $std/typedarray/testArrayMap<Int8Array,i8> (; 126 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<i8>#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i8>#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i8>#__set
+  get_local $0
+  i32.const 24
+  call $~lib/typedarray/Int8Array#map
+  set_local $1
+  get_local $1
+  i32.const 0
+  call $~lib/internal/typedarray/TypedArray<i8>#__get
+  i32.const 24
+  i32.shl
+  i32.const 24
+  i32.shr_s
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 306
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $1
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<i8>#__get
+  i32.const 24
+  i32.shl
+  i32.const 24
+  i32.shr_s
+  i32.const 4
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 307
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i8>#__get
+  i32.const 24
+  i32.shl
+  i32.const 24
+  i32.shr_s
+  i32.const 9
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 308
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayMap<Uint8Array,u8>~anonymous|25 (; 127 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  get_local $0
+  i32.mul
+ )
+ (func $~lib/internal/typedarray/TypedArray<u8>#__unchecked_set (; 128 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
+  get_local $3
+  get_local $1
+  i32.const 0
+  i32.shl
+  i32.add
+  get_local $4
+  i32.add
+  get_local $2
+  i32.store8 offset=8
+ )
+ (func $~lib/typedarray/Uint8Array#map (; 129 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  block $~lib/internal/typedarray/TypedArray<u8>#get:length|inlined.4 (result i32)
+   get_local $0
+   i32.load offset=8
+   i32.const 0
+   i32.shr_u
+  end
+  set_local $2
+  i32.const 0
+  get_local $2
+  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  set_local $3
+  i32.const 0
+  set_local $4
+  block $break|0
+   loop $continue|0
+    get_local $4
+    get_local $2
+    i32.lt_s
+    if
+     block
+      block (result i32)
+       get_local $3
+       tee_local $5
+       get_local $4
+       tee_local $6
+       block (result i32)
+        i32.const 3
+        set_global $~argc
+        get_local $0
+        get_local $4
+        call $~lib/internal/typedarray/TypedArray<u8>#__unchecked_get
+        get_local $4
+        get_local $0
+        get_local $1
+        call_indirect (type $iiii)
+       end
+       i32.const 255
+       i32.and
+       call $~lib/internal/typedarray/TypedArray<u8>#__unchecked_set
+       get_local $5
+       get_local $6
+       call $~lib/internal/typedarray/TypedArray<u8>#__unchecked_get
+      end
+      drop
+      get_local $4
+      i32.const 1
+      i32.add
+      set_local $4
+     end
+     br $continue|0
+    end
+   end
+  end
+  get_local $3
+ )
+ (func $std/typedarray/testArrayMap<Uint8Array,u8> (; 130 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 25
+  call $~lib/typedarray/Uint8Array#map
+  set_local $1
+  get_local $1
+  i32.const 0
+  call $~lib/internal/typedarray/TypedArray<u8>#__get
+  i32.const 255
+  i32.and
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 306
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $1
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<u8>#__get
+  i32.const 255
+  i32.and
+  i32.const 4
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 307
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u8>#__get
+  i32.const 255
+  i32.and
+  i32.const 9
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 308
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8>~anonymous|26 (; 131 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  get_local $0
+  i32.mul
+ )
+ (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8> (; 132 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/typedarray/Uint8ClampedArray#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/typedarray/Uint8ClampedArray#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/typedarray/Uint8ClampedArray#__set
+  get_local $0
+  i32.const 26
+  call $~lib/typedarray/Uint8Array#map
+  set_local $1
+  get_local $1
+  i32.const 0
+  call $~lib/internal/typedarray/TypedArray<u8>#__get
+  i32.const 255
+  i32.and
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 306
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $1
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<u8>#__get
+  i32.const 255
+  i32.and
+  i32.const 4
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 307
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u8>#__get
+  i32.const 255
+  i32.and
+  i32.const 9
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 308
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayMap<Int16Array,i16>~anonymous|27 (; 133 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  get_local $0
+  i32.mul
+ )
+ (func $~lib/internal/typedarray/TypedArray<i16>#__unchecked_set (; 134 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
+  get_local $3
+  get_local $1
+  i32.const 1
+  i32.shl
+  i32.add
+  get_local $4
+  i32.add
+  get_local $2
+  i32.store16 offset=8
+ )
+ (func $~lib/typedarray/Int16Array#map (; 135 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  block $~lib/internal/typedarray/TypedArray<i16>#get:length|inlined.3 (result i32)
+   get_local $0
+   i32.load offset=8
+   i32.const 1
+   i32.shr_u
+  end
+  set_local $2
+  i32.const 0
+  get_local $2
+  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  set_local $3
+  i32.const 0
+  set_local $4
+  block $break|0
+   loop $continue|0
+    get_local $4
+    get_local $2
+    i32.lt_s
+    if
+     block
+      block (result i32)
+       get_local $3
+       tee_local $5
+       get_local $4
+       tee_local $6
+       block (result i32)
+        i32.const 3
+        set_global $~argc
+        get_local $0
+        get_local $4
+        call $~lib/internal/typedarray/TypedArray<i16>#__unchecked_get
+        get_local $4
+        get_local $0
+        get_local $1
+        call_indirect (type $iiii)
+       end
+       i32.const 16
+       i32.shl
+       i32.const 16
+       i32.shr_s
+       call $~lib/internal/typedarray/TypedArray<i16>#__unchecked_set
+       get_local $5
+       get_local $6
+       call $~lib/internal/typedarray/TypedArray<i16>#__unchecked_get
+      end
+      drop
+      get_local $4
+      i32.const 1
+      i32.add
+      set_local $4
+     end
+     br $continue|0
+    end
+   end
+  end
+  get_local $3
+ )
+ (func $~lib/internal/typedarray/TypedArray<i16>#__get (; 136 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  get_local $1
+  get_local $0
+  i32.load offset=8
+  i32.const 1
+  i32.shr_u
+  i32.ge_u
+  if
+   i32.const 0
+   i32.const 48
+   i32.const 40
+   i32.const 63
+   call $~lib/env/abort
+   unreachable
+  end
+  block $~lib/internal/arraybuffer/LOAD<i16,i16>|inlined.1 (result i32)
+   get_local $0
+   i32.load
+   set_local $2
+   get_local $0
+   i32.load offset=4
+   set_local $3
+   get_local $2
+   get_local $1
+   i32.const 1
+   i32.shl
+   i32.add
+   get_local $3
+   i32.add
+   i32.load16_s offset=8
+  end
+ )
+ (func $std/typedarray/testArrayMap<Int16Array,i16> (; 137 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 27
+  call $~lib/typedarray/Int16Array#map
+  set_local $1
+  get_local $1
+  i32.const 0
+  call $~lib/internal/typedarray/TypedArray<i16>#__get
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.shr_s
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 306
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $1
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<i16>#__get
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.shr_s
+  i32.const 4
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 307
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i16>#__get
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.shr_s
+  i32.const 9
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 308
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayMap<Uint16Array,u16>~anonymous|28 (; 138 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  get_local $0
+  i32.mul
+ )
+ (func $~lib/internal/typedarray/TypedArray<u16>#__unchecked_set (; 139 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
+  get_local $3
+  get_local $1
+  i32.const 1
+  i32.shl
+  i32.add
+  get_local $4
+  i32.add
+  get_local $2
+  i32.store16 offset=8
+ )
+ (func $~lib/typedarray/Uint16Array#map (; 140 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  block $~lib/internal/typedarray/TypedArray<u16>#get:length|inlined.3 (result i32)
+   get_local $0
+   i32.load offset=8
+   i32.const 1
+   i32.shr_u
+  end
+  set_local $2
+  i32.const 0
+  get_local $2
+  call $~lib/internal/typedarray/TypedArray<u16>#constructor
+  set_local $3
+  i32.const 0
+  set_local $4
+  block $break|0
+   loop $continue|0
+    get_local $4
+    get_local $2
+    i32.lt_s
+    if
+     block
+      block (result i32)
+       get_local $3
+       tee_local $5
+       get_local $4
+       tee_local $6
+       block (result i32)
+        i32.const 3
+        set_global $~argc
+        get_local $0
+        get_local $4
+        call $~lib/internal/typedarray/TypedArray<u16>#__unchecked_get
+        get_local $4
+        get_local $0
+        get_local $1
+        call_indirect (type $iiii)
+       end
+       i32.const 65535
+       i32.and
+       call $~lib/internal/typedarray/TypedArray<u16>#__unchecked_set
+       get_local $5
+       get_local $6
+       call $~lib/internal/typedarray/TypedArray<u16>#__unchecked_get
+      end
+      drop
+      get_local $4
+      i32.const 1
+      i32.add
+      set_local $4
+     end
+     br $continue|0
+    end
+   end
+  end
+  get_local $3
+ )
+ (func $~lib/internal/typedarray/TypedArray<u16>#__get (; 141 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  get_local $1
+  get_local $0
+  i32.load offset=8
+  i32.const 1
+  i32.shr_u
+  i32.ge_u
+  if
+   i32.const 0
+   i32.const 48
+   i32.const 40
+   i32.const 63
+   call $~lib/env/abort
+   unreachable
+  end
+  block $~lib/internal/arraybuffer/LOAD<u16,u16>|inlined.1 (result i32)
+   get_local $0
+   i32.load
+   set_local $2
+   get_local $0
+   i32.load offset=4
+   set_local $3
+   get_local $2
+   get_local $1
+   i32.const 1
+   i32.shl
+   i32.add
+   get_local $3
+   i32.add
+   i32.load16_u offset=8
+  end
+ )
+ (func $std/typedarray/testArrayMap<Uint16Array,u16> (; 142 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u16>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<u16>#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u16>#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u16>#__set
+  get_local $0
+  i32.const 28
+  call $~lib/typedarray/Uint16Array#map
+  set_local $1
+  get_local $1
+  i32.const 0
+  call $~lib/internal/typedarray/TypedArray<u16>#__get
+  i32.const 65535
+  i32.and
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 306
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $1
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<u16>#__get
+  i32.const 65535
+  i32.and
+  i32.const 4
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 307
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u16>#__get
+  i32.const 65535
+  i32.and
+  i32.const 9
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 308
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayMap<Int32Array,i32>~anonymous|29 (; 143 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  get_local $0
+  i32.mul
+ )
+ (func $~lib/internal/typedarray/TypedArray<i32>#__unchecked_set (; 144 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
+  get_local $3
+  get_local $1
+  i32.const 2
+  i32.shl
+  i32.add
+  get_local $4
+  i32.add
+  get_local $2
+  i32.store offset=8
+ )
+ (func $~lib/typedarray/Int32Array#map (; 145 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  block $~lib/internal/typedarray/TypedArray<i32>#get:length|inlined.11 (result i32)
+   get_local $0
+   i32.load offset=8
+   i32.const 2
+   i32.shr_u
+  end
+  set_local $2
+  i32.const 0
+  get_local $2
+  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  set_local $3
+  i32.const 0
+  set_local $4
+  block $break|0
+   loop $continue|0
+    get_local $4
+    get_local $2
+    i32.lt_s
+    if
+     block
+      block (result i32)
+       get_local $3
+       tee_local $5
+       get_local $4
+       tee_local $6
+       block (result i32)
+        i32.const 3
+        set_global $~argc
+        get_local $0
+        get_local $4
+        call $~lib/internal/typedarray/TypedArray<i32>#__unchecked_get
+        get_local $4
+        get_local $0
+        get_local $1
+        call_indirect (type $iiii)
+       end
+       call $~lib/internal/typedarray/TypedArray<i32>#__unchecked_set
+       get_local $5
+       get_local $6
+       call $~lib/internal/typedarray/TypedArray<i32>#__unchecked_get
+      end
+      drop
+      get_local $4
+      i32.const 1
+      i32.add
+      set_local $4
+     end
+     br $continue|0
+    end
+   end
+  end
+  get_local $3
+ )
+ (func $std/typedarray/testArrayMap<Int32Array,i32> (; 146 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 29
+  call $~lib/typedarray/Int32Array#map
+  set_local $1
+  get_local $1
+  i32.const 0
+  call $~lib/internal/typedarray/TypedArray<i32>#__get
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 306
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $1
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<i32>#__get
+  i32.const 4
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 307
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i32>#__get
+  i32.const 9
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 308
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayMap<Uint32Array,u32>~anonymous|30 (; 147 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  get_local $0
+  i32.mul
+ )
+ (func $~lib/internal/typedarray/TypedArray<u32>#__unchecked_set (; 148 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
+  get_local $3
+  get_local $1
+  i32.const 2
+  i32.shl
+  i32.add
+  get_local $4
+  i32.add
+  get_local $2
+  i32.store offset=8
+ )
+ (func $~lib/typedarray/Uint32Array#map (; 149 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  block $~lib/internal/typedarray/TypedArray<u32>#get:length|inlined.3 (result i32)
+   get_local $0
+   i32.load offset=8
+   i32.const 2
+   i32.shr_u
+  end
+  set_local $2
+  i32.const 0
+  get_local $2
+  call $~lib/internal/typedarray/TypedArray<u32>#constructor
+  set_local $3
+  i32.const 0
+  set_local $4
+  block $break|0
+   loop $continue|0
+    get_local $4
+    get_local $2
+    i32.lt_s
+    if
+     block
+      block (result i32)
+       get_local $3
+       tee_local $5
+       get_local $4
+       tee_local $6
+       block (result i32)
+        i32.const 3
+        set_global $~argc
+        get_local $0
+        get_local $4
+        call $~lib/internal/typedarray/TypedArray<u32>#__unchecked_get
+        get_local $4
+        get_local $0
+        get_local $1
+        call_indirect (type $iiii)
+       end
+       call $~lib/internal/typedarray/TypedArray<u32>#__unchecked_set
+       get_local $5
+       get_local $6
+       call $~lib/internal/typedarray/TypedArray<u32>#__unchecked_get
+      end
+      drop
+      get_local $4
+      i32.const 1
+      i32.add
+      set_local $4
+     end
+     br $continue|0
+    end
+   end
+  end
+  get_local $3
+ )
+ (func $~lib/internal/typedarray/TypedArray<u32>#__get (; 150 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  get_local $1
+  get_local $0
+  i32.load offset=8
+  i32.const 2
+  i32.shr_u
+  i32.ge_u
+  if
+   i32.const 0
+   i32.const 48
+   i32.const 40
+   i32.const 63
+   call $~lib/env/abort
+   unreachable
+  end
+  block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.1 (result i32)
+   get_local $0
+   i32.load
+   set_local $2
+   get_local $0
+   i32.load offset=4
+   set_local $3
+   get_local $2
+   get_local $1
+   i32.const 2
+   i32.shl
+   i32.add
+   get_local $3
+   i32.add
+   i32.load offset=8
+  end
+ )
+ (func $std/typedarray/testArrayMap<Uint32Array,u32> (; 151 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u32>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<u32>#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u32>#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u32>#__set
+  get_local $0
+  i32.const 30
+  call $~lib/typedarray/Uint32Array#map
+  set_local $1
+  get_local $1
+  i32.const 0
+  call $~lib/internal/typedarray/TypedArray<u32>#__get
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 306
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $1
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<u32>#__get
+  i32.const 4
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 307
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u32>#__get
+  i32.const 9
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 308
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 (; 152 ;) (type $IiiI) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+  get_local $0
+  get_local $0
+  i64.mul
+ )
+ (func $~lib/internal/typedarray/TypedArray<i64>#__unchecked_set (; 153 ;) (type $iiIv) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local $4 i32)
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
+  get_local $3
+  get_local $1
+  i32.const 3
+  i32.shl
+  i32.add
+  get_local $4
+  i32.add
+  get_local $2
+  i64.store offset=8
+ )
+ (func $~lib/typedarray/Int64Array#map (; 154 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  block $~lib/internal/typedarray/TypedArray<i64>#get:length|inlined.3 (result i32)
+   get_local $0
+   i32.load offset=8
+   i32.const 3
+   i32.shr_u
+  end
+  set_local $2
+  i32.const 0
+  get_local $2
+  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  set_local $3
+  i32.const 0
+  set_local $4
+  block $break|0
+   loop $continue|0
+    get_local $4
+    get_local $2
+    i32.lt_s
+    if
+     block
+      block (result i64)
+       get_local $3
+       tee_local $5
+       get_local $4
+       tee_local $6
+       block (result i64)
+        i32.const 3
+        set_global $~argc
+        get_local $0
+        get_local $4
+        call $~lib/internal/typedarray/TypedArray<i64>#__unchecked_get
+        get_local $4
+        get_local $0
+        get_local $1
+        call_indirect (type $IiiI)
+       end
+       call $~lib/internal/typedarray/TypedArray<i64>#__unchecked_set
+       get_local $5
+       get_local $6
+       call $~lib/internal/typedarray/TypedArray<i64>#__unchecked_get
+      end
+      drop
+      get_local $4
+      i32.const 1
+      i32.add
+      set_local $4
+     end
+     br $continue|0
+    end
+   end
+  end
+  get_local $3
+ )
+ (func $~lib/internal/typedarray/TypedArray<i64>#__get (; 155 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local $3 i32)
+  get_local $1
+  get_local $0
+  i32.load offset=8
+  i32.const 3
+  i32.shr_u
+  i32.ge_u
+  if
+   i32.const 0
+   i32.const 48
+   i32.const 40
+   i32.const 63
+   call $~lib/env/abort
+   unreachable
+  end
+  block $~lib/internal/arraybuffer/LOAD<i64,i64>|inlined.1 (result i64)
+   get_local $0
+   i32.load
+   set_local $2
+   get_local $0
+   i32.load offset=4
+   set_local $3
+   get_local $2
+   get_local $1
+   i32.const 3
+   i32.shl
+   i32.add
+   get_local $3
+   i32.add
+   i64.load offset=8
+  end
+ )
+ (func $std/typedarray/testArrayMap<Int64Array,i64> (; 156 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i64.const 1
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 1
+  i64.const 2
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 2
+  i64.const 3
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 31
+  call $~lib/typedarray/Int64Array#map
+  set_local $1
+  get_local $1
+  i32.const 0
+  call $~lib/internal/typedarray/TypedArray<i64>#__get
+  i64.const 1
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 306
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $1
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<i64>#__get
+  i64.const 4
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 307
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i64>#__get
+  i64.const 9
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 308
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayMap<Uint64Array,u64>~anonymous|32 (; 157 ;) (type $IiiI) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+  get_local $0
+  get_local $0
+  i64.mul
+ )
+ (func $~lib/internal/typedarray/TypedArray<u64>#__unchecked_set (; 158 ;) (type $iiIv) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local $4 i32)
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
+  get_local $3
+  get_local $1
+  i32.const 3
+  i32.shl
+  i32.add
+  get_local $4
+  i32.add
+  get_local $2
+  i64.store offset=8
+ )
+ (func $~lib/typedarray/Uint64Array#map (; 159 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  block $~lib/internal/typedarray/TypedArray<u64>#get:length|inlined.3 (result i32)
+   get_local $0
+   i32.load offset=8
+   i32.const 3
+   i32.shr_u
+  end
+  set_local $2
+  i32.const 0
+  get_local $2
+  call $~lib/internal/typedarray/TypedArray<u64>#constructor
+  set_local $3
+  i32.const 0
+  set_local $4
+  block $break|0
+   loop $continue|0
+    get_local $4
+    get_local $2
+    i32.lt_s
+    if
+     block
+      block (result i64)
+       get_local $3
+       tee_local $5
+       get_local $4
+       tee_local $6
+       block (result i64)
+        i32.const 3
+        set_global $~argc
+        get_local $0
+        get_local $4
+        call $~lib/internal/typedarray/TypedArray<u64>#__unchecked_get
+        get_local $4
+        get_local $0
+        get_local $1
+        call_indirect (type $IiiI)
+       end
+       call $~lib/internal/typedarray/TypedArray<u64>#__unchecked_set
+       get_local $5
+       get_local $6
+       call $~lib/internal/typedarray/TypedArray<u64>#__unchecked_get
+      end
+      drop
+      get_local $4
+      i32.const 1
+      i32.add
+      set_local $4
+     end
+     br $continue|0
+    end
+   end
+  end
+  get_local $3
+ )
+ (func $~lib/internal/typedarray/TypedArray<u64>#__get (; 160 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local $3 i32)
+  get_local $1
+  get_local $0
+  i32.load offset=8
+  i32.const 3
+  i32.shr_u
+  i32.ge_u
+  if
+   i32.const 0
+   i32.const 48
+   i32.const 40
+   i32.const 63
+   call $~lib/env/abort
+   unreachable
+  end
+  block $~lib/internal/arraybuffer/LOAD<u64,u64>|inlined.1 (result i64)
+   get_local $0
+   i32.load
+   set_local $2
+   get_local $0
+   i32.load offset=4
+   set_local $3
+   get_local $2
+   get_local $1
+   i32.const 3
+   i32.shl
+   i32.add
+   get_local $3
+   i32.add
+   i64.load offset=8
+  end
+ )
+ (func $std/typedarray/testArrayMap<Uint64Array,u64> (; 161 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u64>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i64.const 1
+  call $~lib/internal/typedarray/TypedArray<u64>#__set
+  get_local $0
+  i32.const 1
+  i64.const 2
+  call $~lib/internal/typedarray/TypedArray<u64>#__set
+  get_local $0
+  i32.const 2
+  i64.const 3
+  call $~lib/internal/typedarray/TypedArray<u64>#__set
+  get_local $0
+  i32.const 32
+  call $~lib/typedarray/Uint64Array#map
+  set_local $1
+  get_local $1
+  i32.const 0
+  call $~lib/internal/typedarray/TypedArray<u64>#__get
+  i64.const 1
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 306
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $1
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<u64>#__get
+  i64.const 4
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 307
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u64>#__get
+  i64.const 9
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 308
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|33 (; 162 ;) (type $fiif) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
+  get_local $0
+  get_local $0
+  f32.mul
+ )
+ (func $~lib/internal/typedarray/TypedArray<f32>#__unchecked_set (; 163 ;) (type $iifv) (param $0 i32) (param $1 i32) (param $2 f32)
+  (local $3 i32)
+  (local $4 i32)
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
+  get_local $3
+  get_local $1
+  i32.const 2
+  i32.shl
+  i32.add
+  get_local $4
+  i32.add
+  get_local $2
+  f32.store offset=8
+ )
+ (func $~lib/typedarray/Float32Array#map (; 164 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  block $~lib/internal/typedarray/TypedArray<f32>#get:length|inlined.3 (result i32)
+   get_local $0
+   i32.load offset=8
+   i32.const 2
+   i32.shr_u
+  end
+  set_local $2
+  i32.const 0
+  get_local $2
+  call $~lib/internal/typedarray/TypedArray<f32>#constructor
+  set_local $3
+  i32.const 0
+  set_local $4
+  block $break|0
+   loop $continue|0
+    get_local $4
+    get_local $2
+    i32.lt_s
+    if
+     block
+      block (result f32)
+       get_local $3
+       tee_local $5
+       get_local $4
+       tee_local $6
+       block (result f32)
+        i32.const 3
+        set_global $~argc
+        get_local $0
+        get_local $4
+        call $~lib/internal/typedarray/TypedArray<f32>#__unchecked_get
+        get_local $4
+        get_local $0
+        get_local $1
+        call_indirect (type $fiif)
+       end
+       call $~lib/internal/typedarray/TypedArray<f32>#__unchecked_set
+       get_local $5
+       get_local $6
+       call $~lib/internal/typedarray/TypedArray<f32>#__unchecked_get
+      end
+      drop
+      get_local $4
+      i32.const 1
+      i32.add
+      set_local $4
+     end
+     br $continue|0
+    end
+   end
+  end
+  get_local $3
+ )
+ (func $~lib/internal/typedarray/TypedArray<f32>#__get (; 165 ;) (type $iif) (param $0 i32) (param $1 i32) (result f32)
+  (local $2 i32)
+  (local $3 i32)
+  get_local $1
+  get_local $0
+  i32.load offset=8
+  i32.const 2
+  i32.shr_u
+  i32.ge_u
+  if
+   i32.const 0
+   i32.const 48
+   i32.const 40
+   i32.const 63
+   call $~lib/env/abort
+   unreachable
+  end
+  block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.1 (result f32)
+   get_local $0
+   i32.load
+   set_local $2
+   get_local $0
+   i32.load offset=4
+   set_local $3
+   get_local $2
+   get_local $1
+   i32.const 2
+   i32.shl
+   i32.add
+   get_local $3
+   i32.add
+   f32.load offset=8
+  end
+ )
+ (func $std/typedarray/testArrayMap<Float32Array,f32> (; 166 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<f32>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  f32.const 1
+  call $~lib/internal/typedarray/TypedArray<f32>#__set
+  get_local $0
+  i32.const 1
+  f32.const 2
+  call $~lib/internal/typedarray/TypedArray<f32>#__set
+  get_local $0
+  i32.const 2
+  f32.const 3
+  call $~lib/internal/typedarray/TypedArray<f32>#__set
+  get_local $0
+  i32.const 33
+  call $~lib/typedarray/Float32Array#map
+  set_local $1
+  get_local $1
+  i32.const 0
+  call $~lib/internal/typedarray/TypedArray<f32>#__get
+  f32.const 1
+  f32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 306
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $1
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<f32>#__get
+  f32.const 4
+  f32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 307
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<f32>#__get
+  f32.const 9
+  f32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 308
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|34 (; 167 ;) (type $FiiF) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
+  get_local $0
+  get_local $0
+  f64.mul
+ )
+ (func $~lib/internal/typedarray/TypedArray<f64>#__unchecked_set (; 168 ;) (type $iiFv) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (local $4 i32)
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
+  get_local $3
+  get_local $1
+  i32.const 3
+  i32.shl
+  i32.add
+  get_local $4
+  i32.add
+  get_local $2
+  f64.store offset=8
+ )
+ (func $~lib/typedarray/Float64Array#map (; 169 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  block $~lib/internal/typedarray/TypedArray<f64>#get:length|inlined.6 (result i32)
+   get_local $0
+   i32.load offset=8
+   i32.const 3
+   i32.shr_u
+  end
+  set_local $2
+  i32.const 0
+  get_local $2
+  call $~lib/internal/typedarray/TypedArray<f64>#constructor
+  set_local $3
+  i32.const 0
+  set_local $4
+  block $break|0
+   loop $continue|0
+    get_local $4
+    get_local $2
+    i32.lt_s
+    if
+     block
+      block (result f64)
+       get_local $3
+       tee_local $5
+       get_local $4
+       tee_local $6
+       block (result f64)
+        i32.const 3
+        set_global $~argc
+        get_local $0
+        get_local $4
+        call $~lib/internal/typedarray/TypedArray<f64>#__unchecked_get
+        get_local $4
+        get_local $0
+        get_local $1
+        call_indirect (type $FiiF)
+       end
+       call $~lib/internal/typedarray/TypedArray<f64>#__unchecked_set
+       get_local $5
+       get_local $6
+       call $~lib/internal/typedarray/TypedArray<f64>#__unchecked_get
+      end
+      drop
+      get_local $4
+      i32.const 1
+      i32.add
+      set_local $4
+     end
+     br $continue|0
+    end
+   end
+  end
+  get_local $3
+ )
+ (func $std/typedarray/testArrayMap<Float64Array,f64> (; 170 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<f64>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  f64.const 1
+  call $~lib/internal/typedarray/TypedArray<f64>#__set
+  get_local $0
+  i32.const 1
+  f64.const 2
+  call $~lib/internal/typedarray/TypedArray<f64>#__set
+  get_local $0
+  i32.const 2
+  f64.const 3
+  call $~lib/internal/typedarray/TypedArray<f64>#__set
+  get_local $0
+  i32.const 34
+  call $~lib/typedarray/Float64Array#map
+  set_local $1
+  get_local $1
+  i32.const 0
+  call $~lib/internal/typedarray/TypedArray<f64>#__get
+  f64.const 1
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 306
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $1
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<f64>#__get
+  f64.const 4
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 307
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<f64>#__get
+  f64.const 9
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 308
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $start (; 171 ;) (type $v)
   (local $0 i32)
   get_global $~lib/typedarray/Int8Array.BYTES_PER_ELEMENT
   i32.const 1
@@ -6762,29 +8584,40 @@
    call $~lib/env/abort
    unreachable
   end
-  call $std/typedarray/reduceInt8ArrayTest
-  call $std/typedarray/reduceUint8ArrayTest
-  call $std/typedarray/reduceUint8ClampedArrayTest
-  call $std/typedarray/reduceInt16ArrayTest
-  call $std/typedarray/reduceUint16ArrayTest
-  call $std/typedarray/reduceInt32ArrayTest
-  call $std/typedarray/reduceUint32ArrayTest
-  call $std/typedarray/reduceInt64ArrayTest
-  call $std/typedarray/reduceUint64ArrayTest
-  call $std/typedarray/reduceFloat32ArrayTest
-  call $std/typedarray/reduceFloat64ArrayTest
-  call $std/typedarray/reduceRightInt8ArrayTest
-  call $std/typedarray/reduceRightUint8ArrayTest
-  call $std/typedarray/reduceRightUint8ClampedArrayTest
-  call $std/typedarray/reduceRightInt16ArrayTest
-  call $std/typedarray/reduceRightUint16ArrayTest
-  call $std/typedarray/reduceRightInt32ArrayTest
-  call $std/typedarray/reduceRightUint32ArrayTest
-  call $std/typedarray/reduceRightInt64ArrayTest
-  call $std/typedarray/reduceRightUint64ArrayTest
-  call $std/typedarray/reduceRightFloat32ArrayTest
-  call $std/typedarray/reduceRightFloat64ArrayTest
+  call $std/typedarray/testReduce<Int8Array,i8>
+  call $std/typedarray/testReduce<Uint8Array,u8>
+  call $std/typedarray/testReduce<Uint8ClampedArray,u8>
+  call $std/typedarray/testReduce<Int16Array,i16>
+  call $std/typedarray/testReduce<Uint16Array,u16>
+  call $std/typedarray/testReduce<Int32Array,i32>
+  call $std/typedarray/testReduce<Uint32Array,u32>
+  call $std/typedarray/testReduce<Int64Array,i64>
+  call $std/typedarray/testReduce<Uint64Array,u64>
+  call $std/typedarray/testReduce<Float32Array,f32>
+  call $std/typedarray/testReduce<Float64Array,f64>
+  call $std/typedarray/testReduceRight<Int8Array,i8>
+  call $std/typedarray/testReduceRight<Uint8Array,u8>
+  call $std/typedarray/testReduceRight<Uint8ClampedArray,u8>
+  call $std/typedarray/testReduceRight<Int16Array,i16>
+  call $std/typedarray/testReduceRight<Uint16Array,u16>
+  call $std/typedarray/testReduceRight<Int32Array,i32>
+  call $std/typedarray/testReduceRight<Uint32Array,u32>
+  call $std/typedarray/testReduceRight<Int64Array,i64>
+  call $std/typedarray/testReduceRight<Uint64Array,u64>
+  call $std/typedarray/testReduceRight<Float32Array,f32>
+  call $std/typedarray/testReduceRight<Float64Array,f64>
+  call $std/typedarray/testArrayMap<Int8Array,i8>
+  call $std/typedarray/testArrayMap<Uint8Array,u8>
+  call $std/typedarray/testArrayMap<Uint8ClampedArray,u8>
+  call $std/typedarray/testArrayMap<Int16Array,i16>
+  call $std/typedarray/testArrayMap<Uint16Array,u16>
+  call $std/typedarray/testArrayMap<Int32Array,i32>
+  call $std/typedarray/testArrayMap<Uint32Array,u32>
+  call $std/typedarray/testArrayMap<Int64Array,i64>
+  call $std/typedarray/testArrayMap<Uint64Array,u64>
+  call $std/typedarray/testArrayMap<Float32Array,f32>
+  call $std/typedarray/testArrayMap<Float64Array,f64>
  )
- (func $null (; 124 ;) (type $v)
+ (func $null (; 172 ;) (type $v)
  )
 )


### PR DESCRIPTION
This pull request implements the `TypedArray.prototype.map` method and cleans up the test suite, reducing  the number of lines in the `tests/compiler/std/typedarray.ts` file by 50%!

Any comments are enouraged.

Thanks for the heads up @dcodeIO.