### PR TITLE
Giant TypedArray refactor

### DIFF
--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -591,6 +591,18 @@ declare abstract class TypedArray<T> implements ArrayBufferView<T> {
     callbackfn: (accumulator: W, value: T, index: i32, self: this) => W,
     initialValue: W,
   ): W;
+  /** The some() method tests whether some element in the typed array passes the test implemented by the provided function. This method has the same algorithm as Array.prototype.some().*/
+  some(callbackfn: (value: T, index: i32, self: this) => bool): bool;
+  /** The map() method creates a new typed array with the results of calling a provided function on every element in this typed array. This method has the same algorithm as Array.prototype.map().*/
+  map(callbackfn: (value: T, index: i32, self: this) => T): this;
+  /** The sort() method sorts the elements of a typed array numerically in place and returns the typed array. This method has the same algorithm as Array.prototype.sort(), except that sorts the values numerically instead of as strings. TypedArray is one of the typed array types here. */
+  sort(callback?: (a: T, b: T) => i32): this;
+  /** The fill() method fills all the elements of a typed array from a start index to an end index with a static value. This method has the same algorithm as Array.prototype.fill(). */
+  fill(value: T, start?: i32, end?: i32): this;
+  /** The findIndex() method returns an index in the typed array, if an element in the typed array satisfies the provided testing function. Otherwise -1 is returned. See also the find() [not implemented] method, which returns the value of a found element in the typed array instead of its index. */
+  findIndex(callbackfn: (value: T, index: i32, self: this) => bool): i32;
+  /** The every() method tests whether all elements in the typed array pass the test implemented by the provided function. This method has the same algorithm as Array.prototype.every(). */
+  every(callbackfn: (value: T, index: i32, self: this) => bool): i32;
 }
 
 /** An array of twos-complement 8-bit signed integers. */

--- a/std/assembly/internal/typedarray.ts
+++ b/std/assembly/internal/typedarray.ts
@@ -136,7 +136,7 @@ export function REDUCE<TArray extends TypedArray<T>, T, TRet>(
   var length = array.length;
   var buffer = array.buffer;
   var byteOffset = array.byteOffset;
-  for (var i = 0; i < length; i++) {
+  for (let i = 0; i < length; i++) {
     initialValue = callbackfn(
       initialValue,
       LOAD<T>(buffer, i, byteOffset),
@@ -155,7 +155,7 @@ export function REDUCE_RIGHT<TArray extends TypedArray<T>, T, TRet>(
 ): TRet {
   var buffer = array.buffer;
   var byteOffset = array.byteOffset;
-  for (var i = array.length - 1; i >= 0; i--) {
+  for (let i = array.length - 1; i >= 0; i--) {
     initialValue = callbackfn(
       initialValue,
       LOAD<T>(buffer, i, byteOffset),
@@ -176,7 +176,7 @@ export function MAP<TArray extends TypedArray<T>, T>(
   var byteOffset = array.byteOffset;
   var result = instantiate<TArray>(length);
   var resultBuffer = result.buffer;
-  for (var i = 0; i < length; i++) {
+  for (let i = 0; i < length; i++) {
     STORE<T, NATIVE<T>>(resultBuffer, i, <NATIVE<T>>callbackfn(LOAD<T>(buffer, i, byteOffset), i, array));
   }
 
@@ -191,7 +191,7 @@ export function FIND_INDEX<TArray extends TypedArray<T>, T>(
   var length = array.length;
   var buffer = array.buffer;
   var byteOffset = array.byteOffset;
-  for (var i = 0; i < length; i++) {
+  for (let i = 0; i < length; i++) {
     if (callbackfn(LOAD<T>(buffer, i, byteOffset), i, array)) {
       return i;
     }
@@ -207,7 +207,7 @@ export function SOME<TArray extends TypedArray<T>, T>(
   var length = array.length;
   var buffer = array.buffer;
   var byteOffset = array.byteOffset;
-  for (var i = 0; i < length; i++) {
+  for (let i = 0; i < length; i++) {
     if (callbackfn(LOAD<T>(buffer, i, byteOffset), i, array)) {
       return true;
     }
@@ -223,7 +223,7 @@ export function EVERY<TArray extends TypedArray<T>, T>(
   var length = array.length;
   var buffer = array.buffer;
   var byteOffset = array.byteOffset;
-  for (var i = 0; i < length; i++) {
+  for (let i = 0; i < length; i++) {
     if (callbackfn(LOAD<T>(buffer, i, byteOffset), i, array)) {
       continue;
     }

--- a/std/assembly/internal/typedarray.ts
+++ b/std/assembly/internal/typedarray.ts
@@ -60,7 +60,7 @@ export abstract class TypedArray<T> {
 }
 
 @inline
-export function FILL<TArray extends TypedArray<T>, T>(
+export function FILL<TArray extends TypedArray<T>, T extends number>(
   array: TArray,
   value: NATIVE<T>,
   start: i32,
@@ -133,16 +133,16 @@ export function REDUCE<TArray extends TypedArray<T>, T, TRet>(
   callbackfn: (accumulator: TRet, value: T, index: i32, array: TArray) => TRet,
   initialValue: TRet
 ): TRet {
-  var index = 0;
-  var length = <i32>array.length;
-  while (index != length) {
+  var length = array.length;
+  var buffer = array.buffer;
+  var byteOffset = array.byteOffset;
+  for (var i = 0; i < length; i++) {
     initialValue = callbackfn(
       initialValue,
-      unchecked(array[index]),
-      index,
+      LOAD<T>(buffer, i, byteOffset),
+      i,
       array,
     );
-    ++index;
   }
   return initialValue;
 }
@@ -153,16 +153,15 @@ export function REDUCE_RIGHT<TArray extends TypedArray<T>, T, TRet>(
   callbackfn: (accumulator: TRet, value: T, index: i32, array: TArray) => TRet,
   initialValue: TRet
 ): TRet {
-  var index = <i32>array.length - 1;
-  var length = -1;
-  while (index != length) {
+  var buffer = array.buffer;
+  var byteOffset = array.byteOffset;
+  for (var i = array.length - 1; i >= 0; i--) {
     initialValue = callbackfn(
       initialValue,
-      unchecked(array[index]),
-      index,
+      LOAD<T>(buffer, i, byteOffset),
+      i,
       array,
     );
-    --index;
   }
   return initialValue;
 }
@@ -172,12 +171,63 @@ export function MAP<TArray extends TypedArray<T>, T>(
   array: TArray,
   callbackfn: (value: T, index: i32, self: TArray) => T,
 ): TArray {
-  var length: i32 = array.length;
+  var length = array.length;
+  var buffer = array.buffer;
+  var byteOffset = array.byteOffset;
   var result = instantiate<TArray>(length);
-  var i: i32 = 0;
-  while (i < length) {
-    unchecked(result[i] = callbackfn(array[i], i, <TArray>array));
-    ++i;
+  var resultBuffer = result.buffer;
+  for (var i = 0; i < length; i++) {
+    STORE<T, NATIVE<T>>(resultBuffer, i, <NATIVE<T>>callbackfn(LOAD<T>(buffer, i, byteOffset), i, array));
   }
+
   return result;
+}
+
+@inline
+export function FIND_INDEX<TArray extends TypedArray<T>, T>(
+  array: TArray,
+  callbackfn: (value: T, index: i32, array: TArray) => bool,
+): i32 {
+  var length = array.length;
+  var buffer = array.buffer;
+  var byteOffset = array.byteOffset;
+  for (var i = 0; i < length; i++) {
+    if (callbackfn(LOAD<T>(buffer, i, byteOffset), i, array)) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+@inline
+export function SOME<TArray extends TypedArray<T>, T>(
+  array: TArray,
+  callbackfn: (value: T, index: i32, array: TArray) => bool,
+): bool {
+  var length = array.length;
+  var buffer = array.buffer;
+  var byteOffset = array.byteOffset;
+  for (var i = 0; i < length; i++) {
+    if (callbackfn(LOAD<T>(buffer, i, byteOffset), i, array)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+@inline
+export function EVERY<TArray extends TypedArray<T>, T>(
+  array: TArray,
+  callbackfn: (value: T, index: i32, array: TArray) => bool,
+): bool {
+  var length = array.length;
+  var buffer = array.buffer;
+  var byteOffset = array.byteOffset;
+  for (var i = 0; i < length; i++) {
+    if (callbackfn(LOAD<T>(buffer, i, byteOffset), i, array)) {
+      continue;
+    }
+    return false;
+  }
+  return true;
 }

--- a/std/assembly/typedarray.ts
+++ b/std/assembly/typedarray.ts
@@ -6,6 +6,9 @@ import {
   REDUCE,
   REDUCE_RIGHT,
   MAP,
+  FIND_INDEX,
+  SOME,
+  EVERY,
 } from "./internal/typedarray";
 
 import {
@@ -44,6 +47,18 @@ export class Int8Array extends TypedArray<i8> {
   map(callbackfn: (value: i8, index: i32, self: Int8Array) => i8): Int8Array {
     return MAP<Int8Array, i8>(this, callbackfn);
   }
+
+  findIndex(callbackfn: (value: i8, index: i32, self: Int8Array) => bool): i32 {
+    return FIND_INDEX<Int8Array, i8>(this, callbackfn);
+  }
+
+  some(callbackfn: (value: i8, index: i32, self: Int8Array) => bool): bool {
+    return SOME<Int8Array, i8>(this, callbackfn);
+  }
+
+  every(callbackfn: (value: i8, index: i32, self: Int8Array) => bool): bool {
+    return EVERY<Int8Array, i8>(this, callbackfn);
+  }
 }
 
 export class Uint8Array extends TypedArray<u8> {
@@ -78,6 +93,18 @@ export class Uint8Array extends TypedArray<u8> {
   map(callbackfn: (value: u8, index: i32, self: Uint8Array) => u8): Uint8Array {
     return MAP<Uint8Array, u8>(this, callbackfn);
   }
+
+  findIndex(callbackfn: (value: u8, index: i32, self: Uint8Array) => bool): i32 {
+    return FIND_INDEX<Uint8Array, u8>(this, callbackfn);
+  }
+
+  some(callbackfn: (value: u8, index: i32, self: Uint8Array) => bool): bool {
+    return SOME<Uint8Array, u8>(this, callbackfn);
+  }
+
+  every(callbackfn: (value: u8, index: i32, self: Uint8Array) => bool): bool {
+    return EVERY<Uint8Array, u8>(this, callbackfn);
+  }
 }
 
 export class Uint8ClampedArray extends Uint8Array {
@@ -107,6 +134,18 @@ export class Uint8ClampedArray extends Uint8Array {
 
   map(callbackfn: (value: u8, index: i32, self: Uint8ClampedArray) => u8): Uint8ClampedArray {
     return MAP<Uint8ClampedArray, u8>(this, callbackfn);
+  }
+
+  findIndex(callbackfn: (value: u8, index: i32, self: Uint8ClampedArray) => bool): i32 {
+    return FIND_INDEX<Uint8ClampedArray, u8>(this, callbackfn);
+  }
+
+  some(callbackfn: (value: u8, index: i32, self: Uint8ClampedArray) => bool): bool {
+    return SOME<Uint8ClampedArray, u8>(this, callbackfn);
+  }
+
+  every(callbackfn: (value: u8, index: i32, self: Uint8ClampedArray) => bool): bool {
+    return EVERY<Uint8ClampedArray, u8>(this, callbackfn);
   }
 }
 
@@ -142,6 +181,18 @@ export class Int16Array extends TypedArray<i16> {
   map(callbackfn: (value: i16, index: i32, self: Int16Array) => i16): Int16Array {
     return MAP<Int16Array, i16>(this, callbackfn);
   }
+
+  findIndex(callbackfn: (value: i16, index: i32, self: Int16Array) => bool): i32 {
+    return FIND_INDEX<Int16Array, i16>(this, callbackfn);
+  }
+
+  some(callbackfn: (value: i16, index: i32, self: Int16Array) => bool): bool {
+    return SOME<Int16Array, i16>(this, callbackfn);
+  }
+
+  every(callbackfn: (value: i16, index: i32, self: Int16Array) => bool): bool {
+    return EVERY<Int16Array, i16>(this, callbackfn);
+  }
 }
 
 export class Uint16Array extends TypedArray<u16> {
@@ -175,6 +226,18 @@ export class Uint16Array extends TypedArray<u16> {
 
   map(callbackfn: (value: u16, index: i32, self: Uint16Array) => u16): Uint16Array {
     return MAP<Uint16Array, u16>(this, callbackfn);
+  }
+
+  findIndex(callbackfn: (value: u16, index: i32, self: Uint16Array) => bool): i32 {
+    return FIND_INDEX<Uint16Array, u16>(this, callbackfn);
+  }
+
+  some(callbackfn: (value: u16, index: i32, self: Uint16Array) => bool): bool {
+    return SOME<Uint16Array, u16>(this, callbackfn);
+  }
+
+  every(callbackfn: (value: u16, index: i32, self: Uint16Array) => bool): bool {
+    return EVERY<Uint16Array, u16>(this, callbackfn);
   }
 }
 
@@ -210,6 +273,18 @@ export class Int32Array extends TypedArray<i32> {
   map(callbackfn: (value: i32, index: i32, self: Int32Array) => i32): Int32Array {
     return MAP<Int32Array, i32>(this, callbackfn);
   }
+
+  findIndex(callbackfn: (value: i32, index: i32, self: Int32Array) => bool): i32 {
+    return FIND_INDEX<Int32Array, i32>(this, callbackfn);
+  }
+
+  some(callbackfn: (value: i32, index: i32, self: Int32Array) => bool): bool {
+    return SOME<Int32Array, i32>(this, callbackfn);
+  }
+
+  every(callbackfn: (value: i32, index: i32, self: Int32Array) => bool): bool {
+    return EVERY<Int32Array, i32>(this, callbackfn);
+  }
 }
 
 export class Uint32Array extends TypedArray<u32> {
@@ -243,6 +318,18 @@ export class Uint32Array extends TypedArray<u32> {
 
   map(callbackfn: (value: u32, index: i32, self: Uint32Array) => u32): Uint32Array {
     return MAP<Uint32Array, u32>(this, callbackfn);
+  }
+
+  findIndex(callbackfn: (value: u32, index: i32, self: Uint32Array) => bool): i32 {
+    return FIND_INDEX<Uint32Array, u32>(this, callbackfn);
+  }
+
+  some(callbackfn: (value: u32, index: i32, self: Uint32Array) => bool): bool {
+    return SOME<Uint32Array, u32>(this, callbackfn);
+  }
+
+  every(callbackfn: (value: u32, index: i32, self: Uint32Array) => bool): bool {
+    return EVERY<Uint32Array, u32>(this, callbackfn);
   }
 }
 
@@ -278,6 +365,18 @@ export class Int64Array extends TypedArray<i64> {
   map(callbackfn: (value: i64, index: i32, self: Int64Array) => i64): Int64Array {
     return MAP<Int64Array, i64>(this, callbackfn);
   }
+
+  findIndex(callbackfn: (value: i64, index: i32, self: Int64Array) => bool): i32 {
+    return FIND_INDEX<Int64Array, i64>(this, callbackfn);
+  }
+
+  some(callbackfn: (value: i64, index: i32, self: Int64Array) => bool): bool {
+    return SOME<Int64Array, i64>(this, callbackfn);
+  }
+
+  every(callbackfn: (value: i64, index: i32, self: Int64Array) => bool): bool {
+    return EVERY<Int64Array, i64>(this, callbackfn);
+  }
 }
 
 export class Uint64Array extends TypedArray<u64> {
@@ -311,6 +410,18 @@ export class Uint64Array extends TypedArray<u64> {
 
   map(callbackfn: (value: u64, index: i32, self: Uint64Array) => u64): Uint64Array {
     return MAP<Uint64Array, u64>(this, callbackfn);
+  }
+
+  findIndex(callbackfn: (value: u64, index: i32, self: Uint64Array) => bool): i32 {
+    return FIND_INDEX<Uint64Array, u64>(this, callbackfn);
+  }
+
+  some(callbackfn: (value: u64, index: i32, self: Uint64Array) => bool): bool {
+    return SOME<Uint64Array, u64>(this, callbackfn);
+  }
+
+  every(callbackfn: (value: u64, index: i32, self: Uint64Array) => bool): bool {
+    return EVERY<Uint64Array, u64>(this, callbackfn);
   }
 }
 
@@ -346,6 +457,18 @@ export class Float32Array extends TypedArray<f32> {
   map(callbackfn: (value: f32, index: i32, self: Float32Array) => f32): Float32Array {
     return MAP<Float32Array, f32>(this, callbackfn);
   }
+
+  findIndex(callbackfn: (value: f32, index: i32, self: Float32Array) => bool): i32 {
+    return FIND_INDEX<Float32Array, f32>(this, callbackfn);
+  }
+
+  some(callbackfn: (value: f32, index: i32, self: Float32Array) => bool): bool {
+    return SOME<Float32Array, f32>(this, callbackfn);
+  }
+
+  every(callbackfn: (value: f32, index: i32, self: Float32Array) => bool): bool {
+    return EVERY<Float32Array, f32>(this, callbackfn);
+  }
 }
 
 export class Float64Array extends TypedArray<f64> {
@@ -379,5 +502,17 @@ export class Float64Array extends TypedArray<f64> {
 
   map(callbackfn: (value: f64, index: i32, self: Float64Array) => f64): Float64Array {
     return MAP<Float64Array, f64>(this, callbackfn);
+  }
+
+  findIndex(callbackfn: (value: f64, index: i32, self: Float64Array) => bool): i32 {
+    return FIND_INDEX<Float64Array, f64>(this, callbackfn);
+  }
+
+  some(callbackfn: (value: f64, index: i32, self: Float64Array) => bool): bool {
+    return SOME<Float64Array, f64>(this, callbackfn);
+  }
+
+  every(callbackfn: (value: f64, index: i32, self: Float64Array) => bool): bool {
+    return EVERY<Float64Array, f64>(this, callbackfn);
   }
 }

--- a/tests/compiler/builtins.untouched.wat
+++ b/tests/compiler/builtins.untouched.wat
@@ -318,13 +318,13 @@
   drop
   i32.const -42
   tee_local $0
-  i32.const 0
+  i32.const 31
+  i32.shr_s
+  tee_local $1
   get_local $0
-  i32.sub
-  get_local $0
-  i32.const 0
-  i32.gt_s
-  select
+  i32.add
+  get_local $1
+  i32.xor
   drop
   i32.const 1
   tee_local $0
@@ -363,13 +363,13 @@
   set_global $builtins/i
   i32.const -42
   tee_local $0
-  i32.const 0
+  i32.const 31
+  i32.shr_s
+  tee_local $1
   get_local $0
-  i32.sub
-  get_local $0
-  i32.const 0
-  i32.gt_s
-  select
+  i32.add
+  get_local $1
+  i32.xor
   set_global $builtins/i
   get_global $builtins/i
   i32.const 42
@@ -444,13 +444,13 @@
   drop
   i64.const -42
   tee_local $2
-  i64.const 0
+  i64.const 63
+  i64.shr_s
+  tee_local $3
   get_local $2
-  i64.sub
-  get_local $2
-  i64.const 0
-  i64.gt_s
-  select
+  i64.add
+  get_local $3
+  i64.xor
   drop
   i64.const 1
   i64.clz
@@ -471,13 +471,13 @@
   set_global $builtins/I
   i64.const -42
   tee_local $2
-  i64.const 0
+  i64.const 63
+  i64.shr_s
+  tee_local $3
   get_local $2
-  i64.sub
-  get_local $2
-  i64.const 0
-  i64.gt_s
-  select
+  i64.add
+  get_local $3
+  i64.xor
   set_global $builtins/I
   get_global $builtins/I
   i64.const 42

--- a/tests/compiler/builtins.untouched.wat
+++ b/tests/compiler/builtins.untouched.wat
@@ -318,13 +318,13 @@
   drop
   i32.const -42
   tee_local $0
-  i32.const 31
-  i32.shr_s
-  tee_local $1
+  i32.const 0
   get_local $0
-  i32.add
-  get_local $1
-  i32.xor
+  i32.sub
+  get_local $0
+  i32.const 0
+  i32.gt_s
+  select
   drop
   i32.const 1
   tee_local $0
@@ -363,13 +363,13 @@
   set_global $builtins/i
   i32.const -42
   tee_local $0
-  i32.const 31
-  i32.shr_s
-  tee_local $1
+  i32.const 0
   get_local $0
-  i32.add
-  get_local $1
-  i32.xor
+  i32.sub
+  get_local $0
+  i32.const 0
+  i32.gt_s
+  select
   set_global $builtins/i
   get_global $builtins/i
   i32.const 42
@@ -444,13 +444,13 @@
   drop
   i64.const -42
   tee_local $2
-  i64.const 63
-  i64.shr_s
-  tee_local $3
+  i64.const 0
   get_local $2
-  i64.add
-  get_local $3
-  i64.xor
+  i64.sub
+  get_local $2
+  i64.const 0
+  i64.gt_s
+  select
   drop
   i64.const 1
   i64.clz
@@ -471,13 +471,13 @@
   set_global $builtins/I
   i64.const -42
   tee_local $2
-  i64.const 63
-  i64.shr_s
-  tee_local $3
+  i64.const 0
   get_local $2
-  i64.add
-  get_local $3
-  i64.xor
+  i64.sub
+  get_local $2
+  i64.const 0
+  i64.gt_s
+  select
   set_global $builtins/I
   get_global $builtins/I
   i64.const 42

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -12,20 +12,25 @@
  (type $v (func))
  (type $iiIv (func (param i32 i32 i64)))
  (type $IIiiI (func (param i64 i64 i32 i32) (result i64)))
- (type $iiI (func (param i32 i32) (result i64)))
  (type $iifv (func (param i32 i32 f32)))
  (type $ffiif (func (param f32 f32 i32 i32) (result f32)))
- (type $iif (func (param i32 i32) (result f32)))
  (type $FFiiF (func (param f64 f64 i32 i32) (result f64)))
  (type $IiiI (func (param i64 i32 i32) (result i64)))
+ (type $iiI (func (param i32 i32) (result i64)))
  (type $fiif (func (param f32 i32 i32) (result f32)))
+ (type $iif (func (param i32 i32) (result f32)))
  (type $FiiF (func (param f64 i32 i32) (result f64)))
+ (type $Iiii (func (param i64 i32 i32) (result i32)))
+ (type $fiii (func (param f32 i32 i32) (result i32)))
+ (type $Fiii (func (param f64 i32 i32) (result i32)))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
  (type $FUNCSIG$jii (func (param i32 i32) (result i64)))
  (type $FUNCSIG$fi (func (param i32) (result f32)))
  (type $FUNCSIG$di (func (param i32) (result f64)))
+ (type $FUNCSIG$ff (func (param f32) (result f32)))
+ (type $FUNCSIG$dd (func (param f64) (result f64)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\11\00\00\00s\00t\00d\00/\00t\00y\00p\00e\00d\00a\00r\00r\00a\00y\00.\00t\00s")
@@ -60,8 +65,8 @@
  (data (i32.const 584) "\14\00\00\00\00\00\00\00\01")
  (data (i32.const 608) "\02")
  (data (i32.const 616) "H\02\00\00\05")
- (table $0 35 anyfunc)
- (elem (i32.const 0) $null $~lib/typedarray/Float64Array#sort|trampoline~anonymous|1 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 $std/typedarray/testReduce<Float32Array,f32>~anonymous|11 $std/typedarray/testReduce<Float64Array,f64>~anonymous|12 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 $std/typedarray/testReduce<Float32Array,f32>~anonymous|11 $std/typedarray/testReduce<Float64Array,f64>~anonymous|12 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|33 $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|34)
+ (table $0 101 anyfunc)
+ (elem (i32.const 0) $null $~lib/typedarray/Float64Array#sort|trampoline~anonymous|1 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 $std/typedarray/testReduce<Float32Array,f32>~anonymous|11 $std/typedarray/testReduce<Float64Array,f64>~anonymous|12 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 $std/typedarray/testReduce<Float32Array,f32>~anonymous|11 $std/typedarray/testReduce<Float64Array,f64>~anonymous|12 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|33 $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|34 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|36 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|36 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|36 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|42 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|42 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|46 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|46 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|50 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|50 $std/typedarray/testArraySome<Float32Array,f32>~anonymous|53 $std/typedarray/testArraySome<Float32Array,f32>~anonymous|54 $std/typedarray/testArraySome<Float64Array,f64>~anonymous|55 $std/typedarray/testArraySome<Float64Array,f64>~anonymous|56 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|58 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|58 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|58 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|64 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|64 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|68 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|68 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|72 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|72 $std/typedarray/testArraySome<Float32Array,f32>~anonymous|53 $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|76 $std/typedarray/testArraySome<Float64Array,f64>~anonymous|55 $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|78 $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|79 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|81 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|81 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|85 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|81 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|89 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|81 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|93 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|95 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|97 $std/typedarray/testArraySome<Float32Array,f32>~anonymous|53 $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|99 $std/typedarray/testArraySome<Float64Array,f64>~anonymous|55)
  (global $~lib/allocator/arena/startOffset (mut i32) (i32.const 0))
  (global $~lib/allocator/arena/offset (mut i32) (i32.const 0))
  (global $std/typedarray/arr (mut i32) (i32.const 0))
@@ -2207,23 +2212,29 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   get_local $0
   i32.load offset=8
   set_local $3
-  loop $continue|0
+  get_local $0
+  i32.load
+  set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
+  loop $repeat|0
    get_local $1
    get_local $3
-   i32.ne
+   i32.lt_s
    if
     i32.const 4
     set_global $~argc
     get_local $2
-    get_local $0
-    i32.load offset=4
-    get_local $0
-    i32.load
     get_local $1
+    get_local $4
     i32.add
+    get_local $5
     i32.add
     i32.load8_s offset=8
     get_local $1
@@ -2235,7 +2246,7 @@
     i32.const 1
     i32.add
     set_local $1
-    br $continue|0
+    br $repeat|0
    end
   end
   get_local $2
@@ -2275,23 +2286,29 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   get_local $0
   i32.load offset=8
   set_local $4
-  loop $continue|0
+  get_local $0
+  i32.load
+  set_local $5
+  get_local $0
+  i32.load offset=4
+  set_local $6
+  loop $repeat|0
    get_local $2
    get_local $4
-   i32.ne
+   i32.lt_s
    if
     i32.const 4
     set_global $~argc
     get_local $3
-    get_local $0
-    i32.load offset=4
-    get_local $0
-    i32.load
     get_local $2
+    get_local $5
     i32.add
+    get_local $6
     i32.add
     i32.load8_u offset=8
     get_local $2
@@ -2303,7 +2320,7 @@
     i32.const 1
     i32.add
     set_local $2
-    br $continue|0
+    br $repeat|0
    end
   end
   get_local $3
@@ -2403,27 +2420,33 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   get_local $0
   i32.load offset=8
   i32.const 1
   i32.shr_u
   set_local $3
-  loop $continue|0
+  get_local $0
+  i32.load
+  set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
+  loop $repeat|0
    get_local $1
    get_local $3
-   i32.ne
+   i32.lt_s
    if
     i32.const 4
     set_global $~argc
     get_local $2
-    get_local $0
-    i32.load offset=4
-    get_local $0
-    i32.load
     get_local $1
     i32.const 1
     i32.shl
+    get_local $4
     i32.add
+    get_local $5
     i32.add
     i32.load16_s offset=8
     get_local $1
@@ -2435,7 +2458,7 @@
     i32.const 1
     i32.add
     set_local $1
-    br $continue|0
+    br $repeat|0
    end
   end
   get_local $2
@@ -2475,27 +2498,33 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   get_local $0
   i32.load offset=8
   i32.const 1
   i32.shr_u
   set_local $3
-  loop $continue|0
+  get_local $0
+  i32.load
+  set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
+  loop $repeat|0
    get_local $1
    get_local $3
-   i32.ne
+   i32.lt_s
    if
     i32.const 4
     set_global $~argc
     get_local $2
-    get_local $0
-    i32.load offset=4
-    get_local $0
-    i32.load
     get_local $1
     i32.const 1
     i32.shl
+    get_local $4
     i32.add
+    get_local $5
     i32.add
     i32.load16_u offset=8
     get_local $1
@@ -2507,7 +2536,7 @@
     i32.const 1
     i32.add
     set_local $1
-    br $continue|0
+    br $repeat|0
    end
   end
   get_local $2
@@ -2547,27 +2576,33 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   get_local $0
   i32.load offset=8
   i32.const 2
   i32.shr_u
   set_local $4
-  loop $continue|0
+  get_local $0
+  i32.load
+  set_local $5
+  get_local $0
+  i32.load offset=4
+  set_local $6
+  loop $repeat|0
    get_local $2
    get_local $4
-   i32.ne
+   i32.lt_s
    if
     i32.const 4
     set_global $~argc
     get_local $3
-    get_local $0
-    i32.load offset=4
-    get_local $0
-    i32.load
     get_local $2
     i32.const 2
     i32.shl
+    get_local $5
     i32.add
+    get_local $6
     i32.add
     i32.load offset=8
     get_local $2
@@ -2579,7 +2614,7 @@
     i32.const 1
     i32.add
     set_local $2
-    br $continue|0
+    br $repeat|0
    end
   end
   get_local $3
@@ -2680,27 +2715,33 @@
   (local $2 i32)
   (local $3 i64)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   get_local $0
   i32.load offset=8
   i32.const 3
   i32.shr_u
   set_local $4
-  loop $continue|0
+  get_local $0
+  i32.load
+  set_local $5
+  get_local $0
+  i32.load offset=4
+  set_local $6
+  loop $repeat|0
    get_local $2
    get_local $4
-   i32.ne
+   i32.lt_s
    if
     i32.const 4
     set_global $~argc
     get_local $3
-    get_local $0
-    i32.load offset=4
-    get_local $0
-    i32.load
     get_local $2
     i32.const 3
     i32.shl
+    get_local $5
     i32.add
+    get_local $6
     i32.add
     i64.load offset=8
     get_local $2
@@ -2712,7 +2753,7 @@
     i32.const 1
     i32.add
     set_local $2
-    br $continue|0
+    br $repeat|0
    end
   end
   get_local $3
@@ -2813,27 +2854,33 @@
   (local $1 i32)
   (local $2 f32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   get_local $0
   i32.load offset=8
   i32.const 2
   i32.shr_u
   set_local $3
-  loop $continue|0
+  get_local $0
+  i32.load
+  set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
+  loop $repeat|0
    get_local $1
    get_local $3
-   i32.ne
+   i32.lt_s
    if
     i32.const 4
     set_global $~argc
     get_local $2
-    get_local $0
-    i32.load offset=4
-    get_local $0
-    i32.load
     get_local $1
     i32.const 2
     i32.shl
+    get_local $4
     i32.add
+    get_local $5
     i32.add
     f32.load offset=8
     get_local $1
@@ -2845,7 +2892,7 @@
     i32.const 1
     i32.add
     set_local $1
-    br $continue|0
+    br $repeat|0
    end
   end
   get_local $2
@@ -2888,27 +2935,33 @@
   (local $1 i32)
   (local $2 f64)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   get_local $0
   i32.load offset=8
   i32.const 3
   i32.shr_u
   set_local $3
-  loop $continue|0
+  get_local $0
+  i32.load
+  set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
+  loop $repeat|0
    get_local $1
    get_local $3
-   i32.ne
+   i32.lt_s
    if
     i32.const 4
     set_global $~argc
     get_local $2
-    get_local $0
-    i32.load offset=4
-    get_local $0
-    i32.load
     get_local $1
     i32.const 3
     i32.shl
+    get_local $4
     i32.add
+    get_local $5
     i32.add
     f64.load offset=8
     get_local $1
@@ -2920,7 +2973,7 @@
     i32.const 1
     i32.add
     set_local $1
-    br $continue|0
+    br $repeat|0
    end
   end
   get_local $2
@@ -2957,25 +3010,31 @@
  (func $~lib/typedarray/Int8Array#reduceRight<i8> (; 56 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
   get_local $0
   i32.load offset=8
   i32.const 1
   i32.sub
   set_local $1
-  loop $continue|0
+  loop $repeat|0
    get_local $1
-   i32.const -1
-   i32.ne
+   i32.const 0
+   i32.ge_s
    if
     i32.const 4
     set_global $~argc
     get_local $2
-    get_local $0
-    i32.load offset=4
-    get_local $0
-    i32.load
     get_local $1
+    get_local $3
     i32.add
+    get_local $4
     i32.add
     i32.load8_s offset=8
     get_local $1
@@ -2987,7 +3046,7 @@
     i32.const 1
     i32.sub
     set_local $1
-    br $continue|0
+    br $repeat|0
    end
   end
   get_local $2
@@ -3026,25 +3085,31 @@
  (func $~lib/typedarray/Uint8Array#reduceRight<u8> (; 58 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  get_local $0
+  i32.load
+  set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
   get_local $0
   i32.load offset=8
   i32.const 1
   i32.sub
   set_local $2
-  loop $continue|0
+  loop $repeat|0
    get_local $2
-   i32.const -1
-   i32.ne
+   i32.const 0
+   i32.ge_s
    if
     i32.const 4
     set_global $~argc
     get_local $3
-    get_local $0
-    i32.load offset=4
-    get_local $0
-    i32.load
     get_local $2
+    get_local $4
     i32.add
+    get_local $5
     i32.add
     i32.load8_u offset=8
     get_local $2
@@ -3056,7 +3121,7 @@
     i32.const 1
     i32.sub
     set_local $2
-    br $continue|0
+    br $repeat|0
    end
   end
   get_local $3
@@ -3128,6 +3193,14 @@
  (func $~lib/typedarray/Int16Array#reduceRight<i16> (; 61 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
   get_local $0
   i32.load offset=8
   i32.const 1
@@ -3135,22 +3208,20 @@
   i32.const 1
   i32.sub
   set_local $1
-  loop $continue|0
+  loop $repeat|0
    get_local $1
-   i32.const -1
-   i32.ne
+   i32.const 0
+   i32.ge_s
    if
     i32.const 4
     set_global $~argc
     get_local $2
-    get_local $0
-    i32.load offset=4
-    get_local $0
-    i32.load
     get_local $1
     i32.const 1
     i32.shl
+    get_local $3
     i32.add
+    get_local $4
     i32.add
     i32.load16_s offset=8
     get_local $1
@@ -3162,7 +3233,7 @@
     i32.const 1
     i32.sub
     set_local $1
-    br $continue|0
+    br $repeat|0
    end
   end
   get_local $2
@@ -3201,6 +3272,14 @@
  (func $~lib/typedarray/Uint16Array#reduceRight<u16> (; 63 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
   get_local $0
   i32.load offset=8
   i32.const 1
@@ -3208,22 +3287,20 @@
   i32.const 1
   i32.sub
   set_local $1
-  loop $continue|0
+  loop $repeat|0
    get_local $1
-   i32.const -1
-   i32.ne
+   i32.const 0
+   i32.ge_s
    if
     i32.const 4
     set_global $~argc
     get_local $2
-    get_local $0
-    i32.load offset=4
-    get_local $0
-    i32.load
     get_local $1
     i32.const 1
     i32.shl
+    get_local $3
     i32.add
+    get_local $4
     i32.add
     i32.load16_u offset=8
     get_local $1
@@ -3235,7 +3312,7 @@
     i32.const 1
     i32.sub
     set_local $1
-    br $continue|0
+    br $repeat|0
    end
   end
   get_local $2
@@ -3274,6 +3351,14 @@
  (func $~lib/typedarray/Int32Array#reduceRight<i32> (; 65 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  get_local $0
+  i32.load
+  set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
   get_local $0
   i32.load offset=8
   i32.const 2
@@ -3281,22 +3366,20 @@
   i32.const 1
   i32.sub
   set_local $2
-  loop $continue|0
+  loop $repeat|0
    get_local $2
-   i32.const -1
-   i32.ne
+   i32.const 0
+   i32.ge_s
    if
     i32.const 4
     set_global $~argc
     get_local $3
-    get_local $0
-    i32.load offset=4
-    get_local $0
-    i32.load
     get_local $2
     i32.const 2
     i32.shl
+    get_local $4
     i32.add
+    get_local $5
     i32.add
     i32.load offset=8
     get_local $2
@@ -3308,7 +3391,7 @@
     i32.const 1
     i32.sub
     set_local $2
-    br $continue|0
+    br $repeat|0
    end
   end
   get_local $3
@@ -3376,6 +3459,14 @@
  (func $~lib/typedarray/Int64Array#reduceRight<i64> (; 68 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local $3 i64)
+  (local $4 i32)
+  (local $5 i32)
+  get_local $0
+  i32.load
+  set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
   get_local $0
   i32.load offset=8
   i32.const 3
@@ -3383,22 +3474,20 @@
   i32.const 1
   i32.sub
   set_local $2
-  loop $continue|0
+  loop $repeat|0
    get_local $2
-   i32.const -1
-   i32.ne
+   i32.const 0
+   i32.ge_s
    if
     i32.const 4
     set_global $~argc
     get_local $3
-    get_local $0
-    i32.load offset=4
-    get_local $0
-    i32.load
     get_local $2
     i32.const 3
     i32.shl
+    get_local $4
     i32.add
+    get_local $5
     i32.add
     i64.load offset=8
     get_local $2
@@ -3410,7 +3499,7 @@
     i32.const 1
     i32.sub
     set_local $2
-    br $continue|0
+    br $repeat|0
    end
   end
   get_local $3
@@ -3478,6 +3567,14 @@
  (func $~lib/typedarray/Float32Array#reduceRight<f32> (; 71 ;) (type $FUNCSIG$fi) (param $0 i32) (result f32)
   (local $1 i32)
   (local $2 f32)
+  (local $3 i32)
+  (local $4 i32)
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
   get_local $0
   i32.load offset=8
   i32.const 2
@@ -3485,22 +3582,20 @@
   i32.const 1
   i32.sub
   set_local $1
-  loop $continue|0
+  loop $repeat|0
    get_local $1
-   i32.const -1
-   i32.ne
+   i32.const 0
+   i32.ge_s
    if
     i32.const 4
     set_global $~argc
     get_local $2
-    get_local $0
-    i32.load offset=4
-    get_local $0
-    i32.load
     get_local $1
     i32.const 2
     i32.shl
+    get_local $3
     i32.add
+    get_local $4
     i32.add
     f32.load offset=8
     get_local $1
@@ -3512,7 +3607,7 @@
     i32.const 1
     i32.sub
     set_local $1
-    br $continue|0
+    br $repeat|0
    end
   end
   get_local $2
@@ -3549,6 +3644,14 @@
  (func $~lib/typedarray/Float64Array#reduceRight<f64> (; 73 ;) (type $FUNCSIG$di) (param $0 i32) (result f64)
   (local $1 i32)
   (local $2 f64)
+  (local $3 i32)
+  (local $4 i32)
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
   get_local $0
   i32.load offset=8
   i32.const 3
@@ -3556,22 +3659,20 @@
   i32.const 1
   i32.sub
   set_local $1
-  loop $continue|0
+  loop $repeat|0
    get_local $1
-   i32.const -1
-   i32.ne
+   i32.const 0
+   i32.ge_s
    if
     i32.const 4
     set_global $~argc
     get_local $2
-    get_local $0
-    i32.load offset=4
-    get_local $0
-    i32.load
     get_local $1
     i32.const 3
     i32.shl
+    get_local $3
     i32.add
+    get_local $4
     i32.add
     f64.load offset=8
     get_local $1
@@ -3583,7 +3684,7 @@
     i32.const 1
     i32.sub
     set_local $1
-    br $continue|0
+    br $repeat|0
    end
   end
   get_local $2
@@ -3627,61 +3728,50 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  get_local $0
+  i32.load
+  set_local $2
+  get_local $0
+  i32.load offset=4
+  set_local $3
   get_local $0
   i32.load offset=8
-  tee_local $3
+  tee_local $4
   call $~lib/internal/typedarray/TypedArray<i8>#constructor
-  set_local $2
-  loop $continue|0
+  tee_local $5
+  i32.load
+  set_local $6
+  loop $repeat|0
    get_local $1
-   get_local $3
+   get_local $4
    i32.lt_s
    if
     i32.const 3
     set_global $~argc
-    get_local $0
-    i32.load offset=4
-    get_local $0
-    i32.load
     get_local $1
+    get_local $6
     i32.add
+    get_local $1
+    get_local $2
+    i32.add
+    get_local $3
     i32.add
     i32.load8_s offset=8
     get_local $1
     get_local $0
     i32.const 24
     call_indirect (type $iiii)
-    i32.const 24
-    i32.shl
-    i32.const 24
-    i32.shr_s
-    set_local $4
-    get_local $2
-    i32.load offset=4
-    get_local $2
-    i32.load
-    get_local $1
-    i32.add
-    i32.add
-    get_local $4
     i32.store8 offset=8
-    get_local $2
-    i32.load offset=4
-    get_local $2
-    i32.load
-    get_local $1
-    i32.add
-    i32.add
-    i32.load8_s offset=8
-    drop
     get_local $1
     i32.const 1
     i32.add
     set_local $1
-    br $continue|0
+    br $repeat|0
    end
   end
-  get_local $2
+  get_local $5
  )
  (func $std/typedarray/testArrayMap<Int8Array,i8> (; 77 ;) (type $v)
   (local $0 i32)
@@ -3747,64 +3837,56 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Uint8Array#map (; 78 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  (local $1 i32)
+ (func $~lib/typedarray/Uint8Array#map (; 78 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
   get_local $0
   i32.load offset=8
-  tee_local $3
+  tee_local $5
   call $~lib/internal/typedarray/TypedArray<i8>#constructor
-  set_local $2
-  loop $continue|0
-   get_local $1
-   get_local $3
-   i32.lt_s
-   if
+  tee_local $6
+  i32.load
+  set_local $7
+  loop $repeat|0
+   block $break|0
+    get_local $2
+    get_local $5
+    i32.ge_s
+    br_if $break|0
     i32.const 3
     set_global $~argc
-    get_local $0
-    i32.load offset=4
-    get_local $0
-    i32.load
-    get_local $1
-    i32.add
-    i32.add
-    i32.load8_u offset=8
-    get_local $1
-    get_local $0
-    i32.const 25
-    call_indirect (type $iiii)
-    i32.const 255
-    i32.and
-    set_local $4
     get_local $2
-    i32.load offset=4
-    get_local $2
-    i32.load
-    get_local $1
+    get_local $7
     i32.add
+    get_local $2
+    get_local $3
     i32.add
     get_local $4
-    i32.store8 offset=8
-    get_local $2
-    i32.load offset=4
-    get_local $2
-    i32.load
-    get_local $1
-    i32.add
     i32.add
     i32.load8_u offset=8
-    drop
+    get_local $2
+    get_local $0
     get_local $1
+    call_indirect (type $iiii)
+    i32.store8 offset=8
+    get_local $2
     i32.const 1
     i32.add
-    set_local $1
-    br $continue|0
+    set_local $2
+    br $repeat|0
    end
   end
-  get_local $2
+  get_local $6
  )
  (func $std/typedarray/testArrayMap<Uint8Array,u8> (; 79 ;) (type $v)
   (local $0 i32)
@@ -3823,6 +3905,7 @@
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<u8>#__set
   get_local $0
+  i32.const 25
   call $~lib/typedarray/Uint8Array#map
   tee_local $0
   i32.const 0
@@ -3870,77 +3953,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Uint8ClampedArray#map (; 80 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  get_local $0
-  i32.load offset=8
-  tee_local $4
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
-  set_local $2
-  loop $continue|0
-   get_local $1
-   get_local $4
-   i32.lt_s
-   if
-    i32.const 3
-    set_global $~argc
-    get_local $0
-    i32.load offset=4
-    get_local $0
-    i32.load
-    get_local $1
-    i32.add
-    i32.add
-    i32.load8_u offset=8
-    get_local $1
-    get_local $0
-    i32.const 26
-    call_indirect (type $iiii)
-    i32.const 255
-    i32.and
-    tee_local $3
-    i32.const 255
-    get_local $3
-    i32.const 255
-    i32.lt_s
-    select
-    set_local $3
-    get_local $2
-    i32.load offset=4
-    get_local $2
-    i32.load
-    get_local $1
-    i32.add
-    i32.add
-    get_local $3
-    i32.const 0
-    get_local $3
-    i32.const 0
-    i32.gt_s
-    select
-    i32.store8 offset=8
-    get_local $2
-    i32.load offset=4
-    get_local $2
-    i32.load
-    get_local $1
-    i32.add
-    i32.add
-    i32.load8_u offset=8
-    drop
-    get_local $1
-    i32.const 1
-    i32.add
-    set_local $1
-    br $continue|0
-   end
-  end
-  get_local $2
- )
- (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8> (; 81 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8> (; 80 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i8>#constructor
@@ -3957,7 +3970,8 @@
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#__set
   get_local $0
-  call $~lib/typedarray/Uint8ClampedArray#map
+  i32.const 26
+  call $~lib/typedarray/Uint8Array#map
   tee_local $0
   i32.const 0
   call $~lib/internal/typedarray/TypedArray<u8>#__get
@@ -4004,76 +4018,63 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Int16Array#map (; 82 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#map (; 81 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  get_local $0
+  i32.load
+  set_local $2
+  get_local $0
+  i32.load offset=4
+  set_local $3
   get_local $0
   i32.load offset=8
   i32.const 1
   i32.shr_u
-  tee_local $3
+  tee_local $4
   call $~lib/internal/typedarray/TypedArray<i16>#constructor
-  set_local $2
-  loop $continue|0
+  tee_local $5
+  i32.load
+  set_local $6
+  loop $repeat|0
    get_local $1
-   get_local $3
+   get_local $4
    i32.lt_s
    if
     i32.const 3
     set_global $~argc
-    get_local $0
-    i32.load offset=4
-    get_local $0
-    i32.load
     get_local $1
     i32.const 1
     i32.shl
+    tee_local $7
+    get_local $6
     i32.add
+    get_local $2
+    get_local $7
+    i32.add
+    get_local $3
     i32.add
     i32.load16_s offset=8
     get_local $1
     get_local $0
     i32.const 27
     call_indirect (type $iiii)
-    i32.const 16
-    i32.shl
-    i32.const 16
-    i32.shr_s
-    set_local $4
-    get_local $2
-    i32.load offset=4
-    get_local $2
-    i32.load
-    get_local $1
-    i32.const 1
-    i32.shl
-    i32.add
-    i32.add
-    get_local $4
     i32.store16 offset=8
-    get_local $2
-    i32.load offset=4
-    get_local $2
-    i32.load
-    get_local $1
-    i32.const 1
-    i32.shl
-    i32.add
-    i32.add
-    i32.load16_s offset=8
-    drop
     get_local $1
     i32.const 1
     i32.add
     set_local $1
-    br $continue|0
+    br $repeat|0
    end
   end
-  get_local $2
+  get_local $5
  )
- (func $~lib/internal/typedarray/TypedArray<i16>#__get (; 83 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<i16>#__get (; 82 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   get_local $1
   get_local $0
   i32.load offset=8
@@ -4099,7 +4100,7 @@
   i32.add
   i32.load16_s offset=8
  )
- (func $std/typedarray/testArrayMap<Int16Array,i16> (; 84 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int16Array,i16> (; 83 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i16>#constructor
@@ -4163,74 +4164,63 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Uint16Array#map (; 85 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#map (; 84 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  get_local $0
+  i32.load
+  set_local $2
+  get_local $0
+  i32.load offset=4
+  set_local $3
   get_local $0
   i32.load offset=8
   i32.const 1
   i32.shr_u
-  tee_local $3
+  tee_local $4
   call $~lib/internal/typedarray/TypedArray<i16>#constructor
-  set_local $2
-  loop $continue|0
+  tee_local $5
+  i32.load
+  set_local $6
+  loop $repeat|0
    get_local $1
-   get_local $3
+   get_local $4
    i32.lt_s
    if
     i32.const 3
     set_global $~argc
-    get_local $0
-    i32.load offset=4
-    get_local $0
-    i32.load
     get_local $1
     i32.const 1
     i32.shl
+    tee_local $7
+    get_local $6
     i32.add
+    get_local $2
+    get_local $7
+    i32.add
+    get_local $3
     i32.add
     i32.load16_u offset=8
     get_local $1
     get_local $0
     i32.const 28
     call_indirect (type $iiii)
-    i32.const 65535
-    i32.and
-    set_local $4
-    get_local $2
-    i32.load offset=4
-    get_local $2
-    i32.load
-    get_local $1
-    i32.const 1
-    i32.shl
-    i32.add
-    i32.add
-    get_local $4
     i32.store16 offset=8
-    get_local $2
-    i32.load offset=4
-    get_local $2
-    i32.load
-    get_local $1
-    i32.const 1
-    i32.shl
-    i32.add
-    i32.add
-    i32.load16_u offset=8
-    drop
     get_local $1
     i32.const 1
     i32.add
     set_local $1
-    br $continue|0
+    br $repeat|0
    end
   end
-  get_local $2
+  get_local $5
  )
- (func $~lib/internal/typedarray/TypedArray<u16>#__get (; 86 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<u16>#__get (; 85 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   get_local $1
   get_local $0
   i32.load offset=8
@@ -4256,7 +4246,7 @@
   i32.add
   i32.load16_u offset=8
  )
- (func $std/typedarray/testArrayMap<Uint16Array,u16> (; 87 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint16Array,u16> (; 86 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i16>#constructor
@@ -4320,72 +4310,64 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Int32Array#map (; 88 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#map (; 87 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
   get_local $0
   i32.load offset=8
   i32.const 2
   i32.shr_u
-  tee_local $4
+  tee_local $5
   call $~lib/internal/typedarray/TypedArray<i32>#constructor
-  set_local $3
-  loop $continue|0
-   get_local $2
-   get_local $4
-   i32.lt_s
-   if
+  tee_local $6
+  i32.load
+  set_local $7
+  loop $repeat|0
+   block $break|0
+    get_local $2
+    get_local $5
+    i32.ge_s
+    br_if $break|0
     i32.const 3
     set_global $~argc
-    get_local $0
-    i32.load offset=4
-    get_local $0
-    i32.load
+    get_local $7
     get_local $2
     i32.const 2
     i32.shl
     i32.add
+    get_local $2
+    i32.const 2
+    i32.shl
+    get_local $3
+    i32.add
+    get_local $4
     i32.add
     i32.load offset=8
     get_local $2
     get_local $0
     get_local $1
     call_indirect (type $iiii)
-    set_local $5
-    get_local $3
-    i32.load offset=4
-    get_local $3
-    i32.load
-    get_local $2
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.add
-    get_local $5
     i32.store offset=8
-    get_local $3
-    i32.load offset=4
-    get_local $3
-    i32.load
-    get_local $2
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.add
-    i32.load offset=8
-    drop
     get_local $2
     i32.const 1
     i32.add
     set_local $2
-    br $continue|0
+    br $repeat|0
    end
   end
-  get_local $3
+  get_local $6
  )
- (func $std/typedarray/testArrayMap<Int32Array,i32> (; 89 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int32Array,i32> (; 88 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i32>#constructor
@@ -4444,7 +4426,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint32Array,u32> (; 90 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint32Array,u32> (; 89 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i32>#constructor
@@ -4503,77 +4485,69 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 (; 91 ;) (type $IiiI) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+ (func $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 (; 90 ;) (type $IiiI) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
   get_local $0
   get_local $0
   i64.mul
  )
- (func $~lib/typedarray/Int64Array#map (; 92 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#map (; 91 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i64)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
   get_local $0
   i32.load offset=8
   i32.const 3
   i32.shr_u
-  tee_local $4
+  tee_local $5
   call $~lib/internal/typedarray/TypedArray<i64>#constructor
-  set_local $3
-  loop $continue|0
-   get_local $2
-   get_local $4
-   i32.lt_s
-   if
+  tee_local $6
+  i32.load
+  set_local $7
+  loop $repeat|0
+   block $break|0
+    get_local $2
+    get_local $5
+    i32.ge_s
+    br_if $break|0
     i32.const 3
     set_global $~argc
-    get_local $0
-    i32.load offset=4
-    get_local $0
-    i32.load
+    get_local $7
     get_local $2
     i32.const 3
     i32.shl
     i32.add
+    get_local $2
+    i32.const 3
+    i32.shl
+    get_local $3
+    i32.add
+    get_local $4
     i32.add
     i64.load offset=8
     get_local $2
     get_local $0
     get_local $1
     call_indirect (type $IiiI)
-    set_local $5
-    get_local $3
-    i32.load offset=4
-    get_local $3
-    i32.load
-    get_local $2
-    i32.const 3
-    i32.shl
-    i32.add
-    i32.add
-    get_local $5
     i64.store offset=8
-    get_local $3
-    i32.load offset=4
-    get_local $3
-    i32.load
-    get_local $2
-    i32.const 3
-    i32.shl
-    i32.add
-    i32.add
-    i64.load offset=8
-    drop
     get_local $2
     i32.const 1
     i32.add
     set_local $2
-    br $continue|0
+    br $repeat|0
    end
   end
-  get_local $3
+  get_local $6
  )
- (func $~lib/internal/typedarray/TypedArray<i64>#__get (; 93 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/internal/typedarray/TypedArray<i64>#__get (; 92 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
   get_local $1
   get_local $0
   i32.load offset=8
@@ -4599,7 +4573,7 @@
   i32.add
   i64.load offset=8
  )
- (func $std/typedarray/testArrayMap<Int64Array,i64> (; 94 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int64Array,i64> (; 93 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i64>#constructor
@@ -4658,7 +4632,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint64Array,u64> (; 95 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint64Array,u64> (; 94 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i64>#constructor
@@ -4717,77 +4691,68 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|33 (; 96 ;) (type $fiif) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
+ (func $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|33 (; 95 ;) (type $fiif) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
   get_local $0
   get_local $0
   f32.mul
  )
- (func $~lib/typedarray/Float32Array#map (; 97 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#map (; 96 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 f32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  get_local $0
+  i32.load
+  set_local $2
+  get_local $0
+  i32.load offset=4
+  set_local $3
   get_local $0
   i32.load offset=8
   i32.const 2
   i32.shr_u
-  tee_local $3
+  tee_local $4
   call $~lib/internal/typedarray/TypedArray<i32>#constructor
-  set_local $2
-  loop $continue|0
+  tee_local $5
+  i32.load
+  set_local $6
+  loop $repeat|0
    get_local $1
-   get_local $3
+   get_local $4
    i32.lt_s
    if
     i32.const 3
     set_global $~argc
-    get_local $0
-    i32.load offset=4
-    get_local $0
-    i32.load
     get_local $1
     i32.const 2
     i32.shl
+    tee_local $7
+    get_local $6
     i32.add
+    get_local $2
+    get_local $7
+    i32.add
+    get_local $3
     i32.add
     f32.load offset=8
     get_local $1
     get_local $0
     i32.const 33
     call_indirect (type $fiif)
-    set_local $4
-    get_local $2
-    i32.load offset=4
-    get_local $2
-    i32.load
-    get_local $1
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.add
-    get_local $4
     f32.store offset=8
-    get_local $2
-    i32.load offset=4
-    get_local $2
-    i32.load
-    get_local $1
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.add
-    f32.load offset=8
-    drop
     get_local $1
     i32.const 1
     i32.add
     set_local $1
-    br $continue|0
+    br $repeat|0
    end
   end
-  get_local $2
+  get_local $5
  )
- (func $~lib/internal/typedarray/TypedArray<f32>#__get (; 98 ;) (type $iif) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/internal/typedarray/TypedArray<f32>#__get (; 97 ;) (type $iif) (param $0 i32) (param $1 i32) (result f32)
   get_local $1
   get_local $0
   i32.load offset=8
@@ -4813,7 +4778,7 @@
   i32.add
   f32.load offset=8
  )
- (func $std/typedarray/testArrayMap<Float32Array,f32> (; 99 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Float32Array,f32> (; 98 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i32>#constructor
@@ -4871,77 +4836,68 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|34 (; 100 ;) (type $FiiF) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
+ (func $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|34 (; 99 ;) (type $FiiF) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
   get_local $0
   get_local $0
   f64.mul
  )
- (func $~lib/typedarray/Float64Array#map (; 101 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#map (; 100 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 f64)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  get_local $0
+  i32.load
+  set_local $2
+  get_local $0
+  i32.load offset=4
+  set_local $3
   get_local $0
   i32.load offset=8
   i32.const 3
   i32.shr_u
-  tee_local $3
+  tee_local $4
   call $~lib/internal/typedarray/TypedArray<i64>#constructor
-  set_local $2
-  loop $continue|0
+  tee_local $5
+  i32.load
+  set_local $6
+  loop $repeat|0
    get_local $1
-   get_local $3
+   get_local $4
    i32.lt_s
    if
     i32.const 3
     set_global $~argc
-    get_local $0
-    i32.load offset=4
-    get_local $0
-    i32.load
     get_local $1
     i32.const 3
     i32.shl
+    tee_local $7
+    get_local $6
     i32.add
+    get_local $2
+    get_local $7
+    i32.add
+    get_local $3
     i32.add
     f64.load offset=8
     get_local $1
     get_local $0
     i32.const 34
     call_indirect (type $FiiF)
-    set_local $4
-    get_local $2
-    i32.load offset=4
-    get_local $2
-    i32.load
-    get_local $1
-    i32.const 3
-    i32.shl
-    i32.add
-    i32.add
-    get_local $4
     f64.store offset=8
-    get_local $2
-    i32.load offset=4
-    get_local $2
-    i32.load
-    get_local $1
-    i32.const 3
-    i32.shl
-    i32.add
-    i32.add
-    f64.load offset=8
-    drop
     get_local $1
     i32.const 1
     i32.add
     set_local $1
-    br $continue|0
+    br $repeat|0
    end
   end
-  get_local $2
+  get_local $5
  )
- (func $std/typedarray/testArrayMap<Float64Array,f64> (; 102 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Float64Array,f64> (; 101 ;) (type $v)
   (local $0 i32)
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<i64>#constructor
@@ -4999,7 +4955,3019 @@
    unreachable
   end
  )
- (func $start (; 103 ;) (type $v)
+ (func $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 (; 102 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 255
+  i32.and
+  i32.const 2
+  i32.eq
+ )
+ (func $~lib/typedarray/Int8Array#some (; 103 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/SOME<Int8Array,i8>|inlined.0 (result i32)
+   get_local $0
+   i32.load offset=8
+   set_local $3
+   get_local $0
+   i32.load
+   set_local $4
+   get_local $0
+   i32.load offset=4
+   set_local $5
+   loop $repeat|0
+    block $break|0
+     get_local $2
+     get_local $3
+     i32.ge_s
+     br_if $break|0
+     i32.const 3
+     set_global $~argc
+     i32.const 1
+     get_local $2
+     get_local $4
+     i32.add
+     get_local $5
+     i32.add
+     i32.load8_s offset=8
+     get_local $2
+     get_local $0
+     get_local $1
+     call_indirect (type $iiii)
+     br_if $~lib/internal/typedarray/SOME<Int8Array,i8>|inlined.0
+     drop
+     get_local $2
+     i32.const 1
+     i32.add
+     set_local $2
+     br $repeat|0
+    end
+   end
+   i32.const 0
+  end
+ )
+ (func $std/typedarray/testArraySome<Int8Array,i8>~anonymous|36 (; 104 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 255
+  i32.and
+  i32.eqz
+ )
+ (func $std/typedarray/testArraySome<Int8Array,i8> (; 105 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 35
+  call $~lib/typedarray/Int8Array#some
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 335
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 36
+  call $~lib/typedarray/Int8Array#some
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 338
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $~lib/typedarray/Uint8Array#some (; 106 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/SOME<Uint8Array,u8>|inlined.0 (result i32)
+   get_local $0
+   i32.load offset=8
+   set_local $3
+   get_local $0
+   i32.load
+   set_local $4
+   get_local $0
+   i32.load offset=4
+   set_local $5
+   loop $repeat|0
+    block $break|0
+     get_local $2
+     get_local $3
+     i32.ge_s
+     br_if $break|0
+     i32.const 3
+     set_global $~argc
+     i32.const 1
+     get_local $2
+     get_local $4
+     i32.add
+     get_local $5
+     i32.add
+     i32.load8_u offset=8
+     get_local $2
+     get_local $0
+     get_local $1
+     call_indirect (type $iiii)
+     br_if $~lib/internal/typedarray/SOME<Uint8Array,u8>|inlined.0
+     drop
+     get_local $2
+     i32.const 1
+     i32.add
+     set_local $2
+     br $repeat|0
+    end
+   end
+   i32.const 0
+  end
+ )
+ (func $std/typedarray/testArraySome<Uint8Array,u8> (; 107 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 37
+  call $~lib/typedarray/Uint8Array#some
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 335
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 38
+  call $~lib/typedarray/Uint8Array#some
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 338
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArraySome<Uint8ClampedArray,u8> (; 108 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/typedarray/Uint8ClampedArray#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/typedarray/Uint8ClampedArray#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/typedarray/Uint8ClampedArray#__set
+  get_local $0
+  i32.const 39
+  call $~lib/typedarray/Uint8Array#some
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 335
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 40
+  call $~lib/typedarray/Uint8Array#some
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 338
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 (; 109 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 65535
+  i32.and
+  i32.const 2
+  i32.eq
+ )
+ (func $~lib/typedarray/Int16Array#some (; 110 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/SOME<Int16Array,i16>|inlined.0 (result i32)
+   get_local $0
+   i32.load offset=8
+   i32.const 1
+   i32.shr_u
+   set_local $3
+   get_local $0
+   i32.load
+   set_local $4
+   get_local $0
+   i32.load offset=4
+   set_local $5
+   loop $repeat|0
+    block $break|0
+     get_local $2
+     get_local $3
+     i32.ge_s
+     br_if $break|0
+     i32.const 3
+     set_global $~argc
+     i32.const 1
+     get_local $2
+     i32.const 1
+     i32.shl
+     get_local $4
+     i32.add
+     get_local $5
+     i32.add
+     i32.load16_s offset=8
+     get_local $2
+     get_local $0
+     get_local $1
+     call_indirect (type $iiii)
+     br_if $~lib/internal/typedarray/SOME<Int16Array,i16>|inlined.0
+     drop
+     get_local $2
+     i32.const 1
+     i32.add
+     set_local $2
+     br $repeat|0
+    end
+   end
+   i32.const 0
+  end
+ )
+ (func $std/typedarray/testArraySome<Int16Array,i16>~anonymous|42 (; 111 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 65535
+  i32.and
+  i32.eqz
+ )
+ (func $std/typedarray/testArraySome<Int16Array,i16> (; 112 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 41
+  call $~lib/typedarray/Int16Array#some
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 335
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 42
+  call $~lib/typedarray/Int16Array#some
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 338
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $~lib/typedarray/Uint16Array#some (; 113 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/SOME<Uint16Array,u16>|inlined.0 (result i32)
+   get_local $0
+   i32.load offset=8
+   i32.const 1
+   i32.shr_u
+   set_local $3
+   get_local $0
+   i32.load
+   set_local $4
+   get_local $0
+   i32.load offset=4
+   set_local $5
+   loop $repeat|0
+    block $break|0
+     get_local $2
+     get_local $3
+     i32.ge_s
+     br_if $break|0
+     i32.const 3
+     set_global $~argc
+     i32.const 1
+     get_local $2
+     i32.const 1
+     i32.shl
+     get_local $4
+     i32.add
+     get_local $5
+     i32.add
+     i32.load16_u offset=8
+     get_local $2
+     get_local $0
+     get_local $1
+     call_indirect (type $iiii)
+     br_if $~lib/internal/typedarray/SOME<Uint16Array,u16>|inlined.0
+     drop
+     get_local $2
+     i32.const 1
+     i32.add
+     set_local $2
+     br $repeat|0
+    end
+   end
+   i32.const 0
+  end
+ )
+ (func $std/typedarray/testArraySome<Uint16Array,u16> (; 114 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 43
+  call $~lib/typedarray/Uint16Array#some
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 335
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 44
+  call $~lib/typedarray/Uint16Array#some
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 338
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 (; 115 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 2
+  i32.eq
+ )
+ (func $~lib/typedarray/Int32Array#some (; 116 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/SOME<Int32Array,i32>|inlined.0 (result i32)
+   get_local $0
+   i32.load offset=8
+   i32.const 2
+   i32.shr_u
+   set_local $3
+   get_local $0
+   i32.load
+   set_local $4
+   get_local $0
+   i32.load offset=4
+   set_local $5
+   loop $repeat|0
+    block $break|0
+     get_local $2
+     get_local $3
+     i32.ge_s
+     br_if $break|0
+     i32.const 3
+     set_global $~argc
+     i32.const 1
+     get_local $2
+     i32.const 2
+     i32.shl
+     get_local $4
+     i32.add
+     get_local $5
+     i32.add
+     i32.load offset=8
+     get_local $2
+     get_local $0
+     get_local $1
+     call_indirect (type $iiii)
+     br_if $~lib/internal/typedarray/SOME<Int32Array,i32>|inlined.0
+     drop
+     get_local $2
+     i32.const 1
+     i32.add
+     set_local $2
+     br $repeat|0
+    end
+   end
+   i32.const 0
+  end
+ )
+ (func $std/typedarray/testArraySome<Int32Array,i32>~anonymous|46 (; 117 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.eqz
+ )
+ (func $std/typedarray/testArraySome<Int32Array,i32> (; 118 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 45
+  call $~lib/typedarray/Int32Array#some
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 335
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 46
+  call $~lib/typedarray/Int32Array#some
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 338
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArraySome<Uint32Array,u32> (; 119 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 47
+  call $~lib/typedarray/Int32Array#some
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 335
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 48
+  call $~lib/typedarray/Int32Array#some
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 338
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 (; 120 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i64.const 2
+  i64.eq
+ )
+ (func $~lib/typedarray/Int64Array#some (; 121 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/SOME<Int64Array,i64>|inlined.0 (result i32)
+   get_local $0
+   i32.load offset=8
+   i32.const 3
+   i32.shr_u
+   set_local $3
+   get_local $0
+   i32.load
+   set_local $4
+   get_local $0
+   i32.load offset=4
+   set_local $5
+   loop $repeat|0
+    block $break|0
+     get_local $2
+     get_local $3
+     i32.ge_s
+     br_if $break|0
+     i32.const 3
+     set_global $~argc
+     i32.const 1
+     get_local $2
+     i32.const 3
+     i32.shl
+     get_local $4
+     i32.add
+     get_local $5
+     i32.add
+     i64.load offset=8
+     get_local $2
+     get_local $0
+     get_local $1
+     call_indirect (type $Iiii)
+     br_if $~lib/internal/typedarray/SOME<Int64Array,i64>|inlined.0
+     drop
+     get_local $2
+     i32.const 1
+     i32.add
+     set_local $2
+     br $repeat|0
+    end
+   end
+   i32.const 0
+  end
+ )
+ (func $std/typedarray/testArraySome<Int64Array,i64>~anonymous|50 (; 122 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i64.const 0
+  i64.eq
+ )
+ (func $std/typedarray/testArraySome<Int64Array,i64> (; 123 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  tee_local $0
+  i32.const 0
+  i64.const 2
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 1
+  i64.const 4
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 2
+  i64.const 6
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 49
+  call $~lib/typedarray/Int64Array#some
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 335
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 50
+  call $~lib/typedarray/Int64Array#some
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 338
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArraySome<Uint64Array,u64> (; 124 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  tee_local $0
+  i32.const 0
+  i64.const 2
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 1
+  i64.const 4
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 2
+  i64.const 6
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 51
+  call $~lib/typedarray/Int64Array#some
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 335
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 52
+  call $~lib/typedarray/Int64Array#some
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 338
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArraySome<Float32Array,f32>~anonymous|53 (; 125 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  f32.const 2
+  f32.eq
+ )
+ (func $~lib/typedarray/Float32Array#some (; 126 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/SOME<Float32Array,f32>|inlined.0 (result i32)
+   get_local $0
+   i32.load offset=8
+   i32.const 2
+   i32.shr_u
+   set_local $3
+   get_local $0
+   i32.load
+   set_local $4
+   get_local $0
+   i32.load offset=4
+   set_local $5
+   loop $repeat|0
+    block $break|0
+     get_local $2
+     get_local $3
+     i32.ge_s
+     br_if $break|0
+     i32.const 3
+     set_global $~argc
+     i32.const 1
+     get_local $2
+     i32.const 2
+     i32.shl
+     get_local $4
+     i32.add
+     get_local $5
+     i32.add
+     f32.load offset=8
+     get_local $2
+     get_local $0
+     get_local $1
+     call_indirect (type $fiii)
+     br_if $~lib/internal/typedarray/SOME<Float32Array,f32>|inlined.0
+     drop
+     get_local $2
+     i32.const 1
+     i32.add
+     set_local $2
+     br $repeat|0
+    end
+   end
+   i32.const 0
+  end
+ )
+ (func $std/typedarray/testArraySome<Float32Array,f32>~anonymous|54 (; 127 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  f32.const 0
+  f32.eq
+ )
+ (func $std/typedarray/testArraySome<Float32Array,f32> (; 128 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  tee_local $0
+  i32.const 0
+  f32.const 2
+  call $~lib/internal/typedarray/TypedArray<f32>#__set
+  get_local $0
+  i32.const 1
+  f32.const 4
+  call $~lib/internal/typedarray/TypedArray<f32>#__set
+  get_local $0
+  i32.const 2
+  f32.const 6
+  call $~lib/internal/typedarray/TypedArray<f32>#__set
+  get_local $0
+  i32.const 53
+  call $~lib/typedarray/Float32Array#some
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 335
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 54
+  call $~lib/typedarray/Float32Array#some
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 338
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArraySome<Float64Array,f64>~anonymous|55 (; 129 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  f64.const 2
+  f64.eq
+ )
+ (func $~lib/typedarray/Float64Array#some (; 130 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/SOME<Float64Array,f64>|inlined.0 (result i32)
+   get_local $0
+   i32.load offset=8
+   i32.const 3
+   i32.shr_u
+   set_local $3
+   get_local $0
+   i32.load
+   set_local $4
+   get_local $0
+   i32.load offset=4
+   set_local $5
+   loop $repeat|0
+    block $break|0
+     get_local $2
+     get_local $3
+     i32.ge_s
+     br_if $break|0
+     i32.const 3
+     set_global $~argc
+     i32.const 1
+     get_local $2
+     i32.const 3
+     i32.shl
+     get_local $4
+     i32.add
+     get_local $5
+     i32.add
+     f64.load offset=8
+     get_local $2
+     get_local $0
+     get_local $1
+     call_indirect (type $Fiii)
+     br_if $~lib/internal/typedarray/SOME<Float64Array,f64>|inlined.0
+     drop
+     get_local $2
+     i32.const 1
+     i32.add
+     set_local $2
+     br $repeat|0
+    end
+   end
+   i32.const 0
+  end
+ )
+ (func $std/typedarray/testArraySome<Float64Array,f64>~anonymous|56 (; 131 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  f64.const 0
+  f64.eq
+ )
+ (func $std/typedarray/testArraySome<Float64Array,f64> (; 132 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  tee_local $0
+  i32.const 0
+  f64.const 2
+  call $~lib/internal/typedarray/TypedArray<f64>#__set
+  get_local $0
+  i32.const 1
+  f64.const 4
+  call $~lib/internal/typedarray/TypedArray<f64>#__set
+  get_local $0
+  i32.const 2
+  f64.const 6
+  call $~lib/internal/typedarray/TypedArray<f64>#__set
+  get_local $0
+  i32.const 55
+  call $~lib/typedarray/Float64Array#some
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 335
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 56
+  call $~lib/typedarray/Float64Array#some
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 338
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $~lib/typedarray/Int8Array#findIndex (; 133 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  get_local $0
+  i32.load offset=8
+  set_local $3
+  get_local $0
+  i32.load
+  set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
+  block $~lib/internal/typedarray/FIND_INDEX<Int8Array,i8>|inlined.0
+   loop $repeat|0
+    block $break|0
+     get_local $2
+     get_local $3
+     i32.ge_s
+     br_if $break|0
+     i32.const 3
+     set_global $~argc
+     get_local $2
+     get_local $4
+     i32.add
+     get_local $5
+     i32.add
+     i32.load8_s offset=8
+     get_local $2
+     get_local $0
+     get_local $1
+     call_indirect (type $iiii)
+     br_if $~lib/internal/typedarray/FIND_INDEX<Int8Array,i8>|inlined.0
+     get_local $2
+     i32.const 1
+     i32.add
+     set_local $2
+     br $repeat|0
+    end
+   end
+   i32.const -1
+   set_local $2
+  end
+  get_local $2
+ )
+ (func $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|58 (; 134 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 255
+  i32.and
+  i32.const 4
+  i32.eq
+ )
+ (func $std/typedarray/testArrayFindIndex<Int8Array,i8> (; 135 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 57
+  call $~lib/typedarray/Int8Array#findIndex
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 365
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 58
+  call $~lib/typedarray/Int8Array#findIndex
+  i32.const -1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 368
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $~lib/typedarray/Uint8Array#findIndex (; 136 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  get_local $0
+  i32.load offset=8
+  set_local $3
+  get_local $0
+  i32.load
+  set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
+  block $~lib/internal/typedarray/FIND_INDEX<Uint8Array,u8>|inlined.0
+   loop $repeat|0
+    block $break|0
+     get_local $2
+     get_local $3
+     i32.ge_s
+     br_if $break|0
+     i32.const 3
+     set_global $~argc
+     get_local $2
+     get_local $4
+     i32.add
+     get_local $5
+     i32.add
+     i32.load8_u offset=8
+     get_local $2
+     get_local $0
+     get_local $1
+     call_indirect (type $iiii)
+     br_if $~lib/internal/typedarray/FIND_INDEX<Uint8Array,u8>|inlined.0
+     get_local $2
+     i32.const 1
+     i32.add
+     set_local $2
+     br $repeat|0
+    end
+   end
+   i32.const -1
+   set_local $2
+  end
+  get_local $2
+ )
+ (func $std/typedarray/testArrayFindIndex<Uint8Array,u8> (; 137 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 59
+  call $~lib/typedarray/Uint8Array#findIndex
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 365
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 60
+  call $~lib/typedarray/Uint8Array#findIndex
+  i32.const -1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 368
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8> (; 138 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/typedarray/Uint8ClampedArray#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/typedarray/Uint8ClampedArray#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/typedarray/Uint8ClampedArray#__set
+  get_local $0
+  i32.const 61
+  call $~lib/typedarray/Uint8Array#findIndex
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 365
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 62
+  call $~lib/typedarray/Uint8Array#findIndex
+  i32.const -1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 368
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $~lib/typedarray/Int16Array#findIndex (; 139 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  get_local $0
+  i32.load offset=8
+  i32.const 1
+  i32.shr_u
+  set_local $3
+  get_local $0
+  i32.load
+  set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
+  block $~lib/internal/typedarray/FIND_INDEX<Int16Array,i16>|inlined.0
+   loop $repeat|0
+    block $break|0
+     get_local $2
+     get_local $3
+     i32.ge_s
+     br_if $break|0
+     i32.const 3
+     set_global $~argc
+     get_local $2
+     i32.const 1
+     i32.shl
+     get_local $4
+     i32.add
+     get_local $5
+     i32.add
+     i32.load16_s offset=8
+     get_local $2
+     get_local $0
+     get_local $1
+     call_indirect (type $iiii)
+     br_if $~lib/internal/typedarray/FIND_INDEX<Int16Array,i16>|inlined.0
+     get_local $2
+     i32.const 1
+     i32.add
+     set_local $2
+     br $repeat|0
+    end
+   end
+   i32.const -1
+   set_local $2
+  end
+  get_local $2
+ )
+ (func $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|64 (; 140 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 65535
+  i32.and
+  i32.const 4
+  i32.eq
+ )
+ (func $std/typedarray/testArrayFindIndex<Int16Array,i16> (; 141 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 63
+  call $~lib/typedarray/Int16Array#findIndex
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 365
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 64
+  call $~lib/typedarray/Int16Array#findIndex
+  i32.const -1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 368
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $~lib/typedarray/Uint16Array#findIndex (; 142 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  get_local $0
+  i32.load offset=8
+  i32.const 1
+  i32.shr_u
+  set_local $3
+  get_local $0
+  i32.load
+  set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
+  block $~lib/internal/typedarray/FIND_INDEX<Uint16Array,u16>|inlined.0
+   loop $repeat|0
+    block $break|0
+     get_local $2
+     get_local $3
+     i32.ge_s
+     br_if $break|0
+     i32.const 3
+     set_global $~argc
+     get_local $2
+     i32.const 1
+     i32.shl
+     get_local $4
+     i32.add
+     get_local $5
+     i32.add
+     i32.load16_u offset=8
+     get_local $2
+     get_local $0
+     get_local $1
+     call_indirect (type $iiii)
+     br_if $~lib/internal/typedarray/FIND_INDEX<Uint16Array,u16>|inlined.0
+     get_local $2
+     i32.const 1
+     i32.add
+     set_local $2
+     br $repeat|0
+    end
+   end
+   i32.const -1
+   set_local $2
+  end
+  get_local $2
+ )
+ (func $std/typedarray/testArrayFindIndex<Uint16Array,u16> (; 143 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 65
+  call $~lib/typedarray/Uint16Array#findIndex
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 365
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 66
+  call $~lib/typedarray/Uint16Array#findIndex
+  i32.const -1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 368
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $~lib/typedarray/Int32Array#findIndex (; 144 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  get_local $0
+  i32.load offset=8
+  i32.const 2
+  i32.shr_u
+  set_local $3
+  get_local $0
+  i32.load
+  set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
+  block $~lib/internal/typedarray/FIND_INDEX<Int32Array,i32>|inlined.0
+   loop $repeat|0
+    block $break|0
+     get_local $2
+     get_local $3
+     i32.ge_s
+     br_if $break|0
+     i32.const 3
+     set_global $~argc
+     get_local $2
+     i32.const 2
+     i32.shl
+     get_local $4
+     i32.add
+     get_local $5
+     i32.add
+     i32.load offset=8
+     get_local $2
+     get_local $0
+     get_local $1
+     call_indirect (type $iiii)
+     br_if $~lib/internal/typedarray/FIND_INDEX<Int32Array,i32>|inlined.0
+     get_local $2
+     i32.const 1
+     i32.add
+     set_local $2
+     br $repeat|0
+    end
+   end
+   i32.const -1
+   set_local $2
+  end
+  get_local $2
+ )
+ (func $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|68 (; 145 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 4
+  i32.eq
+ )
+ (func $std/typedarray/testArrayFindIndex<Int32Array,i32> (; 146 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 67
+  call $~lib/typedarray/Int32Array#findIndex
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 365
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 68
+  call $~lib/typedarray/Int32Array#findIndex
+  i32.const -1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 368
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayFindIndex<Uint32Array,u32> (; 147 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 69
+  call $~lib/typedarray/Int32Array#findIndex
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 365
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 70
+  call $~lib/typedarray/Int32Array#findIndex
+  i32.const -1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 368
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $~lib/typedarray/Int64Array#findIndex (; 148 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  get_local $0
+  i32.load offset=8
+  i32.const 3
+  i32.shr_u
+  set_local $3
+  get_local $0
+  i32.load
+  set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
+  block $~lib/internal/typedarray/FIND_INDEX<Int64Array,i64>|inlined.0
+   loop $repeat|0
+    block $break|0
+     get_local $2
+     get_local $3
+     i32.ge_s
+     br_if $break|0
+     i32.const 3
+     set_global $~argc
+     get_local $2
+     i32.const 3
+     i32.shl
+     get_local $4
+     i32.add
+     get_local $5
+     i32.add
+     i64.load offset=8
+     get_local $2
+     get_local $0
+     get_local $1
+     call_indirect (type $Iiii)
+     br_if $~lib/internal/typedarray/FIND_INDEX<Int64Array,i64>|inlined.0
+     get_local $2
+     i32.const 1
+     i32.add
+     set_local $2
+     br $repeat|0
+    end
+   end
+   i32.const -1
+   set_local $2
+  end
+  get_local $2
+ )
+ (func $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|72 (; 149 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i64.const 4
+  i64.eq
+ )
+ (func $std/typedarray/testArrayFindIndex<Int64Array,i64> (; 150 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  tee_local $0
+  i32.const 0
+  i64.const 1
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 1
+  i64.const 2
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 2
+  i64.const 3
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 71
+  call $~lib/typedarray/Int64Array#findIndex
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 365
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 72
+  call $~lib/typedarray/Int64Array#findIndex
+  i32.const -1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 368
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayFindIndex<Uint64Array,u64> (; 151 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  tee_local $0
+  i32.const 0
+  i64.const 1
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 1
+  i64.const 2
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 2
+  i64.const 3
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 73
+  call $~lib/typedarray/Int64Array#findIndex
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 365
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 74
+  call $~lib/typedarray/Int64Array#findIndex
+  i32.const -1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 368
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $~lib/typedarray/Float32Array#findIndex (; 152 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  get_local $0
+  i32.load offset=8
+  i32.const 2
+  i32.shr_u
+  set_local $3
+  get_local $0
+  i32.load
+  set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
+  block $~lib/internal/typedarray/FIND_INDEX<Float32Array,f32>|inlined.0
+   loop $repeat|0
+    block $break|0
+     get_local $2
+     get_local $3
+     i32.ge_s
+     br_if $break|0
+     i32.const 3
+     set_global $~argc
+     get_local $2
+     i32.const 2
+     i32.shl
+     get_local $4
+     i32.add
+     get_local $5
+     i32.add
+     f32.load offset=8
+     get_local $2
+     get_local $0
+     get_local $1
+     call_indirect (type $fiii)
+     br_if $~lib/internal/typedarray/FIND_INDEX<Float32Array,f32>|inlined.0
+     get_local $2
+     i32.const 1
+     i32.add
+     set_local $2
+     br $repeat|0
+    end
+   end
+   i32.const -1
+   set_local $2
+  end
+  get_local $2
+ )
+ (func $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|76 (; 153 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  f32.const 4
+  f32.eq
+ )
+ (func $std/typedarray/testArrayFindIndex<Float32Array,f32> (; 154 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  tee_local $0
+  i32.const 0
+  f32.const 1
+  call $~lib/internal/typedarray/TypedArray<f32>#__set
+  get_local $0
+  i32.const 1
+  f32.const 2
+  call $~lib/internal/typedarray/TypedArray<f32>#__set
+  get_local $0
+  i32.const 2
+  f32.const 3
+  call $~lib/internal/typedarray/TypedArray<f32>#__set
+  get_local $0
+  i32.const 75
+  call $~lib/typedarray/Float32Array#findIndex
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 365
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 76
+  call $~lib/typedarray/Float32Array#findIndex
+  i32.const -1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 368
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $~lib/typedarray/Float64Array#findIndex (; 155 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  get_local $0
+  i32.load offset=8
+  i32.const 3
+  i32.shr_u
+  set_local $3
+  get_local $0
+  i32.load
+  set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
+  block $~lib/internal/typedarray/FIND_INDEX<Float64Array,f64>|inlined.0
+   loop $repeat|0
+    block $break|0
+     get_local $2
+     get_local $3
+     i32.ge_s
+     br_if $break|0
+     i32.const 3
+     set_global $~argc
+     get_local $2
+     i32.const 3
+     i32.shl
+     get_local $4
+     i32.add
+     get_local $5
+     i32.add
+     f64.load offset=8
+     get_local $2
+     get_local $0
+     get_local $1
+     call_indirect (type $Fiii)
+     br_if $~lib/internal/typedarray/FIND_INDEX<Float64Array,f64>|inlined.0
+     get_local $2
+     i32.const 1
+     i32.add
+     set_local $2
+     br $repeat|0
+    end
+   end
+   i32.const -1
+   set_local $2
+  end
+  get_local $2
+ )
+ (func $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|78 (; 156 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  f64.const 4
+  f64.eq
+ )
+ (func $std/typedarray/testArrayFindIndex<Float64Array,f64> (; 157 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  tee_local $0
+  i32.const 0
+  f64.const 1
+  call $~lib/internal/typedarray/TypedArray<f64>#__set
+  get_local $0
+  i32.const 1
+  f64.const 2
+  call $~lib/internal/typedarray/TypedArray<f64>#__set
+  get_local $0
+  i32.const 2
+  f64.const 3
+  call $~lib/internal/typedarray/TypedArray<f64>#__set
+  get_local $0
+  i32.const 77
+  call $~lib/typedarray/Float64Array#findIndex
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 365
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 78
+  call $~lib/typedarray/Float64Array#findIndex
+  i32.const -1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 368
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|79 (; 158 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 24
+  i32.shl
+  i32.const 24
+  i32.shr_s
+  i32.const 2
+  i32.rem_s
+  i32.eqz
+ )
+ (func $~lib/typedarray/Int8Array#every (; 159 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/EVERY<Int8Array,i8>|inlined.0 (result i32)
+   get_local $0
+   i32.load offset=8
+   set_local $3
+   get_local $0
+   i32.load
+   set_local $4
+   get_local $0
+   i32.load offset=4
+   set_local $5
+   loop $repeat|0
+    block $break|0
+     get_local $2
+     get_local $3
+     i32.ge_s
+     br_if $break|0
+     i32.const 3
+     set_global $~argc
+     get_local $2
+     get_local $4
+     i32.add
+     get_local $5
+     i32.add
+     i32.load8_s offset=8
+     get_local $2
+     get_local $0
+     get_local $1
+     call_indirect (type $iiii)
+     i32.eqz
+     if
+      i32.const 0
+      br $~lib/internal/typedarray/EVERY<Int8Array,i8>|inlined.0
+     end
+     get_local $2
+     i32.const 1
+     i32.add
+     set_local $2
+     br $repeat|0
+    end
+   end
+   i32.const 1
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Int8Array,i8> (; 160 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 79
+  call $~lib/typedarray/Int8Array#every
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 395
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 80
+  call $~lib/typedarray/Int8Array#every
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 398
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|81 (; 161 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 1
+  i32.and
+  i32.eqz
+ )
+ (func $~lib/typedarray/Uint8Array#every (; 162 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/EVERY<Uint8Array,u8>|inlined.0 (result i32)
+   get_local $0
+   i32.load offset=8
+   set_local $3
+   get_local $0
+   i32.load
+   set_local $4
+   get_local $0
+   i32.load offset=4
+   set_local $5
+   loop $repeat|0
+    block $break|0
+     get_local $2
+     get_local $3
+     i32.ge_s
+     br_if $break|0
+     i32.const 3
+     set_global $~argc
+     get_local $2
+     get_local $4
+     i32.add
+     get_local $5
+     i32.add
+     i32.load8_u offset=8
+     get_local $2
+     get_local $0
+     get_local $1
+     call_indirect (type $iiii)
+     i32.eqz
+     if
+      i32.const 0
+      br $~lib/internal/typedarray/EVERY<Uint8Array,u8>|inlined.0
+     end
+     get_local $2
+     i32.const 1
+     i32.add
+     set_local $2
+     br $repeat|0
+    end
+   end
+   i32.const 1
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Uint8Array,u8> (; 163 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 81
+  call $~lib/typedarray/Uint8Array#every
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 395
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 82
+  call $~lib/typedarray/Uint8Array#every
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 398
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8> (; 164 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/typedarray/Uint8ClampedArray#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/typedarray/Uint8ClampedArray#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/typedarray/Uint8ClampedArray#__set
+  get_local $0
+  i32.const 83
+  call $~lib/typedarray/Uint8Array#every
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 395
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 84
+  call $~lib/typedarray/Uint8Array#every
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 398
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|85 (; 165 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.shr_s
+  i32.const 2
+  i32.rem_s
+  i32.eqz
+ )
+ (func $~lib/typedarray/Int16Array#every (; 166 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/EVERY<Int16Array,i16>|inlined.0 (result i32)
+   get_local $0
+   i32.load offset=8
+   i32.const 1
+   i32.shr_u
+   set_local $3
+   get_local $0
+   i32.load
+   set_local $4
+   get_local $0
+   i32.load offset=4
+   set_local $5
+   loop $repeat|0
+    block $break|0
+     get_local $2
+     get_local $3
+     i32.ge_s
+     br_if $break|0
+     i32.const 3
+     set_global $~argc
+     get_local $2
+     i32.const 1
+     i32.shl
+     get_local $4
+     i32.add
+     get_local $5
+     i32.add
+     i32.load16_s offset=8
+     get_local $2
+     get_local $0
+     get_local $1
+     call_indirect (type $iiii)
+     i32.eqz
+     if
+      i32.const 0
+      br $~lib/internal/typedarray/EVERY<Int16Array,i16>|inlined.0
+     end
+     get_local $2
+     i32.const 1
+     i32.add
+     set_local $2
+     br $repeat|0
+    end
+   end
+   i32.const 1
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Int16Array,i16> (; 167 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 85
+  call $~lib/typedarray/Int16Array#every
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 395
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 86
+  call $~lib/typedarray/Int16Array#every
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 398
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $~lib/typedarray/Uint16Array#every (; 168 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/EVERY<Uint16Array,u16>|inlined.0 (result i32)
+   get_local $0
+   i32.load offset=8
+   i32.const 1
+   i32.shr_u
+   set_local $3
+   get_local $0
+   i32.load
+   set_local $4
+   get_local $0
+   i32.load offset=4
+   set_local $5
+   loop $repeat|0
+    block $break|0
+     get_local $2
+     get_local $3
+     i32.ge_s
+     br_if $break|0
+     i32.const 3
+     set_global $~argc
+     get_local $2
+     i32.const 1
+     i32.shl
+     get_local $4
+     i32.add
+     get_local $5
+     i32.add
+     i32.load16_u offset=8
+     get_local $2
+     get_local $0
+     get_local $1
+     call_indirect (type $iiii)
+     i32.eqz
+     if
+      i32.const 0
+      br $~lib/internal/typedarray/EVERY<Uint16Array,u16>|inlined.0
+     end
+     get_local $2
+     i32.const 1
+     i32.add
+     set_local $2
+     br $repeat|0
+    end
+   end
+   i32.const 1
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Uint16Array,u16> (; 169 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 87
+  call $~lib/typedarray/Uint16Array#every
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 395
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 88
+  call $~lib/typedarray/Uint16Array#every
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 398
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|89 (; 170 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 2
+  i32.rem_s
+  i32.eqz
+ )
+ (func $~lib/typedarray/Int32Array#every (; 171 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/EVERY<Int32Array,i32>|inlined.0 (result i32)
+   get_local $0
+   i32.load offset=8
+   i32.const 2
+   i32.shr_u
+   set_local $3
+   get_local $0
+   i32.load
+   set_local $4
+   get_local $0
+   i32.load offset=4
+   set_local $5
+   loop $repeat|0
+    block $break|0
+     get_local $2
+     get_local $3
+     i32.ge_s
+     br_if $break|0
+     i32.const 3
+     set_global $~argc
+     get_local $2
+     i32.const 2
+     i32.shl
+     get_local $4
+     i32.add
+     get_local $5
+     i32.add
+     i32.load offset=8
+     get_local $2
+     get_local $0
+     get_local $1
+     call_indirect (type $iiii)
+     i32.eqz
+     if
+      i32.const 0
+      br $~lib/internal/typedarray/EVERY<Int32Array,i32>|inlined.0
+     end
+     get_local $2
+     i32.const 1
+     i32.add
+     set_local $2
+     br $repeat|0
+    end
+   end
+   i32.const 1
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Int32Array,i32> (; 172 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 89
+  call $~lib/typedarray/Int32Array#every
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 395
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 90
+  call $~lib/typedarray/Int32Array#every
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 398
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Uint32Array,u32> (; 173 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  tee_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 91
+  call $~lib/typedarray/Int32Array#every
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 395
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 92
+  call $~lib/typedarray/Int32Array#every
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 398
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|93 (; 174 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i64.const 2
+  i64.rem_s
+  i64.const 0
+  i64.eq
+ )
+ (func $~lib/typedarray/Int64Array#every (; 175 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/EVERY<Int64Array,i64>|inlined.0 (result i32)
+   get_local $0
+   i32.load offset=8
+   i32.const 3
+   i32.shr_u
+   set_local $3
+   get_local $0
+   i32.load
+   set_local $4
+   get_local $0
+   i32.load offset=4
+   set_local $5
+   loop $repeat|0
+    block $break|0
+     get_local $2
+     get_local $3
+     i32.ge_s
+     br_if $break|0
+     i32.const 3
+     set_global $~argc
+     get_local $2
+     i32.const 3
+     i32.shl
+     get_local $4
+     i32.add
+     get_local $5
+     i32.add
+     i64.load offset=8
+     get_local $2
+     get_local $0
+     get_local $1
+     call_indirect (type $Iiii)
+     i32.eqz
+     if
+      i32.const 0
+      br $~lib/internal/typedarray/EVERY<Int64Array,i64>|inlined.0
+     end
+     get_local $2
+     i32.const 1
+     i32.add
+     set_local $2
+     br $repeat|0
+    end
+   end
+   i32.const 1
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Int64Array,i64> (; 176 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  tee_local $0
+  i32.const 0
+  i64.const 2
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 1
+  i64.const 4
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 2
+  i64.const 6
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 93
+  call $~lib/typedarray/Int64Array#every
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 395
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 94
+  call $~lib/typedarray/Int64Array#every
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 398
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|95 (; 177 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i64.const 2
+  i64.rem_u
+  i64.const 0
+  i64.eq
+ )
+ (func $std/typedarray/testArrayEvery<Uint64Array,u64> (; 178 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  tee_local $0
+  i32.const 0
+  i64.const 2
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 1
+  i64.const 4
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 2
+  i64.const 6
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 95
+  call $~lib/typedarray/Int64Array#every
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 395
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 96
+  call $~lib/typedarray/Int64Array#every
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 398
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $~lib/math/NativeMathf.mod (; 179 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  get_local $0
+  i32.reinterpret/f32
+  tee_local $1
+  i32.const 23
+  i32.shr_u
+  i32.const 255
+  i32.and
+  set_local $2
+  get_local $1
+  i32.const -2147483648
+  i32.and
+  set_local $4
+  get_local $2
+  i32.const 255
+  i32.eq
+  tee_local $3
+  if (result i32)
+   get_local $3
+  else   
+   i32.const 0
+  end
+  if
+   get_local $0
+   f32.const 2
+   f32.mul
+   tee_local $0
+   get_local $0
+   f32.div
+   return
+  end
+  block $folding-inner0
+   get_local $1
+   i32.const 1
+   i32.shl
+   tee_local $3
+   i32.const -2147483648
+   i32.le_u
+   if
+    get_local $3
+    i32.const -2147483648
+    i32.eq
+    br_if $folding-inner0
+    get_local $0
+    return
+   end
+   get_local $2
+   if (result i32)
+    get_local $1
+    i32.const 8388607
+    i32.and
+    i32.const 8388608
+    i32.or
+   else    
+    get_local $1
+    i32.const 1
+    get_local $2
+    get_local $1
+    i32.const 9
+    i32.shl
+    i32.clz
+    i32.sub
+    tee_local $2
+    i32.sub
+    i32.shl
+   end
+   set_local $1
+   loop $continue|0
+    get_local $2
+    i32.const 128
+    i32.gt_s
+    if
+     get_local $1
+     i32.const 8388608
+     i32.ge_u
+     if
+      get_local $1
+      i32.const 8388608
+      i32.eq
+      br_if $folding-inner0
+      get_local $1
+      i32.const 8388608
+      i32.sub
+      set_local $1
+     end
+     get_local $1
+     i32.const 1
+     i32.shl
+     set_local $1
+     get_local $2
+     i32.const 1
+     i32.sub
+     set_local $2
+     br $continue|0
+    end
+   end
+   get_local $1
+   i32.const 8388608
+   i32.ge_u
+   if
+    get_local $1
+    i32.const 8388608
+    i32.eq
+    br_if $folding-inner0
+    get_local $1
+    i32.const 8388608
+    i32.sub
+    set_local $1
+   end
+   get_local $1
+   get_local $1
+   i32.const 8
+   i32.shl
+   i32.clz
+   tee_local $3
+   i32.shl
+   set_local $1
+   get_local $2
+   get_local $3
+   i32.sub
+   tee_local $2
+   i32.const 0
+   i32.gt_s
+   if (result i32)
+    get_local $1
+    i32.const 8388608
+    i32.sub
+    get_local $2
+    i32.const 23
+    i32.shl
+    i32.or
+   else    
+    get_local $1
+    i32.const 1
+    get_local $2
+    i32.sub
+    i32.shr_u
+   end
+   get_local $4
+   i32.or
+   f32.reinterpret/i32
+   return
+  end
+  f32.const 0
+  get_local $0
+  f32.mul
+ )
+ (func $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|97 (; 180 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  call $~lib/math/NativeMathf.mod
+  f32.const 0
+  f32.eq
+ )
+ (func $~lib/typedarray/Float32Array#every (; 181 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/EVERY<Float32Array,f32>|inlined.0 (result i32)
+   get_local $0
+   i32.load offset=8
+   i32.const 2
+   i32.shr_u
+   set_local $3
+   get_local $0
+   i32.load
+   set_local $4
+   get_local $0
+   i32.load offset=4
+   set_local $5
+   loop $repeat|0
+    block $break|0
+     get_local $2
+     get_local $3
+     i32.ge_s
+     br_if $break|0
+     i32.const 3
+     set_global $~argc
+     get_local $2
+     i32.const 2
+     i32.shl
+     get_local $4
+     i32.add
+     get_local $5
+     i32.add
+     f32.load offset=8
+     get_local $2
+     get_local $0
+     get_local $1
+     call_indirect (type $fiii)
+     i32.eqz
+     if
+      i32.const 0
+      br $~lib/internal/typedarray/EVERY<Float32Array,f32>|inlined.0
+     end
+     get_local $2
+     i32.const 1
+     i32.add
+     set_local $2
+     br $repeat|0
+    end
+   end
+   i32.const 1
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Float32Array,f32> (; 182 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  tee_local $0
+  i32.const 0
+  f32.const 2
+  call $~lib/internal/typedarray/TypedArray<f32>#__set
+  get_local $0
+  i32.const 1
+  f32.const 4
+  call $~lib/internal/typedarray/TypedArray<f32>#__set
+  get_local $0
+  i32.const 2
+  f32.const 6
+  call $~lib/internal/typedarray/TypedArray<f32>#__set
+  get_local $0
+  i32.const 97
+  call $~lib/typedarray/Float32Array#every
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 395
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 98
+  call $~lib/typedarray/Float32Array#every
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 398
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $~lib/math/NativeMath.mod (; 183 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+  (local $1 i64)
+  (local $2 i64)
+  (local $3 i64)
+  (local $4 i64)
+  (local $5 i32)
+  get_local $0
+  i64.reinterpret/f64
+  tee_local $1
+  i64.const 52
+  i64.shr_u
+  i64.const 2047
+  i64.and
+  set_local $2
+  get_local $1
+  i64.const 63
+  i64.shr_u
+  set_local $4
+  get_local $2
+  i64.const 2047
+  i64.eq
+  tee_local $5
+  if (result i32)
+   get_local $5
+  else   
+   i32.const 0
+  end
+  if
+   get_local $0
+   f64.const 2
+   f64.mul
+   tee_local $0
+   get_local $0
+   f64.div
+   return
+  end
+  block $folding-inner0
+   get_local $1
+   i64.const 1
+   i64.shl
+   tee_local $3
+   i64.const -9223372036854775808
+   i64.le_u
+   if
+    get_local $3
+    i64.const -9223372036854775808
+    i64.eq
+    br_if $folding-inner0
+    get_local $0
+    return
+   end
+   get_local $2
+   i64.eqz
+   if (result i64)
+    get_local $1
+    i64.const 0
+    get_local $2
+    get_local $1
+    i64.const 12
+    i64.shl
+    i64.clz
+    i64.sub
+    tee_local $2
+    i64.sub
+    i64.const 1
+    i64.add
+    i64.shl
+   else    
+    get_local $1
+    i64.const 4503599627370495
+    i64.and
+    i64.const 4503599627370496
+    i64.or
+   end
+   set_local $1
+   loop $continue|0
+    get_local $2
+    i64.const 1024
+    i64.gt_s
+    if
+     get_local $1
+     i64.const 4503599627370496
+     i64.ge_u
+     if
+      get_local $1
+      i64.const 4503599627370496
+      i64.eq
+      br_if $folding-inner0
+      get_local $1
+      i64.const 4503599627370496
+      i64.sub
+      set_local $1
+     end
+     get_local $1
+     i64.const 1
+     i64.shl
+     set_local $1
+     get_local $2
+     i64.const 1
+     i64.sub
+     set_local $2
+     br $continue|0
+    end
+   end
+   get_local $1
+   i64.const 4503599627370496
+   i64.ge_u
+   if
+    get_local $1
+    i64.const 4503599627370496
+    i64.eq
+    br_if $folding-inner0
+    get_local $1
+    i64.const 4503599627370496
+    i64.sub
+    set_local $1
+   end
+   get_local $1
+   get_local $1
+   i64.const 11
+   i64.shl
+   i64.clz
+   tee_local $3
+   i64.shl
+   set_local $1
+   get_local $2
+   get_local $3
+   i64.sub
+   tee_local $2
+   i64.const 0
+   i64.gt_s
+   if (result i64)
+    get_local $1
+    i64.const 4503599627370496
+    i64.sub
+    get_local $2
+    i64.const 52
+    i64.shl
+    i64.or
+   else    
+    get_local $1
+    i64.const 0
+    get_local $2
+    i64.sub
+    i64.const 1
+    i64.add
+    i64.shr_u
+   end
+   get_local $4
+   i64.const 63
+   i64.shl
+   i64.or
+   f64.reinterpret/i64
+   return
+  end
+  f64.const 0
+  get_local $0
+  f64.mul
+ )
+ (func $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|99 (; 184 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  call $~lib/math/NativeMath.mod
+  f64.const 0
+  f64.eq
+ )
+ (func $~lib/typedarray/Float64Array#every (; 185 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/EVERY<Float64Array,f64>|inlined.0 (result i32)
+   get_local $0
+   i32.load offset=8
+   i32.const 3
+   i32.shr_u
+   set_local $3
+   get_local $0
+   i32.load
+   set_local $4
+   get_local $0
+   i32.load offset=4
+   set_local $5
+   loop $repeat|0
+    block $break|0
+     get_local $2
+     get_local $3
+     i32.ge_s
+     br_if $break|0
+     i32.const 3
+     set_global $~argc
+     get_local $2
+     i32.const 3
+     i32.shl
+     get_local $4
+     i32.add
+     get_local $5
+     i32.add
+     f64.load offset=8
+     get_local $2
+     get_local $0
+     get_local $1
+     call_indirect (type $Fiii)
+     i32.eqz
+     if
+      i32.const 0
+      br $~lib/internal/typedarray/EVERY<Float64Array,f64>|inlined.0
+     end
+     get_local $2
+     i32.const 1
+     i32.add
+     set_local $2
+     br $repeat|0
+    end
+   end
+   i32.const 1
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Float64Array,f64> (; 186 ;) (type $v)
+  (local $0 i32)
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  tee_local $0
+  i32.const 0
+  f64.const 2
+  call $~lib/internal/typedarray/TypedArray<f64>#__set
+  get_local $0
+  i32.const 1
+  f64.const 4
+  call $~lib/internal/typedarray/TypedArray<f64>#__set
+  get_local $0
+  i32.const 2
+  f64.const 6
+  call $~lib/internal/typedarray/TypedArray<f64>#__set
+  get_local $0
+  i32.const 99
+  call $~lib/typedarray/Float64Array#every
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 395
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 100
+  call $~lib/typedarray/Float64Array#every
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 398
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $start (; 187 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 624
@@ -5956,8 +8924,41 @@
   call $std/typedarray/testArrayMap<Uint64Array,u64>
   call $std/typedarray/testArrayMap<Float32Array,f32>
   call $std/typedarray/testArrayMap<Float64Array,f64>
+  call $std/typedarray/testArraySome<Int8Array,i8>
+  call $std/typedarray/testArraySome<Uint8Array,u8>
+  call $std/typedarray/testArraySome<Uint8ClampedArray,u8>
+  call $std/typedarray/testArraySome<Int16Array,i16>
+  call $std/typedarray/testArraySome<Uint16Array,u16>
+  call $std/typedarray/testArraySome<Int32Array,i32>
+  call $std/typedarray/testArraySome<Uint32Array,u32>
+  call $std/typedarray/testArraySome<Int64Array,i64>
+  call $std/typedarray/testArraySome<Uint64Array,u64>
+  call $std/typedarray/testArraySome<Float32Array,f32>
+  call $std/typedarray/testArraySome<Float64Array,f64>
+  call $std/typedarray/testArrayFindIndex<Int8Array,i8>
+  call $std/typedarray/testArrayFindIndex<Uint8Array,u8>
+  call $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8>
+  call $std/typedarray/testArrayFindIndex<Int16Array,i16>
+  call $std/typedarray/testArrayFindIndex<Uint16Array,u16>
+  call $std/typedarray/testArrayFindIndex<Int32Array,i32>
+  call $std/typedarray/testArrayFindIndex<Uint32Array,u32>
+  call $std/typedarray/testArrayFindIndex<Int64Array,i64>
+  call $std/typedarray/testArrayFindIndex<Uint64Array,u64>
+  call $std/typedarray/testArrayFindIndex<Float32Array,f32>
+  call $std/typedarray/testArrayFindIndex<Float64Array,f64>
+  call $std/typedarray/testArrayEvery<Int8Array,i8>
+  call $std/typedarray/testArrayEvery<Uint8Array,u8>
+  call $std/typedarray/testArrayEvery<Uint8ClampedArray,u8>
+  call $std/typedarray/testArrayEvery<Int16Array,i16>
+  call $std/typedarray/testArrayEvery<Uint16Array,u16>
+  call $std/typedarray/testArrayEvery<Int32Array,i32>
+  call $std/typedarray/testArrayEvery<Uint32Array,u32>
+  call $std/typedarray/testArrayEvery<Int64Array,i64>
+  call $std/typedarray/testArrayEvery<Uint64Array,u64>
+  call $std/typedarray/testArrayEvery<Float32Array,f32>
+  call $std/typedarray/testArrayEvery<Float64Array,f64>
  )
- (func $null (; 104 ;) (type $v)
+ (func $null (; 188 ;) (type $v)
   nop
  )
 )

--- a/tests/compiler/std/typedarray.ts
+++ b/tests/compiler/std/typedarray.ts
@@ -237,7 +237,7 @@ assert(multisubarr3.byteLength === 3);
  * tests work.
  */
 
-function testReduce<ArrayType, T>(): void {
+function testReduce<ArrayType extends TypedArray<T>, T extends number>(): void {
   var array: ArrayType = instantiate<ArrayType>(3);
   array[0] = <T>1;
   array[1] = <T>2;
@@ -247,8 +247,8 @@ function testReduce<ArrayType, T>(): void {
     // assert(testindex == index);
     // assert(array == self);
     // --testindex;
-    return acc + val;
-  }, 0);
+    return <T>(acc + val);
+  }, <T>0);
   assert(result == <T>6);
 }
 
@@ -264,7 +264,7 @@ testReduce<Uint64Array, u64>();
 testReduce<Float32Array, f32>();
 testReduce<Float64Array, f64>();
 
-function testReduceRight<ArrayType, T>(): void {
+function testReduceRight<ArrayType extends TypedArray<T>, T extends number>(): void {
   var array: ArrayType = instantiate<ArrayType>(3);
   array[0] = <T>1;
   array[1] = <T>2;
@@ -274,8 +274,8 @@ function testReduceRight<ArrayType, T>(): void {
     // assert(testindex == index);
     // assert(array == self);
     // --testindex;
-    return acc + val;
-  }, 0);
+    return <T>(acc + val);
+  }, <T>0);
   assert(result == <T>6);
 }
 
@@ -291,7 +291,7 @@ testReduceRight<Uint64Array, u64>();
 testReduceRight<Float32Array, f32>();
 testReduceRight<Float64Array, f64>();
 
-function testArrayMap<ArrayType extends TypedArray<T>, T>(): void {
+function testArrayMap<ArrayType extends TypedArray<T>, T extends number>(): void {
   var source: ArrayType = instantiate<ArrayType>(3);
   source[0] = <T>1;
   source[1] = <T>2;
@@ -301,7 +301,7 @@ function testArrayMap<ArrayType extends TypedArray<T>, T>(): void {
     // assert(self == source);
     // assert(testIndex == testIndex);
     // testIndex++;
-    return value * value;
+    return <T>(value * value);
   });
   assert(result[0] == <T>1);
   assert(result[1] == <T>4);
@@ -319,3 +319,93 @@ testArrayMap<Int64Array, i64>();
 testArrayMap<Uint64Array, u64>();
 testArrayMap<Float32Array, f32>();
 testArrayMap<Float64Array, f64>();
+
+function testArraySome<ArrayType extends TypedArray<T>, T extends number>(): void {
+  var source: ArrayType = instantiate<ArrayType>(3);
+  source[0] = <T>2;
+  source[1] = <T>4;
+  source[2] = <T>6;
+  // var testIndex: i32 = 0;
+  var result: bool = source.some((value: T, index: i32, self: ArrayType): bool => {
+    // assert(self == source);
+    // assert(testIndex == testIndex);
+    // testIndex++;
+    return value == <T>2;
+  });
+  assert(result);
+  var failResult = source.some((value: T, index: i32, self: ArrayType): bool => value == <T>0);
+
+  assert(!failResult);
+}
+
+testArraySome<Int8Array, i8>();
+testArraySome<Uint8Array, u8>();
+testArraySome<Uint8ClampedArray, u8>();
+testArraySome<Int16Array, i16>();
+testArraySome<Uint16Array, u16>();
+testArraySome<Int32Array, i32>();
+testArraySome<Uint32Array, u32>();
+testArraySome<Int64Array, i64>();
+testArraySome<Uint64Array, u64>();
+testArraySome<Float32Array, f32>();
+testArraySome<Float64Array, f64>();
+
+function testArrayFindIndex<ArrayType extends TypedArray<T>, T extends number>(): void {
+  var source: ArrayType = instantiate<ArrayType>(3);
+  source[0] = <T>1;
+  source[1] = <T>2;
+  source[2] = <T>3;
+  // var testIndex: i32 = 0;
+  var result = source.findIndex((value: T, index: i32, self: ArrayType): bool => {
+    // assert(self == source);
+    // assert(testIndex == testIndex);
+    // testIndex++;
+    return value == <T>2;
+  });
+  assert(result == 1);
+  var failResult = source.findIndex((value: T, index: i32, self: ArrayType): bool => value == <T>4);
+
+  assert(failResult == -1);
+}
+
+testArrayFindIndex<Int8Array, i8>();
+testArrayFindIndex<Uint8Array, u8>();
+testArrayFindIndex<Uint8ClampedArray, u8>();
+testArrayFindIndex<Int16Array, i16>();
+testArrayFindIndex<Uint16Array, u16>();
+testArrayFindIndex<Int32Array, i32>();
+testArrayFindIndex<Uint32Array, u32>();
+testArrayFindIndex<Int64Array, i64>();
+testArrayFindIndex<Uint64Array, u64>();
+testArrayFindIndex<Float32Array, f32>();
+testArrayFindIndex<Float64Array, f64>();
+
+function testArrayEvery<ArrayType extends TypedArray<T>, T extends number>(): void {
+  var source: ArrayType = instantiate<ArrayType>(3);
+  source[0] = <T>2;
+  source[1] = <T>4;
+  source[2] = <T>6;
+  // var testIndex: i32 = 0;
+  var result: bool = source.every((value: T, index: i32, self: ArrayType): bool => {
+    // assert(self == source);
+    // assert(testIndex == testIndex);
+    // testIndex++;
+    return (value % <T>2) == <T>0;
+  });
+  assert(result);
+  var failResult = source.every((value: T, index: i32, self: ArrayType): bool => value == <T>2);
+
+  assert(!failResult);
+}
+
+testArrayEvery<Int8Array, i8>();
+testArrayEvery<Uint8Array, u8>();
+testArrayEvery<Uint8ClampedArray, u8>();
+testArrayEvery<Int16Array, i16>();
+testArrayEvery<Uint16Array, u16>();
+testArrayEvery<Int32Array, i32>();
+testArrayEvery<Uint32Array, u32>();
+testArrayEvery<Int64Array, i64>();
+testArrayEvery<Uint64Array, u64>();
+testArrayEvery<Float32Array, f32>();
+testArrayEvery<Float64Array, f64>();

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -13,16 +13,21 @@
  (type $iiIv (func (param i32 i32 i64)))
  (type $IIiiI (func (param i64 i64 i32 i32) (result i64)))
  (type $iiII (func (param i32 i32 i64) (result i64)))
- (type $iiI (func (param i32 i32) (result i64)))
  (type $iifv (func (param i32 i32 f32)))
  (type $ffiif (func (param f32 f32 i32 i32) (result f32)))
  (type $iiff (func (param i32 i32 f32) (result f32)))
- (type $iif (func (param i32 i32) (result f32)))
  (type $FFiiF (func (param f64 f64 i32 i32) (result f64)))
  (type $iiFF (func (param i32 i32 f64) (result f64)))
  (type $IiiI (func (param i64 i32 i32) (result i64)))
+ (type $iiI (func (param i32 i32) (result i64)))
  (type $fiif (func (param f32 i32 i32) (result f32)))
+ (type $iif (func (param i32 i32) (result f32)))
  (type $FiiF (func (param f64 i32 i32) (result f64)))
+ (type $Iiii (func (param i64 i32 i32) (result i32)))
+ (type $fiii (func (param f32 i32 i32) (result i32)))
+ (type $Fiii (func (param f64 i32 i32) (result i32)))
+ (type $fff (func (param f32 f32) (result f32)))
+ (type $FFF (func (param f64 f64) (result f64)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\11\00\00\00s\00t\00d\00/\00t\00y\00p\00e\00d\00a\00r\00r\00a\00y\00.\00t\00s\00")
@@ -56,8 +61,8 @@
  (data (i32.const 576) " \02\00\00\03\00\00\00")
  (data (i32.const 584) "\14\00\00\00\00\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\00\00\00\00")
  (data (i32.const 616) "H\02\00\00\05\00\00\00")
- (table $0 35 anyfunc)
- (elem (i32.const 0) $null $~lib/typedarray/Float64Array#sort|trampoline~anonymous|1 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Uint8Array,u8>~anonymous|3 $std/typedarray/testReduce<Uint8ClampedArray,u8>~anonymous|4 $std/typedarray/testReduce<Int16Array,i16>~anonymous|5 $std/typedarray/testReduce<Uint16Array,u16>~anonymous|6 $std/typedarray/testReduce<Int32Array,i32>~anonymous|7 $std/typedarray/testReduce<Uint32Array,u32>~anonymous|8 $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 $std/typedarray/testReduce<Uint64Array,u64>~anonymous|10 $std/typedarray/testReduce<Float32Array,f32>~anonymous|11 $std/typedarray/testReduce<Float64Array,f64>~anonymous|12 $std/typedarray/testReduceRight<Int8Array,i8>~anonymous|13 $std/typedarray/testReduceRight<Uint8Array,u8>~anonymous|14 $std/typedarray/testReduceRight<Uint8ClampedArray,u8>~anonymous|15 $std/typedarray/testReduceRight<Int16Array,i16>~anonymous|16 $std/typedarray/testReduceRight<Uint16Array,u16>~anonymous|17 $std/typedarray/testReduceRight<Int32Array,i32>~anonymous|18 $std/typedarray/testReduceRight<Uint32Array,u32>~anonymous|19 $std/typedarray/testReduceRight<Int64Array,i64>~anonymous|20 $std/typedarray/testReduceRight<Uint64Array,u64>~anonymous|21 $std/typedarray/testReduceRight<Float32Array,f32>~anonymous|22 $std/typedarray/testReduceRight<Float64Array,f64>~anonymous|23 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Uint8Array,u8>~anonymous|25 $std/typedarray/testArrayMap<Uint8ClampedArray,u8>~anonymous|26 $std/typedarray/testArrayMap<Int16Array,i16>~anonymous|27 $std/typedarray/testArrayMap<Uint16Array,u16>~anonymous|28 $std/typedarray/testArrayMap<Int32Array,i32>~anonymous|29 $std/typedarray/testArrayMap<Uint32Array,u32>~anonymous|30 $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 $std/typedarray/testArrayMap<Uint64Array,u64>~anonymous|32 $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|33 $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|34)
+ (table $0 101 anyfunc)
+ (elem (i32.const 0) $null $~lib/typedarray/Float64Array#sort|trampoline~anonymous|1 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Uint8Array,u8>~anonymous|3 $std/typedarray/testReduce<Uint8ClampedArray,u8>~anonymous|4 $std/typedarray/testReduce<Int16Array,i16>~anonymous|5 $std/typedarray/testReduce<Uint16Array,u16>~anonymous|6 $std/typedarray/testReduce<Int32Array,i32>~anonymous|7 $std/typedarray/testReduce<Uint32Array,u32>~anonymous|8 $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 $std/typedarray/testReduce<Uint64Array,u64>~anonymous|10 $std/typedarray/testReduce<Float32Array,f32>~anonymous|11 $std/typedarray/testReduce<Float64Array,f64>~anonymous|12 $std/typedarray/testReduceRight<Int8Array,i8>~anonymous|13 $std/typedarray/testReduceRight<Uint8Array,u8>~anonymous|14 $std/typedarray/testReduceRight<Uint8ClampedArray,u8>~anonymous|15 $std/typedarray/testReduceRight<Int16Array,i16>~anonymous|16 $std/typedarray/testReduceRight<Uint16Array,u16>~anonymous|17 $std/typedarray/testReduceRight<Int32Array,i32>~anonymous|18 $std/typedarray/testReduceRight<Uint32Array,u32>~anonymous|19 $std/typedarray/testReduceRight<Int64Array,i64>~anonymous|20 $std/typedarray/testReduceRight<Uint64Array,u64>~anonymous|21 $std/typedarray/testReduceRight<Float32Array,f32>~anonymous|22 $std/typedarray/testReduceRight<Float64Array,f64>~anonymous|23 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Uint8Array,u8>~anonymous|25 $std/typedarray/testArrayMap<Uint8ClampedArray,u8>~anonymous|26 $std/typedarray/testArrayMap<Int16Array,i16>~anonymous|27 $std/typedarray/testArrayMap<Uint16Array,u16>~anonymous|28 $std/typedarray/testArrayMap<Int32Array,i32>~anonymous|29 $std/typedarray/testArrayMap<Uint32Array,u32>~anonymous|30 $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 $std/typedarray/testArrayMap<Uint64Array,u64>~anonymous|32 $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|33 $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|34 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|36 $std/typedarray/testArraySome<Uint8Array,u8>~anonymous|37 $std/typedarray/testArraySome<Uint8Array,u8>~anonymous|38 $std/typedarray/testArraySome<Uint8ClampedArray,u8>~anonymous|39 $std/typedarray/testArraySome<Uint8ClampedArray,u8>~anonymous|40 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|42 $std/typedarray/testArraySome<Uint16Array,u16>~anonymous|43 $std/typedarray/testArraySome<Uint16Array,u16>~anonymous|44 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|46 $std/typedarray/testArraySome<Uint32Array,u32>~anonymous|47 $std/typedarray/testArraySome<Uint32Array,u32>~anonymous|48 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|50 $std/typedarray/testArraySome<Uint64Array,u64>~anonymous|51 $std/typedarray/testArraySome<Uint64Array,u64>~anonymous|52 $std/typedarray/testArraySome<Float32Array,f32>~anonymous|53 $std/typedarray/testArraySome<Float32Array,f32>~anonymous|54 $std/typedarray/testArraySome<Float64Array,f64>~anonymous|55 $std/typedarray/testArraySome<Float64Array,f64>~anonymous|56 $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|57 $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|58 $std/typedarray/testArrayFindIndex<Uint8Array,u8>~anonymous|59 $std/typedarray/testArrayFindIndex<Uint8Array,u8>~anonymous|60 $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8>~anonymous|61 $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8>~anonymous|62 $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|63 $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|64 $std/typedarray/testArrayFindIndex<Uint16Array,u16>~anonymous|65 $std/typedarray/testArrayFindIndex<Uint16Array,u16>~anonymous|66 $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|67 $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|68 $std/typedarray/testArrayFindIndex<Uint32Array,u32>~anonymous|69 $std/typedarray/testArrayFindIndex<Uint32Array,u32>~anonymous|70 $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|71 $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|72 $std/typedarray/testArrayFindIndex<Uint64Array,u64>~anonymous|73 $std/typedarray/testArrayFindIndex<Uint64Array,u64>~anonymous|74 $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|75 $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|76 $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|77 $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|78 $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|79 $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|80 $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|81 $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|82 $std/typedarray/testArrayEvery<Uint8ClampedArray,u8>~anonymous|83 $std/typedarray/testArrayEvery<Uint8ClampedArray,u8>~anonymous|84 $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|85 $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|86 $std/typedarray/testArrayEvery<Uint16Array,u16>~anonymous|87 $std/typedarray/testArrayEvery<Uint16Array,u16>~anonymous|88 $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|89 $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|90 $std/typedarray/testArrayEvery<Uint32Array,u32>~anonymous|91 $std/typedarray/testArrayEvery<Uint32Array,u32>~anonymous|92 $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|93 $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|94 $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|95 $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|96 $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|97 $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|98 $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|99 $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|100)
  (global $~lib/typedarray/Int8Array.BYTES_PER_ELEMENT i32 (i32.const 1))
  (global $~lib/typedarray/Uint8Array.BYTES_PER_ELEMENT i32 (i32.const 1))
  (global $~lib/typedarray/Uint8ClampedArray.BYTES_PER_ELEMENT i32 (i32.const 1))
@@ -3376,68 +3381,65 @@
   get_local $1
   i32.add
  )
- (func $~lib/internal/typedarray/TypedArray<i8>#__unchecked_get (; 44 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  get_local $0
-  i32.load
-  set_local $2
-  get_local $0
-  i32.load offset=4
-  set_local $3
-  get_local $2
-  get_local $1
-  i32.const 0
-  i32.shl
-  i32.add
-  get_local $3
-  i32.add
-  i32.load8_s offset=8
- )
- (func $~lib/typedarray/Int8Array#reduce<i8> (; 45 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#reduce<i8> (; 44 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
-  i32.const 0
-  set_local $3
+  (local $5 i32)
+  (local $6 i32)
   block $~lib/internal/typedarray/TypedArray<i8>#get:length|inlined.10 (result i32)
    get_local $0
    i32.load offset=8
    i32.const 0
    i32.shr_u
   end
+  set_local $3
+  get_local $0
+  i32.load
   set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
   block $break|0
-   loop $continue|0
+   i32.const 0
+   set_local $6
+   loop $repeat|0
+    get_local $6
     get_local $3
-    get_local $4
-    i32.ne
-    if
-     block
-      block (result i32)
-       i32.const 4
-       set_global $~argc
-       get_local $2
-       get_local $0
-       get_local $3
-       call $~lib/internal/typedarray/TypedArray<i8>#__unchecked_get
-       get_local $3
-       get_local $0
-       get_local $1
-       call_indirect (type $iiiii)
-      end
-      set_local $2
-      get_local $3
-      i32.const 1
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    block (result i32)
+     i32.const 4
+     set_global $~argc
+     get_local $2
+     block $~lib/internal/arraybuffer/LOAD<i8,i8>|inlined.2 (result i32)
+      get_local $4
+      get_local $6
+      i32.const 0
+      i32.shl
       i32.add
-      set_local $3
+      get_local $5
+      i32.add
+      i32.load8_s offset=8
      end
-     br $continue|0
+     get_local $6
+     get_local $0
+     get_local $1
+     call_indirect (type $iiiii)
     end
+    set_local $2
+    get_local $6
+    i32.const 1
+    i32.add
+    set_local $6
+    br $repeat|0
+    unreachable
    end
+   unreachable
   end
   get_local $2
  )
- (func $std/typedarray/testReduce<Int8Array,i8> (; 46 ;) (type $v)
+ (func $std/typedarray/testReduce<Int8Array,i8> (; 45 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -3478,73 +3480,70 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Uint8Array,u8>~anonymous|3 (; 47 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Uint8Array,u8>~anonymous|3 (; 46 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/internal/typedarray/TypedArray<u8>#__unchecked_get (; 48 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  get_local $0
-  i32.load
-  set_local $2
-  get_local $0
-  i32.load offset=4
-  set_local $3
-  get_local $2
-  get_local $1
-  i32.const 0
-  i32.shl
-  i32.add
-  get_local $3
-  i32.add
-  i32.load8_u offset=8
- )
- (func $~lib/typedarray/Uint8Array#reduce<u8> (; 49 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#reduce<u8> (; 47 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
-  i32.const 0
-  set_local $3
+  (local $5 i32)
+  (local $6 i32)
   block $~lib/internal/typedarray/TypedArray<u8>#get:length|inlined.2 (result i32)
    get_local $0
    i32.load offset=8
    i32.const 0
    i32.shr_u
   end
+  set_local $3
+  get_local $0
+  i32.load
   set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
   block $break|0
-   loop $continue|0
+   i32.const 0
+   set_local $6
+   loop $repeat|0
+    get_local $6
     get_local $3
-    get_local $4
-    i32.ne
-    if
-     block
-      block (result i32)
-       i32.const 4
-       set_global $~argc
-       get_local $2
-       get_local $0
-       get_local $3
-       call $~lib/internal/typedarray/TypedArray<u8>#__unchecked_get
-       get_local $3
-       get_local $0
-       get_local $1
-       call_indirect (type $iiiii)
-      end
-      set_local $2
-      get_local $3
-      i32.const 1
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    block (result i32)
+     i32.const 4
+     set_global $~argc
+     get_local $2
+     block $~lib/internal/arraybuffer/LOAD<u8,u8>|inlined.1 (result i32)
+      get_local $4
+      get_local $6
+      i32.const 0
+      i32.shl
       i32.add
-      set_local $3
+      get_local $5
+      i32.add
+      i32.load8_u offset=8
      end
-     br $continue|0
+     get_local $6
+     get_local $0
+     get_local $1
+     call_indirect (type $iiiii)
     end
+    set_local $2
+    get_local $6
+    i32.const 1
+    i32.add
+    set_local $6
+    br $repeat|0
+    unreachable
    end
+   unreachable
   end
   get_local $2
  )
- (func $std/typedarray/testReduce<Uint8Array,u8> (; 50 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint8Array,u8> (; 48 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -3583,12 +3582,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Uint8ClampedArray,u8>~anonymous|4 (; 51 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Uint8ClampedArray,u8>~anonymous|4 (; 49 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $std/typedarray/testReduce<Uint8ClampedArray,u8> (; 52 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint8ClampedArray,u8> (; 50 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -3627,7 +3626,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i16>#__set (; 53 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<i16>#__set (; 51 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   get_local $1
@@ -3660,73 +3659,70 @@
   get_local $2
   i32.store16 offset=8
  )
- (func $std/typedarray/testReduce<Int16Array,i16>~anonymous|5 (; 54 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Int16Array,i16>~anonymous|5 (; 52 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/internal/typedarray/TypedArray<i16>#__unchecked_get (; 55 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  get_local $0
-  i32.load
-  set_local $2
-  get_local $0
-  i32.load offset=4
-  set_local $3
-  get_local $2
-  get_local $1
-  i32.const 1
-  i32.shl
-  i32.add
-  get_local $3
-  i32.add
-  i32.load16_s offset=8
- )
- (func $~lib/typedarray/Int16Array#reduce<i16> (; 56 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#reduce<i16> (; 53 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
-  i32.const 0
-  set_local $3
+  (local $5 i32)
+  (local $6 i32)
   block $~lib/internal/typedarray/TypedArray<i16>#get:length|inlined.1 (result i32)
    get_local $0
    i32.load offset=8
    i32.const 1
    i32.shr_u
   end
+  set_local $3
+  get_local $0
+  i32.load
   set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
   block $break|0
-   loop $continue|0
+   i32.const 0
+   set_local $6
+   loop $repeat|0
+    get_local $6
     get_local $3
-    get_local $4
-    i32.ne
-    if
-     block
-      block (result i32)
-       i32.const 4
-       set_global $~argc
-       get_local $2
-       get_local $0
-       get_local $3
-       call $~lib/internal/typedarray/TypedArray<i16>#__unchecked_get
-       get_local $3
-       get_local $0
-       get_local $1
-       call_indirect (type $iiiii)
-      end
-      set_local $2
-      get_local $3
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    block (result i32)
+     i32.const 4
+     set_global $~argc
+     get_local $2
+     block $~lib/internal/arraybuffer/LOAD<i16,i16>|inlined.0 (result i32)
+      get_local $4
+      get_local $6
       i32.const 1
+      i32.shl
       i32.add
-      set_local $3
+      get_local $5
+      i32.add
+      i32.load16_s offset=8
      end
-     br $continue|0
+     get_local $6
+     get_local $0
+     get_local $1
+     call_indirect (type $iiiii)
     end
+    set_local $2
+    get_local $6
+    i32.const 1
+    i32.add
+    set_local $6
+    br $repeat|0
+    unreachable
    end
+   unreachable
   end
   get_local $2
  )
- (func $std/typedarray/testReduce<Int16Array,i16> (; 57 ;) (type $v)
+ (func $std/typedarray/testReduce<Int16Array,i16> (; 54 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -3767,7 +3763,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<u16>#__set (; 58 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<u16>#__set (; 55 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   get_local $1
@@ -3800,73 +3796,70 @@
   get_local $2
   i32.store16 offset=8
  )
- (func $std/typedarray/testReduce<Uint16Array,u16>~anonymous|6 (; 59 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Uint16Array,u16>~anonymous|6 (; 56 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/internal/typedarray/TypedArray<u16>#__unchecked_get (; 60 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  get_local $0
-  i32.load
-  set_local $2
-  get_local $0
-  i32.load offset=4
-  set_local $3
-  get_local $2
-  get_local $1
-  i32.const 1
-  i32.shl
-  i32.add
-  get_local $3
-  i32.add
-  i32.load16_u offset=8
- )
- (func $~lib/typedarray/Uint16Array#reduce<u16> (; 61 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#reduce<u16> (; 57 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
-  i32.const 0
-  set_local $3
+  (local $5 i32)
+  (local $6 i32)
   block $~lib/internal/typedarray/TypedArray<u16>#get:length|inlined.1 (result i32)
    get_local $0
    i32.load offset=8
    i32.const 1
    i32.shr_u
   end
+  set_local $3
+  get_local $0
+  i32.load
   set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
   block $break|0
-   loop $continue|0
+   i32.const 0
+   set_local $6
+   loop $repeat|0
+    get_local $6
     get_local $3
-    get_local $4
-    i32.ne
-    if
-     block
-      block (result i32)
-       i32.const 4
-       set_global $~argc
-       get_local $2
-       get_local $0
-       get_local $3
-       call $~lib/internal/typedarray/TypedArray<u16>#__unchecked_get
-       get_local $3
-       get_local $0
-       get_local $1
-       call_indirect (type $iiiii)
-      end
-      set_local $2
-      get_local $3
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    block (result i32)
+     i32.const 4
+     set_global $~argc
+     get_local $2
+     block $~lib/internal/arraybuffer/LOAD<u16,u16>|inlined.0 (result i32)
+      get_local $4
+      get_local $6
       i32.const 1
+      i32.shl
       i32.add
-      set_local $3
+      get_local $5
+      i32.add
+      i32.load16_u offset=8
      end
-     br $continue|0
+     get_local $6
+     get_local $0
+     get_local $1
+     call_indirect (type $iiiii)
     end
+    set_local $2
+    get_local $6
+    i32.const 1
+    i32.add
+    set_local $6
+    br $repeat|0
+    unreachable
    end
+   unreachable
   end
   get_local $2
  )
- (func $std/typedarray/testReduce<Uint16Array,u16> (; 62 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint16Array,u16> (; 58 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -3905,73 +3898,70 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Int32Array,i32>~anonymous|7 (; 63 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Int32Array,i32>~anonymous|7 (; 59 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/internal/typedarray/TypedArray<i32>#__unchecked_get (; 64 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  get_local $0
-  i32.load
-  set_local $2
-  get_local $0
-  i32.load offset=4
-  set_local $3
-  get_local $2
-  get_local $1
-  i32.const 2
-  i32.shl
-  i32.add
-  get_local $3
-  i32.add
-  i32.load offset=8
- )
- (func $~lib/typedarray/Int32Array#reduce<i32> (; 65 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#reduce<i32> (; 60 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
-  i32.const 0
-  set_local $3
+  (local $5 i32)
+  (local $6 i32)
   block $~lib/internal/typedarray/TypedArray<i32>#get:length|inlined.9 (result i32)
    get_local $0
    i32.load offset=8
    i32.const 2
    i32.shr_u
   end
+  set_local $3
+  get_local $0
+  i32.load
   set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
   block $break|0
-   loop $continue|0
+   i32.const 0
+   set_local $6
+   loop $repeat|0
+    get_local $6
     get_local $3
-    get_local $4
-    i32.ne
-    if
-     block
-      block (result i32)
-       i32.const 4
-       set_global $~argc
-       get_local $2
-       get_local $0
-       get_local $3
-       call $~lib/internal/typedarray/TypedArray<i32>#__unchecked_get
-       get_local $3
-       get_local $0
-       get_local $1
-       call_indirect (type $iiiii)
-      end
-      set_local $2
-      get_local $3
-      i32.const 1
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    block (result i32)
+     i32.const 4
+     set_global $~argc
+     get_local $2
+     block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.2 (result i32)
+      get_local $4
+      get_local $6
+      i32.const 2
+      i32.shl
       i32.add
-      set_local $3
+      get_local $5
+      i32.add
+      i32.load offset=8
      end
-     br $continue|0
+     get_local $6
+     get_local $0
+     get_local $1
+     call_indirect (type $iiiii)
     end
+    set_local $2
+    get_local $6
+    i32.const 1
+    i32.add
+    set_local $6
+    br $repeat|0
+    unreachable
    end
+   unreachable
   end
   get_local $2
  )
- (func $std/typedarray/testReduce<Int32Array,i32> (; 66 ;) (type $v)
+ (func $std/typedarray/testReduce<Int32Array,i32> (; 61 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4008,7 +3998,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<u32>#__set (; 67 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<u32>#__set (; 62 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   get_local $1
@@ -4041,73 +4031,70 @@
   get_local $2
   i32.store offset=8
  )
- (func $std/typedarray/testReduce<Uint32Array,u32>~anonymous|8 (; 68 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Uint32Array,u32>~anonymous|8 (; 63 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/internal/typedarray/TypedArray<u32>#__unchecked_get (; 69 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  get_local $0
-  i32.load
-  set_local $2
-  get_local $0
-  i32.load offset=4
-  set_local $3
-  get_local $2
-  get_local $1
-  i32.const 2
-  i32.shl
-  i32.add
-  get_local $3
-  i32.add
-  i32.load offset=8
- )
- (func $~lib/typedarray/Uint32Array#reduce<u32> (; 70 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#reduce<u32> (; 64 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
-  i32.const 0
-  set_local $3
+  (local $5 i32)
+  (local $6 i32)
   block $~lib/internal/typedarray/TypedArray<u32>#get:length|inlined.1 (result i32)
    get_local $0
    i32.load offset=8
    i32.const 2
    i32.shr_u
   end
+  set_local $3
+  get_local $0
+  i32.load
   set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
   block $break|0
-   loop $continue|0
+   i32.const 0
+   set_local $6
+   loop $repeat|0
+    get_local $6
     get_local $3
-    get_local $4
-    i32.ne
-    if
-     block
-      block (result i32)
-       i32.const 4
-       set_global $~argc
-       get_local $2
-       get_local $0
-       get_local $3
-       call $~lib/internal/typedarray/TypedArray<u32>#__unchecked_get
-       get_local $3
-       get_local $0
-       get_local $1
-       call_indirect (type $iiiii)
-      end
-      set_local $2
-      get_local $3
-      i32.const 1
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    block (result i32)
+     i32.const 4
+     set_global $~argc
+     get_local $2
+     block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.0 (result i32)
+      get_local $4
+      get_local $6
+      i32.const 2
+      i32.shl
       i32.add
-      set_local $3
+      get_local $5
+      i32.add
+      i32.load offset=8
      end
-     br $continue|0
+     get_local $6
+     get_local $0
+     get_local $1
+     call_indirect (type $iiiii)
     end
+    set_local $2
+    get_local $6
+    i32.const 1
+    i32.add
+    set_local $6
+    br $repeat|0
+    unreachable
    end
+   unreachable
   end
   get_local $2
  )
- (func $std/typedarray/testReduce<Uint32Array,u32> (; 71 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint32Array,u32> (; 65 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4144,7 +4131,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i64>#__set (; 72 ;) (type $iiIv) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/internal/typedarray/TypedArray<i64>#__set (; 66 ;) (type $iiIv) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local $4 i32)
   get_local $1
@@ -4177,73 +4164,70 @@
   get_local $2
   i64.store offset=8
  )
- (func $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 (; 73 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 (; 67 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   get_local $0
   get_local $1
   i64.add
  )
- (func $~lib/internal/typedarray/TypedArray<i64>#__unchecked_get (; 74 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
-  (local $2 i32)
-  (local $3 i32)
-  get_local $0
-  i32.load
-  set_local $2
-  get_local $0
-  i32.load offset=4
-  set_local $3
-  get_local $2
-  get_local $1
-  i32.const 3
-  i32.shl
-  i32.add
-  get_local $3
-  i32.add
-  i64.load offset=8
- )
- (func $~lib/typedarray/Int64Array#reduce<i64> (; 75 ;) (type $iiII) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
+ (func $~lib/typedarray/Int64Array#reduce<i64> (; 68 ;) (type $iiII) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
   (local $3 i32)
   (local $4 i32)
-  i32.const 0
-  set_local $3
+  (local $5 i32)
+  (local $6 i32)
   block $~lib/internal/typedarray/TypedArray<i64>#get:length|inlined.1 (result i32)
    get_local $0
    i32.load offset=8
    i32.const 3
    i32.shr_u
   end
+  set_local $3
+  get_local $0
+  i32.load
   set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
   block $break|0
-   loop $continue|0
+   i32.const 0
+   set_local $6
+   loop $repeat|0
+    get_local $6
     get_local $3
-    get_local $4
-    i32.ne
-    if
-     block
-      block (result i64)
-       i32.const 4
-       set_global $~argc
-       get_local $2
-       get_local $0
-       get_local $3
-       call $~lib/internal/typedarray/TypedArray<i64>#__unchecked_get
-       get_local $3
-       get_local $0
-       get_local $1
-       call_indirect (type $IIiiI)
-      end
-      set_local $2
-      get_local $3
-      i32.const 1
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    block (result i64)
+     i32.const 4
+     set_global $~argc
+     get_local $2
+     block $~lib/internal/arraybuffer/LOAD<i64,i64>|inlined.0 (result i64)
+      get_local $4
+      get_local $6
+      i32.const 3
+      i32.shl
       i32.add
-      set_local $3
+      get_local $5
+      i32.add
+      i64.load offset=8
      end
-     br $continue|0
+     get_local $6
+     get_local $0
+     get_local $1
+     call_indirect (type $IIiiI)
     end
+    set_local $2
+    get_local $6
+    i32.const 1
+    i32.add
+    set_local $6
+    br $repeat|0
+    unreachable
    end
+   unreachable
   end
   get_local $2
  )
- (func $std/typedarray/testReduce<Int64Array,i64> (; 76 ;) (type $v)
+ (func $std/typedarray/testReduce<Int64Array,i64> (; 69 ;) (type $v)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -4280,7 +4264,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<u64>#__set (; 77 ;) (type $iiIv) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/internal/typedarray/TypedArray<u64>#__set (; 70 ;) (type $iiIv) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local $4 i32)
   get_local $1
@@ -4313,73 +4297,70 @@
   get_local $2
   i64.store offset=8
  )
- (func $std/typedarray/testReduce<Uint64Array,u64>~anonymous|10 (; 78 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduce<Uint64Array,u64>~anonymous|10 (; 71 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   get_local $0
   get_local $1
   i64.add
  )
- (func $~lib/internal/typedarray/TypedArray<u64>#__unchecked_get (; 79 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
-  (local $2 i32)
-  (local $3 i32)
-  get_local $0
-  i32.load
-  set_local $2
-  get_local $0
-  i32.load offset=4
-  set_local $3
-  get_local $2
-  get_local $1
-  i32.const 3
-  i32.shl
-  i32.add
-  get_local $3
-  i32.add
-  i64.load offset=8
- )
- (func $~lib/typedarray/Uint64Array#reduce<u64> (; 80 ;) (type $iiII) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
+ (func $~lib/typedarray/Uint64Array#reduce<u64> (; 72 ;) (type $iiII) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
   (local $3 i32)
   (local $4 i32)
-  i32.const 0
-  set_local $3
+  (local $5 i32)
+  (local $6 i32)
   block $~lib/internal/typedarray/TypedArray<u64>#get:length|inlined.1 (result i32)
    get_local $0
    i32.load offset=8
    i32.const 3
    i32.shr_u
   end
+  set_local $3
+  get_local $0
+  i32.load
   set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
   block $break|0
-   loop $continue|0
+   i32.const 0
+   set_local $6
+   loop $repeat|0
+    get_local $6
     get_local $3
-    get_local $4
-    i32.ne
-    if
-     block
-      block (result i64)
-       i32.const 4
-       set_global $~argc
-       get_local $2
-       get_local $0
-       get_local $3
-       call $~lib/internal/typedarray/TypedArray<u64>#__unchecked_get
-       get_local $3
-       get_local $0
-       get_local $1
-       call_indirect (type $IIiiI)
-      end
-      set_local $2
-      get_local $3
-      i32.const 1
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    block (result i64)
+     i32.const 4
+     set_global $~argc
+     get_local $2
+     block $~lib/internal/arraybuffer/LOAD<u64,u64>|inlined.0 (result i64)
+      get_local $4
+      get_local $6
+      i32.const 3
+      i32.shl
       i32.add
-      set_local $3
+      get_local $5
+      i32.add
+      i64.load offset=8
      end
-     br $continue|0
+     get_local $6
+     get_local $0
+     get_local $1
+     call_indirect (type $IIiiI)
     end
+    set_local $2
+    get_local $6
+    i32.const 1
+    i32.add
+    set_local $6
+    br $repeat|0
+    unreachable
    end
+   unreachable
   end
   get_local $2
  )
- (func $std/typedarray/testReduce<Uint64Array,u64> (; 81 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint64Array,u64> (; 73 ;) (type $v)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -4416,7 +4397,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<f32>#__set (; 82 ;) (type $iifv) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/internal/typedarray/TypedArray<f32>#__set (; 74 ;) (type $iifv) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (local $4 i32)
   get_local $1
@@ -4449,73 +4430,70 @@
   get_local $2
   f32.store offset=8
  )
- (func $std/typedarray/testReduce<Float32Array,f32>~anonymous|11 (; 83 ;) (type $ffiif) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
+ (func $std/typedarray/testReduce<Float32Array,f32>~anonymous|11 (; 75 ;) (type $ffiif) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
   get_local $0
   get_local $1
   f32.add
  )
- (func $~lib/internal/typedarray/TypedArray<f32>#__unchecked_get (; 84 ;) (type $iif) (param $0 i32) (param $1 i32) (result f32)
-  (local $2 i32)
-  (local $3 i32)
-  get_local $0
-  i32.load
-  set_local $2
-  get_local $0
-  i32.load offset=4
-  set_local $3
-  get_local $2
-  get_local $1
-  i32.const 2
-  i32.shl
-  i32.add
-  get_local $3
-  i32.add
-  f32.load offset=8
- )
- (func $~lib/typedarray/Float32Array#reduce<f32> (; 85 ;) (type $iiff) (param $0 i32) (param $1 i32) (param $2 f32) (result f32)
+ (func $~lib/typedarray/Float32Array#reduce<f32> (; 76 ;) (type $iiff) (param $0 i32) (param $1 i32) (param $2 f32) (result f32)
   (local $3 i32)
   (local $4 i32)
-  i32.const 0
-  set_local $3
+  (local $5 i32)
+  (local $6 i32)
   block $~lib/internal/typedarray/TypedArray<f32>#get:length|inlined.1 (result i32)
    get_local $0
    i32.load offset=8
    i32.const 2
    i32.shr_u
   end
+  set_local $3
+  get_local $0
+  i32.load
   set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
   block $break|0
-   loop $continue|0
+   i32.const 0
+   set_local $6
+   loop $repeat|0
+    get_local $6
     get_local $3
-    get_local $4
-    i32.ne
-    if
-     block
-      block (result f32)
-       i32.const 4
-       set_global $~argc
-       get_local $2
-       get_local $0
-       get_local $3
-       call $~lib/internal/typedarray/TypedArray<f32>#__unchecked_get
-       get_local $3
-       get_local $0
-       get_local $1
-       call_indirect (type $ffiif)
-      end
-      set_local $2
-      get_local $3
-      i32.const 1
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    block (result f32)
+     i32.const 4
+     set_global $~argc
+     get_local $2
+     block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.0 (result f32)
+      get_local $4
+      get_local $6
+      i32.const 2
+      i32.shl
       i32.add
-      set_local $3
+      get_local $5
+      i32.add
+      f32.load offset=8
      end
-     br $continue|0
+     get_local $6
+     get_local $0
+     get_local $1
+     call_indirect (type $ffiif)
     end
+    set_local $2
+    get_local $6
+    i32.const 1
+    i32.add
+    set_local $6
+    br $repeat|0
+    unreachable
    end
+   unreachable
   end
   get_local $2
  )
- (func $std/typedarray/testReduce<Float32Array,f32> (; 86 ;) (type $v)
+ (func $std/typedarray/testReduce<Float32Array,f32> (; 77 ;) (type $v)
   (local $0 i32)
   (local $1 f32)
   i32.const 0
@@ -4552,73 +4530,70 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Float64Array,f64>~anonymous|12 (; 87 ;) (type $FFiiF) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
+ (func $std/typedarray/testReduce<Float64Array,f64>~anonymous|12 (; 78 ;) (type $FFiiF) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
   get_local $0
   get_local $1
   f64.add
  )
- (func $~lib/internal/typedarray/TypedArray<f64>#__unchecked_get (; 88 ;) (type $iiF) (param $0 i32) (param $1 i32) (result f64)
-  (local $2 i32)
-  (local $3 i32)
-  get_local $0
-  i32.load
-  set_local $2
-  get_local $0
-  i32.load offset=4
-  set_local $3
-  get_local $2
-  get_local $1
-  i32.const 3
-  i32.shl
-  i32.add
-  get_local $3
-  i32.add
-  f64.load offset=8
- )
- (func $~lib/typedarray/Float64Array#reduce<f64> (; 89 ;) (type $iiFF) (param $0 i32) (param $1 i32) (param $2 f64) (result f64)
+ (func $~lib/typedarray/Float64Array#reduce<f64> (; 79 ;) (type $iiFF) (param $0 i32) (param $1 i32) (param $2 f64) (result f64)
   (local $3 i32)
   (local $4 i32)
-  i32.const 0
-  set_local $3
+  (local $5 i32)
+  (local $6 i32)
   block $~lib/internal/typedarray/TypedArray<f64>#get:length|inlined.4 (result i32)
    get_local $0
    i32.load offset=8
    i32.const 3
    i32.shr_u
   end
+  set_local $3
+  get_local $0
+  i32.load
   set_local $4
+  get_local $0
+  i32.load offset=4
+  set_local $5
   block $break|0
-   loop $continue|0
+   i32.const 0
+   set_local $6
+   loop $repeat|0
+    get_local $6
     get_local $3
-    get_local $4
-    i32.ne
-    if
-     block
-      block (result f64)
-       i32.const 4
-       set_global $~argc
-       get_local $2
-       get_local $0
-       get_local $3
-       call $~lib/internal/typedarray/TypedArray<f64>#__unchecked_get
-       get_local $3
-       get_local $0
-       get_local $1
-       call_indirect (type $FFiiF)
-      end
-      set_local $2
-      get_local $3
-      i32.const 1
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    block (result f64)
+     i32.const 4
+     set_global $~argc
+     get_local $2
+     block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.13 (result f64)
+      get_local $4
+      get_local $6
+      i32.const 3
+      i32.shl
       i32.add
-      set_local $3
+      get_local $5
+      i32.add
+      f64.load offset=8
      end
-     br $continue|0
+     get_local $6
+     get_local $0
+     get_local $1
+     call_indirect (type $FFiiF)
     end
+    set_local $2
+    get_local $6
+    i32.const 1
+    i32.add
+    set_local $6
+    br $repeat|0
+    unreachable
    end
+   unreachable
   end
   get_local $2
  )
- (func $std/typedarray/testReduce<Float64Array,f64> (; 90 ;) (type $v)
+ (func $std/typedarray/testReduce<Float64Array,f64> (; 80 ;) (type $v)
   (local $0 i32)
   (local $1 f64)
   i32.const 0
@@ -4655,57 +4630,69 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Int8Array,i8>~anonymous|13 (; 91 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Int8Array,i8>~anonymous|13 (; 81 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/typedarray/Int8Array#reduceRight<i8> (; 92 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#reduceRight<i8> (; 82 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
-  block $~lib/internal/typedarray/TypedArray<i8>#get:length|inlined.11 (result i32)
-   get_local $0
-   i32.load offset=8
-   i32.const 0
-   i32.shr_u
-  end
-  i32.const 1
-  i32.sub
+  (local $5 i32)
+  get_local $0
+  i32.load
   set_local $3
-  i32.const -1
+  get_local $0
+  i32.load offset=4
   set_local $4
   block $break|0
-   loop $continue|0
-    get_local $3
-    get_local $4
-    i32.ne
-    if
-     block
-      block (result i32)
-       i32.const 4
-       set_global $~argc
-       get_local $2
-       get_local $0
-       get_local $3
-       call $~lib/internal/typedarray/TypedArray<i8>#__unchecked_get
-       get_local $3
-       get_local $0
-       get_local $1
-       call_indirect (type $iiiii)
-      end
-      set_local $2
-      get_local $3
-      i32.const 1
-      i32.sub
-      set_local $3
-     end
-     br $continue|0
-    end
+   block $~lib/internal/typedarray/TypedArray<i8>#get:length|inlined.11 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 0
+    i32.shr_u
    end
+   i32.const 1
+   i32.sub
+   set_local $5
+   loop $repeat|0
+    get_local $5
+    i32.const 0
+    i32.ge_s
+    i32.eqz
+    br_if $break|0
+    block (result i32)
+     i32.const 4
+     set_global $~argc
+     get_local $2
+     block $~lib/internal/arraybuffer/LOAD<i8,i8>|inlined.3 (result i32)
+      get_local $3
+      get_local $5
+      i32.const 0
+      i32.shl
+      i32.add
+      get_local $4
+      i32.add
+      i32.load8_s offset=8
+     end
+     get_local $5
+     get_local $0
+     get_local $1
+     call_indirect (type $iiiii)
+    end
+    set_local $2
+    get_local $5
+    i32.const 1
+    i32.sub
+    set_local $5
+    br $repeat|0
+    unreachable
+   end
+   unreachable
   end
   get_local $2
  )
- (func $std/typedarray/testReduceRight<Int8Array,i8> (; 93 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int8Array,i8> (; 83 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4746,57 +4733,69 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint8Array,u8>~anonymous|14 (; 94 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Uint8Array,u8>~anonymous|14 (; 84 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/typedarray/Uint8Array#reduceRight<u8> (; 95 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#reduceRight<u8> (; 85 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
-  block $~lib/internal/typedarray/TypedArray<u8>#get:length|inlined.3 (result i32)
-   get_local $0
-   i32.load offset=8
-   i32.const 0
-   i32.shr_u
-  end
-  i32.const 1
-  i32.sub
+  (local $5 i32)
+  get_local $0
+  i32.load
   set_local $3
-  i32.const -1
+  get_local $0
+  i32.load offset=4
   set_local $4
   block $break|0
-   loop $continue|0
-    get_local $3
-    get_local $4
-    i32.ne
-    if
-     block
-      block (result i32)
-       i32.const 4
-       set_global $~argc
-       get_local $2
-       get_local $0
-       get_local $3
-       call $~lib/internal/typedarray/TypedArray<u8>#__unchecked_get
-       get_local $3
-       get_local $0
-       get_local $1
-       call_indirect (type $iiiii)
-      end
-      set_local $2
-      get_local $3
-      i32.const 1
-      i32.sub
-      set_local $3
-     end
-     br $continue|0
-    end
+   block $~lib/internal/typedarray/TypedArray<u8>#get:length|inlined.3 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 0
+    i32.shr_u
    end
+   i32.const 1
+   i32.sub
+   set_local $5
+   loop $repeat|0
+    get_local $5
+    i32.const 0
+    i32.ge_s
+    i32.eqz
+    br_if $break|0
+    block (result i32)
+     i32.const 4
+     set_global $~argc
+     get_local $2
+     block $~lib/internal/arraybuffer/LOAD<u8,u8>|inlined.2 (result i32)
+      get_local $3
+      get_local $5
+      i32.const 0
+      i32.shl
+      i32.add
+      get_local $4
+      i32.add
+      i32.load8_u offset=8
+     end
+     get_local $5
+     get_local $0
+     get_local $1
+     call_indirect (type $iiiii)
+    end
+    set_local $2
+    get_local $5
+    i32.const 1
+    i32.sub
+    set_local $5
+    br $repeat|0
+    unreachable
+   end
+   unreachable
   end
   get_local $2
  )
- (func $std/typedarray/testReduceRight<Uint8Array,u8> (; 96 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint8Array,u8> (; 86 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4835,12 +4834,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8>~anonymous|15 (; 97 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8>~anonymous|15 (; 87 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8> (; 98 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8> (; 88 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4879,57 +4878,69 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Int16Array,i16>~anonymous|16 (; 99 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Int16Array,i16>~anonymous|16 (; 89 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/typedarray/Int16Array#reduceRight<i16> (; 100 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#reduceRight<i16> (; 90 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
-  block $~lib/internal/typedarray/TypedArray<i16>#get:length|inlined.2 (result i32)
-   get_local $0
-   i32.load offset=8
-   i32.const 1
-   i32.shr_u
-  end
-  i32.const 1
-  i32.sub
+  (local $5 i32)
+  get_local $0
+  i32.load
   set_local $3
-  i32.const -1
+  get_local $0
+  i32.load offset=4
   set_local $4
   block $break|0
-   loop $continue|0
-    get_local $3
-    get_local $4
-    i32.ne
-    if
-     block
-      block (result i32)
-       i32.const 4
-       set_global $~argc
-       get_local $2
-       get_local $0
-       get_local $3
-       call $~lib/internal/typedarray/TypedArray<i16>#__unchecked_get
-       get_local $3
-       get_local $0
-       get_local $1
-       call_indirect (type $iiiii)
-      end
-      set_local $2
-      get_local $3
-      i32.const 1
-      i32.sub
-      set_local $3
-     end
-     br $continue|0
-    end
+   block $~lib/internal/typedarray/TypedArray<i16>#get:length|inlined.2 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 1
+    i32.shr_u
    end
+   i32.const 1
+   i32.sub
+   set_local $5
+   loop $repeat|0
+    get_local $5
+    i32.const 0
+    i32.ge_s
+    i32.eqz
+    br_if $break|0
+    block (result i32)
+     i32.const 4
+     set_global $~argc
+     get_local $2
+     block $~lib/internal/arraybuffer/LOAD<i16,i16>|inlined.1 (result i32)
+      get_local $3
+      get_local $5
+      i32.const 1
+      i32.shl
+      i32.add
+      get_local $4
+      i32.add
+      i32.load16_s offset=8
+     end
+     get_local $5
+     get_local $0
+     get_local $1
+     call_indirect (type $iiiii)
+    end
+    set_local $2
+    get_local $5
+    i32.const 1
+    i32.sub
+    set_local $5
+    br $repeat|0
+    unreachable
+   end
+   unreachable
   end
   get_local $2
  )
- (func $std/typedarray/testReduceRight<Int16Array,i16> (; 101 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int16Array,i16> (; 91 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4970,57 +4981,69 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint16Array,u16>~anonymous|17 (; 102 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Uint16Array,u16>~anonymous|17 (; 92 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/typedarray/Uint16Array#reduceRight<u16> (; 103 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#reduceRight<u16> (; 93 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
-  block $~lib/internal/typedarray/TypedArray<u16>#get:length|inlined.2 (result i32)
-   get_local $0
-   i32.load offset=8
-   i32.const 1
-   i32.shr_u
-  end
-  i32.const 1
-  i32.sub
+  (local $5 i32)
+  get_local $0
+  i32.load
   set_local $3
-  i32.const -1
+  get_local $0
+  i32.load offset=4
   set_local $4
   block $break|0
-   loop $continue|0
-    get_local $3
-    get_local $4
-    i32.ne
-    if
-     block
-      block (result i32)
-       i32.const 4
-       set_global $~argc
-       get_local $2
-       get_local $0
-       get_local $3
-       call $~lib/internal/typedarray/TypedArray<u16>#__unchecked_get
-       get_local $3
-       get_local $0
-       get_local $1
-       call_indirect (type $iiiii)
-      end
-      set_local $2
-      get_local $3
-      i32.const 1
-      i32.sub
-      set_local $3
-     end
-     br $continue|0
-    end
+   block $~lib/internal/typedarray/TypedArray<u16>#get:length|inlined.2 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 1
+    i32.shr_u
    end
+   i32.const 1
+   i32.sub
+   set_local $5
+   loop $repeat|0
+    get_local $5
+    i32.const 0
+    i32.ge_s
+    i32.eqz
+    br_if $break|0
+    block (result i32)
+     i32.const 4
+     set_global $~argc
+     get_local $2
+     block $~lib/internal/arraybuffer/LOAD<u16,u16>|inlined.1 (result i32)
+      get_local $3
+      get_local $5
+      i32.const 1
+      i32.shl
+      i32.add
+      get_local $4
+      i32.add
+      i32.load16_u offset=8
+     end
+     get_local $5
+     get_local $0
+     get_local $1
+     call_indirect (type $iiiii)
+    end
+    set_local $2
+    get_local $5
+    i32.const 1
+    i32.sub
+    set_local $5
+    br $repeat|0
+    unreachable
+   end
+   unreachable
   end
   get_local $2
  )
- (func $std/typedarray/testReduceRight<Uint16Array,u16> (; 104 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint16Array,u16> (; 94 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -5059,57 +5082,69 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Int32Array,i32>~anonymous|18 (; 105 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Int32Array,i32>~anonymous|18 (; 95 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/typedarray/Int32Array#reduceRight<i32> (; 106 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#reduceRight<i32> (; 96 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
-  block $~lib/internal/typedarray/TypedArray<i32>#get:length|inlined.10 (result i32)
-   get_local $0
-   i32.load offset=8
-   i32.const 2
-   i32.shr_u
-  end
-  i32.const 1
-  i32.sub
+  (local $5 i32)
+  get_local $0
+  i32.load
   set_local $3
-  i32.const -1
+  get_local $0
+  i32.load offset=4
   set_local $4
   block $break|0
-   loop $continue|0
-    get_local $3
-    get_local $4
-    i32.ne
-    if
-     block
-      block (result i32)
-       i32.const 4
-       set_global $~argc
-       get_local $2
-       get_local $0
-       get_local $3
-       call $~lib/internal/typedarray/TypedArray<i32>#__unchecked_get
-       get_local $3
-       get_local $0
-       get_local $1
-       call_indirect (type $iiiii)
-      end
-      set_local $2
-      get_local $3
-      i32.const 1
-      i32.sub
-      set_local $3
-     end
-     br $continue|0
-    end
+   block $~lib/internal/typedarray/TypedArray<i32>#get:length|inlined.10 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 2
+    i32.shr_u
    end
+   i32.const 1
+   i32.sub
+   set_local $5
+   loop $repeat|0
+    get_local $5
+    i32.const 0
+    i32.ge_s
+    i32.eqz
+    br_if $break|0
+    block (result i32)
+     i32.const 4
+     set_global $~argc
+     get_local $2
+     block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.3 (result i32)
+      get_local $3
+      get_local $5
+      i32.const 2
+      i32.shl
+      i32.add
+      get_local $4
+      i32.add
+      i32.load offset=8
+     end
+     get_local $5
+     get_local $0
+     get_local $1
+     call_indirect (type $iiiii)
+    end
+    set_local $2
+    get_local $5
+    i32.const 1
+    i32.sub
+    set_local $5
+    br $repeat|0
+    unreachable
+   end
+   unreachable
   end
   get_local $2
  )
- (func $std/typedarray/testReduceRight<Int32Array,i32> (; 107 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int32Array,i32> (; 97 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -5146,57 +5181,69 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint32Array,u32>~anonymous|19 (; 108 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Uint32Array,u32>~anonymous|19 (; 98 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/typedarray/Uint32Array#reduceRight<u32> (; 109 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#reduceRight<u32> (; 99 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
-  block $~lib/internal/typedarray/TypedArray<u32>#get:length|inlined.2 (result i32)
-   get_local $0
-   i32.load offset=8
-   i32.const 2
-   i32.shr_u
-  end
-  i32.const 1
-  i32.sub
+  (local $5 i32)
+  get_local $0
+  i32.load
   set_local $3
-  i32.const -1
+  get_local $0
+  i32.load offset=4
   set_local $4
   block $break|0
-   loop $continue|0
-    get_local $3
-    get_local $4
-    i32.ne
-    if
-     block
-      block (result i32)
-       i32.const 4
-       set_global $~argc
-       get_local $2
-       get_local $0
-       get_local $3
-       call $~lib/internal/typedarray/TypedArray<u32>#__unchecked_get
-       get_local $3
-       get_local $0
-       get_local $1
-       call_indirect (type $iiiii)
-      end
-      set_local $2
-      get_local $3
-      i32.const 1
-      i32.sub
-      set_local $3
-     end
-     br $continue|0
-    end
+   block $~lib/internal/typedarray/TypedArray<u32>#get:length|inlined.2 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 2
+    i32.shr_u
    end
+   i32.const 1
+   i32.sub
+   set_local $5
+   loop $repeat|0
+    get_local $5
+    i32.const 0
+    i32.ge_s
+    i32.eqz
+    br_if $break|0
+    block (result i32)
+     i32.const 4
+     set_global $~argc
+     get_local $2
+     block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.1 (result i32)
+      get_local $3
+      get_local $5
+      i32.const 2
+      i32.shl
+      i32.add
+      get_local $4
+      i32.add
+      i32.load offset=8
+     end
+     get_local $5
+     get_local $0
+     get_local $1
+     call_indirect (type $iiiii)
+    end
+    set_local $2
+    get_local $5
+    i32.const 1
+    i32.sub
+    set_local $5
+    br $repeat|0
+    unreachable
+   end
+   unreachable
   end
   get_local $2
  )
- (func $std/typedarray/testReduceRight<Uint32Array,u32> (; 110 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint32Array,u32> (; 100 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -5233,57 +5280,69 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Int64Array,i64>~anonymous|20 (; 111 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduceRight<Int64Array,i64>~anonymous|20 (; 101 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   get_local $0
   get_local $1
   i64.add
  )
- (func $~lib/typedarray/Int64Array#reduceRight<i64> (; 112 ;) (type $iiII) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
+ (func $~lib/typedarray/Int64Array#reduceRight<i64> (; 102 ;) (type $iiII) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
   (local $3 i32)
   (local $4 i32)
-  block $~lib/internal/typedarray/TypedArray<i64>#get:length|inlined.2 (result i32)
-   get_local $0
-   i32.load offset=8
-   i32.const 3
-   i32.shr_u
-  end
-  i32.const 1
-  i32.sub
+  (local $5 i32)
+  get_local $0
+  i32.load
   set_local $3
-  i32.const -1
+  get_local $0
+  i32.load offset=4
   set_local $4
   block $break|0
-   loop $continue|0
-    get_local $3
-    get_local $4
-    i32.ne
-    if
-     block
-      block (result i64)
-       i32.const 4
-       set_global $~argc
-       get_local $2
-       get_local $0
-       get_local $3
-       call $~lib/internal/typedarray/TypedArray<i64>#__unchecked_get
-       get_local $3
-       get_local $0
-       get_local $1
-       call_indirect (type $IIiiI)
-      end
-      set_local $2
-      get_local $3
-      i32.const 1
-      i32.sub
-      set_local $3
-     end
-     br $continue|0
-    end
+   block $~lib/internal/typedarray/TypedArray<i64>#get:length|inlined.2 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 3
+    i32.shr_u
    end
+   i32.const 1
+   i32.sub
+   set_local $5
+   loop $repeat|0
+    get_local $5
+    i32.const 0
+    i32.ge_s
+    i32.eqz
+    br_if $break|0
+    block (result i64)
+     i32.const 4
+     set_global $~argc
+     get_local $2
+     block $~lib/internal/arraybuffer/LOAD<i64,i64>|inlined.1 (result i64)
+      get_local $3
+      get_local $5
+      i32.const 3
+      i32.shl
+      i32.add
+      get_local $4
+      i32.add
+      i64.load offset=8
+     end
+     get_local $5
+     get_local $0
+     get_local $1
+     call_indirect (type $IIiiI)
+    end
+    set_local $2
+    get_local $5
+    i32.const 1
+    i32.sub
+    set_local $5
+    br $repeat|0
+    unreachable
+   end
+   unreachable
   end
   get_local $2
  )
- (func $std/typedarray/testReduceRight<Int64Array,i64> (; 113 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int64Array,i64> (; 103 ;) (type $v)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -5320,57 +5379,69 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint64Array,u64>~anonymous|21 (; 114 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduceRight<Uint64Array,u64>~anonymous|21 (; 104 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   get_local $0
   get_local $1
   i64.add
  )
- (func $~lib/typedarray/Uint64Array#reduceRight<u64> (; 115 ;) (type $iiII) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
+ (func $~lib/typedarray/Uint64Array#reduceRight<u64> (; 105 ;) (type $iiII) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
   (local $3 i32)
   (local $4 i32)
-  block $~lib/internal/typedarray/TypedArray<u64>#get:length|inlined.2 (result i32)
-   get_local $0
-   i32.load offset=8
-   i32.const 3
-   i32.shr_u
-  end
-  i32.const 1
-  i32.sub
+  (local $5 i32)
+  get_local $0
+  i32.load
   set_local $3
-  i32.const -1
+  get_local $0
+  i32.load offset=4
   set_local $4
   block $break|0
-   loop $continue|0
-    get_local $3
-    get_local $4
-    i32.ne
-    if
-     block
-      block (result i64)
-       i32.const 4
-       set_global $~argc
-       get_local $2
-       get_local $0
-       get_local $3
-       call $~lib/internal/typedarray/TypedArray<u64>#__unchecked_get
-       get_local $3
-       get_local $0
-       get_local $1
-       call_indirect (type $IIiiI)
-      end
-      set_local $2
-      get_local $3
-      i32.const 1
-      i32.sub
-      set_local $3
-     end
-     br $continue|0
-    end
+   block $~lib/internal/typedarray/TypedArray<u64>#get:length|inlined.2 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 3
+    i32.shr_u
    end
+   i32.const 1
+   i32.sub
+   set_local $5
+   loop $repeat|0
+    get_local $5
+    i32.const 0
+    i32.ge_s
+    i32.eqz
+    br_if $break|0
+    block (result i64)
+     i32.const 4
+     set_global $~argc
+     get_local $2
+     block $~lib/internal/arraybuffer/LOAD<u64,u64>|inlined.1 (result i64)
+      get_local $3
+      get_local $5
+      i32.const 3
+      i32.shl
+      i32.add
+      get_local $4
+      i32.add
+      i64.load offset=8
+     end
+     get_local $5
+     get_local $0
+     get_local $1
+     call_indirect (type $IIiiI)
+    end
+    set_local $2
+    get_local $5
+    i32.const 1
+    i32.sub
+    set_local $5
+    br $repeat|0
+    unreachable
+   end
+   unreachable
   end
   get_local $2
  )
- (func $std/typedarray/testReduceRight<Uint64Array,u64> (; 116 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint64Array,u64> (; 106 ;) (type $v)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -5407,57 +5478,69 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Float32Array,f32>~anonymous|22 (; 117 ;) (type $ffiif) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
+ (func $std/typedarray/testReduceRight<Float32Array,f32>~anonymous|22 (; 107 ;) (type $ffiif) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
   get_local $0
   get_local $1
   f32.add
  )
- (func $~lib/typedarray/Float32Array#reduceRight<f32> (; 118 ;) (type $iiff) (param $0 i32) (param $1 i32) (param $2 f32) (result f32)
+ (func $~lib/typedarray/Float32Array#reduceRight<f32> (; 108 ;) (type $iiff) (param $0 i32) (param $1 i32) (param $2 f32) (result f32)
   (local $3 i32)
   (local $4 i32)
-  block $~lib/internal/typedarray/TypedArray<f32>#get:length|inlined.2 (result i32)
-   get_local $0
-   i32.load offset=8
-   i32.const 2
-   i32.shr_u
-  end
-  i32.const 1
-  i32.sub
+  (local $5 i32)
+  get_local $0
+  i32.load
   set_local $3
-  i32.const -1
+  get_local $0
+  i32.load offset=4
   set_local $4
   block $break|0
-   loop $continue|0
-    get_local $3
-    get_local $4
-    i32.ne
-    if
-     block
-      block (result f32)
-       i32.const 4
-       set_global $~argc
-       get_local $2
-       get_local $0
-       get_local $3
-       call $~lib/internal/typedarray/TypedArray<f32>#__unchecked_get
-       get_local $3
-       get_local $0
-       get_local $1
-       call_indirect (type $ffiif)
-      end
-      set_local $2
-      get_local $3
-      i32.const 1
-      i32.sub
-      set_local $3
-     end
-     br $continue|0
-    end
+   block $~lib/internal/typedarray/TypedArray<f32>#get:length|inlined.2 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 2
+    i32.shr_u
    end
+   i32.const 1
+   i32.sub
+   set_local $5
+   loop $repeat|0
+    get_local $5
+    i32.const 0
+    i32.ge_s
+    i32.eqz
+    br_if $break|0
+    block (result f32)
+     i32.const 4
+     set_global $~argc
+     get_local $2
+     block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.1 (result f32)
+      get_local $3
+      get_local $5
+      i32.const 2
+      i32.shl
+      i32.add
+      get_local $4
+      i32.add
+      f32.load offset=8
+     end
+     get_local $5
+     get_local $0
+     get_local $1
+     call_indirect (type $ffiif)
+    end
+    set_local $2
+    get_local $5
+    i32.const 1
+    i32.sub
+    set_local $5
+    br $repeat|0
+    unreachable
+   end
+   unreachable
   end
   get_local $2
  )
- (func $std/typedarray/testReduceRight<Float32Array,f32> (; 119 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Float32Array,f32> (; 109 ;) (type $v)
   (local $0 i32)
   (local $1 f32)
   i32.const 0
@@ -5494,57 +5577,69 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Float64Array,f64>~anonymous|23 (; 120 ;) (type $FFiiF) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
+ (func $std/typedarray/testReduceRight<Float64Array,f64>~anonymous|23 (; 110 ;) (type $FFiiF) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
   get_local $0
   get_local $1
   f64.add
  )
- (func $~lib/typedarray/Float64Array#reduceRight<f64> (; 121 ;) (type $iiFF) (param $0 i32) (param $1 i32) (param $2 f64) (result f64)
+ (func $~lib/typedarray/Float64Array#reduceRight<f64> (; 111 ;) (type $iiFF) (param $0 i32) (param $1 i32) (param $2 f64) (result f64)
   (local $3 i32)
   (local $4 i32)
-  block $~lib/internal/typedarray/TypedArray<f64>#get:length|inlined.5 (result i32)
-   get_local $0
-   i32.load offset=8
-   i32.const 3
-   i32.shr_u
-  end
-  i32.const 1
-  i32.sub
+  (local $5 i32)
+  get_local $0
+  i32.load
   set_local $3
-  i32.const -1
+  get_local $0
+  i32.load offset=4
   set_local $4
   block $break|0
-   loop $continue|0
-    get_local $3
-    get_local $4
-    i32.ne
-    if
-     block
-      block (result f64)
-       i32.const 4
-       set_global $~argc
-       get_local $2
-       get_local $0
-       get_local $3
-       call $~lib/internal/typedarray/TypedArray<f64>#__unchecked_get
-       get_local $3
-       get_local $0
-       get_local $1
-       call_indirect (type $FFiiF)
-      end
-      set_local $2
-      get_local $3
-      i32.const 1
-      i32.sub
-      set_local $3
-     end
-     br $continue|0
-    end
+   block $~lib/internal/typedarray/TypedArray<f64>#get:length|inlined.5 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 3
+    i32.shr_u
    end
+   i32.const 1
+   i32.sub
+   set_local $5
+   loop $repeat|0
+    get_local $5
+    i32.const 0
+    i32.ge_s
+    i32.eqz
+    br_if $break|0
+    block (result f64)
+     i32.const 4
+     set_global $~argc
+     get_local $2
+     block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.14 (result f64)
+      get_local $3
+      get_local $5
+      i32.const 3
+      i32.shl
+      i32.add
+      get_local $4
+      i32.add
+      f64.load offset=8
+     end
+     get_local $5
+     get_local $0
+     get_local $1
+     call_indirect (type $FFiiF)
+    end
+    set_local $2
+    get_local $5
+    i32.const 1
+    i32.sub
+    set_local $5
+    br $repeat|0
+    unreachable
+   end
+   unreachable
   end
   get_local $2
  )
- (func $std/typedarray/testReduceRight<Float64Array,f64> (; 122 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Float64Array,f64> (; 112 ;) (type $v)
   (local $0 i32)
   (local $1 f64)
   i32.const 0
@@ -5581,36 +5676,20 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 (; 123 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 (; 113 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   get_local $0
   i32.mul
  )
- (func $~lib/internal/typedarray/TypedArray<i8>#__unchecked_set (; 124 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  get_local $0
-  i32.load
-  set_local $3
-  get_local $0
-  i32.load offset=4
-  set_local $4
-  get_local $3
-  get_local $1
-  i32.const 0
-  i32.shl
-  i32.add
-  get_local $4
-  i32.add
-  get_local $2
-  i32.store8 offset=8
- )
- (func $~lib/typedarray/Int8Array#map (; 125 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#map (; 114 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   block $~lib/internal/typedarray/TypedArray<i8>#get:length|inlined.12 (result i32)
    get_local $0
    i32.load offset=8
@@ -5618,57 +5697,76 @@
    i32.shr_u
   end
   set_local $2
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
   i32.const 0
   get_local $2
   call $~lib/internal/typedarray/TypedArray<i8>#constructor
-  set_local $3
-  i32.const 0
-  set_local $4
+  set_local $5
+  get_local $5
+  i32.load
+  set_local $6
   block $break|0
-   loop $continue|0
-    get_local $4
+   i32.const 0
+   set_local $7
+   loop $repeat|0
+    get_local $7
     get_local $2
     i32.lt_s
-    if
-     block
-      block (result i32)
+    i32.eqz
+    br_if $break|0
+    block
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<i8,i8>|inlined.4 (result i32)
        get_local $3
-       tee_local $5
-       get_local $4
-       tee_local $6
-       block (result i32)
-        i32.const 3
-        set_global $~argc
-        get_local $0
-        get_local $4
-        call $~lib/internal/typedarray/TypedArray<i8>#__unchecked_get
-        get_local $4
-        get_local $0
-        get_local $1
-        call_indirect (type $iiii)
-       end
-       i32.const 24
+       get_local $7
+       i32.const 0
        i32.shl
-       i32.const 24
-       i32.shr_s
-       call $~lib/internal/typedarray/TypedArray<i8>#__unchecked_set
-       get_local $5
-       get_local $6
-       call $~lib/internal/typedarray/TypedArray<i8>#__unchecked_get
+       i32.add
+       get_local $4
+       i32.add
+       i32.load8_s offset=8
       end
-      drop
-      get_local $4
-      i32.const 1
-      i32.add
-      set_local $4
+      get_local $7
+      get_local $0
+      get_local $1
+      call_indirect (type $iiii)
      end
-     br $continue|0
+     i32.const 24
+     i32.shl
+     i32.const 24
+     i32.shr_s
+     set_local $8
+     i32.const 0
+     set_local $9
+     get_local $6
+     get_local $7
+     i32.const 0
+     i32.shl
+     i32.add
+     get_local $9
+     i32.add
+     get_local $8
+     i32.store8 offset=8
     end
+    get_local $7
+    i32.const 1
+    i32.add
+    set_local $7
+    br $repeat|0
+    unreachable
    end
+   unreachable
   end
-  get_local $3
+  get_local $5
  )
- (func $std/typedarray/testArrayMap<Int8Array,i8> (; 126 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int8Array,i8> (; 115 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -5746,36 +5844,20 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint8Array,u8>~anonymous|25 (; 127 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Uint8Array,u8>~anonymous|25 (; 116 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   get_local $0
   i32.mul
  )
- (func $~lib/internal/typedarray/TypedArray<u8>#__unchecked_set (; 128 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  get_local $0
-  i32.load
-  set_local $3
-  get_local $0
-  i32.load offset=4
-  set_local $4
-  get_local $3
-  get_local $1
-  i32.const 0
-  i32.shl
-  i32.add
-  get_local $4
-  i32.add
-  get_local $2
-  i32.store8 offset=8
- )
- (func $~lib/typedarray/Uint8Array#map (; 129 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#map (; 117 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   block $~lib/internal/typedarray/TypedArray<u8>#get:length|inlined.4 (result i32)
    get_local $0
    i32.load offset=8
@@ -5783,55 +5865,74 @@
    i32.shr_u
   end
   set_local $2
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
   i32.const 0
   get_local $2
   call $~lib/internal/typedarray/TypedArray<u8>#constructor
-  set_local $3
-  i32.const 0
-  set_local $4
+  set_local $5
+  get_local $5
+  i32.load
+  set_local $6
   block $break|0
-   loop $continue|0
-    get_local $4
+   i32.const 0
+   set_local $7
+   loop $repeat|0
+    get_local $7
     get_local $2
     i32.lt_s
-    if
-     block
-      block (result i32)
+    i32.eqz
+    br_if $break|0
+    block
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<u8,u8>|inlined.3 (result i32)
        get_local $3
-       tee_local $5
+       get_local $7
+       i32.const 0
+       i32.shl
+       i32.add
        get_local $4
-       tee_local $6
-       block (result i32)
-        i32.const 3
-        set_global $~argc
-        get_local $0
-        get_local $4
-        call $~lib/internal/typedarray/TypedArray<u8>#__unchecked_get
-        get_local $4
-        get_local $0
-        get_local $1
-        call_indirect (type $iiii)
-       end
-       i32.const 255
-       i32.and
-       call $~lib/internal/typedarray/TypedArray<u8>#__unchecked_set
-       get_local $5
-       get_local $6
-       call $~lib/internal/typedarray/TypedArray<u8>#__unchecked_get
+       i32.add
+       i32.load8_u offset=8
       end
-      drop
-      get_local $4
-      i32.const 1
-      i32.add
-      set_local $4
+      get_local $7
+      get_local $0
+      get_local $1
+      call_indirect (type $iiii)
      end
-     br $continue|0
+     i32.const 255
+     i32.and
+     set_local $8
+     i32.const 0
+     set_local $9
+     get_local $6
+     get_local $7
+     i32.const 0
+     i32.shl
+     i32.add
+     get_local $9
+     i32.add
+     get_local $8
+     i32.store8 offset=8
     end
+    get_local $7
+    i32.const 1
+    i32.add
+    set_local $7
+    br $repeat|0
+    unreachable
    end
+   unreachable
   end
-  get_local $3
+  get_local $5
  )
- (func $std/typedarray/testArrayMap<Uint8Array,u8> (; 130 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint8Array,u8> (; 118 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -5903,55 +6004,20 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8>~anonymous|26 (; 131 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8>~anonymous|26 (; 119 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   get_local $0
   i32.mul
  )
- (func $~lib/typedarray/Uint8ClampedArray#__unchecked_set (; 132 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  get_local $2
-  tee_local $3
-  i32.const 255
-  tee_local $4
-  get_local $3
-  get_local $4
-  i32.lt_s
-  select
-  tee_local $3
-  i32.const 0
-  tee_local $4
-  get_local $3
-  get_local $4
-  i32.gt_s
-  select
-  set_local $3
-  block
-   get_local $0
-   i32.load
-   set_local $4
-   get_local $0
-   i32.load offset=4
-   set_local $5
-   get_local $4
-   get_local $1
-   i32.const 0
-   i32.shl
-   i32.add
-   get_local $5
-   i32.add
-   get_local $3
-   i32.store8 offset=8
-  end
- )
- (func $~lib/typedarray/Uint8ClampedArray#map (; 133 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#map (; 120 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   block $~lib/internal/typedarray/TypedArray<u8>#get:length|inlined.5 (result i32)
    get_local $0
    i32.load offset=8
@@ -5959,55 +6025,74 @@
    i32.shr_u
   end
   set_local $2
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
   i32.const 0
   get_local $2
   call $~lib/internal/typedarray/TypedArray<u8>#constructor
-  set_local $3
-  i32.const 0
-  set_local $4
+  set_local $5
+  get_local $5
+  i32.load
+  set_local $6
   block $break|0
-   loop $continue|0
-    get_local $4
+   i32.const 0
+   set_local $7
+   loop $repeat|0
+    get_local $7
     get_local $2
     i32.lt_s
-    if
-     block
-      block (result i32)
+    i32.eqz
+    br_if $break|0
+    block
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<u8,u8>|inlined.4 (result i32)
        get_local $3
-       tee_local $5
+       get_local $7
+       i32.const 0
+       i32.shl
+       i32.add
        get_local $4
-       tee_local $6
-       block (result i32)
-        i32.const 3
-        set_global $~argc
-        get_local $0
-        get_local $4
-        call $~lib/internal/typedarray/TypedArray<u8>#__unchecked_get
-        get_local $4
-        get_local $0
-        get_local $1
-        call_indirect (type $iiii)
-       end
-       i32.const 255
-       i32.and
-       call $~lib/typedarray/Uint8ClampedArray#__unchecked_set
-       get_local $5
-       get_local $6
-       call $~lib/internal/typedarray/TypedArray<u8>#__unchecked_get
+       i32.add
+       i32.load8_u offset=8
       end
-      drop
-      get_local $4
-      i32.const 1
-      i32.add
-      set_local $4
+      get_local $7
+      get_local $0
+      get_local $1
+      call_indirect (type $iiii)
      end
-     br $continue|0
+     i32.const 255
+     i32.and
+     set_local $8
+     i32.const 0
+     set_local $9
+     get_local $6
+     get_local $7
+     i32.const 0
+     i32.shl
+     i32.add
+     get_local $9
+     i32.add
+     get_local $8
+     i32.store8 offset=8
     end
+    get_local $7
+    i32.const 1
+    i32.add
+    set_local $7
+    br $repeat|0
+    unreachable
    end
+   unreachable
   end
-  get_local $3
+  get_local $5
  )
- (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8> (; 134 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8> (; 121 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -6079,36 +6164,20 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int16Array,i16>~anonymous|27 (; 135 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Int16Array,i16>~anonymous|27 (; 122 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   get_local $0
   i32.mul
  )
- (func $~lib/internal/typedarray/TypedArray<i16>#__unchecked_set (; 136 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  get_local $0
-  i32.load
-  set_local $3
-  get_local $0
-  i32.load offset=4
-  set_local $4
-  get_local $3
-  get_local $1
-  i32.const 1
-  i32.shl
-  i32.add
-  get_local $4
-  i32.add
-  get_local $2
-  i32.store16 offset=8
- )
- (func $~lib/typedarray/Int16Array#map (; 137 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#map (; 123 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   block $~lib/internal/typedarray/TypedArray<i16>#get:length|inlined.3 (result i32)
    get_local $0
    i32.load offset=8
@@ -6116,57 +6185,76 @@
    i32.shr_u
   end
   set_local $2
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
   i32.const 0
   get_local $2
   call $~lib/internal/typedarray/TypedArray<i16>#constructor
-  set_local $3
-  i32.const 0
-  set_local $4
+  set_local $5
+  get_local $5
+  i32.load
+  set_local $6
   block $break|0
-   loop $continue|0
-    get_local $4
+   i32.const 0
+   set_local $7
+   loop $repeat|0
+    get_local $7
     get_local $2
     i32.lt_s
-    if
-     block
-      block (result i32)
+    i32.eqz
+    br_if $break|0
+    block
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<i16,i16>|inlined.2 (result i32)
        get_local $3
-       tee_local $5
-       get_local $4
-       tee_local $6
-       block (result i32)
-        i32.const 3
-        set_global $~argc
-        get_local $0
-        get_local $4
-        call $~lib/internal/typedarray/TypedArray<i16>#__unchecked_get
-        get_local $4
-        get_local $0
-        get_local $1
-        call_indirect (type $iiii)
-       end
-       i32.const 16
+       get_local $7
+       i32.const 1
        i32.shl
-       i32.const 16
-       i32.shr_s
-       call $~lib/internal/typedarray/TypedArray<i16>#__unchecked_set
-       get_local $5
-       get_local $6
-       call $~lib/internal/typedarray/TypedArray<i16>#__unchecked_get
+       i32.add
+       get_local $4
+       i32.add
+       i32.load16_s offset=8
       end
-      drop
-      get_local $4
-      i32.const 1
-      i32.add
-      set_local $4
+      get_local $7
+      get_local $0
+      get_local $1
+      call_indirect (type $iiii)
      end
-     br $continue|0
+     i32.const 16
+     i32.shl
+     i32.const 16
+     i32.shr_s
+     set_local $8
+     i32.const 0
+     set_local $9
+     get_local $6
+     get_local $7
+     i32.const 1
+     i32.shl
+     i32.add
+     get_local $9
+     i32.add
+     get_local $8
+     i32.store16 offset=8
     end
+    get_local $7
+    i32.const 1
+    i32.add
+    set_local $7
+    br $repeat|0
+    unreachable
    end
+   unreachable
   end
-  get_local $3
+  get_local $5
  )
- (func $~lib/internal/typedarray/TypedArray<i16>#__get (; 138 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<i16>#__get (; 124 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   get_local $1
@@ -6183,7 +6271,7 @@
    call $~lib/env/abort
    unreachable
   end
-  block $~lib/internal/arraybuffer/LOAD<i16,i16>|inlined.1 (result i32)
+  block $~lib/internal/arraybuffer/LOAD<i16,i16>|inlined.3 (result i32)
    get_local $0
    i32.load
    set_local $2
@@ -6200,7 +6288,7 @@
    i32.load16_s offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Int16Array,i16> (; 139 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int16Array,i16> (; 125 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -6278,36 +6366,20 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint16Array,u16>~anonymous|28 (; 140 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Uint16Array,u16>~anonymous|28 (; 126 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   get_local $0
   i32.mul
  )
- (func $~lib/internal/typedarray/TypedArray<u16>#__unchecked_set (; 141 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  get_local $0
-  i32.load
-  set_local $3
-  get_local $0
-  i32.load offset=4
-  set_local $4
-  get_local $3
-  get_local $1
-  i32.const 1
-  i32.shl
-  i32.add
-  get_local $4
-  i32.add
-  get_local $2
-  i32.store16 offset=8
- )
- (func $~lib/typedarray/Uint16Array#map (; 142 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#map (; 127 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   block $~lib/internal/typedarray/TypedArray<u16>#get:length|inlined.3 (result i32)
    get_local $0
    i32.load offset=8
@@ -6315,55 +6387,74 @@
    i32.shr_u
   end
   set_local $2
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
   i32.const 0
   get_local $2
   call $~lib/internal/typedarray/TypedArray<u16>#constructor
-  set_local $3
-  i32.const 0
-  set_local $4
+  set_local $5
+  get_local $5
+  i32.load
+  set_local $6
   block $break|0
-   loop $continue|0
-    get_local $4
+   i32.const 0
+   set_local $7
+   loop $repeat|0
+    get_local $7
     get_local $2
     i32.lt_s
-    if
-     block
-      block (result i32)
+    i32.eqz
+    br_if $break|0
+    block
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<u16,u16>|inlined.2 (result i32)
        get_local $3
-       tee_local $5
+       get_local $7
+       i32.const 1
+       i32.shl
+       i32.add
        get_local $4
-       tee_local $6
-       block (result i32)
-        i32.const 3
-        set_global $~argc
-        get_local $0
-        get_local $4
-        call $~lib/internal/typedarray/TypedArray<u16>#__unchecked_get
-        get_local $4
-        get_local $0
-        get_local $1
-        call_indirect (type $iiii)
-       end
-       i32.const 65535
-       i32.and
-       call $~lib/internal/typedarray/TypedArray<u16>#__unchecked_set
-       get_local $5
-       get_local $6
-       call $~lib/internal/typedarray/TypedArray<u16>#__unchecked_get
+       i32.add
+       i32.load16_u offset=8
       end
-      drop
-      get_local $4
-      i32.const 1
-      i32.add
-      set_local $4
+      get_local $7
+      get_local $0
+      get_local $1
+      call_indirect (type $iiii)
      end
-     br $continue|0
+     i32.const 65535
+     i32.and
+     set_local $8
+     i32.const 0
+     set_local $9
+     get_local $6
+     get_local $7
+     i32.const 1
+     i32.shl
+     i32.add
+     get_local $9
+     i32.add
+     get_local $8
+     i32.store16 offset=8
     end
+    get_local $7
+    i32.const 1
+    i32.add
+    set_local $7
+    br $repeat|0
+    unreachable
    end
+   unreachable
   end
-  get_local $3
+  get_local $5
  )
- (func $~lib/internal/typedarray/TypedArray<u16>#__get (; 143 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<u16>#__get (; 128 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   get_local $1
@@ -6380,7 +6471,7 @@
    call $~lib/env/abort
    unreachable
   end
-  block $~lib/internal/arraybuffer/LOAD<u16,u16>|inlined.1 (result i32)
+  block $~lib/internal/arraybuffer/LOAD<u16,u16>|inlined.3 (result i32)
    get_local $0
    i32.load
    set_local $2
@@ -6397,7 +6488,7 @@
    i32.load16_u offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Uint16Array,u16> (; 144 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint16Array,u16> (; 129 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -6469,36 +6560,20 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int32Array,i32>~anonymous|29 (; 145 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Int32Array,i32>~anonymous|29 (; 130 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   get_local $0
   i32.mul
  )
- (func $~lib/internal/typedarray/TypedArray<i32>#__unchecked_set (; 146 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  get_local $0
-  i32.load
-  set_local $3
-  get_local $0
-  i32.load offset=4
-  set_local $4
-  get_local $3
-  get_local $1
-  i32.const 2
-  i32.shl
-  i32.add
-  get_local $4
-  i32.add
-  get_local $2
-  i32.store offset=8
- )
- (func $~lib/typedarray/Int32Array#map (; 147 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#map (; 131 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   block $~lib/internal/typedarray/TypedArray<i32>#get:length|inlined.11 (result i32)
    get_local $0
    i32.load offset=8
@@ -6506,53 +6581,72 @@
    i32.shr_u
   end
   set_local $2
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
   i32.const 0
   get_local $2
   call $~lib/internal/typedarray/TypedArray<i32>#constructor
-  set_local $3
-  i32.const 0
-  set_local $4
+  set_local $5
+  get_local $5
+  i32.load
+  set_local $6
   block $break|0
-   loop $continue|0
-    get_local $4
+   i32.const 0
+   set_local $7
+   loop $repeat|0
+    get_local $7
     get_local $2
     i32.lt_s
-    if
-     block
-      block (result i32)
+    i32.eqz
+    br_if $break|0
+    block
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.4 (result i32)
        get_local $3
-       tee_local $5
+       get_local $7
+       i32.const 2
+       i32.shl
+       i32.add
        get_local $4
-       tee_local $6
-       block (result i32)
-        i32.const 3
-        set_global $~argc
-        get_local $0
-        get_local $4
-        call $~lib/internal/typedarray/TypedArray<i32>#__unchecked_get
-        get_local $4
-        get_local $0
-        get_local $1
-        call_indirect (type $iiii)
-       end
-       call $~lib/internal/typedarray/TypedArray<i32>#__unchecked_set
-       get_local $5
-       get_local $6
-       call $~lib/internal/typedarray/TypedArray<i32>#__unchecked_get
+       i32.add
+       i32.load offset=8
       end
-      drop
-      get_local $4
-      i32.const 1
-      i32.add
-      set_local $4
+      get_local $7
+      get_local $0
+      get_local $1
+      call_indirect (type $iiii)
      end
-     br $continue|0
+     set_local $8
+     i32.const 0
+     set_local $9
+     get_local $6
+     get_local $7
+     i32.const 2
+     i32.shl
+     i32.add
+     get_local $9
+     i32.add
+     get_local $8
+     i32.store offset=8
     end
+    get_local $7
+    i32.const 1
+    i32.add
+    set_local $7
+    br $repeat|0
+    unreachable
    end
+   unreachable
   end
-  get_local $3
+  get_local $5
  )
- (func $std/typedarray/testArrayMap<Int32Array,i32> (; 148 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int32Array,i32> (; 132 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -6618,36 +6712,20 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint32Array,u32>~anonymous|30 (; 149 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Uint32Array,u32>~anonymous|30 (; 133 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   get_local $0
   i32.mul
  )
- (func $~lib/internal/typedarray/TypedArray<u32>#__unchecked_set (; 150 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  get_local $0
-  i32.load
-  set_local $3
-  get_local $0
-  i32.load offset=4
-  set_local $4
-  get_local $3
-  get_local $1
-  i32.const 2
-  i32.shl
-  i32.add
-  get_local $4
-  i32.add
-  get_local $2
-  i32.store offset=8
- )
- (func $~lib/typedarray/Uint32Array#map (; 151 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#map (; 134 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   block $~lib/internal/typedarray/TypedArray<u32>#get:length|inlined.3 (result i32)
    get_local $0
    i32.load offset=8
@@ -6655,53 +6733,72 @@
    i32.shr_u
   end
   set_local $2
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
   i32.const 0
   get_local $2
   call $~lib/internal/typedarray/TypedArray<u32>#constructor
-  set_local $3
-  i32.const 0
-  set_local $4
+  set_local $5
+  get_local $5
+  i32.load
+  set_local $6
   block $break|0
-   loop $continue|0
-    get_local $4
+   i32.const 0
+   set_local $7
+   loop $repeat|0
+    get_local $7
     get_local $2
     i32.lt_s
-    if
-     block
-      block (result i32)
+    i32.eqz
+    br_if $break|0
+    block
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.2 (result i32)
        get_local $3
-       tee_local $5
+       get_local $7
+       i32.const 2
+       i32.shl
+       i32.add
        get_local $4
-       tee_local $6
-       block (result i32)
-        i32.const 3
-        set_global $~argc
-        get_local $0
-        get_local $4
-        call $~lib/internal/typedarray/TypedArray<u32>#__unchecked_get
-        get_local $4
-        get_local $0
-        get_local $1
-        call_indirect (type $iiii)
-       end
-       call $~lib/internal/typedarray/TypedArray<u32>#__unchecked_set
-       get_local $5
-       get_local $6
-       call $~lib/internal/typedarray/TypedArray<u32>#__unchecked_get
+       i32.add
+       i32.load offset=8
       end
-      drop
-      get_local $4
-      i32.const 1
-      i32.add
-      set_local $4
+      get_local $7
+      get_local $0
+      get_local $1
+      call_indirect (type $iiii)
      end
-     br $continue|0
+     set_local $8
+     i32.const 0
+     set_local $9
+     get_local $6
+     get_local $7
+     i32.const 2
+     i32.shl
+     i32.add
+     get_local $9
+     i32.add
+     get_local $8
+     i32.store offset=8
     end
+    get_local $7
+    i32.const 1
+    i32.add
+    set_local $7
+    br $repeat|0
+    unreachable
    end
+   unreachable
   end
-  get_local $3
+  get_local $5
  )
- (func $~lib/internal/typedarray/TypedArray<u32>#__get (; 152 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<u32>#__get (; 135 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   get_local $1
@@ -6718,7 +6815,7 @@
    call $~lib/env/abort
    unreachable
   end
-  block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.1 (result i32)
+  block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.3 (result i32)
    get_local $0
    i32.load
    set_local $2
@@ -6735,7 +6832,7 @@
    i32.load offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Uint32Array,u32> (; 153 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint32Array,u32> (; 136 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -6801,36 +6898,20 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 (; 154 ;) (type $IiiI) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+ (func $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 (; 137 ;) (type $IiiI) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
   get_local $0
   get_local $0
   i64.mul
  )
- (func $~lib/internal/typedarray/TypedArray<i64>#__unchecked_set (; 155 ;) (type $iiIv) (param $0 i32) (param $1 i32) (param $2 i64)
-  (local $3 i32)
-  (local $4 i32)
-  get_local $0
-  i32.load
-  set_local $3
-  get_local $0
-  i32.load offset=4
-  set_local $4
-  get_local $3
-  get_local $1
-  i32.const 3
-  i32.shl
-  i32.add
-  get_local $4
-  i32.add
-  get_local $2
-  i64.store offset=8
- )
- (func $~lib/typedarray/Int64Array#map (; 156 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#map (; 138 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/internal/typedarray/TypedArray<i64>#get:length|inlined.3 (result i32)
    get_local $0
    i32.load offset=8
@@ -6838,53 +6919,72 @@
    i32.shr_u
   end
   set_local $2
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
   i32.const 0
   get_local $2
   call $~lib/internal/typedarray/TypedArray<i64>#constructor
-  set_local $3
-  i32.const 0
-  set_local $4
+  set_local $5
+  get_local $5
+  i32.load
+  set_local $6
   block $break|0
-   loop $continue|0
-    get_local $4
+   i32.const 0
+   set_local $7
+   loop $repeat|0
+    get_local $7
     get_local $2
     i32.lt_s
-    if
-     block
-      block (result i64)
+    i32.eqz
+    br_if $break|0
+    block
+     block (result i64)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<i64,i64>|inlined.2 (result i64)
        get_local $3
-       tee_local $5
+       get_local $7
+       i32.const 3
+       i32.shl
+       i32.add
        get_local $4
-       tee_local $6
-       block (result i64)
-        i32.const 3
-        set_global $~argc
-        get_local $0
-        get_local $4
-        call $~lib/internal/typedarray/TypedArray<i64>#__unchecked_get
-        get_local $4
-        get_local $0
-        get_local $1
-        call_indirect (type $IiiI)
-       end
-       call $~lib/internal/typedarray/TypedArray<i64>#__unchecked_set
-       get_local $5
-       get_local $6
-       call $~lib/internal/typedarray/TypedArray<i64>#__unchecked_get
+       i32.add
+       i64.load offset=8
       end
-      drop
-      get_local $4
-      i32.const 1
-      i32.add
-      set_local $4
+      get_local $7
+      get_local $0
+      get_local $1
+      call_indirect (type $IiiI)
      end
-     br $continue|0
+     set_local $8
+     i32.const 0
+     set_local $9
+     get_local $6
+     get_local $7
+     i32.const 3
+     i32.shl
+     i32.add
+     get_local $9
+     i32.add
+     get_local $8
+     i64.store offset=8
     end
+    get_local $7
+    i32.const 1
+    i32.add
+    set_local $7
+    br $repeat|0
+    unreachable
    end
+   unreachable
   end
-  get_local $3
+  get_local $5
  )
- (func $~lib/internal/typedarray/TypedArray<i64>#__get (; 157 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/internal/typedarray/TypedArray<i64>#__get (; 139 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local $3 i32)
   get_local $1
@@ -6901,7 +7001,7 @@
    call $~lib/env/abort
    unreachable
   end
-  block $~lib/internal/arraybuffer/LOAD<i64,i64>|inlined.1 (result i64)
+  block $~lib/internal/arraybuffer/LOAD<i64,i64>|inlined.3 (result i64)
    get_local $0
    i32.load
    set_local $2
@@ -6918,7 +7018,7 @@
    i64.load offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Int64Array,i64> (; 158 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int64Array,i64> (; 140 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -6984,36 +7084,20 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint64Array,u64>~anonymous|32 (; 159 ;) (type $IiiI) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+ (func $std/typedarray/testArrayMap<Uint64Array,u64>~anonymous|32 (; 141 ;) (type $IiiI) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
   get_local $0
   get_local $0
   i64.mul
  )
- (func $~lib/internal/typedarray/TypedArray<u64>#__unchecked_set (; 160 ;) (type $iiIv) (param $0 i32) (param $1 i32) (param $2 i64)
-  (local $3 i32)
-  (local $4 i32)
-  get_local $0
-  i32.load
-  set_local $3
-  get_local $0
-  i32.load offset=4
-  set_local $4
-  get_local $3
-  get_local $1
-  i32.const 3
-  i32.shl
-  i32.add
-  get_local $4
-  i32.add
-  get_local $2
-  i64.store offset=8
- )
- (func $~lib/typedarray/Uint64Array#map (; 161 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#map (; 142 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i64)
+  (local $9 i32)
   block $~lib/internal/typedarray/TypedArray<u64>#get:length|inlined.3 (result i32)
    get_local $0
    i32.load offset=8
@@ -7021,53 +7105,72 @@
    i32.shr_u
   end
   set_local $2
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
   i32.const 0
   get_local $2
   call $~lib/internal/typedarray/TypedArray<u64>#constructor
-  set_local $3
-  i32.const 0
-  set_local $4
+  set_local $5
+  get_local $5
+  i32.load
+  set_local $6
   block $break|0
-   loop $continue|0
-    get_local $4
+   i32.const 0
+   set_local $7
+   loop $repeat|0
+    get_local $7
     get_local $2
     i32.lt_s
-    if
-     block
-      block (result i64)
+    i32.eqz
+    br_if $break|0
+    block
+     block (result i64)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<u64,u64>|inlined.2 (result i64)
        get_local $3
-       tee_local $5
+       get_local $7
+       i32.const 3
+       i32.shl
+       i32.add
        get_local $4
-       tee_local $6
-       block (result i64)
-        i32.const 3
-        set_global $~argc
-        get_local $0
-        get_local $4
-        call $~lib/internal/typedarray/TypedArray<u64>#__unchecked_get
-        get_local $4
-        get_local $0
-        get_local $1
-        call_indirect (type $IiiI)
-       end
-       call $~lib/internal/typedarray/TypedArray<u64>#__unchecked_set
-       get_local $5
-       get_local $6
-       call $~lib/internal/typedarray/TypedArray<u64>#__unchecked_get
+       i32.add
+       i64.load offset=8
       end
-      drop
-      get_local $4
-      i32.const 1
-      i32.add
-      set_local $4
+      get_local $7
+      get_local $0
+      get_local $1
+      call_indirect (type $IiiI)
      end
-     br $continue|0
+     set_local $8
+     i32.const 0
+     set_local $9
+     get_local $6
+     get_local $7
+     i32.const 3
+     i32.shl
+     i32.add
+     get_local $9
+     i32.add
+     get_local $8
+     i64.store offset=8
     end
+    get_local $7
+    i32.const 1
+    i32.add
+    set_local $7
+    br $repeat|0
+    unreachable
    end
+   unreachable
   end
-  get_local $3
+  get_local $5
  )
- (func $~lib/internal/typedarray/TypedArray<u64>#__get (; 162 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/internal/typedarray/TypedArray<u64>#__get (; 143 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local $3 i32)
   get_local $1
@@ -7084,7 +7187,7 @@
    call $~lib/env/abort
    unreachable
   end
-  block $~lib/internal/arraybuffer/LOAD<u64,u64>|inlined.1 (result i64)
+  block $~lib/internal/arraybuffer/LOAD<u64,u64>|inlined.3 (result i64)
    get_local $0
    i32.load
    set_local $2
@@ -7101,7 +7204,7 @@
    i64.load offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Uint64Array,u64> (; 163 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint64Array,u64> (; 144 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -7167,36 +7270,20 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|33 (; 164 ;) (type $fiif) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
+ (func $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|33 (; 145 ;) (type $fiif) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
   get_local $0
   get_local $0
   f32.mul
  )
- (func $~lib/internal/typedarray/TypedArray<f32>#__unchecked_set (; 165 ;) (type $iifv) (param $0 i32) (param $1 i32) (param $2 f32)
-  (local $3 i32)
-  (local $4 i32)
-  get_local $0
-  i32.load
-  set_local $3
-  get_local $0
-  i32.load offset=4
-  set_local $4
-  get_local $3
-  get_local $1
-  i32.const 2
-  i32.shl
-  i32.add
-  get_local $4
-  i32.add
-  get_local $2
-  f32.store offset=8
- )
- (func $~lib/typedarray/Float32Array#map (; 166 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#map (; 146 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 f32)
+  (local $9 i32)
   block $~lib/internal/typedarray/TypedArray<f32>#get:length|inlined.3 (result i32)
    get_local $0
    i32.load offset=8
@@ -7204,53 +7291,72 @@
    i32.shr_u
   end
   set_local $2
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
   i32.const 0
   get_local $2
   call $~lib/internal/typedarray/TypedArray<f32>#constructor
-  set_local $3
-  i32.const 0
-  set_local $4
+  set_local $5
+  get_local $5
+  i32.load
+  set_local $6
   block $break|0
-   loop $continue|0
-    get_local $4
+   i32.const 0
+   set_local $7
+   loop $repeat|0
+    get_local $7
     get_local $2
     i32.lt_s
-    if
-     block
-      block (result f32)
+    i32.eqz
+    br_if $break|0
+    block
+     block (result f32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.2 (result f32)
        get_local $3
-       tee_local $5
+       get_local $7
+       i32.const 2
+       i32.shl
+       i32.add
        get_local $4
-       tee_local $6
-       block (result f32)
-        i32.const 3
-        set_global $~argc
-        get_local $0
-        get_local $4
-        call $~lib/internal/typedarray/TypedArray<f32>#__unchecked_get
-        get_local $4
-        get_local $0
-        get_local $1
-        call_indirect (type $fiif)
-       end
-       call $~lib/internal/typedarray/TypedArray<f32>#__unchecked_set
-       get_local $5
-       get_local $6
-       call $~lib/internal/typedarray/TypedArray<f32>#__unchecked_get
+       i32.add
+       f32.load offset=8
       end
-      drop
-      get_local $4
-      i32.const 1
-      i32.add
-      set_local $4
+      get_local $7
+      get_local $0
+      get_local $1
+      call_indirect (type $fiif)
      end
-     br $continue|0
+     set_local $8
+     i32.const 0
+     set_local $9
+     get_local $6
+     get_local $7
+     i32.const 2
+     i32.shl
+     i32.add
+     get_local $9
+     i32.add
+     get_local $8
+     f32.store offset=8
     end
+    get_local $7
+    i32.const 1
+    i32.add
+    set_local $7
+    br $repeat|0
+    unreachable
    end
+   unreachable
   end
-  get_local $3
+  get_local $5
  )
- (func $~lib/internal/typedarray/TypedArray<f32>#__get (; 167 ;) (type $iif) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/internal/typedarray/TypedArray<f32>#__get (; 147 ;) (type $iif) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (local $3 i32)
   get_local $1
@@ -7267,7 +7373,7 @@
    call $~lib/env/abort
    unreachable
   end
-  block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.1 (result f32)
+  block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.3 (result f32)
    get_local $0
    i32.load
    set_local $2
@@ -7284,7 +7390,7 @@
    f32.load offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Float32Array,f32> (; 168 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Float32Array,f32> (; 148 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -7350,36 +7456,20 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|34 (; 169 ;) (type $FiiF) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
+ (func $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|34 (; 149 ;) (type $FiiF) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
   get_local $0
   get_local $0
   f64.mul
  )
- (func $~lib/internal/typedarray/TypedArray<f64>#__unchecked_set (; 170 ;) (type $iiFv) (param $0 i32) (param $1 i32) (param $2 f64)
-  (local $3 i32)
-  (local $4 i32)
-  get_local $0
-  i32.load
-  set_local $3
-  get_local $0
-  i32.load offset=4
-  set_local $4
-  get_local $3
-  get_local $1
-  i32.const 3
-  i32.shl
-  i32.add
-  get_local $4
-  i32.add
-  get_local $2
-  f64.store offset=8
- )
- (func $~lib/typedarray/Float64Array#map (; 171 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#map (; 150 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 f64)
+  (local $9 i32)
   block $~lib/internal/typedarray/TypedArray<f64>#get:length|inlined.6 (result i32)
    get_local $0
    i32.load offset=8
@@ -7387,53 +7477,72 @@
    i32.shr_u
   end
   set_local $2
+  get_local $0
+  i32.load
+  set_local $3
+  get_local $0
+  i32.load offset=4
+  set_local $4
   i32.const 0
   get_local $2
   call $~lib/internal/typedarray/TypedArray<f64>#constructor
-  set_local $3
-  i32.const 0
-  set_local $4
+  set_local $5
+  get_local $5
+  i32.load
+  set_local $6
   block $break|0
-   loop $continue|0
-    get_local $4
+   i32.const 0
+   set_local $7
+   loop $repeat|0
+    get_local $7
     get_local $2
     i32.lt_s
-    if
-     block
-      block (result f64)
+    i32.eqz
+    br_if $break|0
+    block
+     block (result f64)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.15 (result f64)
        get_local $3
-       tee_local $5
+       get_local $7
+       i32.const 3
+       i32.shl
+       i32.add
        get_local $4
-       tee_local $6
-       block (result f64)
-        i32.const 3
-        set_global $~argc
-        get_local $0
-        get_local $4
-        call $~lib/internal/typedarray/TypedArray<f64>#__unchecked_get
-        get_local $4
-        get_local $0
-        get_local $1
-        call_indirect (type $FiiF)
-       end
-       call $~lib/internal/typedarray/TypedArray<f64>#__unchecked_set
-       get_local $5
-       get_local $6
-       call $~lib/internal/typedarray/TypedArray<f64>#__unchecked_get
+       i32.add
+       f64.load offset=8
       end
-      drop
-      get_local $4
-      i32.const 1
-      i32.add
-      set_local $4
+      get_local $7
+      get_local $0
+      get_local $1
+      call_indirect (type $FiiF)
      end
-     br $continue|0
+     set_local $8
+     i32.const 0
+     set_local $9
+     get_local $6
+     get_local $7
+     i32.const 3
+     i32.shl
+     i32.add
+     get_local $9
+     i32.add
+     get_local $8
+     f64.store offset=8
     end
+    get_local $7
+    i32.const 1
+    i32.add
+    set_local $7
+    br $repeat|0
+    unreachable
    end
+   unreachable
   end
-  get_local $3
+  get_local $5
  )
- (func $std/typedarray/testArrayMap<Float64Array,f64> (; 172 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Float64Array,f64> (; 151 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -7499,7 +7608,4911 @@
    unreachable
   end
  )
- (func $start (; 173 ;) (type $v)
+ (func $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 (; 152 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 24
+  i32.shl
+  i32.const 24
+  i32.shr_s
+  i32.const 2
+  i32.eq
+ )
+ (func $~lib/typedarray/Int8Array#some (; 153 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/SOME<Int8Array,i8>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<i8>#get:length|inlined.13 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 0
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     get_local $5
+     get_local $2
+     i32.lt_s
+     i32.eqz
+     br_if $break|0
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<i8,i8>|inlined.6 (result i32)
+       get_local $3
+       get_local $5
+       i32.const 0
+       i32.shl
+       i32.add
+       get_local $4
+       i32.add
+       i32.load8_s offset=8
+      end
+      get_local $5
+      get_local $0
+      get_local $1
+      call_indirect (type $iiii)
+     end
+     i32.const 0
+     i32.ne
+     if
+      i32.const 1
+      br $~lib/internal/typedarray/SOME<Int8Array,i8>|inlined.0
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const 0
+  end
+ )
+ (func $std/typedarray/testArraySome<Int8Array,i8>~anonymous|36 (; 154 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 24
+  i32.shl
+  i32.const 24
+  i32.shr_s
+  i32.const 0
+  i32.eq
+ )
+ (func $std/typedarray/testArraySome<Int8Array,i8> (; 155 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i8>#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/internal/typedarray/TypedArray<i8>#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/internal/typedarray/TypedArray<i8>#__set
+  get_local $0
+  i32.const 35
+  call $~lib/typedarray/Int8Array#some
+  set_local $1
+  get_local $1
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 335
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 36
+  call $~lib/typedarray/Int8Array#some
+  set_local $2
+  get_local $2
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 338
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArraySome<Uint8Array,u8>~anonymous|37 (; 156 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 255
+  i32.and
+  i32.const 2
+  i32.eq
+ )
+ (func $~lib/typedarray/Uint8Array#some (; 157 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/SOME<Uint8Array,u8>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<u8>#get:length|inlined.6 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 0
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     get_local $5
+     get_local $2
+     i32.lt_s
+     i32.eqz
+     br_if $break|0
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<u8,u8>|inlined.6 (result i32)
+       get_local $3
+       get_local $5
+       i32.const 0
+       i32.shl
+       i32.add
+       get_local $4
+       i32.add
+       i32.load8_u offset=8
+      end
+      get_local $5
+      get_local $0
+      get_local $1
+      call_indirect (type $iiii)
+     end
+     i32.const 0
+     i32.ne
+     if
+      i32.const 1
+      br $~lib/internal/typedarray/SOME<Uint8Array,u8>|inlined.0
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const 0
+  end
+ )
+ (func $std/typedarray/testArraySome<Uint8Array,u8>~anonymous|38 (; 158 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 255
+  i32.and
+  i32.const 0
+  i32.eq
+ )
+ (func $std/typedarray/testArraySome<Uint8Array,u8> (; 159 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 37
+  call $~lib/typedarray/Uint8Array#some
+  set_local $1
+  get_local $1
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 335
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 38
+  call $~lib/typedarray/Uint8Array#some
+  set_local $2
+  get_local $2
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 338
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArraySome<Uint8ClampedArray,u8>~anonymous|39 (; 160 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 255
+  i32.and
+  i32.const 2
+  i32.eq
+ )
+ (func $~lib/typedarray/Uint8ClampedArray#some (; 161 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/SOME<Uint8ClampedArray,u8>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<u8>#get:length|inlined.7 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 0
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     get_local $5
+     get_local $2
+     i32.lt_s
+     i32.eqz
+     br_if $break|0
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<u8,u8>|inlined.8 (result i32)
+       get_local $3
+       get_local $5
+       i32.const 0
+       i32.shl
+       i32.add
+       get_local $4
+       i32.add
+       i32.load8_u offset=8
+      end
+      get_local $5
+      get_local $0
+      get_local $1
+      call_indirect (type $iiii)
+     end
+     i32.const 0
+     i32.ne
+     if
+      i32.const 1
+      br $~lib/internal/typedarray/SOME<Uint8ClampedArray,u8>|inlined.0
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const 0
+  end
+ )
+ (func $std/typedarray/testArraySome<Uint8ClampedArray,u8>~anonymous|40 (; 162 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 255
+  i32.and
+  i32.const 0
+  i32.eq
+ )
+ (func $std/typedarray/testArraySome<Uint8ClampedArray,u8> (; 163 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/typedarray/Uint8ClampedArray#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/typedarray/Uint8ClampedArray#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/typedarray/Uint8ClampedArray#__set
+  get_local $0
+  i32.const 39
+  call $~lib/typedarray/Uint8ClampedArray#some
+  set_local $1
+  get_local $1
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 335
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 40
+  call $~lib/typedarray/Uint8ClampedArray#some
+  set_local $2
+  get_local $2
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 338
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 (; 164 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.shr_s
+  i32.const 2
+  i32.eq
+ )
+ (func $~lib/typedarray/Int16Array#some (; 165 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/SOME<Int16Array,i16>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<i16>#get:length|inlined.4 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 1
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     get_local $5
+     get_local $2
+     i32.lt_s
+     i32.eqz
+     br_if $break|0
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<i16,i16>|inlined.5 (result i32)
+       get_local $3
+       get_local $5
+       i32.const 1
+       i32.shl
+       i32.add
+       get_local $4
+       i32.add
+       i32.load16_s offset=8
+      end
+      get_local $5
+      get_local $0
+      get_local $1
+      call_indirect (type $iiii)
+     end
+     i32.const 0
+     i32.ne
+     if
+      i32.const 1
+      br $~lib/internal/typedarray/SOME<Int16Array,i16>|inlined.0
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const 0
+  end
+ )
+ (func $std/typedarray/testArraySome<Int16Array,i16>~anonymous|42 (; 166 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.shr_s
+  i32.const 0
+  i32.eq
+ )
+ (func $std/typedarray/testArraySome<Int16Array,i16> (; 167 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 41
+  call $~lib/typedarray/Int16Array#some
+  set_local $1
+  get_local $1
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 335
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 42
+  call $~lib/typedarray/Int16Array#some
+  set_local $2
+  get_local $2
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 338
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArraySome<Uint16Array,u16>~anonymous|43 (; 168 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 65535
+  i32.and
+  i32.const 2
+  i32.eq
+ )
+ (func $~lib/typedarray/Uint16Array#some (; 169 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/SOME<Uint16Array,u16>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<u16>#get:length|inlined.4 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 1
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     get_local $5
+     get_local $2
+     i32.lt_s
+     i32.eqz
+     br_if $break|0
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<u16,u16>|inlined.5 (result i32)
+       get_local $3
+       get_local $5
+       i32.const 1
+       i32.shl
+       i32.add
+       get_local $4
+       i32.add
+       i32.load16_u offset=8
+      end
+      get_local $5
+      get_local $0
+      get_local $1
+      call_indirect (type $iiii)
+     end
+     i32.const 0
+     i32.ne
+     if
+      i32.const 1
+      br $~lib/internal/typedarray/SOME<Uint16Array,u16>|inlined.0
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const 0
+  end
+ )
+ (func $std/typedarray/testArraySome<Uint16Array,u16>~anonymous|44 (; 170 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 65535
+  i32.and
+  i32.const 0
+  i32.eq
+ )
+ (func $std/typedarray/testArraySome<Uint16Array,u16> (; 171 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u16>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u16>#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/internal/typedarray/TypedArray<u16>#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/internal/typedarray/TypedArray<u16>#__set
+  get_local $0
+  i32.const 43
+  call $~lib/typedarray/Uint16Array#some
+  set_local $1
+  get_local $1
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 335
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 44
+  call $~lib/typedarray/Uint16Array#some
+  set_local $2
+  get_local $2
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 338
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 (; 172 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 2
+  i32.eq
+ )
+ (func $~lib/typedarray/Int32Array#some (; 173 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/SOME<Int32Array,i32>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<i32>#get:length|inlined.12 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 2
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     get_local $5
+     get_local $2
+     i32.lt_s
+     i32.eqz
+     br_if $break|0
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.6 (result i32)
+       get_local $3
+       get_local $5
+       i32.const 2
+       i32.shl
+       i32.add
+       get_local $4
+       i32.add
+       i32.load offset=8
+      end
+      get_local $5
+      get_local $0
+      get_local $1
+      call_indirect (type $iiii)
+     end
+     i32.const 0
+     i32.ne
+     if
+      i32.const 1
+      br $~lib/internal/typedarray/SOME<Int32Array,i32>|inlined.0
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const 0
+  end
+ )
+ (func $std/typedarray/testArraySome<Int32Array,i32>~anonymous|46 (; 174 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 0
+  i32.eq
+ )
+ (func $std/typedarray/testArraySome<Int32Array,i32> (; 175 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 45
+  call $~lib/typedarray/Int32Array#some
+  set_local $1
+  get_local $1
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 335
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 46
+  call $~lib/typedarray/Int32Array#some
+  set_local $2
+  get_local $2
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 338
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArraySome<Uint32Array,u32>~anonymous|47 (; 176 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 2
+  i32.eq
+ )
+ (func $~lib/typedarray/Uint32Array#some (; 177 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/SOME<Uint32Array,u32>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<u32>#get:length|inlined.4 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 2
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     get_local $5
+     get_local $2
+     i32.lt_s
+     i32.eqz
+     br_if $break|0
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.5 (result i32)
+       get_local $3
+       get_local $5
+       i32.const 2
+       i32.shl
+       i32.add
+       get_local $4
+       i32.add
+       i32.load offset=8
+      end
+      get_local $5
+      get_local $0
+      get_local $1
+      call_indirect (type $iiii)
+     end
+     i32.const 0
+     i32.ne
+     if
+      i32.const 1
+      br $~lib/internal/typedarray/SOME<Uint32Array,u32>|inlined.0
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const 0
+  end
+ )
+ (func $std/typedarray/testArraySome<Uint32Array,u32>~anonymous|48 (; 178 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 0
+  i32.eq
+ )
+ (func $std/typedarray/testArraySome<Uint32Array,u32> (; 179 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u32>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u32>#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/internal/typedarray/TypedArray<u32>#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/internal/typedarray/TypedArray<u32>#__set
+  get_local $0
+  i32.const 47
+  call $~lib/typedarray/Uint32Array#some
+  set_local $1
+  get_local $1
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 335
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 48
+  call $~lib/typedarray/Uint32Array#some
+  set_local $2
+  get_local $2
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 338
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 (; 180 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i64.const 2
+  i64.eq
+ )
+ (func $~lib/typedarray/Int64Array#some (; 181 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/SOME<Int64Array,i64>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<i64>#get:length|inlined.4 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 3
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     get_local $5
+     get_local $2
+     i32.lt_s
+     i32.eqz
+     br_if $break|0
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<i64,i64>|inlined.5 (result i64)
+       get_local $3
+       get_local $5
+       i32.const 3
+       i32.shl
+       i32.add
+       get_local $4
+       i32.add
+       i64.load offset=8
+      end
+      get_local $5
+      get_local $0
+      get_local $1
+      call_indirect (type $Iiii)
+     end
+     i32.const 0
+     i32.ne
+     if
+      i32.const 1
+      br $~lib/internal/typedarray/SOME<Int64Array,i64>|inlined.0
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const 0
+  end
+ )
+ (func $std/typedarray/testArraySome<Int64Array,i64>~anonymous|50 (; 182 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i64.const 0
+  i64.eq
+ )
+ (func $std/typedarray/testArraySome<Int64Array,i64> (; 183 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i64.const 2
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 1
+  i64.const 4
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 2
+  i64.const 6
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 49
+  call $~lib/typedarray/Int64Array#some
+  set_local $1
+  get_local $1
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 335
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 50
+  call $~lib/typedarray/Int64Array#some
+  set_local $2
+  get_local $2
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 338
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArraySome<Uint64Array,u64>~anonymous|51 (; 184 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i64.const 2
+  i64.eq
+ )
+ (func $~lib/typedarray/Uint64Array#some (; 185 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/SOME<Uint64Array,u64>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<u64>#get:length|inlined.4 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 3
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     get_local $5
+     get_local $2
+     i32.lt_s
+     i32.eqz
+     br_if $break|0
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<u64,u64>|inlined.5 (result i64)
+       get_local $3
+       get_local $5
+       i32.const 3
+       i32.shl
+       i32.add
+       get_local $4
+       i32.add
+       i64.load offset=8
+      end
+      get_local $5
+      get_local $0
+      get_local $1
+      call_indirect (type $Iiii)
+     end
+     i32.const 0
+     i32.ne
+     if
+      i32.const 1
+      br $~lib/internal/typedarray/SOME<Uint64Array,u64>|inlined.0
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const 0
+  end
+ )
+ (func $std/typedarray/testArraySome<Uint64Array,u64>~anonymous|52 (; 186 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i64.const 0
+  i64.eq
+ )
+ (func $std/typedarray/testArraySome<Uint64Array,u64> (; 187 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u64>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i64.const 2
+  call $~lib/internal/typedarray/TypedArray<u64>#__set
+  get_local $0
+  i32.const 1
+  i64.const 4
+  call $~lib/internal/typedarray/TypedArray<u64>#__set
+  get_local $0
+  i32.const 2
+  i64.const 6
+  call $~lib/internal/typedarray/TypedArray<u64>#__set
+  get_local $0
+  i32.const 51
+  call $~lib/typedarray/Uint64Array#some
+  set_local $1
+  get_local $1
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 335
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 52
+  call $~lib/typedarray/Uint64Array#some
+  set_local $2
+  get_local $2
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 338
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArraySome<Float32Array,f32>~anonymous|53 (; 188 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  f32.const 2
+  f32.eq
+ )
+ (func $~lib/typedarray/Float32Array#some (; 189 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/SOME<Float32Array,f32>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<f32>#get:length|inlined.4 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 2
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     get_local $5
+     get_local $2
+     i32.lt_s
+     i32.eqz
+     br_if $break|0
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.5 (result f32)
+       get_local $3
+       get_local $5
+       i32.const 2
+       i32.shl
+       i32.add
+       get_local $4
+       i32.add
+       f32.load offset=8
+      end
+      get_local $5
+      get_local $0
+      get_local $1
+      call_indirect (type $fiii)
+     end
+     i32.const 0
+     i32.ne
+     if
+      i32.const 1
+      br $~lib/internal/typedarray/SOME<Float32Array,f32>|inlined.0
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const 0
+  end
+ )
+ (func $std/typedarray/testArraySome<Float32Array,f32>~anonymous|54 (; 190 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  f32.const 0
+  f32.eq
+ )
+ (func $std/typedarray/testArraySome<Float32Array,f32> (; 191 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<f32>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  f32.const 2
+  call $~lib/internal/typedarray/TypedArray<f32>#__set
+  get_local $0
+  i32.const 1
+  f32.const 4
+  call $~lib/internal/typedarray/TypedArray<f32>#__set
+  get_local $0
+  i32.const 2
+  f32.const 6
+  call $~lib/internal/typedarray/TypedArray<f32>#__set
+  get_local $0
+  i32.const 53
+  call $~lib/typedarray/Float32Array#some
+  set_local $1
+  get_local $1
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 335
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 54
+  call $~lib/typedarray/Float32Array#some
+  set_local $2
+  get_local $2
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 338
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArraySome<Float64Array,f64>~anonymous|55 (; 192 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  f64.const 2
+  f64.eq
+ )
+ (func $~lib/typedarray/Float64Array#some (; 193 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/SOME<Float64Array,f64>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<f64>#get:length|inlined.7 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 3
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     get_local $5
+     get_local $2
+     i32.lt_s
+     i32.eqz
+     br_if $break|0
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.17 (result f64)
+       get_local $3
+       get_local $5
+       i32.const 3
+       i32.shl
+       i32.add
+       get_local $4
+       i32.add
+       f64.load offset=8
+      end
+      get_local $5
+      get_local $0
+      get_local $1
+      call_indirect (type $Fiii)
+     end
+     i32.const 0
+     i32.ne
+     if
+      i32.const 1
+      br $~lib/internal/typedarray/SOME<Float64Array,f64>|inlined.0
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const 0
+  end
+ )
+ (func $std/typedarray/testArraySome<Float64Array,f64>~anonymous|56 (; 194 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  f64.const 0
+  f64.eq
+ )
+ (func $std/typedarray/testArraySome<Float64Array,f64> (; 195 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<f64>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  f64.const 2
+  call $~lib/internal/typedarray/TypedArray<f64>#__set
+  get_local $0
+  i32.const 1
+  f64.const 4
+  call $~lib/internal/typedarray/TypedArray<f64>#__set
+  get_local $0
+  i32.const 2
+  f64.const 6
+  call $~lib/internal/typedarray/TypedArray<f64>#__set
+  get_local $0
+  i32.const 55
+  call $~lib/typedarray/Float64Array#some
+  set_local $1
+  get_local $1
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 335
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 56
+  call $~lib/typedarray/Float64Array#some
+  set_local $2
+  get_local $2
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 338
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|57 (; 196 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 24
+  i32.shl
+  i32.const 24
+  i32.shr_s
+  i32.const 2
+  i32.eq
+ )
+ (func $~lib/typedarray/Int8Array#findIndex (; 197 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/FIND_INDEX<Int8Array,i8>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<i8>#get:length|inlined.14 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 0
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     get_local $5
+     get_local $2
+     i32.lt_s
+     i32.eqz
+     br_if $break|0
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<i8,i8>|inlined.8 (result i32)
+       get_local $3
+       get_local $5
+       i32.const 0
+       i32.shl
+       i32.add
+       get_local $4
+       i32.add
+       i32.load8_s offset=8
+      end
+      get_local $5
+      get_local $0
+      get_local $1
+      call_indirect (type $iiii)
+     end
+     i32.const 0
+     i32.ne
+     if
+      get_local $5
+      br $~lib/internal/typedarray/FIND_INDEX<Int8Array,i8>|inlined.0
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const -1
+  end
+ )
+ (func $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|58 (; 198 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 24
+  i32.shl
+  i32.const 24
+  i32.shr_s
+  i32.const 4
+  i32.eq
+ )
+ (func $std/typedarray/testArrayFindIndex<Int8Array,i8> (; 199 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<i8>#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i8>#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i8>#__set
+  get_local $0
+  i32.const 57
+  call $~lib/typedarray/Int8Array#findIndex
+  set_local $1
+  get_local $1
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 365
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 58
+  call $~lib/typedarray/Int8Array#findIndex
+  set_local $2
+  get_local $2
+  i32.const -1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 368
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayFindIndex<Uint8Array,u8>~anonymous|59 (; 200 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 255
+  i32.and
+  i32.const 2
+  i32.eq
+ )
+ (func $~lib/typedarray/Uint8Array#findIndex (; 201 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/FIND_INDEX<Uint8Array,u8>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<u8>#get:length|inlined.8 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 0
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     get_local $5
+     get_local $2
+     i32.lt_s
+     i32.eqz
+     br_if $break|0
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<u8,u8>|inlined.10 (result i32)
+       get_local $3
+       get_local $5
+       i32.const 0
+       i32.shl
+       i32.add
+       get_local $4
+       i32.add
+       i32.load8_u offset=8
+      end
+      get_local $5
+      get_local $0
+      get_local $1
+      call_indirect (type $iiii)
+     end
+     i32.const 0
+     i32.ne
+     if
+      get_local $5
+      br $~lib/internal/typedarray/FIND_INDEX<Uint8Array,u8>|inlined.0
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const -1
+  end
+ )
+ (func $std/typedarray/testArrayFindIndex<Uint8Array,u8>~anonymous|60 (; 202 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 255
+  i32.and
+  i32.const 4
+  i32.eq
+ )
+ (func $std/typedarray/testArrayFindIndex<Uint8Array,u8> (; 203 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 59
+  call $~lib/typedarray/Uint8Array#findIndex
+  set_local $1
+  get_local $1
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 365
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 60
+  call $~lib/typedarray/Uint8Array#findIndex
+  set_local $2
+  get_local $2
+  i32.const -1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 368
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8>~anonymous|61 (; 204 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 255
+  i32.and
+  i32.const 2
+  i32.eq
+ )
+ (func $~lib/typedarray/Uint8ClampedArray#findIndex (; 205 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/FIND_INDEX<Uint8ClampedArray,u8>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<u8>#get:length|inlined.9 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 0
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     get_local $5
+     get_local $2
+     i32.lt_s
+     i32.eqz
+     br_if $break|0
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<u8,u8>|inlined.12 (result i32)
+       get_local $3
+       get_local $5
+       i32.const 0
+       i32.shl
+       i32.add
+       get_local $4
+       i32.add
+       i32.load8_u offset=8
+      end
+      get_local $5
+      get_local $0
+      get_local $1
+      call_indirect (type $iiii)
+     end
+     i32.const 0
+     i32.ne
+     if
+      get_local $5
+      br $~lib/internal/typedarray/FIND_INDEX<Uint8ClampedArray,u8>|inlined.0
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const -1
+  end
+ )
+ (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8>~anonymous|62 (; 206 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 255
+  i32.and
+  i32.const 4
+  i32.eq
+ )
+ (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8> (; 207 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/typedarray/Uint8ClampedArray#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/typedarray/Uint8ClampedArray#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/typedarray/Uint8ClampedArray#__set
+  get_local $0
+  i32.const 61
+  call $~lib/typedarray/Uint8ClampedArray#findIndex
+  set_local $1
+  get_local $1
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 365
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 62
+  call $~lib/typedarray/Uint8ClampedArray#findIndex
+  set_local $2
+  get_local $2
+  i32.const -1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 368
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|63 (; 208 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.shr_s
+  i32.const 2
+  i32.eq
+ )
+ (func $~lib/typedarray/Int16Array#findIndex (; 209 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/FIND_INDEX<Int16Array,i16>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<i16>#get:length|inlined.5 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 1
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     get_local $5
+     get_local $2
+     i32.lt_s
+     i32.eqz
+     br_if $break|0
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<i16,i16>|inlined.7 (result i32)
+       get_local $3
+       get_local $5
+       i32.const 1
+       i32.shl
+       i32.add
+       get_local $4
+       i32.add
+       i32.load16_s offset=8
+      end
+      get_local $5
+      get_local $0
+      get_local $1
+      call_indirect (type $iiii)
+     end
+     i32.const 0
+     i32.ne
+     if
+      get_local $5
+      br $~lib/internal/typedarray/FIND_INDEX<Int16Array,i16>|inlined.0
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const -1
+  end
+ )
+ (func $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|64 (; 210 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.shr_s
+  i32.const 4
+  i32.eq
+ )
+ (func $std/typedarray/testArrayFindIndex<Int16Array,i16> (; 211 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 63
+  call $~lib/typedarray/Int16Array#findIndex
+  set_local $1
+  get_local $1
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 365
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 64
+  call $~lib/typedarray/Int16Array#findIndex
+  set_local $2
+  get_local $2
+  i32.const -1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 368
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayFindIndex<Uint16Array,u16>~anonymous|65 (; 212 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 65535
+  i32.and
+  i32.const 2
+  i32.eq
+ )
+ (func $~lib/typedarray/Uint16Array#findIndex (; 213 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/FIND_INDEX<Uint16Array,u16>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<u16>#get:length|inlined.5 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 1
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     get_local $5
+     get_local $2
+     i32.lt_s
+     i32.eqz
+     br_if $break|0
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<u16,u16>|inlined.7 (result i32)
+       get_local $3
+       get_local $5
+       i32.const 1
+       i32.shl
+       i32.add
+       get_local $4
+       i32.add
+       i32.load16_u offset=8
+      end
+      get_local $5
+      get_local $0
+      get_local $1
+      call_indirect (type $iiii)
+     end
+     i32.const 0
+     i32.ne
+     if
+      get_local $5
+      br $~lib/internal/typedarray/FIND_INDEX<Uint16Array,u16>|inlined.0
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const -1
+  end
+ )
+ (func $std/typedarray/testArrayFindIndex<Uint16Array,u16>~anonymous|66 (; 214 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 65535
+  i32.and
+  i32.const 4
+  i32.eq
+ )
+ (func $std/typedarray/testArrayFindIndex<Uint16Array,u16> (; 215 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u16>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<u16>#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u16>#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u16>#__set
+  get_local $0
+  i32.const 65
+  call $~lib/typedarray/Uint16Array#findIndex
+  set_local $1
+  get_local $1
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 365
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 66
+  call $~lib/typedarray/Uint16Array#findIndex
+  set_local $2
+  get_local $2
+  i32.const -1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 368
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|67 (; 216 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 2
+  i32.eq
+ )
+ (func $~lib/typedarray/Int32Array#findIndex (; 217 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/FIND_INDEX<Int32Array,i32>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<i32>#get:length|inlined.13 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 2
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     get_local $5
+     get_local $2
+     i32.lt_s
+     i32.eqz
+     br_if $break|0
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.8 (result i32)
+       get_local $3
+       get_local $5
+       i32.const 2
+       i32.shl
+       i32.add
+       get_local $4
+       i32.add
+       i32.load offset=8
+      end
+      get_local $5
+      get_local $0
+      get_local $1
+      call_indirect (type $iiii)
+     end
+     i32.const 0
+     i32.ne
+     if
+      get_local $5
+      br $~lib/internal/typedarray/FIND_INDEX<Int32Array,i32>|inlined.0
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const -1
+  end
+ )
+ (func $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|68 (; 218 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 4
+  i32.eq
+ )
+ (func $std/typedarray/testArrayFindIndex<Int32Array,i32> (; 219 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 67
+  call $~lib/typedarray/Int32Array#findIndex
+  set_local $1
+  get_local $1
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 365
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 68
+  call $~lib/typedarray/Int32Array#findIndex
+  set_local $2
+  get_local $2
+  i32.const -1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 368
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayFindIndex<Uint32Array,u32>~anonymous|69 (; 220 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 2
+  i32.eq
+ )
+ (func $~lib/typedarray/Uint32Array#findIndex (; 221 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/FIND_INDEX<Uint32Array,u32>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<u32>#get:length|inlined.5 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 2
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     get_local $5
+     get_local $2
+     i32.lt_s
+     i32.eqz
+     br_if $break|0
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.7 (result i32)
+       get_local $3
+       get_local $5
+       i32.const 2
+       i32.shl
+       i32.add
+       get_local $4
+       i32.add
+       i32.load offset=8
+      end
+      get_local $5
+      get_local $0
+      get_local $1
+      call_indirect (type $iiii)
+     end
+     i32.const 0
+     i32.ne
+     if
+      get_local $5
+      br $~lib/internal/typedarray/FIND_INDEX<Uint32Array,u32>|inlined.0
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const -1
+  end
+ )
+ (func $std/typedarray/testArrayFindIndex<Uint32Array,u32>~anonymous|70 (; 222 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 4
+  i32.eq
+ )
+ (func $std/typedarray/testArrayFindIndex<Uint32Array,u32> (; 223 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u32>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 1
+  call $~lib/internal/typedarray/TypedArray<u32>#__set
+  get_local $0
+  i32.const 1
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u32>#__set
+  get_local $0
+  i32.const 2
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u32>#__set
+  get_local $0
+  i32.const 69
+  call $~lib/typedarray/Uint32Array#findIndex
+  set_local $1
+  get_local $1
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 365
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 70
+  call $~lib/typedarray/Uint32Array#findIndex
+  set_local $2
+  get_local $2
+  i32.const -1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 368
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|71 (; 224 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i64.const 2
+  i64.eq
+ )
+ (func $~lib/typedarray/Int64Array#findIndex (; 225 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/FIND_INDEX<Int64Array,i64>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<i64>#get:length|inlined.5 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 3
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     get_local $5
+     get_local $2
+     i32.lt_s
+     i32.eqz
+     br_if $break|0
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<i64,i64>|inlined.7 (result i64)
+       get_local $3
+       get_local $5
+       i32.const 3
+       i32.shl
+       i32.add
+       get_local $4
+       i32.add
+       i64.load offset=8
+      end
+      get_local $5
+      get_local $0
+      get_local $1
+      call_indirect (type $Iiii)
+     end
+     i32.const 0
+     i32.ne
+     if
+      get_local $5
+      br $~lib/internal/typedarray/FIND_INDEX<Int64Array,i64>|inlined.0
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const -1
+  end
+ )
+ (func $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|72 (; 226 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i64.const 4
+  i64.eq
+ )
+ (func $std/typedarray/testArrayFindIndex<Int64Array,i64> (; 227 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i64.const 1
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 1
+  i64.const 2
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 2
+  i64.const 3
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 71
+  call $~lib/typedarray/Int64Array#findIndex
+  set_local $1
+  get_local $1
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 365
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 72
+  call $~lib/typedarray/Int64Array#findIndex
+  set_local $2
+  get_local $2
+  i32.const -1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 368
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayFindIndex<Uint64Array,u64>~anonymous|73 (; 228 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i64.const 2
+  i64.eq
+ )
+ (func $~lib/typedarray/Uint64Array#findIndex (; 229 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/FIND_INDEX<Uint64Array,u64>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<u64>#get:length|inlined.5 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 3
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     get_local $5
+     get_local $2
+     i32.lt_s
+     i32.eqz
+     br_if $break|0
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<u64,u64>|inlined.7 (result i64)
+       get_local $3
+       get_local $5
+       i32.const 3
+       i32.shl
+       i32.add
+       get_local $4
+       i32.add
+       i64.load offset=8
+      end
+      get_local $5
+      get_local $0
+      get_local $1
+      call_indirect (type $Iiii)
+     end
+     i32.const 0
+     i32.ne
+     if
+      get_local $5
+      br $~lib/internal/typedarray/FIND_INDEX<Uint64Array,u64>|inlined.0
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const -1
+  end
+ )
+ (func $std/typedarray/testArrayFindIndex<Uint64Array,u64>~anonymous|74 (; 230 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i64.const 4
+  i64.eq
+ )
+ (func $std/typedarray/testArrayFindIndex<Uint64Array,u64> (; 231 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u64>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i64.const 1
+  call $~lib/internal/typedarray/TypedArray<u64>#__set
+  get_local $0
+  i32.const 1
+  i64.const 2
+  call $~lib/internal/typedarray/TypedArray<u64>#__set
+  get_local $0
+  i32.const 2
+  i64.const 3
+  call $~lib/internal/typedarray/TypedArray<u64>#__set
+  get_local $0
+  i32.const 73
+  call $~lib/typedarray/Uint64Array#findIndex
+  set_local $1
+  get_local $1
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 365
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 74
+  call $~lib/typedarray/Uint64Array#findIndex
+  set_local $2
+  get_local $2
+  i32.const -1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 368
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|75 (; 232 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  f32.const 2
+  f32.eq
+ )
+ (func $~lib/typedarray/Float32Array#findIndex (; 233 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/FIND_INDEX<Float32Array,f32>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<f32>#get:length|inlined.5 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 2
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     get_local $5
+     get_local $2
+     i32.lt_s
+     i32.eqz
+     br_if $break|0
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.7 (result f32)
+       get_local $3
+       get_local $5
+       i32.const 2
+       i32.shl
+       i32.add
+       get_local $4
+       i32.add
+       f32.load offset=8
+      end
+      get_local $5
+      get_local $0
+      get_local $1
+      call_indirect (type $fiii)
+     end
+     i32.const 0
+     i32.ne
+     if
+      get_local $5
+      br $~lib/internal/typedarray/FIND_INDEX<Float32Array,f32>|inlined.0
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const -1
+  end
+ )
+ (func $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|76 (; 234 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  f32.const 4
+  f32.eq
+ )
+ (func $std/typedarray/testArrayFindIndex<Float32Array,f32> (; 235 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<f32>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  f32.const 1
+  call $~lib/internal/typedarray/TypedArray<f32>#__set
+  get_local $0
+  i32.const 1
+  f32.const 2
+  call $~lib/internal/typedarray/TypedArray<f32>#__set
+  get_local $0
+  i32.const 2
+  f32.const 3
+  call $~lib/internal/typedarray/TypedArray<f32>#__set
+  get_local $0
+  i32.const 75
+  call $~lib/typedarray/Float32Array#findIndex
+  set_local $1
+  get_local $1
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 365
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 76
+  call $~lib/typedarray/Float32Array#findIndex
+  set_local $2
+  get_local $2
+  i32.const -1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 368
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|77 (; 236 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  f64.const 2
+  f64.eq
+ )
+ (func $~lib/typedarray/Float64Array#findIndex (; 237 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/FIND_INDEX<Float64Array,f64>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<f64>#get:length|inlined.8 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 3
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     get_local $5
+     get_local $2
+     i32.lt_s
+     i32.eqz
+     br_if $break|0
+     block (result i32)
+      i32.const 3
+      set_global $~argc
+      block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.19 (result f64)
+       get_local $3
+       get_local $5
+       i32.const 3
+       i32.shl
+       i32.add
+       get_local $4
+       i32.add
+       f64.load offset=8
+      end
+      get_local $5
+      get_local $0
+      get_local $1
+      call_indirect (type $Fiii)
+     end
+     i32.const 0
+     i32.ne
+     if
+      get_local $5
+      br $~lib/internal/typedarray/FIND_INDEX<Float64Array,f64>|inlined.0
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const -1
+  end
+ )
+ (func $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|78 (; 238 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  f64.const 4
+  f64.eq
+ )
+ (func $std/typedarray/testArrayFindIndex<Float64Array,f64> (; 239 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<f64>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  f64.const 1
+  call $~lib/internal/typedarray/TypedArray<f64>#__set
+  get_local $0
+  i32.const 1
+  f64.const 2
+  call $~lib/internal/typedarray/TypedArray<f64>#__set
+  get_local $0
+  i32.const 2
+  f64.const 3
+  call $~lib/internal/typedarray/TypedArray<f64>#__set
+  get_local $0
+  i32.const 77
+  call $~lib/typedarray/Float64Array#findIndex
+  set_local $1
+  get_local $1
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 365
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 78
+  call $~lib/typedarray/Float64Array#findIndex
+  set_local $2
+  get_local $2
+  i32.const -1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 368
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|79 (; 240 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 24
+  i32.shl
+  i32.const 24
+  i32.shr_s
+  i32.const 2
+  i32.rem_s
+  i32.const 0
+  i32.eq
+ )
+ (func $~lib/typedarray/Int8Array#every (; 241 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/EVERY<Int8Array,i8>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<i8>#get:length|inlined.15 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 0
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     block $continue|0
+      get_local $5
+      get_local $2
+      i32.lt_s
+      i32.eqz
+      br_if $break|0
+      block
+       block (result i32)
+        i32.const 3
+        set_global $~argc
+        block $~lib/internal/arraybuffer/LOAD<i8,i8>|inlined.10 (result i32)
+         get_local $3
+         get_local $5
+         i32.const 0
+         i32.shl
+         i32.add
+         get_local $4
+         i32.add
+         i32.load8_s offset=8
+        end
+        get_local $5
+        get_local $0
+        get_local $1
+        call_indirect (type $iiii)
+       end
+       i32.const 0
+       i32.ne
+       if
+        br $continue|0
+       end
+       i32.const 0
+       br $~lib/internal/typedarray/EVERY<Int8Array,i8>|inlined.0
+       unreachable
+      end
+      unreachable
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const 1
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|80 (; 242 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 24
+  i32.shl
+  i32.const 24
+  i32.shr_s
+  i32.const 2
+  i32.eq
+ )
+ (func $std/typedarray/testArrayEvery<Int8Array,i8> (; 243 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i8>#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/internal/typedarray/TypedArray<i8>#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/internal/typedarray/TypedArray<i8>#__set
+  get_local $0
+  i32.const 79
+  call $~lib/typedarray/Int8Array#every
+  set_local $1
+  get_local $1
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 395
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 80
+  call $~lib/typedarray/Int8Array#every
+  set_local $2
+  get_local $2
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 398
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|81 (; 244 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 255
+  i32.and
+  i32.const 2
+  i32.rem_u
+  i32.const 0
+  i32.eq
+ )
+ (func $~lib/typedarray/Uint8Array#every (; 245 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/EVERY<Uint8Array,u8>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<u8>#get:length|inlined.10 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 0
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     block $continue|0
+      get_local $5
+      get_local $2
+      i32.lt_s
+      i32.eqz
+      br_if $break|0
+      block
+       block (result i32)
+        i32.const 3
+        set_global $~argc
+        block $~lib/internal/arraybuffer/LOAD<u8,u8>|inlined.14 (result i32)
+         get_local $3
+         get_local $5
+         i32.const 0
+         i32.shl
+         i32.add
+         get_local $4
+         i32.add
+         i32.load8_u offset=8
+        end
+        get_local $5
+        get_local $0
+        get_local $1
+        call_indirect (type $iiii)
+       end
+       i32.const 0
+       i32.ne
+       if
+        br $continue|0
+       end
+       i32.const 0
+       br $~lib/internal/typedarray/EVERY<Uint8Array,u8>|inlined.0
+       unreachable
+      end
+      unreachable
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const 1
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|82 (; 246 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 255
+  i32.and
+  i32.const 2
+  i32.eq
+ )
+ (func $std/typedarray/testArrayEvery<Uint8Array,u8> (; 247 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/internal/typedarray/TypedArray<u8>#__set
+  get_local $0
+  i32.const 81
+  call $~lib/typedarray/Uint8Array#every
+  set_local $1
+  get_local $1
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 395
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 82
+  call $~lib/typedarray/Uint8Array#every
+  set_local $2
+  get_local $2
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 398
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8>~anonymous|83 (; 248 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 255
+  i32.and
+  i32.const 2
+  i32.rem_u
+  i32.const 0
+  i32.eq
+ )
+ (func $~lib/typedarray/Uint8ClampedArray#every (; 249 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/EVERY<Uint8ClampedArray,u8>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<u8>#get:length|inlined.11 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 0
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     block $continue|0
+      get_local $5
+      get_local $2
+      i32.lt_s
+      i32.eqz
+      br_if $break|0
+      block
+       block (result i32)
+        i32.const 3
+        set_global $~argc
+        block $~lib/internal/arraybuffer/LOAD<u8,u8>|inlined.16 (result i32)
+         get_local $3
+         get_local $5
+         i32.const 0
+         i32.shl
+         i32.add
+         get_local $4
+         i32.add
+         i32.load8_u offset=8
+        end
+        get_local $5
+        get_local $0
+        get_local $1
+        call_indirect (type $iiii)
+       end
+       i32.const 0
+       i32.ne
+       if
+        br $continue|0
+       end
+       i32.const 0
+       br $~lib/internal/typedarray/EVERY<Uint8ClampedArray,u8>|inlined.0
+       unreachable
+      end
+      unreachable
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const 1
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8>~anonymous|84 (; 250 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 255
+  i32.and
+  i32.const 2
+  i32.eq
+ )
+ (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8> (; 251 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/typedarray/Uint8ClampedArray#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/typedarray/Uint8ClampedArray#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/typedarray/Uint8ClampedArray#__set
+  get_local $0
+  i32.const 83
+  call $~lib/typedarray/Uint8ClampedArray#every
+  set_local $1
+  get_local $1
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 395
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 84
+  call $~lib/typedarray/Uint8ClampedArray#every
+  set_local $2
+  get_local $2
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 398
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|85 (; 252 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.shr_s
+  i32.const 2
+  i32.rem_s
+  i32.const 0
+  i32.eq
+ )
+ (func $~lib/typedarray/Int16Array#every (; 253 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/EVERY<Int16Array,i16>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<i16>#get:length|inlined.6 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 1
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     block $continue|0
+      get_local $5
+      get_local $2
+      i32.lt_s
+      i32.eqz
+      br_if $break|0
+      block
+       block (result i32)
+        i32.const 3
+        set_global $~argc
+        block $~lib/internal/arraybuffer/LOAD<i16,i16>|inlined.9 (result i32)
+         get_local $3
+         get_local $5
+         i32.const 1
+         i32.shl
+         i32.add
+         get_local $4
+         i32.add
+         i32.load16_s offset=8
+        end
+        get_local $5
+        get_local $0
+        get_local $1
+        call_indirect (type $iiii)
+       end
+       i32.const 0
+       i32.ne
+       if
+        br $continue|0
+       end
+       i32.const 0
+       br $~lib/internal/typedarray/EVERY<Int16Array,i16>|inlined.0
+       unreachable
+      end
+      unreachable
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const 1
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|86 (; 254 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.shr_s
+  i32.const 2
+  i32.eq
+ )
+ (func $std/typedarray/testArrayEvery<Int16Array,i16> (; 255 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/internal/typedarray/TypedArray<i16>#__set
+  get_local $0
+  i32.const 85
+  call $~lib/typedarray/Int16Array#every
+  set_local $1
+  get_local $1
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 395
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 86
+  call $~lib/typedarray/Int16Array#every
+  set_local $2
+  get_local $2
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 398
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Uint16Array,u16>~anonymous|87 (; 256 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 65535
+  i32.and
+  i32.const 2
+  i32.rem_u
+  i32.const 0
+  i32.eq
+ )
+ (func $~lib/typedarray/Uint16Array#every (; 257 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/EVERY<Uint16Array,u16>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<u16>#get:length|inlined.6 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 1
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     block $continue|0
+      get_local $5
+      get_local $2
+      i32.lt_s
+      i32.eqz
+      br_if $break|0
+      block
+       block (result i32)
+        i32.const 3
+        set_global $~argc
+        block $~lib/internal/arraybuffer/LOAD<u16,u16>|inlined.9 (result i32)
+         get_local $3
+         get_local $5
+         i32.const 1
+         i32.shl
+         i32.add
+         get_local $4
+         i32.add
+         i32.load16_u offset=8
+        end
+        get_local $5
+        get_local $0
+        get_local $1
+        call_indirect (type $iiii)
+       end
+       i32.const 0
+       i32.ne
+       if
+        br $continue|0
+       end
+       i32.const 0
+       br $~lib/internal/typedarray/EVERY<Uint16Array,u16>|inlined.0
+       unreachable
+      end
+      unreachable
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const 1
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Uint16Array,u16>~anonymous|88 (; 258 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 65535
+  i32.and
+  i32.const 2
+  i32.eq
+ )
+ (func $std/typedarray/testArrayEvery<Uint16Array,u16> (; 259 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u16>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u16>#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/internal/typedarray/TypedArray<u16>#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/internal/typedarray/TypedArray<u16>#__set
+  get_local $0
+  i32.const 87
+  call $~lib/typedarray/Uint16Array#every
+  set_local $1
+  get_local $1
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 395
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 88
+  call $~lib/typedarray/Uint16Array#every
+  set_local $2
+  get_local $2
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 398
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|89 (; 260 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 2
+  i32.rem_s
+  i32.const 0
+  i32.eq
+ )
+ (func $~lib/typedarray/Int32Array#every (; 261 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/EVERY<Int32Array,i32>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<i32>#get:length|inlined.14 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 2
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     block $continue|0
+      get_local $5
+      get_local $2
+      i32.lt_s
+      i32.eqz
+      br_if $break|0
+      block
+       block (result i32)
+        i32.const 3
+        set_global $~argc
+        block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.10 (result i32)
+         get_local $3
+         get_local $5
+         i32.const 2
+         i32.shl
+         i32.add
+         get_local $4
+         i32.add
+         i32.load offset=8
+        end
+        get_local $5
+        get_local $0
+        get_local $1
+        call_indirect (type $iiii)
+       end
+       i32.const 0
+       i32.ne
+       if
+        br $continue|0
+       end
+       i32.const 0
+       br $~lib/internal/typedarray/EVERY<Int32Array,i32>|inlined.0
+       unreachable
+      end
+      unreachable
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const 1
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|90 (; 262 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 2
+  i32.eq
+ )
+ (func $std/typedarray/testArrayEvery<Int32Array,i32> (; 263 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/internal/typedarray/TypedArray<i32>#__set
+  get_local $0
+  i32.const 89
+  call $~lib/typedarray/Int32Array#every
+  set_local $1
+  get_local $1
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 395
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 90
+  call $~lib/typedarray/Int32Array#every
+  set_local $2
+  get_local $2
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 398
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Uint32Array,u32>~anonymous|91 (; 264 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 2
+  i32.rem_u
+  i32.const 0
+  i32.eq
+ )
+ (func $~lib/typedarray/Uint32Array#every (; 265 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/EVERY<Uint32Array,u32>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<u32>#get:length|inlined.6 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 2
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     block $continue|0
+      get_local $5
+      get_local $2
+      i32.lt_s
+      i32.eqz
+      br_if $break|0
+      block
+       block (result i32)
+        i32.const 3
+        set_global $~argc
+        block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.9 (result i32)
+         get_local $3
+         get_local $5
+         i32.const 2
+         i32.shl
+         i32.add
+         get_local $4
+         i32.add
+         i32.load offset=8
+        end
+        get_local $5
+        get_local $0
+        get_local $1
+        call_indirect (type $iiii)
+       end
+       i32.const 0
+       i32.ne
+       if
+        br $continue|0
+       end
+       i32.const 0
+       br $~lib/internal/typedarray/EVERY<Uint32Array,u32>|inlined.0
+       unreachable
+      end
+      unreachable
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const 1
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Uint32Array,u32>~anonymous|92 (; 266 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i32.const 2
+  i32.eq
+ )
+ (func $std/typedarray/testArrayEvery<Uint32Array,u32> (; 267 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u32>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.const 2
+  call $~lib/internal/typedarray/TypedArray<u32>#__set
+  get_local $0
+  i32.const 1
+  i32.const 4
+  call $~lib/internal/typedarray/TypedArray<u32>#__set
+  get_local $0
+  i32.const 2
+  i32.const 6
+  call $~lib/internal/typedarray/TypedArray<u32>#__set
+  get_local $0
+  i32.const 91
+  call $~lib/typedarray/Uint32Array#every
+  set_local $1
+  get_local $1
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 395
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 92
+  call $~lib/typedarray/Uint32Array#every
+  set_local $2
+  get_local $2
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 398
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|93 (; 268 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i64.const 2
+  i64.rem_s
+  i64.const 0
+  i64.eq
+ )
+ (func $~lib/typedarray/Int64Array#every (; 269 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/EVERY<Int64Array,i64>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<i64>#get:length|inlined.6 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 3
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     block $continue|0
+      get_local $5
+      get_local $2
+      i32.lt_s
+      i32.eqz
+      br_if $break|0
+      block
+       block (result i32)
+        i32.const 3
+        set_global $~argc
+        block $~lib/internal/arraybuffer/LOAD<i64,i64>|inlined.9 (result i64)
+         get_local $3
+         get_local $5
+         i32.const 3
+         i32.shl
+         i32.add
+         get_local $4
+         i32.add
+         i64.load offset=8
+        end
+        get_local $5
+        get_local $0
+        get_local $1
+        call_indirect (type $Iiii)
+       end
+       i32.const 0
+       i32.ne
+       if
+        br $continue|0
+       end
+       i32.const 0
+       br $~lib/internal/typedarray/EVERY<Int64Array,i64>|inlined.0
+       unreachable
+      end
+      unreachable
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const 1
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|94 (; 270 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i64.const 2
+  i64.eq
+ )
+ (func $std/typedarray/testArrayEvery<Int64Array,i64> (; 271 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i64.const 2
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 1
+  i64.const 4
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 2
+  i64.const 6
+  call $~lib/internal/typedarray/TypedArray<i64>#__set
+  get_local $0
+  i32.const 93
+  call $~lib/typedarray/Int64Array#every
+  set_local $1
+  get_local $1
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 395
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 94
+  call $~lib/typedarray/Int64Array#every
+  set_local $2
+  get_local $2
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 398
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|95 (; 272 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i64.const 2
+  i64.rem_u
+  i64.const 0
+  i64.eq
+ )
+ (func $~lib/typedarray/Uint64Array#every (; 273 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/EVERY<Uint64Array,u64>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<u64>#get:length|inlined.6 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 3
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     block $continue|0
+      get_local $5
+      get_local $2
+      i32.lt_s
+      i32.eqz
+      br_if $break|0
+      block
+       block (result i32)
+        i32.const 3
+        set_global $~argc
+        block $~lib/internal/arraybuffer/LOAD<u64,u64>|inlined.9 (result i64)
+         get_local $3
+         get_local $5
+         i32.const 3
+         i32.shl
+         i32.add
+         get_local $4
+         i32.add
+         i64.load offset=8
+        end
+        get_local $5
+        get_local $0
+        get_local $1
+        call_indirect (type $Iiii)
+       end
+       i32.const 0
+       i32.ne
+       if
+        br $continue|0
+       end
+       i32.const 0
+       br $~lib/internal/typedarray/EVERY<Uint64Array,u64>|inlined.0
+       unreachable
+      end
+      unreachable
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const 1
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|96 (; 274 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  i64.const 2
+  i64.eq
+ )
+ (func $std/typedarray/testArrayEvery<Uint64Array,u64> (; 275 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<u64>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i64.const 2
+  call $~lib/internal/typedarray/TypedArray<u64>#__set
+  get_local $0
+  i32.const 1
+  i64.const 4
+  call $~lib/internal/typedarray/TypedArray<u64>#__set
+  get_local $0
+  i32.const 2
+  i64.const 6
+  call $~lib/internal/typedarray/TypedArray<u64>#__set
+  get_local $0
+  i32.const 95
+  call $~lib/typedarray/Uint64Array#every
+  set_local $1
+  get_local $1
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 395
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 96
+  call $~lib/typedarray/Uint64Array#every
+  set_local $2
+  get_local $2
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 398
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $~lib/math/NativeMathf.mod (; 276 ;) (type $fff) (param $0 f32) (param $1 f32) (result f32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  get_local $0
+  i32.reinterpret/f32
+  set_local $2
+  get_local $1
+  i32.reinterpret/f32
+  set_local $3
+  get_local $2
+  i32.const 23
+  i32.shr_u
+  i32.const 255
+  i32.and
+  set_local $4
+  get_local $3
+  i32.const 23
+  i32.shr_u
+  i32.const 255
+  i32.and
+  set_local $5
+  get_local $2
+  i32.const -2147483648
+  i32.and
+  set_local $6
+  get_local $3
+  i32.const 1
+  i32.shl
+  set_local $7
+  get_local $7
+  i32.const 0
+  i32.eq
+  tee_local $8
+  if (result i32)
+   get_local $8
+  else   
+   get_local $4
+   i32.const 255
+   i32.eq
+  end
+  tee_local $8
+  if (result i32)
+   get_local $8
+  else   
+   get_local $1
+   get_local $1
+   f32.ne
+  end
+  i32.const 0
+  i32.ne
+  if
+   get_local $0
+   get_local $1
+   f32.mul
+   get_local $0
+   get_local $1
+   f32.mul
+   f32.div
+   return
+  end
+  get_local $2
+  i32.const 1
+  i32.shl
+  set_local $9
+  get_local $9
+  get_local $7
+  i32.le_u
+  if
+   get_local $9
+   get_local $7
+   i32.eq
+   if
+    f32.const 0
+    get_local $0
+    f32.mul
+    return
+   end
+   get_local $0
+   return
+  end
+  get_local $4
+  i32.eqz
+  if
+   get_local $4
+   get_local $2
+   i32.const 9
+   i32.shl
+   i32.clz
+   i32.sub
+   set_local $4
+   get_local $2
+   i32.const 0
+   get_local $4
+   i32.sub
+   i32.const 1
+   i32.add
+   i32.shl
+   set_local $2
+  else   
+   get_local $2
+   i32.const -1
+   i32.const 9
+   i32.shr_u
+   i32.and
+   set_local $2
+   get_local $2
+   i32.const 1
+   i32.const 23
+   i32.shl
+   i32.or
+   set_local $2
+  end
+  get_local $5
+  i32.eqz
+  if
+   get_local $5
+   get_local $3
+   i32.const 9
+   i32.shl
+   i32.clz
+   i32.sub
+   set_local $5
+   get_local $3
+   i32.const 0
+   get_local $5
+   i32.sub
+   i32.const 1
+   i32.add
+   i32.shl
+   set_local $3
+  else   
+   get_local $3
+   i32.const -1
+   i32.const 9
+   i32.shr_u
+   i32.and
+   set_local $3
+   get_local $3
+   i32.const 1
+   i32.const 23
+   i32.shl
+   i32.or
+   set_local $3
+  end
+  block $break|0
+   loop $continue|0
+    get_local $4
+    get_local $5
+    i32.gt_s
+    if
+     block
+      get_local $2
+      get_local $3
+      i32.ge_u
+      if
+       get_local $2
+       get_local $3
+       i32.eq
+       if
+        f32.const 0
+        get_local $0
+        f32.mul
+        return
+       end
+       get_local $2
+       get_local $3
+       i32.sub
+       set_local $2
+      end
+      get_local $2
+      i32.const 1
+      i32.shl
+      set_local $2
+      get_local $4
+      i32.const 1
+      i32.sub
+      set_local $4
+     end
+     br $continue|0
+    end
+   end
+  end
+  get_local $2
+  get_local $3
+  i32.ge_u
+  if
+   get_local $2
+   get_local $3
+   i32.eq
+   if
+    f32.const 0
+    get_local $0
+    f32.mul
+    return
+   end
+   get_local $2
+   get_local $3
+   i32.sub
+   set_local $2
+  end
+  get_local $2
+  i32.const 8
+  i32.shl
+  i32.clz
+  set_local $10
+  get_local $4
+  get_local $10
+  i32.sub
+  set_local $4
+  get_local $2
+  get_local $10
+  i32.shl
+  set_local $2
+  get_local $4
+  i32.const 0
+  i32.gt_s
+  if
+   get_local $2
+   i32.const 1
+   i32.const 23
+   i32.shl
+   i32.sub
+   set_local $2
+   get_local $2
+   get_local $4
+   i32.const 23
+   i32.shl
+   i32.or
+   set_local $2
+  else   
+   get_local $2
+   i32.const 0
+   get_local $4
+   i32.sub
+   i32.const 1
+   i32.add
+   i32.shr_u
+   set_local $2
+  end
+  get_local $2
+  get_local $6
+  i32.or
+  set_local $2
+  get_local $2
+  f32.reinterpret/i32
+ )
+ (func $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|97 (; 277 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  f32.const 2
+  call $~lib/math/NativeMathf.mod
+  f32.const 0
+  f32.eq
+ )
+ (func $~lib/typedarray/Float32Array#every (; 278 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/EVERY<Float32Array,f32>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<f32>#get:length|inlined.6 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 2
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     block $continue|0
+      get_local $5
+      get_local $2
+      i32.lt_s
+      i32.eqz
+      br_if $break|0
+      block
+       block (result i32)
+        i32.const 3
+        set_global $~argc
+        block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.9 (result f32)
+         get_local $3
+         get_local $5
+         i32.const 2
+         i32.shl
+         i32.add
+         get_local $4
+         i32.add
+         f32.load offset=8
+        end
+        get_local $5
+        get_local $0
+        get_local $1
+        call_indirect (type $fiii)
+       end
+       i32.const 0
+       i32.ne
+       if
+        br $continue|0
+       end
+       i32.const 0
+       br $~lib/internal/typedarray/EVERY<Float32Array,f32>|inlined.0
+       unreachable
+      end
+      unreachable
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const 1
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|98 (; 279 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  f32.const 2
+  f32.eq
+ )
+ (func $std/typedarray/testArrayEvery<Float32Array,f32> (; 280 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<f32>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  f32.const 2
+  call $~lib/internal/typedarray/TypedArray<f32>#__set
+  get_local $0
+  i32.const 1
+  f32.const 4
+  call $~lib/internal/typedarray/TypedArray<f32>#__set
+  get_local $0
+  i32.const 2
+  f32.const 6
+  call $~lib/internal/typedarray/TypedArray<f32>#__set
+  get_local $0
+  i32.const 97
+  call $~lib/typedarray/Float32Array#every
+  set_local $1
+  get_local $1
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 395
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 98
+  call $~lib/typedarray/Float32Array#every
+  set_local $2
+  get_local $2
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 398
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $~lib/math/NativeMath.mod (; 281 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+  (local $2 i64)
+  (local $3 i64)
+  (local $4 i64)
+  (local $5 i64)
+  (local $6 i64)
+  (local $7 i64)
+  (local $8 i32)
+  (local $9 i64)
+  (local $10 i64)
+  get_local $0
+  i64.reinterpret/f64
+  set_local $2
+  get_local $1
+  i64.reinterpret/f64
+  set_local $3
+  get_local $2
+  i64.const 52
+  i64.shr_u
+  i64.const 2047
+  i64.and
+  set_local $4
+  get_local $3
+  i64.const 52
+  i64.shr_u
+  i64.const 2047
+  i64.and
+  set_local $5
+  get_local $2
+  i64.const 63
+  i64.shr_u
+  set_local $6
+  get_local $3
+  i64.const 1
+  i64.shl
+  set_local $7
+  get_local $7
+  i64.const 0
+  i64.eq
+  tee_local $8
+  if (result i32)
+   get_local $8
+  else   
+   get_local $4
+   i64.const 2047
+   i64.eq
+  end
+  tee_local $8
+  if (result i32)
+   get_local $8
+  else   
+   get_local $1
+   get_local $1
+   f64.ne
+  end
+  i32.const 0
+  i32.ne
+  if
+   get_local $0
+   get_local $1
+   f64.mul
+   get_local $0
+   get_local $1
+   f64.mul
+   f64.div
+   return
+  end
+  get_local $2
+  i64.const 1
+  i64.shl
+  set_local $9
+  get_local $9
+  get_local $7
+  i64.le_u
+  if
+   get_local $9
+   get_local $7
+   i64.eq
+   if
+    f64.const 0
+    get_local $0
+    f64.mul
+    return
+   end
+   get_local $0
+   return
+  end
+  get_local $4
+  i64.eqz
+  if
+   get_local $4
+   get_local $2
+   i64.const 12
+   i64.shl
+   i64.clz
+   i64.sub
+   set_local $4
+   get_local $2
+   i64.const 0
+   get_local $4
+   i64.sub
+   i64.const 1
+   i64.add
+   i64.shl
+   set_local $2
+  else   
+   get_local $2
+   i64.const -1
+   i64.const 12
+   i64.shr_u
+   i64.and
+   set_local $2
+   get_local $2
+   i64.const 1
+   i64.const 52
+   i64.shl
+   i64.or
+   set_local $2
+  end
+  get_local $5
+  i64.eqz
+  if
+   get_local $5
+   get_local $3
+   i64.const 12
+   i64.shl
+   i64.clz
+   i64.sub
+   set_local $5
+   get_local $3
+   i64.const 0
+   get_local $5
+   i64.sub
+   i64.const 1
+   i64.add
+   i64.shl
+   set_local $3
+  else   
+   get_local $3
+   i64.const -1
+   i64.const 12
+   i64.shr_u
+   i64.and
+   set_local $3
+   get_local $3
+   i64.const 1
+   i64.const 52
+   i64.shl
+   i64.or
+   set_local $3
+  end
+  block $break|0
+   loop $continue|0
+    get_local $4
+    get_local $5
+    i64.gt_s
+    if
+     block
+      get_local $2
+      get_local $3
+      i64.ge_u
+      if
+       get_local $2
+       get_local $3
+       i64.eq
+       if
+        f64.const 0
+        get_local $0
+        f64.mul
+        return
+       end
+       get_local $2
+       get_local $3
+       i64.sub
+       set_local $2
+      end
+      get_local $2
+      i64.const 1
+      i64.shl
+      set_local $2
+      get_local $4
+      i64.const 1
+      i64.sub
+      set_local $4
+     end
+     br $continue|0
+    end
+   end
+  end
+  get_local $2
+  get_local $3
+  i64.ge_u
+  if
+   get_local $2
+   get_local $3
+   i64.eq
+   if
+    f64.const 0
+    get_local $0
+    f64.mul
+    return
+   end
+   get_local $2
+   get_local $3
+   i64.sub
+   set_local $2
+  end
+  get_local $2
+  i64.const 11
+  i64.shl
+  i64.clz
+  set_local $10
+  get_local $4
+  get_local $10
+  i64.sub
+  set_local $4
+  get_local $2
+  get_local $10
+  i64.shl
+  set_local $2
+  get_local $4
+  i64.const 0
+  i64.gt_s
+  if
+   get_local $2
+   i64.const 1
+   i64.const 52
+   i64.shl
+   i64.sub
+   set_local $2
+   get_local $2
+   get_local $4
+   i64.const 52
+   i64.shl
+   i64.or
+   set_local $2
+  else   
+   get_local $2
+   i64.const 0
+   get_local $4
+   i64.sub
+   i64.const 1
+   i64.add
+   i64.shr_u
+   set_local $2
+  end
+  get_local $2
+  get_local $6
+  i64.const 63
+  i64.shl
+  i64.or
+  set_local $2
+  get_local $2
+  f64.reinterpret/i64
+ )
+ (func $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|99 (; 282 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  f64.const 2
+  call $~lib/math/NativeMath.mod
+  f64.const 0
+  f64.eq
+ )
+ (func $~lib/typedarray/Float64Array#every (; 283 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $~lib/internal/typedarray/EVERY<Float64Array,f64>|inlined.0 (result i32)
+   block $~lib/internal/typedarray/TypedArray<f64>#get:length|inlined.9 (result i32)
+    get_local $0
+    i32.load offset=8
+    i32.const 3
+    i32.shr_u
+   end
+   set_local $2
+   get_local $0
+   i32.load
+   set_local $3
+   get_local $0
+   i32.load offset=4
+   set_local $4
+   block $break|0
+    i32.const 0
+    set_local $5
+    loop $repeat|0
+     block $continue|0
+      get_local $5
+      get_local $2
+      i32.lt_s
+      i32.eqz
+      br_if $break|0
+      block
+       block (result i32)
+        i32.const 3
+        set_global $~argc
+        block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.21 (result f64)
+         get_local $3
+         get_local $5
+         i32.const 3
+         i32.shl
+         i32.add
+         get_local $4
+         i32.add
+         f64.load offset=8
+        end
+        get_local $5
+        get_local $0
+        get_local $1
+        call_indirect (type $Fiii)
+       end
+       i32.const 0
+       i32.ne
+       if
+        br $continue|0
+       end
+       i32.const 0
+       br $~lib/internal/typedarray/EVERY<Float64Array,f64>|inlined.0
+       unreachable
+      end
+      unreachable
+     end
+     get_local $5
+     i32.const 1
+     i32.add
+     set_local $5
+     br $repeat|0
+     unreachable
+    end
+    unreachable
+   end
+   i32.const 1
+  end
+ )
+ (func $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|100 (; 284 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+  get_local $0
+  f64.const 2
+  f64.eq
+ )
+ (func $std/typedarray/testArrayEvery<Float64Array,f64> (; 285 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  i32.const 3
+  call $~lib/internal/typedarray/TypedArray<f64>#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  f64.const 2
+  call $~lib/internal/typedarray/TypedArray<f64>#__set
+  get_local $0
+  i32.const 1
+  f64.const 4
+  call $~lib/internal/typedarray/TypedArray<f64>#__set
+  get_local $0
+  i32.const 2
+  f64.const 6
+  call $~lib/internal/typedarray/TypedArray<f64>#__set
+  get_local $0
+  i32.const 99
+  call $~lib/typedarray/Float64Array#every
+  set_local $1
+  get_local $1
+  i32.const 0
+  i32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 395
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.const 100
+  call $~lib/typedarray/Float64Array#every
+  set_local $2
+  get_local $2
+  i32.const 0
+  i32.ne
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 398
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $start (; 286 ;) (type $v)
   (local $0 i32)
   get_global $~lib/typedarray/Int8Array.BYTES_PER_ELEMENT
   i32.const 1
@@ -8711,7 +13724,40 @@
   call $std/typedarray/testArrayMap<Uint64Array,u64>
   call $std/typedarray/testArrayMap<Float32Array,f32>
   call $std/typedarray/testArrayMap<Float64Array,f64>
+  call $std/typedarray/testArraySome<Int8Array,i8>
+  call $std/typedarray/testArraySome<Uint8Array,u8>
+  call $std/typedarray/testArraySome<Uint8ClampedArray,u8>
+  call $std/typedarray/testArraySome<Int16Array,i16>
+  call $std/typedarray/testArraySome<Uint16Array,u16>
+  call $std/typedarray/testArraySome<Int32Array,i32>
+  call $std/typedarray/testArraySome<Uint32Array,u32>
+  call $std/typedarray/testArraySome<Int64Array,i64>
+  call $std/typedarray/testArraySome<Uint64Array,u64>
+  call $std/typedarray/testArraySome<Float32Array,f32>
+  call $std/typedarray/testArraySome<Float64Array,f64>
+  call $std/typedarray/testArrayFindIndex<Int8Array,i8>
+  call $std/typedarray/testArrayFindIndex<Uint8Array,u8>
+  call $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8>
+  call $std/typedarray/testArrayFindIndex<Int16Array,i16>
+  call $std/typedarray/testArrayFindIndex<Uint16Array,u16>
+  call $std/typedarray/testArrayFindIndex<Int32Array,i32>
+  call $std/typedarray/testArrayFindIndex<Uint32Array,u32>
+  call $std/typedarray/testArrayFindIndex<Int64Array,i64>
+  call $std/typedarray/testArrayFindIndex<Uint64Array,u64>
+  call $std/typedarray/testArrayFindIndex<Float32Array,f32>
+  call $std/typedarray/testArrayFindIndex<Float64Array,f64>
+  call $std/typedarray/testArrayEvery<Int8Array,i8>
+  call $std/typedarray/testArrayEvery<Uint8Array,u8>
+  call $std/typedarray/testArrayEvery<Uint8ClampedArray,u8>
+  call $std/typedarray/testArrayEvery<Int16Array,i16>
+  call $std/typedarray/testArrayEvery<Uint16Array,u16>
+  call $std/typedarray/testArrayEvery<Int32Array,i32>
+  call $std/typedarray/testArrayEvery<Uint32Array,u32>
+  call $std/typedarray/testArrayEvery<Int64Array,i64>
+  call $std/typedarray/testArrayEvery<Uint64Array,u64>
+  call $std/typedarray/testArrayEvery<Float32Array,f32>
+  call $std/typedarray/testArrayEvery<Float64Array,f64>
  )
- (func $null (; 174 ;) (type $v)
+ (func $null (; 287 ;) (type $v)
  )
 )


### PR DESCRIPTION
This is a very big resubmission of the `TypedArray` prototype functions in the std lib. A lot of these changes were requested by @MaxGraey, and I fixed the exported types in the `/std/index.d.ts` file.

Thank you very much for this wonderful contribution to the web.