### PR TITLE
loader: check for null pointer in getArray() and getString()

### DIFF
--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -80,6 +80,11 @@ function postInstantiate(baseModule, instance) {
   }
   checkMem();
 
+  /** Raises an exception if a pointer is the NULL pointer. */
+  function checkNull(ptr) {
+    if (!ptr) throw Error("null pointer deref");
+  }
+
   /** Allocates a new string in the module's memory and returns its pointer. */
   function newString(str) {
     var dataLength = str.length;
@@ -96,6 +101,7 @@ function postInstantiate(baseModule, instance) {
   /** Gets a string from the module's memory by its pointer. */
   function getString(ptr) {
     checkMem();
+    checkNull(ptr);
     return getStringImpl(U32, U16, ptr);
   }
 
@@ -145,6 +151,7 @@ function postInstantiate(baseModule, instance) {
     var elementSize = ctor.BYTES_PER_ELEMENT;
     if (!elementSize) throw Error("not a typed array");
     checkMem();
+    checkNull(ptr);
     var buf        = U32[ ptr      >>> 2];
     var byteOffset = U32[(ptr + 4) >>> 2];
     var byteLength = U32[(ptr + 8) >>> 2];


### PR DESCRIPTION
When `NULL` pointers are returned, the `loader`'s module `getArray()` and `getString()` return arbitrary data sitting at offset `0`.

Even though `null` shouldn't be returned for error handling, this can happen in real code.

Throwing an exception instead prevents undefined behaviors.