### PR TITLE
Added shared memory support in binaryen definition

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -11,6 +11,7 @@ under the licensing terms detailed in LICENSE:
 * Palmer <pengliao@live.cn>
 * Linus Unnebäck <linus@folkdatorn.se>
 * Joshua Tenner <tenner.joshua@gmail.com>
+* Nidin Vinayakan <01@01alchemist.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/src/glue/binaryen.d.ts
+++ b/src/glue/binaryen.d.ts
@@ -552,7 +552,7 @@ declare type BinaryenImportRef = usize;
 
 declare function _BinaryenAddFunctionImport(module: BinaryenModuleRef, internalName: usize, externalModuleName: usize, externalBaseName: usize, functionType: BinaryenFunctionTypeRef): BinaryenImportRef;
 declare function _BinaryenAddTableImport(module: BinaryenModuleRef, internalName: usize, externalModuleName: usize, externalBaseName: usize): BinaryenImportRef;
-declare function _BinaryenAddMemoryImport(module: BinaryenModuleRef, internalName: usize, externalModuleName: usize, externalBaseName: usize): BinaryenImportRef;
+declare function _BinaryenAddMemoryImport(module: BinaryenModuleRef, internalName: usize, externalModuleName: usize, externalBaseName: usize, shared:bool): BinaryenImportRef;
 declare function _BinaryenAddGlobalImport(module: BinaryenModuleRef, internalName: usize, externalModuleName: usize, externalBaseName: usize, globalType: BinaryenType): BinaryenImportRef;
 
 declare type BinaryenExportRef = usize;
@@ -570,7 +570,7 @@ declare function _BinaryenRemoveGlobal(module: BinaryenModuleRef, name: usize): 
 
 declare function _BinaryenSetFunctionTable(module: BinaryenModuleRef, initial: BinaryenIndex, maximum: BinaryenIndex, funcs: usize, numFuncs: BinaryenIndex): void;
 
-declare function _BinaryenSetMemory(module: BinaryenModuleRef, initial: BinaryenIndex, maximum: BinaryenIndex, exportName: usize, segments: usize, segmentOffsets: usize, segmentSizes: usize, numSegments: BinaryenIndex): void;
+declare function _BinaryenSetMemory(module: BinaryenModuleRef, initial: BinaryenIndex, maximum: BinaryenIndex, exportName: usize, segments: usize, segmentOffsets: usize, segmentSizes: usize, numSegments: BinaryenIndex, shared: bool): void;
 
 declare function _BinaryenSetStart(module: BinaryenModuleRef, start: BinaryenFunctionRef): void;
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -905,13 +905,14 @@ export class Module {
   addMemoryImport(
     internalName: string,
     externalModuleName: string,
-    externalBaseName: string
+    externalBaseName: string,
+    shared: bool = false,
   ): ImportRef {
     var cStr1 = allocString(internalName);
     var cStr2 = allocString(externalModuleName);
     var cStr3 = allocString(externalBaseName);
     try {
-      return _BinaryenAddMemoryImport(this.ref, cStr1, cStr2, cStr3);
+      return _BinaryenAddMemoryImport(this.ref, cStr1, cStr2, cStr3, shared);
     } finally {
       memory.free(cStr3);
       memory.free(cStr2);
@@ -945,7 +946,8 @@ export class Module {
     maximum: Index,
     segments: MemorySegment[],
     target: Target,
-    exportName: string | null = null
+    exportName: string | null = null,
+    shared: bool = false
   ): void {
     var cStr = allocString(exportName);
     var k = segments.length;
@@ -965,7 +967,7 @@ export class Module {
     var cArr2 = allocI32Array(offs);
     var cArr3 = allocI32Array(sizs);
     try {
-      _BinaryenSetMemory(this.ref, initial, maximum, cStr, cArr1, cArr2, cArr3, k);
+      _BinaryenSetMemory(this.ref, initial, maximum, cStr, cArr1, cArr2, cArr3, k, shared);
     } finally {
       memory.free(cArr3);
       memory.free(cArr2);


### PR DESCRIPTION
Extended `_BinaryenAddMemoryImport` and `_BinaryenSetMemory` functions with `shared: bool` argument
This will configure WASM memory as shared.