### PR TITLE
implement array#flat

### DIFF
--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -585,6 +585,42 @@ export class Array<T> {
     return this.join();
   }
 
+  flat<U>(): Array<U> {
+    if (!isArray<T>()) {
+      throw new Error("Cannot call flat on array whose children are not an array type.");
+    }
+    var count: i32 = 0;
+    var i: i32 = 0;
+    var j: i32;
+    var length: i32 = this.length_;
+    var sublength: i32;
+    var child: Array<U>;
+
+    // reduce length to a single sum
+    while (i < length) {
+      unchecked(child = <Array<U>>this[i]); // safe because we know the length
+      count += child.length_;
+      ++i;
+    }
+    var result: Array<U> = new Array<U>(count);
+
+    // use count as target result index
+    i = 0;
+    count = 0;
+    while (i < length) {
+      j = 0;
+      unchecked(child = <Array<U>>this[i]); // safe because we know the length
+      sublength = child.length_;
+      while (j < sublength) {
+        unchecked(result[count] = child[j]); // safe because we know the length
+        ++count;
+        ++j;
+      }
+      ++i;
+    }
+    return result;
+  }
+
   private __gc(): void {
     var buffer = this.buffer_;
     __gc_mark(changetype<usize>(buffer)); // tslint:disable-line

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -590,6 +590,7 @@ declare class Array<T> {
   splice(start: i32, deleteCount?: i32): Array<T>;
   sort(comparator?: (a: T, b: T) => i32): this;
   join(separator?: string): string;
+  flat<U>(): Array<U>;
   reverse(): T[];
   toString(): string;
 }

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -335,6 +335,14 @@
  (data (i32.const 8320) "p \00\00\01")
  (data (i32.const 8328) "\04\00\00\00\00\00\00\00\80 ")
  (data (i32.const 8344) "\88 \00\00\01")
+ (data (i32.const 8352) "\03\00\00\00\00\00\00\00\01\02\03")
+ (data (i32.const 8368) "\a0 \00\00\03")
+ (data (i32.const 8376) "\02\00\00\00\00\00\00\00\04\05")
+ (data (i32.const 8392) "\b8 \00\00\02")
+ (data (i32.const 8400) "\04\00\00\00\00\00\00\00\06\07\08\t")
+ (data (i32.const 8416) "\d0 \00\00\04")
+ (data (i32.const 8424) "\0c\00\00\00\00\00\00\00\b0 \00\00\c8 \00\00\e0 ")
+ (data (i32.const 8456) "\e8 \00\00\03")
  (table $0 56 anyfunc)
  (elem (i32.const 0) $null $start~anonymous|1 $start~anonymous|2 $start~anonymous|3 $start~anonymous|4 $start~anonymous|3 $start~anonymous|6 $start~anonymous|7 $start~anonymous|8 $start~anonymous|9 $start~anonymous|10 $start~anonymous|11 $start~anonymous|12 $start~anonymous|13 $start~anonymous|14 $start~anonymous|15 $start~anonymous|16 $start~anonymous|17 $start~anonymous|18 $start~anonymous|17 $start~anonymous|20 $start~anonymous|21 $start~anonymous|22 $start~anonymous|23 $start~anonymous|24 $start~anonymous|25 $start~anonymous|26 $start~anonymous|27 $start~anonymous|28 $start~anonymous|29 $start~anonymous|29 $start~anonymous|31 $start~anonymous|32 $start~anonymous|33 $start~anonymous|29 $start~anonymous|35 $start~anonymous|29 $start~anonymous|29 $start~anonymous|31 $start~anonymous|32 $start~anonymous|33 $start~anonymous|29 $start~anonymous|35 $~lib/array/Array<f32>#sort|trampoline~anonymous|43 $~lib/array/Array<f64>#sort|trampoline~anonymous|44 $~lib/array/Array<i32>#sort|trampoline~anonymous|45 $~lib/array/Array<u32>#sort|trampoline~anonymous|46 $~lib/array/Array<i32>#sort|trampoline~anonymous|45 $~lib/array/Array<i32>#sort|trampoline~anonymous|45 $start~anonymous|49 $~lib/array/Array<i32>#sort|trampoline~anonymous|45 $start~anonymous|49 $start~anonymous|52 $start~anonymous|53 $start~anonymous|54 $start~anonymous|54)
  (global $~lib/allocator/arena/startOffset (mut i32) (i32.const 0))
@@ -392,6 +400,8 @@
  (global $std/array/subarr32 (mut i32) (i32.const 8176))
  (global $std/array/subarr8 (mut i32) (i32.const 8272))
  (global $std/array/subarrU32 (mut i32) (i32.const 8344))
+ (global $std/array/flattest (mut i32) (i32.const 8456))
+ (global $std/array/flattestresult (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
@@ -9974,10 +9984,148 @@
   end
   get_local $1
  )
- (func $start (; 146 ;) (type $v)
+ (func $~lib/array/Array<u8>#constructor (; 146 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  get_local $0
+  i32.const 1073741816
+  i32.gt_u
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 45
+   i32.const 39
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  call $~lib/internal/arraybuffer/allocateUnsafe
+  set_local $2
+  i32.const 8
+  call $~lib/allocator/arena/__memory_allocate
+  tee_local $1
+  i32.const 0
+  i32.store
+  get_local $1
+  i32.const 0
+  i32.store offset=4
+  get_local $1
+  get_local $2
+  i32.store
+  get_local $1
+  get_local $0
+  i32.store offset=4
+  get_local $2
+  i32.const 8
+  i32.add
+  i32.const 0
+  get_local $0
+  call $~lib/internal/memory/memset
+  get_local $1
+ )
+ (func $~lib/array/Array<Array<u8>>#flat<u8> (; 147 ;) (type $ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  get_local $0
+  i32.load offset=4
+  set_local $5
+  loop $continue|0
+   get_local $1
+   get_local $5
+   i32.lt_s
+   if
+    get_local $0
+    i32.load
+    get_local $1
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load offset=8
+    i32.load offset=4
+    get_local $2
+    i32.add
+    set_local $2
+    get_local $1
+    i32.const 1
+    i32.add
+    set_local $1
+    br $continue|0
+   end
+  end
+  get_local $2
+  call $~lib/array/Array<u8>#constructor
+  set_local $4
+  i32.const 0
+  set_local $1
+  i32.const 0
+  set_local $2
+  loop $continue|1
+   get_local $1
+   get_local $5
+   i32.lt_s
+   if
+    i32.const 0
+    set_local $3
+    get_local $0
+    i32.load
+    get_local $1
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load offset=8
+    tee_local $6
+    i32.load offset=4
+    set_local $7
+    loop $continue|2
+     get_local $3
+     get_local $7
+     i32.lt_s
+     if
+      get_local $4
+      i32.load
+      get_local $2
+      i32.add
+      get_local $6
+      i32.load
+      get_local $3
+      i32.add
+      i32.load8_u offset=8
+      i32.store8 offset=8
+      get_local $4
+      i32.load
+      get_local $2
+      i32.add
+      i32.load8_u offset=8
+      drop
+      get_local $2
+      i32.const 1
+      i32.add
+      set_local $2
+      get_local $3
+      i32.const 1
+      i32.add
+      set_local $3
+      br $continue|2
+     end
+    end
+    get_local $1
+    i32.const 1
+    i32.add
+    set_local $1
+    br $continue|1
+   end
+  end
+  get_local $4
+ )
+ (func $start (; 148 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
-  i32.const 8352
+  i32.const 8464
   set_global $~lib/allocator/arena/startOffset
   get_global $~lib/allocator/arena/startOffset
   set_global $~lib/allocator/arena/offset
@@ -14413,8 +14561,264 @@
    call $~lib/env/abort
    unreachable
   end
+  get_global $std/array/flattest
+  call $~lib/array/Array<Array<u8>>#flat<u8>
+  set_global $std/array/flattestresult
+  get_global $std/array/flattestresult
+  i32.load offset=4
+  i32.const 9
+  i32.ne
+  if
+   i32.const 0
+   i32.const 104
+   i32.const 921
+   i32.const 0
+   call $~lib/env/abort
+   unreachable
+  end
+  i32.const 0
+  get_global $std/array/flattestresult
+  i32.load
+  tee_local $0
+  i32.load
+  i32.lt_u
+  if (result i32)
+   get_local $0
+   i32.load8_u offset=8
+  else   
+   unreachable
+  end
+  tee_local $0
+  i32.const 255
+  i32.and
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 104
+   i32.const 922
+   i32.const 0
+   call $~lib/env/abort
+   unreachable
+  end
+  i32.const 1
+  get_global $std/array/flattestresult
+  i32.load
+  tee_local $0
+  i32.load
+  i32.lt_u
+  if (result i32)
+   get_local $0
+   i32.const 1
+   i32.add
+   i32.load8_u offset=8
+  else   
+   unreachable
+  end
+  tee_local $0
+  i32.const 255
+  i32.and
+  i32.const 2
+  i32.ne
+  if
+   i32.const 0
+   i32.const 104
+   i32.const 923
+   i32.const 0
+   call $~lib/env/abort
+   unreachable
+  end
+  i32.const 2
+  get_global $std/array/flattestresult
+  i32.load
+  tee_local $0
+  i32.load
+  i32.lt_u
+  if (result i32)
+   get_local $0
+   i32.const 2
+   i32.add
+   i32.load8_u offset=8
+  else   
+   unreachable
+  end
+  tee_local $0
+  i32.const 255
+  i32.and
+  i32.const 3
+  i32.ne
+  if
+   i32.const 0
+   i32.const 104
+   i32.const 924
+   i32.const 0
+   call $~lib/env/abort
+   unreachable
+  end
+  i32.const 3
+  get_global $std/array/flattestresult
+  i32.load
+  tee_local $0
+  i32.load
+  i32.lt_u
+  if (result i32)
+   get_local $0
+   i32.const 3
+   i32.add
+   i32.load8_u offset=8
+  else   
+   unreachable
+  end
+  tee_local $0
+  i32.const 255
+  i32.and
+  i32.const 4
+  i32.ne
+  if
+   i32.const 0
+   i32.const 104
+   i32.const 925
+   i32.const 0
+   call $~lib/env/abort
+   unreachable
+  end
+  i32.const 4
+  get_global $std/array/flattestresult
+  i32.load
+  tee_local $0
+  i32.load
+  i32.lt_u
+  if (result i32)
+   get_local $0
+   i32.const 4
+   i32.add
+   i32.load8_u offset=8
+  else   
+   unreachable
+  end
+  tee_local $0
+  i32.const 255
+  i32.and
+  i32.const 5
+  i32.ne
+  if
+   i32.const 0
+   i32.const 104
+   i32.const 926
+   i32.const 0
+   call $~lib/env/abort
+   unreachable
+  end
+  i32.const 5
+  get_global $std/array/flattestresult
+  i32.load
+  tee_local $0
+  i32.load
+  i32.lt_u
+  if (result i32)
+   get_local $0
+   i32.const 5
+   i32.add
+   i32.load8_u offset=8
+  else   
+   unreachable
+  end
+  tee_local $0
+  i32.const 255
+  i32.and
+  i32.const 6
+  i32.ne
+  if
+   i32.const 0
+   i32.const 104
+   i32.const 927
+   i32.const 0
+   call $~lib/env/abort
+   unreachable
+  end
+  i32.const 6
+  get_global $std/array/flattestresult
+  i32.load
+  tee_local $0
+  i32.load
+  i32.lt_u
+  if (result i32)
+   get_local $0
+   i32.const 6
+   i32.add
+   i32.load8_u offset=8
+  else   
+   unreachable
+  end
+  tee_local $0
+  i32.const 255
+  i32.and
+  i32.const 7
+  i32.ne
+  if
+   i32.const 0
+   i32.const 104
+   i32.const 928
+   i32.const 0
+   call $~lib/env/abort
+   unreachable
+  end
+  i32.const 7
+  get_global $std/array/flattestresult
+  i32.load
+  tee_local $0
+  i32.load
+  i32.lt_u
+  if (result i32)
+   get_local $0
+   i32.const 7
+   i32.add
+   i32.load8_u offset=8
+  else   
+   unreachable
+  end
+  tee_local $0
+  i32.const 255
+  i32.and
+  i32.const 8
+  i32.ne
+  if
+   i32.const 0
+   i32.const 104
+   i32.const 929
+   i32.const 0
+   call $~lib/env/abort
+   unreachable
+  end
+  i32.const 8
+  get_global $std/array/flattestresult
+  i32.load
+  tee_local $0
+  i32.load
+  i32.lt_u
+  if (result i32)
+   get_local $0
+   i32.const 8
+   i32.add
+   i32.load8_u offset=8
+  else   
+   unreachable
+  end
+  tee_local $0
+  i32.const 255
+  i32.and
+  i32.const 9
+  i32.ne
+  if
+   i32.const 0
+   i32.const 104
+   i32.const 930
+   i32.const 0
+   call $~lib/env/abort
+   unreachable
+  end
  )
- (func $null (; 147 ;) (type $v)
+ (func $null (; 149 ;) (type $v)
   nop
  )
 )

--- a/tests/compiler/std/array.ts
+++ b/tests/compiler/std/array.ts
@@ -908,3 +908,23 @@ assert(subarr8.toString() == "1,2,3,4");
 
 var subarrU32: u32[][][] = [[[1]]];
 assert(subarrU32.toString() == "1");
+
+// Array#flat //////////////////////////////////////////////////////////////////////////////////////
+
+var flattest: u8[][] = [
+  [<u8>1, <u8>2, <u8>3],
+  [<u8>4, <u8>5],
+  [<u8>6, <u8>7, <u8>8, <u8>9],
+];
+
+var flattestresult: u8[] = flattest.flat<u8>();
+assert(flattestresult.length == 9);
+assert(flattestresult[0] == <u8>1);
+assert(flattestresult[1] == <u8>2);
+assert(flattestresult[2] == <u8>3);
+assert(flattestresult[3] == <u8>4);
+assert(flattestresult[4] == <u8>5);
+assert(flattestresult[5] == <u8>6);
+assert(flattestresult[6] == <u8>7);
+assert(flattestresult[7] == <u8>8);
+assert(flattestresult[8] == <u8>9);

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -331,6 +331,14 @@
  (data (i32.const 8320) "p \00\00\01\00\00\00")
  (data (i32.const 8328) "\04\00\00\00\00\00\00\00\80 \00\00\00\00\00\00")
  (data (i32.const 8344) "\88 \00\00\01\00\00\00")
+ (data (i32.const 8352) "\03\00\00\00\00\00\00\00\01\02\03\00\00\00\00\00")
+ (data (i32.const 8368) "\a0 \00\00\03\00\00\00")
+ (data (i32.const 8376) "\02\00\00\00\00\00\00\00\04\05\00\00\00\00\00\00")
+ (data (i32.const 8392) "\b8 \00\00\02\00\00\00")
+ (data (i32.const 8400) "\04\00\00\00\00\00\00\00\06\07\08\t\00\00\00\00")
+ (data (i32.const 8416) "\d0 \00\00\04\00\00\00")
+ (data (i32.const 8424) "\0c\00\00\00\00\00\00\00\b0 \00\00\c8 \00\00\e0 \00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 8456) "\e8 \00\00\03\00\00\00")
  (table $0 56 anyfunc)
  (elem (i32.const 0) $null $start~anonymous|1 $start~anonymous|2 $start~anonymous|3 $start~anonymous|4 $start~anonymous|5 $start~anonymous|6 $start~anonymous|7 $start~anonymous|8 $start~anonymous|9 $start~anonymous|10 $start~anonymous|11 $start~anonymous|12 $start~anonymous|13 $start~anonymous|14 $start~anonymous|15 $start~anonymous|16 $start~anonymous|17 $start~anonymous|18 $start~anonymous|19 $start~anonymous|20 $start~anonymous|21 $start~anonymous|22 $start~anonymous|23 $start~anonymous|24 $start~anonymous|25 $start~anonymous|26 $start~anonymous|27 $start~anonymous|28 $start~anonymous|29 $start~anonymous|30 $start~anonymous|31 $start~anonymous|32 $start~anonymous|33 $start~anonymous|34 $start~anonymous|35 $start~anonymous|36 $start~anonymous|37 $start~anonymous|38 $start~anonymous|39 $start~anonymous|40 $start~anonymous|41 $start~anonymous|42 $~lib/array/Array<f32>#sort|trampoline~anonymous|43 $~lib/array/Array<f64>#sort|trampoline~anonymous|44 $~lib/array/Array<i32>#sort|trampoline~anonymous|45 $~lib/array/Array<u32>#sort|trampoline~anonymous|46 $std/array/assertSortedDefault<i32>~anonymous|47 $start~anonymous|48 $start~anonymous|49 $start~anonymous|50 $start~anonymous|51 $start~anonymous|52 $start~anonymous|53 $start~anonymous|54 $start~anonymous|55)
  (global $~lib/internal/allocator/AL_BITS i32 (i32.const 3))
@@ -434,7 +442,9 @@
  (global $std/array/subarr32 (mut i32) (i32.const 8176))
  (global $std/array/subarr8 (mut i32) (i32.const 8272))
  (global $std/array/subarrU32 (mut i32) (i32.const 8344))
- (global $HEAP_BASE i32 (i32.const 8352))
+ (global $std/array/flattest (mut i32) (i32.const 8456))
+ (global $std/array/flattestresult (mut i32) (i32.const 0))
+ (global $HEAP_BASE i32 (i32.const 8464))
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
@@ -15551,7 +15561,231 @@
   get_local $3
   return
  )
- (func $start (; 221 ;) (type $v)
+ (func $~lib/array/Array<Array<u8>>#__unchecked_get (; 221 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  get_local $0
+  i32.load
+  set_local $2
+  i32.const 0
+  set_local $3
+  get_local $2
+  get_local $1
+  i32.const 2
+  i32.shl
+  i32.add
+  get_local $3
+  i32.add
+  i32.load offset=8
+ )
+ (func $~lib/array/Array<u8>#constructor (; 222 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  get_local $1
+  i32.const 1073741816
+  i32.gt_u
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 45
+   i32.const 39
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $1
+  i32.const 0
+  i32.shl
+  set_local $2
+  get_local $2
+  call $~lib/internal/arraybuffer/allocateUnsafe
+  set_local $3
+  get_local $0
+  if (result i32)
+   get_local $0
+  else   
+   block (result i32)
+    i32.const 8
+    call $~lib/memory/memory.allocate
+    set_local $4
+    get_local $4
+    i32.const 0
+    i32.store
+    get_local $4
+    i32.const 0
+    i32.store offset=4
+    get_local $4
+   end
+   tee_local $0
+  end
+  tee_local $0
+  get_local $3
+  i32.store
+  get_local $0
+  get_local $1
+  i32.store offset=4
+  get_local $3
+  get_global $~lib/internal/arraybuffer/HEADER_SIZE
+  i32.add
+  set_local $4
+  i32.const 0
+  set_local $5
+  get_local $4
+  get_local $5
+  get_local $2
+  call $~lib/internal/memory/memset
+  get_local $0
+ )
+ (func $~lib/array/Array<u8>#__unchecked_get (; 223 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  get_local $0
+  i32.load
+  set_local $2
+  i32.const 0
+  set_local $3
+  get_local $2
+  get_local $1
+  i32.const 0
+  i32.shl
+  i32.add
+  get_local $3
+  i32.add
+  i32.load8_u offset=8
+ )
+ (func $~lib/array/Array<u8>#__unchecked_set (; 224 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  get_local $0
+  i32.load
+  set_local $3
+  i32.const 0
+  set_local $4
+  get_local $3
+  get_local $1
+  i32.const 0
+  i32.shl
+  i32.add
+  get_local $4
+  i32.add
+  get_local $2
+  i32.store8 offset=8
+ )
+ (func $~lib/array/Array<Array<u8>>#flat<u8> (; 225 ;) (type $ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  i32.const 0
+  set_local $1
+  i32.const 0
+  set_local $2
+  get_local $0
+  i32.load offset=4
+  set_local $4
+  block $break|0
+   loop $continue|0
+    get_local $2
+    get_local $4
+    i32.lt_s
+    if
+     block
+      get_local $0
+      get_local $2
+      call $~lib/array/Array<Array<u8>>#__unchecked_get
+      tee_local $6
+      drop
+      get_local $1
+      get_local $6
+      i32.load offset=4
+      i32.add
+      set_local $1
+      get_local $2
+      i32.const 1
+      i32.add
+      set_local $2
+     end
+     br $continue|0
+    end
+   end
+  end
+  i32.const 0
+  get_local $1
+  call $~lib/array/Array<u8>#constructor
+  set_local $7
+  i32.const 0
+  set_local $2
+  i32.const 0
+  set_local $1
+  block $break|1
+   loop $continue|1
+    get_local $2
+    get_local $4
+    i32.lt_s
+    if
+     block
+      i32.const 0
+      set_local $3
+      get_local $0
+      get_local $2
+      call $~lib/array/Array<Array<u8>>#__unchecked_get
+      tee_local $6
+      drop
+      get_local $6
+      i32.load offset=4
+      set_local $5
+      block $break|2
+       loop $continue|2
+        get_local $3
+        get_local $5
+        i32.lt_s
+        if
+         block
+          block (result i32)
+           get_local $7
+           tee_local $8
+           get_local $1
+           tee_local $9
+           get_local $6
+           get_local $3
+           call $~lib/array/Array<u8>#__unchecked_get
+           call $~lib/array/Array<u8>#__unchecked_set
+           get_local $8
+           get_local $9
+           call $~lib/array/Array<u8>#__unchecked_get
+          end
+          drop
+          get_local $1
+          i32.const 1
+          i32.add
+          set_local $1
+          get_local $3
+          i32.const 1
+          i32.add
+          set_local $3
+         end
+         br $continue|2
+        end
+       end
+      end
+      get_local $2
+      i32.const 1
+      i32.add
+      set_local $2
+     end
+     br $continue|1
+    end
+   end
+  end
+  get_local $7
+ )
+ (func $start (; 226 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -19962,7 +20196,171 @@
    call $~lib/env/abort
    unreachable
   end
+  get_global $std/array/flattest
+  call $~lib/array/Array<Array<u8>>#flat<u8>
+  set_global $std/array/flattestresult
+  block $~lib/array/Array<u8>#get:length|inlined.3 (result i32)
+   get_global $std/array/flattestresult
+   set_local $3
+   get_local $3
+   i32.load offset=4
+  end
+  i32.const 9
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 104
+   i32.const 921
+   i32.const 0
+   call $~lib/env/abort
+   unreachable
+  end
+  get_global $std/array/flattestresult
+  i32.const 0
+  call $~lib/array/Array<u8>#__get
+  i32.const 255
+  i32.and
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 104
+   i32.const 922
+   i32.const 0
+   call $~lib/env/abort
+   unreachable
+  end
+  get_global $std/array/flattestresult
+  i32.const 1
+  call $~lib/array/Array<u8>#__get
+  i32.const 255
+  i32.and
+  i32.const 2
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 104
+   i32.const 923
+   i32.const 0
+   call $~lib/env/abort
+   unreachable
+  end
+  get_global $std/array/flattestresult
+  i32.const 2
+  call $~lib/array/Array<u8>#__get
+  i32.const 255
+  i32.and
+  i32.const 3
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 104
+   i32.const 924
+   i32.const 0
+   call $~lib/env/abort
+   unreachable
+  end
+  get_global $std/array/flattestresult
+  i32.const 3
+  call $~lib/array/Array<u8>#__get
+  i32.const 255
+  i32.and
+  i32.const 4
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 104
+   i32.const 925
+   i32.const 0
+   call $~lib/env/abort
+   unreachable
+  end
+  get_global $std/array/flattestresult
+  i32.const 4
+  call $~lib/array/Array<u8>#__get
+  i32.const 255
+  i32.and
+  i32.const 5
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 104
+   i32.const 926
+   i32.const 0
+   call $~lib/env/abort
+   unreachable
+  end
+  get_global $std/array/flattestresult
+  i32.const 5
+  call $~lib/array/Array<u8>#__get
+  i32.const 255
+  i32.and
+  i32.const 6
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 104
+   i32.const 927
+   i32.const 0
+   call $~lib/env/abort
+   unreachable
+  end
+  get_global $std/array/flattestresult
+  i32.const 6
+  call $~lib/array/Array<u8>#__get
+  i32.const 255
+  i32.and
+  i32.const 7
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 104
+   i32.const 928
+   i32.const 0
+   call $~lib/env/abort
+   unreachable
+  end
+  get_global $std/array/flattestresult
+  i32.const 7
+  call $~lib/array/Array<u8>#__get
+  i32.const 255
+  i32.and
+  i32.const 8
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 104
+   i32.const 929
+   i32.const 0
+   call $~lib/env/abort
+   unreachable
+  end
+  get_global $std/array/flattestresult
+  i32.const 8
+  call $~lib/array/Array<u8>#__get
+  i32.const 255
+  i32.and
+  i32.const 9
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 104
+   i32.const 930
+   i32.const 0
+   call $~lib/env/abort
+   unreachable
+  end
  )
- (func $null (; 222 ;) (type $v)
+ (func $null (; 227 ;) (type $v)
  )
 )


### PR DESCRIPTION
Array#flat isn't type safe, and with what little knowledge I have, all I can do is verify that `this` is an array using the `isArray<T>()` macro.

The tests pass in `tests/compiler/std/array.ts` using the implemented `flat` function.

Is it possible to use a macro and verify an object's type at compile time?

Something like...

```ts
isType<this, Array<Array<U>>>();
```