### PR TITLE
Rework constructor handling

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1111,8 +1111,7 @@ export class Compiler extends DiagnosticEmitter {
         assert(instance.is(CommonFlags.INSTANCE));
         let classInstance = assert(instance.parent); assert(classInstance.kind == ElementKind.CLASS);
 
-        // implicitly return `this` if the constructor doesn't always return on its own
-        if (!flow.is(FlowFlags.RETURNS)) {
+        if (!flow.isAny(FlowFlags.ANY_TERMINATING)) {
 
           // if `this` wasn't accessed before, allocate if necessary and initialize `this`
           if (!flow.is(FlowFlags.ALLOCATES)) {
@@ -1133,6 +1132,8 @@ export class Compiler extends DiagnosticEmitter {
             );
             this.makeFieldInitialization(<Class>classInstance, stmts);
           }
+
+          // implicitly return `this`
           stmts.push(
             module.createGetLocal(0, nativeSizeType)
           );

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -3,7 +3,7 @@
  * @module compiler
  *//***/
 
- import {
+import {
   compileCall as compileBuiltinCall,
   compileAbort,
   compileIterateRoots,

--- a/src/program.ts
+++ b/src/program.ts
@@ -2509,43 +2509,45 @@ export class Function extends Element {
     this.flags = prototype.flags;
     this.decoratorFlags = prototype.decoratorFlags;
     this.contextualTypeArguments = contextualTypeArguments;
-    if (!(prototype.is(CommonFlags.AMBIENT))) {
-      let localIndex = 0;
-      if (parent && parent.kind == ElementKind.CLASS) {
-        assert(this.is(CommonFlags.INSTANCE));
-        let local = new Local(
-          prototype.program,
-          "this",
-          localIndex++,
-          assert(signature.thisType)
-        );
-        this.localsByName.set("this", local);
-        this.localsByIndex[local.index] = local;
-        let inheritedTypeArguments = (<Class>parent).contextualTypeArguments;
-        if (inheritedTypeArguments) {
-          if (!this.contextualTypeArguments) this.contextualTypeArguments = new Map();
-          for (let [inheritedName, inheritedType] of inheritedTypeArguments) {
-            if (!this.contextualTypeArguments.has(inheritedName)) {
-              this.contextualTypeArguments.set(inheritedName, inheritedType);
+    if (prototype.internalName != "NATIVE_CODE") { // e.g. generated constructor without a real prototype
+      if (!(prototype.is(CommonFlags.AMBIENT))) {
+        let localIndex = 0;
+        if (parent && parent.kind == ElementKind.CLASS) {
+          assert(this.is(CommonFlags.INSTANCE));
+          let local = new Local(
+            prototype.program,
+            "this",
+            localIndex++,
+            assert(signature.thisType)
+          );
+          this.localsByName.set("this", local);
+          this.localsByIndex[local.index] = local;
+          let inheritedTypeArguments = (<Class>parent).contextualTypeArguments;
+          if (inheritedTypeArguments) {
+            if (!this.contextualTypeArguments) this.contextualTypeArguments = new Map();
+            for (let [inheritedName, inheritedType] of inheritedTypeArguments) {
+              if (!this.contextualTypeArguments.has(inheritedName)) {
+                this.contextualTypeArguments.set(inheritedName, inheritedType);
+              }
             }
           }
+        } else {
+          assert(!this.is(CommonFlags.INSTANCE)); // internal error
         }
-      } else {
-        assert(!this.is(CommonFlags.INSTANCE)); // internal error
-      }
-      let parameterTypes = signature.parameterTypes;
-      for (let i = 0, k = parameterTypes.length; i < k; ++i) {
-        let parameterType = parameterTypes[i];
-        let parameterName = signature.getParameterName(i);
-        let local = new Local(
-          prototype.program,
-          parameterName,
-          localIndex++,
-          parameterType
-          // FIXME: declaration?
-        );
-        this.localsByName.set(parameterName, local);
-        this.localsByIndex[local.index] = local;
+        let parameterTypes = signature.parameterTypes;
+        for (let i = 0, k = parameterTypes.length; i < k; ++i) {
+          let parameterType = parameterTypes[i];
+          let parameterName = signature.getParameterName(i);
+          let local = new Local(
+            prototype.program,
+            parameterName,
+            localIndex++,
+            parameterType
+            // FIXME: declaration?
+          );
+          this.localsByName.set(parameterName, local);
+          this.localsByIndex[local.index] = local;
+        }
       }
     }
     this.flow = Flow.create(this);

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -420,6 +420,7 @@ export function operatorTokenToString(token: Token): string {
 }
 
 export class Range {
+
   source: Source;
   start: i32;
   end: i32;

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -420,7 +420,6 @@ export function operatorTokenToString(token: Token): string {
 }
 
 export class Range {
-
   source: Source;
   start: i32;
   end: i32;

--- a/std/assembly/builtins.ts
+++ b/std/assembly/builtins.ts
@@ -191,3 +191,5 @@ export namespace f64 {
 }
 
 @builtin export declare function start(): void;
+
+@builtin export function NATIVE_CODE(): void {}

--- a/std/assembly/builtins.ts
+++ b/std/assembly/builtins.ts
@@ -192,4 +192,4 @@ export namespace f64 {
 
 @builtin export declare function start(): void;
 
-@builtin export function NATIVE_CODE(): void {}
+@builtin export function NATIVE_CODE(): void { unreachable(); }

--- a/tests/compiler/call-super.optimized.wat
+++ b/tests/compiler/call-super.optimized.wat
@@ -93,7 +93,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 6
+   i32.const 8
    i32.const 4
    call $~lib/env/abort
    unreachable
@@ -115,7 +115,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 15
+   i32.const 17
    i32.const 4
    call $~lib/env/abort
    unreachable
@@ -127,7 +127,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 16
+   i32.const 18
    i32.const 4
    call $~lib/env/abort
    unreachable
@@ -144,7 +144,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 22
+   i32.const 24
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -156,7 +156,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 23
+   i32.const 25
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -190,7 +190,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 36
+   i32.const 40
    i32.const 4
    call $~lib/env/abort
    unreachable
@@ -202,7 +202,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 37
+   i32.const 41
    i32.const 4
    call $~lib/env/abort
    unreachable
@@ -219,7 +219,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 43
+   i32.const 47
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -231,7 +231,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 44
+   i32.const 48
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -255,7 +255,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 52
+   i32.const 58
    i32.const 4
    call $~lib/env/abort
    unreachable
@@ -277,7 +277,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 62
+   i32.const 68
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -289,13 +289,13 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 63
+   i32.const 69
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $call-super/test4 (; 10 ;) (type $v)
+ (func $call-super/H#constructor (; 10 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   i32.const 8
   call $~lib/allocator/arena/__memory_allocate
@@ -304,13 +304,18 @@
   i32.const 2
   i32.store offset=4
   get_local $0
+ )
+ (func $call-super/test4 (; 11 ;) (type $v)
+  (local $0 i32)
+  call $call-super/H#constructor
+  tee_local $0
   i32.load
   i32.const 1
   i32.ne
   if
    i32.const 0
    i32.const 8
-   i32.const 81
+   i32.const 86
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -322,13 +327,41 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 82
+   i32.const 87
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $start (; 11 ;) (type $v)
+ (func $call-super/test5 (; 12 ;) (type $v)
+  (local $0 i32)
+  call $call-super/H#constructor
+  tee_local $0
+  i32.load
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 106
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.load offset=4
+  i32.const 2
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 107
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $start (; 13 ;) (type $v)
   i32.const 40
   set_global $~lib/allocator/arena/startOffset
   get_global $~lib/allocator/arena/startOffset
@@ -337,8 +370,9 @@
   call $call-super/test2
   call $call-super/test3
   call $call-super/test4
+  call $call-super/test5
  )
- (func $null (; 12 ;) (type $v)
+ (func $null (; 14 ;) (type $v)
   nop
  )
 )

--- a/tests/compiler/call-super.optimized.wat
+++ b/tests/compiler/call-super.optimized.wat
@@ -81,10 +81,11 @@
   if
    i32.const 4
    call $~lib/allocator/arena/__memory_allocate
-   tee_local $0
-   i32.const 1
-   i32.store
+   set_local $0
   end
+  get_local $0
+  i32.const 1
+  i32.store
   get_local $0
   i32.load
   i32.const 1
@@ -103,15 +104,11 @@
   (local $0 i32)
   i32.const 8
   call $~lib/allocator/arena/__memory_allocate
+  call $call-super/A#constructor
   tee_local $0
-  i32.const 1
-  i32.store
-  get_local $0
   i32.const 2
   i32.store offset=4
   get_local $0
-  call $call-super/A#constructor
-  tee_local $0
   i32.load
   i32.const 1
   i32.ne
@@ -165,14 +162,25 @@
    unreachable
   end
  )
- (func $call-super/D#constructor (; 5 ;) (type $FUNCSIG$i) (result i32)
-  (local $0 i32)
-  i32.const 8
-  call $~lib/allocator/arena/__memory_allocate
-  tee_local $0
+ (func $call-super/C#constructor (; 5 ;) (type $ii) (param $0 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 4
+   call $~lib/allocator/arena/__memory_allocate
+   set_local $0
+  end
+  get_local $0
   i32.const 1
   i32.store
   get_local $0
+ )
+ (func $call-super/D#constructor (; 6 ;) (type $FUNCSIG$i) (result i32)
+  (local $0 i32)
+  i32.const 8
+  call $~lib/allocator/arena/__memory_allocate
+  call $call-super/C#constructor
+  tee_local $0
   i32.const 2
   i32.store offset=4
   get_local $0
@@ -201,7 +209,7 @@
   end
   get_local $0
  )
- (func $call-super/test2 (; 6 ;) (type $v)
+ (func $call-super/test2 (; 7 ;) (type $v)
   (local $0 i32)
   call $call-super/D#constructor
   tee_local $0
@@ -229,11 +237,15 @@
    unreachable
   end
  )
- (func $call-super/E#constructor (; 7 ;) (type $FUNCSIG$i) (result i32)
-  (local $0 i32)
-  i32.const 4
-  call $~lib/allocator/arena/__memory_allocate
-  tee_local $0
+ (func $call-super/E#constructor (; 8 ;) (type $ii) (param $0 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 4
+   call $~lib/allocator/arena/__memory_allocate
+   set_local $0
+  end
+  get_local $0
   i32.const 1
   i32.store
   get_local $0
@@ -250,14 +262,15 @@
   end
   get_local $0
  )
- (func $start (; 8 ;) (type $v)
-  i32.const 40
-  set_global $~lib/allocator/arena/startOffset
-  get_global $~lib/allocator/arena/startOffset
-  set_global $~lib/allocator/arena/offset
-  call $call-super/test1
-  call $call-super/test2
+ (func $call-super/test3 (; 9 ;) (type $v)
+  (local $0 i32)
+  i32.const 8
+  call $~lib/allocator/arena/__memory_allocate
   call $call-super/E#constructor
+  tee_local $0
+  i32.const 2
+  i32.store offset=4
+  get_local $0
   i32.load
   i32.const 1
   i32.ne
@@ -269,8 +282,63 @@
    call $~lib/env/abort
    unreachable
   end
+  get_local $0
+  i32.load offset=4
+  i32.const 2
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 63
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
  )
- (func $null (; 9 ;) (type $v)
+ (func $call-super/test4 (; 10 ;) (type $v)
+  (local $0 i32)
+  i32.const 8
+  call $~lib/allocator/arena/__memory_allocate
+  call $call-super/C#constructor
+  tee_local $0
+  i32.const 2
+  i32.store offset=4
+  get_local $0
+  i32.load
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 81
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.load offset=4
+  i32.const 2
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 82
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $start (; 11 ;) (type $v)
+  i32.const 40
+  set_global $~lib/allocator/arena/startOffset
+  get_global $~lib/allocator/arena/startOffset
+  set_global $~lib/allocator/arena/offset
+  call $call-super/test1
+  call $call-super/test2
+  call $call-super/test3
+  call $call-super/test4
+ )
+ (func $null (; 12 ;) (type $v)
   nop
  )
 )

--- a/tests/compiler/call-super.ts
+++ b/tests/compiler/call-super.ts
@@ -60,7 +60,26 @@ class F extends E {
 function test3(): void {
   var f = new F();
   assert(f.a == 1);
-  // assert(f.b == 2); // FIXME: uses E#constructor, not initializing fields
+  assert(f.b == 2);
 }
 
 test3();
+
+class G {
+  a: i32 = 1;
+  constructor() {
+    // no access to this
+  }
+}
+
+class H extends G {
+  b: i32 = 2;
+}
+
+function test4(): void {
+  var h = new H();
+  assert(h.a == 1);
+  assert(h.b == 2);
+}
+
+test4();

--- a/tests/compiler/call-super.ts
+++ b/tests/compiler/call-super.ts
@@ -1,5 +1,7 @@
 import "allocator/arena";
 
+// both constructors present
+
 class A {
   a: i32 = 1;
   constructor() {
@@ -25,6 +27,8 @@ function test1(): void {
 
 test1();
 
+// this constructor present
+
 class C {
   a: i32 = 1;
 }
@@ -46,6 +50,8 @@ function test2(): void {
 
 test2();
 
+// super constructor present
+
 class E {
   a: i32 = 1;
   constructor() {
@@ -65,11 +71,10 @@ function test3(): void {
 
 test3();
 
+// no constructor present
+
 class G {
   a: i32 = 1;
-  constructor() {
-    // no access to this
-  }
 }
 
 class H extends G {
@@ -83,3 +88,23 @@ function test4(): void {
 }
 
 test4();
+
+// this constructor present with fallback allocation (`this` is not accessed)
+
+class I {
+  a: i32 = 1;
+  constructor() {
+  }
+}
+
+class J extends I {
+  b: i32 = 2;
+}
+
+function test5(): void {
+  var h = new J();
+  assert(h.a == 1);
+  assert(h.b == 2);
+}
+
+test5();

--- a/tests/compiler/call-super.untouched.wat
+++ b/tests/compiler/call-super.untouched.wat
@@ -102,23 +102,19 @@
   return
  )
  (func $call-super/A#constructor (; 3 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 4
     call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 1
-    i32.store
-    get_local $1
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 1
+   i32.store
+   get_local $0
   end
-  tee_local $0
   i32.load
   i32.const 1
   i32.eq
@@ -134,21 +130,18 @@
   get_local $0
  )
  (func $call-super/B#constructor (; 4 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  block (result i32)
+  get_local $0
+  if (result i32)
+   get_local $0
+  else   
    i32.const 8
    call $~lib/memory/memory.allocate
-   set_local $1
-   get_local $1
-   i32.const 1
-   i32.store
-   get_local $1
-   i32.const 2
-   i32.store offset=4
-   get_local $1
   end
   call $call-super/A#constructor
   set_local $0
+  get_local $0
+  i32.const 2
+  i32.store offset=4
   get_local $0
   i32.load
   i32.const 1
@@ -209,21 +202,32 @@
    unreachable
   end
  )
- (func $call-super/D#constructor (; 6 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  block (result i32)
+ (func $call-super/C#constructor (; 6 ;) (type $ii) (param $0 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 4
+   call $~lib/memory/memory.allocate
+   set_local $0
+  end
+  get_local $0
+  i32.const 1
+  i32.store
+  get_local $0
+ )
+ (func $call-super/D#constructor (; 7 ;) (type $ii) (param $0 i32) (result i32)
+  get_local $0
+  if (result i32)
+   get_local $0
+  else   
    i32.const 8
    call $~lib/memory/memory.allocate
-   set_local $1
-   get_local $1
-   i32.const 1
-   i32.store
-   get_local $1
-   i32.const 2
-   i32.store offset=4
-   get_local $1
   end
+  call $call-super/C#constructor
   set_local $0
+  get_local $0
+  i32.const 2
+  i32.store offset=4
   get_local $0
   i32.load
   i32.const 1
@@ -252,7 +256,7 @@
   end
   get_local $0
  )
- (func $call-super/test2 (; 7 ;) (type $v)
+ (func $call-super/test2 (; 8 ;) (type $v)
   (local $0 i32)
   i32.const 0
   call $call-super/D#constructor
@@ -284,24 +288,20 @@
    unreachable
   end
  )
- (func $call-super/E#constructor (; 8 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  get_local $0
-  if (result i32)
+ (func $call-super/E#constructor (; 9 ;) (type $ii) (param $0 i32) (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 4
     call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 1
-    i32.store
-    get_local $1
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 1
+   i32.store
+   get_local $0
   end
-  tee_local $0
   i32.load
   i32.const 1
   i32.eq
@@ -316,10 +316,26 @@
   end
   get_local $0
  )
- (func $call-super/test3 (; 9 ;) (type $v)
+ (func $call-super/F#constructor (; 10 ;) (type $ii) (param $0 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 8
+   call $~lib/memory/memory.allocate
+   set_local $0
+  end
+  get_local $0
+  call $call-super/E#constructor
+  set_local $0
+  get_local $0
+  i32.const 2
+  i32.store offset=4
+  get_local $0
+ )
+ (func $call-super/test3 (; 11 ;) (type $v)
   (local $0 i32)
   i32.const 0
-  call $call-super/E#constructor
+  call $call-super/F#constructor
   set_local $0
   get_local $0
   i32.load
@@ -334,8 +350,82 @@
    call $~lib/env/abort
    unreachable
   end
+  get_local $0
+  i32.load offset=4
+  i32.const 2
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 63
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
  )
- (func $start (; 10 ;) (type $v)
+ (func $call-super/G#constructor (; 12 ;) (type $ii) (param $0 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 4
+   call $~lib/memory/memory.allocate
+   set_local $0
+  end
+  get_local $0
+  i32.const 1
+  i32.store
+  get_local $0
+ )
+ (func $call-super/H#constructor (; 13 ;) (type $ii) (param $0 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 8
+   call $~lib/memory/memory.allocate
+   set_local $0
+  end
+  get_local $0
+  call $call-super/G#constructor
+  set_local $0
+  get_local $0
+  i32.const 2
+  i32.store offset=4
+  get_local $0
+ )
+ (func $call-super/test4 (; 14 ;) (type $v)
+  (local $0 i32)
+  i32.const 0
+  call $call-super/H#constructor
+  set_local $0
+  get_local $0
+  i32.load
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 81
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.load offset=4
+  i32.const 2
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 82
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $start (; 15 ;) (type $v)
   get_global $HEAP_BASE
   get_global $~lib/internal/allocator/AL_MASK
   i32.add
@@ -349,7 +439,8 @@
   call $call-super/test1
   call $call-super/test2
   call $call-super/test3
+  call $call-super/test4
  )
- (func $null (; 11 ;) (type $v)
+ (func $null (; 16 ;) (type $v)
  )
 )

--- a/tests/compiler/call-super.untouched.wat
+++ b/tests/compiler/call-super.untouched.wat
@@ -122,7 +122,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 6
+   i32.const 8
    i32.const 4
    call $~lib/env/abort
    unreachable
@@ -150,7 +150,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 15
+   i32.const 17
    i32.const 4
    call $~lib/env/abort
    unreachable
@@ -163,7 +163,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 16
+   i32.const 18
    i32.const 4
    call $~lib/env/abort
    unreachable
@@ -183,7 +183,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 22
+   i32.const 24
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -196,7 +196,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 23
+   i32.const 25
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -236,7 +236,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 36
+   i32.const 40
    i32.const 4
    call $~lib/env/abort
    unreachable
@@ -249,7 +249,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 37
+   i32.const 41
    i32.const 4
    call $~lib/env/abort
    unreachable
@@ -269,7 +269,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 43
+   i32.const 47
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -282,7 +282,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 44
+   i32.const 48
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -309,7 +309,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 52
+   i32.const 58
    i32.const 4
    call $~lib/env/abort
    unreachable
@@ -345,7 +345,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 62
+   i32.const 68
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -358,7 +358,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 63
+   i32.const 69
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -406,7 +406,7 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 81
+   i32.const 86
    i32.const 2
    call $~lib/env/abort
    unreachable
@@ -419,13 +419,74 @@
   if
    i32.const 0
    i32.const 8
-   i32.const 82
+   i32.const 87
    i32.const 2
    call $~lib/env/abort
    unreachable
   end
  )
- (func $start (; 15 ;) (type $v)
+ (func $call-super/I#constructor (; 15 ;) (type $ii) (param $0 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 4
+   call $~lib/memory/memory.allocate
+   set_local $0
+  end
+  get_local $0
+  i32.const 1
+  i32.store
+  get_local $0
+ )
+ (func $call-super/J#constructor (; 16 ;) (type $ii) (param $0 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 8
+   call $~lib/memory/memory.allocate
+   set_local $0
+  end
+  get_local $0
+  call $call-super/I#constructor
+  set_local $0
+  get_local $0
+  i32.const 2
+  i32.store offset=4
+  get_local $0
+ )
+ (func $call-super/test5 (; 17 ;) (type $v)
+  (local $0 i32)
+  i32.const 0
+  call $call-super/J#constructor
+  set_local $0
+  get_local $0
+  i32.load
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 106
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $0
+  i32.load offset=4
+  i32.const 2
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 107
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $start (; 18 ;) (type $v)
   get_global $HEAP_BASE
   get_global $~lib/internal/allocator/AL_MASK
   i32.add
@@ -440,7 +501,8 @@
   call $call-super/test2
   call $call-super/test3
   call $call-super/test4
+  call $call-super/test5
  )
- (func $null (; 16 ;) (type $v)
+ (func $null (; 19 ;) (type $v)
  )
 )

--- a/tests/compiler/exports.optimized.wat
+++ b/tests/compiler/exports.optimized.wat
@@ -181,10 +181,11 @@
   if
    i32.const 4
    call $~lib/allocator/arena/__memory_allocate
-   tee_local $0
-   get_local $1
-   i32.store
+   set_local $0
   end
+  get_local $0
+  get_local $1
+  i32.store
   get_local $0
   get_local $1
   i32.store

--- a/tests/compiler/exports.untouched.wat
+++ b/tests/compiler/exports.untouched.wat
@@ -154,23 +154,19 @@
   return
  )
  (func $exports/Car#constructor (; 6 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 4
     call $~lib/memory/memory.allocate
-    set_local $2
-    get_local $2
-    get_local $1
-    i32.store
-    get_local $2
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   get_local $1
+   i32.store
+   get_local $0
   end
-  tee_local $0
   get_local $1
   i32.store
   get_local $0
@@ -191,23 +187,19 @@
   get_global $exports/vehicles.Car.TIRES
  )
  (func $exports/vehicles.Car#constructor (; 11 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 4
     call $~lib/memory/memory.allocate
-    set_local $2
-    get_local $2
-    get_local $1
-    i32.store
-    get_local $2
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   get_local $1
+   i32.store
+   get_local $0
   end
-  tee_local $0
   get_local $1
   i32.store
   get_local $0

--- a/tests/compiler/getter-call.untouched.wat
+++ b/tests/compiler/getter-call.untouched.wat
@@ -101,20 +101,26 @@
   call $~lib/allocator/arena/__memory_allocate
   return
  )
- (func $getter-call/C#get:x~anonymous|1 (; 2 ;) (type $i) (result i32)
-  i32.const 42
- )
- (func $getter-call/C#get:x (; 3 ;) (type $ii) (param $0 i32) (result i32)
-  i32.const 1
- )
- (func $getter-call/test (; 4 ;) (type $i) (result i32)
-  (local $0 i32)
-  block (result i32)
+ (func $getter-call/C#constructor (; 2 ;) (type $ii) (param $0 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
    i32.const 0
    call $~lib/memory/memory.allocate
    set_local $0
-   get_local $0
   end
+  get_local $0
+ )
+ (func $getter-call/C#get:x~anonymous|1 (; 3 ;) (type $i) (result i32)
+  i32.const 42
+ )
+ (func $getter-call/C#get:x (; 4 ;) (type $ii) (param $0 i32) (result i32)
+  i32.const 1
+ )
+ (func $getter-call/test (; 5 ;) (type $i) (result i32)
+  (local $0 i32)
+  i32.const 0
+  call $getter-call/C#constructor
   set_local $0
   i32.const 0
   set_global $~argc
@@ -122,7 +128,7 @@
   call $getter-call/C#get:x
   call_indirect (type $i)
  )
- (func $start (; 5 ;) (type $v)
+ (func $start (; 6 ;) (type $v)
   get_global $HEAP_BASE
   get_global $~lib/internal/allocator/AL_MASK
   i32.add
@@ -134,6 +140,6 @@
   get_global $~lib/allocator/arena/startOffset
   set_global $~lib/allocator/arena/offset
  )
- (func $null (; 6 ;) (type $v)
+ (func $null (; 7 ;) (type $v)
  )
 )

--- a/tests/compiler/new-without-allocator.untouched.wat
+++ b/tests/compiler/new-without-allocator.untouched.wat
@@ -12,18 +12,23 @@
  (func $~lib/memory/memory.allocate (; 0 ;) (type $ii) (param $0 i32) (result i32)
   unreachable
  )
- (func $new-without-allocator/test (; 1 ;) (type $i) (result i32)
-  (local $0 i32)
-  (local $1 i32)
-  block (result i32)
+ (func $new-without-allocator/A#constructor (; 1 ;) (type $ii) (param $0 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
    i32.const 0
    call $~lib/memory/memory.allocate
    set_local $0
-   get_local $0
   end
-  set_local $1
+  get_local $0
+ )
+ (func $new-without-allocator/test (; 2 ;) (type $i) (result i32)
+  (local $0 i32)
+  i32.const 0
+  call $new-without-allocator/A#constructor
+  set_local $0
   i32.const 3
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 3 ;) (type $v)
  )
 )

--- a/tests/compiler/optional-typeparameters.untouched.wat
+++ b/tests/compiler/optional-typeparameters.untouched.wat
@@ -108,18 +108,37 @@
   call $~lib/allocator/arena/__memory_allocate
   return
  )
- (func $optional-typeparameters/TestConcrete<i32,i32>#test<i32> (; 4 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $optional-typeparameters/TestConcrete<i32,i32>#constructor (; 4 ;) (type $ii) (param $0 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 0
+   call $~lib/memory/memory.allocate
+   set_local $0
+  end
+  get_local $0
+ )
+ (func $optional-typeparameters/TestConcrete<i32,i32>#test<i32> (; 5 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $1
   get_local $2
   i32.add
  )
- (func $optional-typeparameters/TestDerived<f64,f64>#test<f64> (; 5 ;) (type $iFFF) (param $0 i32) (param $1 f64) (param $2 f64) (result f64)
+ (func $optional-typeparameters/TestDerived<f64,f64>#constructor (; 6 ;) (type $ii) (param $0 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 0
+   call $~lib/memory/memory.allocate
+   set_local $0
+  end
+  get_local $0
+ )
+ (func $optional-typeparameters/TestDerived<f64,f64>#test<f64> (; 7 ;) (type $iFFF) (param $0 i32) (param $1 f64) (param $2 f64) (result f64)
   get_local $1
   get_local $2
   f64.add
  )
- (func $start (; 6 ;) (type $v)
-  (local $0 i32)
+ (func $start (; 8 ;) (type $v)
   i32.const 1
   call $optional-typeparameters/testConcrete<i32,i32>
   drop
@@ -136,24 +155,16 @@
   set_global $~lib/allocator/arena/startOffset
   get_global $~lib/allocator/arena/startOffset
   set_global $~lib/allocator/arena/offset
-  block (result i32)
-   i32.const 0
-   call $~lib/memory/memory.allocate
-   set_local $0
-   get_local $0
-  end
+  i32.const 0
+  call $optional-typeparameters/TestConcrete<i32,i32>#constructor
   set_global $optional-typeparameters/tConcrete
   get_global $optional-typeparameters/tConcrete
   i32.const 1
   i32.const 2
   call $optional-typeparameters/TestConcrete<i32,i32>#test<i32>
   drop
-  block (result i32)
-   i32.const 0
-   call $~lib/memory/memory.allocate
-   set_local $0
-   get_local $0
-  end
+  i32.const 0
+  call $optional-typeparameters/TestDerived<f64,f64>#constructor
   set_global $optional-typeparameters/tDerived
   get_global $optional-typeparameters/tDerived
   f64.const 1
@@ -161,6 +172,6 @@
   call $optional-typeparameters/TestDerived<f64,f64>#test<f64>
   drop
  )
- (func $null (; 7 ;) (type $v)
+ (func $null (; 9 ;) (type $v)
  )
 )

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -493,25 +493,22 @@
   get_local $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   set_local $3
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 8
     call $~lib/memory/memory.allocate
-    set_local $4
-    get_local $4
-    i32.const 0
-    i32.store
-    get_local $4
-    i32.const 0
-    i32.store offset=4
-    get_local $4
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
   end
-  tee_local $0
   get_local $3
   i32.store
   get_local $0
@@ -570,25 +567,22 @@
   get_local $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   set_local $3
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 8
     call $~lib/memory/memory.allocate
-    set_local $4
-    get_local $4
-    i32.const 0
-    i32.store
-    get_local $4
-    i32.const 0
-    i32.store offset=4
-    get_local $4
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
   end
-  tee_local $0
   get_local $3
   i32.store
   get_local $0
@@ -624,7 +618,17 @@
   get_local $2
   i32.store offset=8
  )
- (func $~lib/array/Array<Ref>#constructor (; 12 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array-literal/Ref#constructor (; 12 ;) (type $ii) (param $0 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 0
+   call $~lib/memory/memory.allocate
+   set_local $0
+  end
+  get_local $0
+ )
+ (func $~lib/array/Array<Ref>#constructor (; 13 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -647,25 +651,22 @@
   get_local $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   set_local $3
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 8
     call $~lib/memory/memory.allocate
-    set_local $4
-    get_local $4
-    i32.const 0
-    i32.store
-    get_local $4
-    i32.const 0
-    i32.store offset=4
-    get_local $4
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
   end
-  tee_local $0
   get_local $3
   i32.store
   get_local $0
@@ -683,7 +684,7 @@
   call $~lib/internal/memory/memset
   get_local $0
  )
- (func $~lib/array/Array<Ref>#__unchecked_set (; 13 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<Ref>#__unchecked_set (; 14 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   get_local $0
@@ -701,23 +702,17 @@
   get_local $2
   i32.store offset=8
  )
- (func $std/array-literal/RefWithCtor#constructor (; 14 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
+ (func $std/array-literal/RefWithCtor#constructor (; 15 ;) (type $ii) (param $0 i32) (result i32)
   get_local $0
-  if (result i32)
-   get_local $0
-  else   
-   block (result i32)
-    i32.const 0
-    call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-   end
-   tee_local $0
+  i32.eqz
+  if
+   i32.const 0
+   call $~lib/memory/memory.allocate
+   set_local $0
   end
-  tee_local $0
+  get_local $0
  )
- (func $~lib/array/Array<RefWithCtor>#constructor (; 15 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<RefWithCtor>#constructor (; 16 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -740,25 +735,22 @@
   get_local $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   set_local $3
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 8
     call $~lib/memory/memory.allocate
-    set_local $4
-    get_local $4
-    i32.const 0
-    i32.store
-    get_local $4
-    i32.const 0
-    i32.store offset=4
-    get_local $4
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
   end
-  tee_local $0
   get_local $3
   i32.store
   get_local $0
@@ -776,7 +768,7 @@
   call $~lib/internal/memory/memset
   get_local $0
  )
- (func $~lib/array/Array<RefWithCtor>#__unchecked_set (; 16 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<RefWithCtor>#__unchecked_set (; 17 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   get_local $0
@@ -794,7 +786,7 @@
   get_local $2
   i32.store offset=8
  )
- (func $start (; 17 ;) (type $v)
+ (func $start (; 18 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1160,30 +1152,18 @@
    set_local $3
    get_local $3
    i32.const 0
-   block (result i32)
-    i32.const 0
-    call $~lib/memory/memory.allocate
-    set_local $2
-    get_local $2
-   end
+   i32.const 0
+   call $std/array-literal/Ref#constructor
    call $~lib/array/Array<Ref>#__unchecked_set
    get_local $3
    i32.const 1
-   block (result i32)
-    i32.const 0
-    call $~lib/memory/memory.allocate
-    set_local $2
-    get_local $2
-   end
+   i32.const 0
+   call $std/array-literal/Ref#constructor
    call $~lib/array/Array<Ref>#__unchecked_set
    get_local $3
    i32.const 2
-   block (result i32)
-    i32.const 0
-    call $~lib/memory/memory.allocate
-    set_local $2
-    get_local $2
-   end
+   i32.const 0
+   call $std/array-literal/Ref#constructor
    call $~lib/array/Array<Ref>#__unchecked_set
    get_local $3
   end
@@ -1246,6 +1226,6 @@
    unreachable
   end
  )
- (func $null (; 18 ;) (type $v)
+ (func $null (; 19 ;) (type $v)
  )
 )

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -840,25 +840,22 @@
   get_local $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   set_local $3
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 8
     call $~lib/memory/memory.allocate
-    set_local $4
-    get_local $4
-    i32.const 0
-    i32.store
-    get_local $4
-    i32.const 0
-    i32.store offset=4
-    get_local $4
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
   end
-  tee_local $0
   get_local $3
   i32.store
   get_local $0
@@ -896,7 +893,17 @@
    i32.const 1
   end
  )
- (func $~lib/array/Array.isArray<P> (; 10 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array/P#constructor (; 10 ;) (type $ii) (param $0 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 0
+   call $~lib/memory/memory.allocate
+   set_local $0
+  end
+  get_local $0
+ )
+ (func $~lib/array/Array.isArray<P> (; 11 ;) (type $ii) (param $0 i32) (result i32)
   i32.const 0
   if (result i32)
    get_local $0
@@ -906,7 +913,7 @@
    i32.const 0
   end
  )
- (func $~lib/array/Array.isArray<i32> (; 11 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array.isArray<i32> (; 12 ;) (type $ii) (param $0 i32) (result i32)
   i32.const 0
   if (result i32)
    get_local $0
@@ -916,7 +923,7 @@
    i32.const 0
   end
  )
- (func $~lib/array/Array<u8>#fill (; 12 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/array/Array<u8>#fill (; 13 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -998,7 +1005,7 @@
   end
   get_local $0
  )
- (func $~lib/array/Array<u8>#__get (; 13 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__get (; 14 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   get_local $0
@@ -1025,7 +1032,7 @@
    unreachable
   end
  )
- (func $std/array/isArraysEqual<u8> (; 14 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<u8> (; 15 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   get_local $2
   i32.eqz
@@ -1088,7 +1095,7 @@
   end
   i32.const 1
  )
- (func $~lib/array/Array<u8>#fill|trampoline (; 15 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/array/Array<u8>#fill|trampoline (; 16 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -1112,7 +1119,7 @@
   get_local $3
   call $~lib/array/Array<u8>#fill
  )
- (func $~lib/array/Array<u32>#fill (; 16 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/array/Array<u32>#fill (; 17 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1204,7 +1211,7 @@
   end
   get_local $0
  )
- (func $~lib/array/Array<u32>#__get (; 17 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#__get (; 18 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   get_local $0
@@ -1231,7 +1238,7 @@
    unreachable
   end
  )
- (func $std/array/isArraysEqual<u32> (; 18 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<u32> (; 19 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   get_local $2
   i32.eqz
@@ -1290,7 +1297,7 @@
   end
   i32.const 1
  )
- (func $~lib/array/Array<u32>#fill|trampoline (; 19 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/array/Array<u32>#fill|trampoline (; 20 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -1314,7 +1321,7 @@
   get_local $3
   call $~lib/array/Array<u32>#fill
  )
- (func $std/array/internalCapacity<i32> (; 20 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array/internalCapacity<i32> (; 21 ;) (type $ii) (param $0 i32) (result i32)
   (local $1 i32)
   get_local $0
   i32.load
@@ -1324,7 +1331,7 @@
   i32.const 2
   i32.shr_s
  )
- (func $~lib/internal/memory/memcpy (; 21 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 22 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2525,7 +2532,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 22 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 23 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   get_local $0
   get_local $1
@@ -2752,10 +2759,10 @@
    end
   end
  )
- (func $~lib/allocator/arena/__memory_free (; 23 ;) (type $iv) (param $0 i32)
+ (func $~lib/allocator/arena/__memory_free (; 24 ;) (type $iv) (param $0 i32)
   nop
  )
- (func $~lib/internal/arraybuffer/reallocateUnsafe (; 24 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/arraybuffer/reallocateUnsafe (; 25 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2857,7 +2864,7 @@
   end
   get_local $0
  )
- (func $~lib/array/Array<i32>#push (; 25 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#push (; 26 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2919,7 +2926,7 @@
   i32.store offset=8
   get_local $5
  )
- (func $~lib/array/Array<i32>#__get (; 26 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (; 27 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   get_local $0
@@ -2946,7 +2953,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<i32>#pop (; 27 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#pop (; 28 ;) (type $ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2992,7 +2999,7 @@
   i32.store offset=4
   get_local $5
  )
- (func $~lib/array/Array<i32>#concat (; 28 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#concat (; 29 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3067,7 +3074,7 @@
   end
   get_local $5
  )
- (func $~lib/array/Array<i32>#copyWithin (; 29 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/array/Array<i32>#copyWithin (; 30 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3280,7 +3287,7 @@
   end
   get_local $0
  )
- (func $~lib/array/Array<i32>#copyWithin|trampoline (; 30 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/array/Array<i32>#copyWithin|trampoline (; 31 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -3300,7 +3307,7 @@
   get_local $3
   call $~lib/array/Array<i32>#copyWithin
  )
- (func $std/array/isArraysEqual<i32> (; 31 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<i32> (; 32 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   get_local $2
   i32.eqz
@@ -3359,7 +3366,7 @@
   end
   i32.const 1
  )
- (func $~lib/array/Array<i32>#unshift (; 32 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#unshift (; 33 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3450,7 +3457,7 @@
   i32.store offset=4
   get_local $5
  )
- (func $~lib/array/Array<i32>#shift (; 33 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#shift (; 34 ;) (type $ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3530,7 +3537,7 @@
   i32.store offset=4
   get_local $5
  )
- (func $~lib/array/Array<i32>#reverse (; 34 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#reverse (; 35 ;) (type $ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3623,7 +3630,7 @@
   end
   get_local $0
  )
- (func $~lib/array/Array<i32>#indexOf (; 35 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#indexOf (; 36 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3701,7 +3708,7 @@
   end
   i32.const -1
  )
- (func $~lib/array/Array<i32>#splice (; 36 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#splice (; 37 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3817,7 +3824,7 @@
   i32.store offset=4
   get_local $7
  )
- (func $~lib/array/Array<i32>#splice|trampoline (; 37 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#splice|trampoline (; 38 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -3836,7 +3843,7 @@
   get_local $2
   call $~lib/array/Array<i32>#splice
  )
- (func $~lib/array/Array<i32>#__set (; 38 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__set (; 39 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3892,12 +3899,12 @@
   get_local $2
   i32.store offset=8
  )
- (func $start~anonymous|1 (; 39 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start~anonymous|1 (; 40 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 0
   i32.eq
  )
- (func $~lib/array/Array<i32>#findIndex (; 40 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#findIndex (; 41 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3964,17 +3971,17 @@
   end
   i32.const -1
  )
- (func $start~anonymous|2 (; 41 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start~anonymous|2 (; 42 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 1
   i32.eq
  )
- (func $start~anonymous|3 (; 42 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start~anonymous|3 (; 43 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 100
   i32.eq
  )
- (func $start~anonymous|4 (; 43 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start~anonymous|4 (; 44 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3983,12 +3990,12 @@
   i32.const 100
   i32.eq
  )
- (func $start~anonymous|5 (; 44 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start~anonymous|5 (; 45 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 100
   i32.eq
  )
- (func $start~anonymous|6 (; 45 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start~anonymous|6 (; 46 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -3996,12 +4003,12 @@
   i32.const 100
   i32.eq
  )
- (func $start~anonymous|7 (; 46 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start~anonymous|7 (; 47 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 0
   i32.ge_s
  )
- (func $~lib/array/Array<i32>#every (; 47 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#every (; 48 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4069,12 +4076,12 @@
   end
   i32.const 1
  )
- (func $start~anonymous|8 (; 48 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start~anonymous|8 (; 49 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 0
   i32.le_s
  )
- (func $start~anonymous|9 (; 49 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start~anonymous|9 (; 50 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -4083,12 +4090,12 @@
   i32.const 10
   i32.lt_s
  )
- (func $start~anonymous|10 (; 50 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start~anonymous|10 (; 51 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 10
   i32.lt_s
  )
- (func $start~anonymous|11 (; 51 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start~anonymous|11 (; 52 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -4096,12 +4103,12 @@
   i32.const 3
   i32.lt_s
  )
- (func $start~anonymous|12 (; 52 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start~anonymous|12 (; 53 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 3
   i32.ge_s
  )
- (func $~lib/array/Array<i32>#some (; 53 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#some (; 54 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4168,12 +4175,12 @@
   end
   i32.const 0
  )
- (func $start~anonymous|13 (; 54 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start~anonymous|13 (; 55 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const -1
   i32.le_s
  )
- (func $start~anonymous|14 (; 55 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start~anonymous|14 (; 56 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -4182,12 +4189,12 @@
   i32.const 10
   i32.gt_s
  )
- (func $start~anonymous|15 (; 56 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start~anonymous|15 (; 57 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 10
   i32.gt_s
  )
- (func $start~anonymous|16 (; 57 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start~anonymous|16 (; 58 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -4195,13 +4202,13 @@
   i32.const 3
   i32.gt_s
  )
- (func $start~anonymous|17 (; 58 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start~anonymous|17 (; 59 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   get_global $std/array/i
   get_local $0
   i32.add
   set_global $std/array/i
  )
- (func $~lib/array/Array<i32>#forEach (; 59 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#forEach (; 60 ;) (type $iiv) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4261,7 +4268,7 @@
    unreachable
   end
  )
- (func $start~anonymous|18 (; 60 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start~anonymous|18 (; 61 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   get_local $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -4271,13 +4278,13 @@
   i32.add
   set_global $std/array/i
  )
- (func $start~anonymous|19 (; 61 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start~anonymous|19 (; 62 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   get_global $std/array/i
   get_local $0
   i32.add
   set_global $std/array/i
  )
- (func $start~anonymous|20 (; 62 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start~anonymous|20 (; 63 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   get_local $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -4286,7 +4293,7 @@
   i32.add
   set_global $std/array/i
  )
- (func $start~anonymous|21 (; 63 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start~anonymous|21 (; 64 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   get_local $1
   i32.const 0
@@ -4401,11 +4408,11 @@
    end
   end
  )
- (func $start~anonymous|22 (; 64 ;) (type $iiif) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
+ (func $start~anonymous|22 (; 65 ;) (type $iiif) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
   get_local $0
   f32.convert_s/i32
  )
- (func $~lib/array/Array<f32>#constructor (; 65 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f32>#constructor (; 66 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4428,25 +4435,22 @@
   get_local $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   set_local $3
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 8
     call $~lib/memory/memory.allocate
-    set_local $4
-    get_local $4
-    i32.const 0
-    i32.store
-    get_local $4
-    i32.const 0
-    i32.store offset=4
-    get_local $4
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
   end
-  tee_local $0
   get_local $3
   i32.store
   get_local $0
@@ -4464,7 +4468,7 @@
   call $~lib/internal/memory/memset
   get_local $0
  )
- (func $~lib/array/Array<i32>#map<f32> (; 66 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#map<f32> (; 67 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4547,7 +4551,7 @@
   end
   get_local $3
  )
- (func $~lib/array/Array<f32>#__get (; 67 ;) (type $iif) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__get (; 68 ;) (type $iif) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (local $3 i32)
   get_local $0
@@ -4574,7 +4578,7 @@
    unreachable
   end
  )
- (func $start~anonymous|23 (; 68 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start~anonymous|23 (; 69 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -4585,7 +4589,7 @@
   set_global $std/array/i
   get_local $0
  )
- (func $~lib/array/Array<i32>#map<i32> (; 69 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#map<i32> (; 70 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4667,14 +4671,14 @@
   end
   get_local $3
  )
- (func $start~anonymous|24 (; 70 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start~anonymous|24 (; 71 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_global $std/array/i
   get_local $0
   i32.add
   set_global $std/array/i
   get_local $0
  )
- (func $start~anonymous|25 (; 71 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start~anonymous|25 (; 72 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -4684,12 +4688,12 @@
   set_global $std/array/i
   get_local $0
  )
- (func $start~anonymous|26 (; 72 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start~anonymous|26 (; 73 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 2
   i32.ge_s
  )
- (func $~lib/array/Array<i32>#filter (; 73 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#filter (; 74 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4767,7 +4771,7 @@
   end
   get_local $2
  )
- (func $start~anonymous|27 (; 74 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start~anonymous|27 (; 75 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -4780,7 +4784,7 @@
   i32.const 2
   i32.ge_s
  )
- (func $start~anonymous|28 (; 75 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start~anonymous|28 (; 76 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_global $std/array/i
   get_local $0
   i32.add
@@ -4789,7 +4793,7 @@
   i32.const 2
   i32.ge_s
  )
- (func $start~anonymous|29 (; 76 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start~anonymous|29 (; 77 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -4801,12 +4805,12 @@
   i32.const 2
   i32.ge_s
  )
- (func $start~anonymous|30 (; 77 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start~anonymous|30 (; 78 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/array/Array<i32>#reduce<i32> (; 78 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduce<i32> (; 79 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4872,12 +4876,12 @@
   end
   get_local $3
  )
- (func $start~anonymous|31 (; 79 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start~anonymous|31 (; 80 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $start~anonymous|32 (; 80 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start~anonymous|32 (; 81 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   i32.const 0
   i32.ne
@@ -4889,7 +4893,7 @@
    i32.gt_s
   end
  )
- (func $~lib/array/Array<i32>#reduce<bool> (; 81 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduce<bool> (; 82 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4955,7 +4959,7 @@
   end
   get_local $3
  )
- (func $start~anonymous|33 (; 82 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start~anonymous|33 (; 83 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   i32.const 0
   i32.ne
@@ -4967,7 +4971,7 @@
    i32.gt_s
   end
  )
- (func $start~anonymous|34 (; 83 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start~anonymous|34 (; 84 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $3
   i32.const 1
   call $~lib/array/Array<i32>#push
@@ -4976,12 +4980,12 @@
   get_local $1
   i32.add
  )
- (func $start~anonymous|35 (; 84 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start~anonymous|35 (; 85 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $start~anonymous|36 (; 85 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start~anonymous|36 (; 86 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $3
   call $~lib/array/Array<i32>#pop
   drop
@@ -4989,12 +4993,12 @@
   get_local $1
   i32.add
  )
- (func $start~anonymous|37 (; 86 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start~anonymous|37 (; 87 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/array/Array<i32>#reduceRight<i32> (; 87 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduceRight<i32> (; 88 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5049,12 +5053,12 @@
   end
   get_local $3
  )
- (func $start~anonymous|38 (; 88 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start~anonymous|38 (; 89 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $start~anonymous|39 (; 89 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start~anonymous|39 (; 90 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   i32.const 0
   i32.ne
@@ -5066,7 +5070,7 @@
    i32.gt_s
   end
  )
- (func $~lib/array/Array<i32>#reduceRight<bool> (; 90 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduceRight<bool> (; 91 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5121,7 +5125,7 @@
   end
   get_local $3
  )
- (func $start~anonymous|40 (; 91 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start~anonymous|40 (; 92 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   i32.const 0
   i32.ne
@@ -5133,7 +5137,7 @@
    i32.gt_s
   end
  )
- (func $start~anonymous|41 (; 92 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start~anonymous|41 (; 93 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $3
   i32.const 1
   call $~lib/array/Array<i32>#push
@@ -5142,12 +5146,12 @@
   get_local $1
   i32.add
  )
- (func $start~anonymous|42 (; 93 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start~anonymous|42 (; 94 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $start~anonymous|43 (; 94 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start~anonymous|43 (; 95 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $3
   call $~lib/array/Array<i32>#pop
   drop
@@ -5155,7 +5159,7 @@
   get_local $1
   i32.add
  )
- (func $~lib/math/murmurHash3 (; 95 ;) (type $II) (param $0 i64) (result i64)
+ (func $~lib/math/murmurHash3 (; 96 ;) (type $II) (param $0 i64) (result i64)
   get_local $0
   get_local $0
   i64.const 33
@@ -5184,7 +5188,7 @@
   set_local $0
   get_local $0
  )
- (func $~lib/math/splitMix32 (; 96 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/math/splitMix32 (; 97 ;) (type $ii) (param $0 i32) (result i32)
   get_local $0
   i32.const 1831565813
   i32.add
@@ -5219,7 +5223,7 @@
   i32.shr_u
   i32.xor
  )
- (func $~lib/math/NativeMath.seedRandom (; 97 ;) (type $Iv) (param $0 i64)
+ (func $~lib/math/NativeMath.seedRandom (; 98 ;) (type $Iv) (param $0 i64)
   get_local $0
   i64.eqz
   if
@@ -5248,7 +5252,7 @@
   call $~lib/math/splitMix32
   set_global $~lib/math/random_state1_32
  )
- (func $~lib/internal/sort/insertionSort<f32> (; 98 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<f32> (; 99 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 f32)
   (local $6 i32)
@@ -5360,7 +5364,7 @@
    unreachable
   end
  )
- (func $~lib/internal/sort/weakHeapSort<f32> (; 99 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/weakHeapSort<f32> (; 100 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -5773,7 +5777,7 @@
   get_local $12
   f32.store offset=8
  )
- (func $~lib/array/Array<f32>#sort (; 100 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f32>#sort (; 101 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5898,7 +5902,7 @@
   end
   get_local $0
  )
- (func $~lib/array/Array<f32>#sort|trampoline~anonymous|44 (; 101 ;) (type $ffi) (param $0 f32) (param $1 f32) (result i32)
+ (func $~lib/array/Array<f32>#sort|trampoline~anonymous|44 (; 102 ;) (type $ffi) (param $0 f32) (param $1 f32) (result i32)
   (local $2 i32)
   (local $3 i32)
   get_local $0
@@ -5931,7 +5935,7 @@
   i32.lt_s
   i32.sub
  )
- (func $~lib/array/Array<f32>#sort|trampoline (; 102 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f32>#sort|trampoline (; 103 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -5950,12 +5954,12 @@
   get_local $1
   call $~lib/array/Array<f32>#sort
  )
- (func $~lib/builtins/isNaN<f32> (; 103 ;) (type $fi) (param $0 f32) (result i32)
+ (func $~lib/builtins/isNaN<f32> (; 104 ;) (type $fi) (param $0 f32) (result i32)
   get_local $0
   get_local $0
   f32.ne
  )
- (func $std/array/isArraysEqual<f32> (; 104 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<f32> (; 105 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   get_local $2
   i32.eqz
@@ -6030,7 +6034,7 @@
   end
   i32.const 1
  )
- (func $~lib/internal/sort/insertionSort<f64> (; 105 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<f64> (; 106 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 f64)
   (local $6 i32)
@@ -6142,7 +6146,7 @@
    unreachable
   end
  )
- (func $~lib/internal/sort/weakHeapSort<f64> (; 106 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/weakHeapSort<f64> (; 107 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -6555,7 +6559,7 @@
   get_local $12
   f64.store offset=8
  )
- (func $~lib/array/Array<f64>#sort (; 107 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f64>#sort (; 108 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6680,7 +6684,7 @@
   end
   get_local $0
  )
- (func $~lib/array/Array<f64>#sort|trampoline~anonymous|45 (; 108 ;) (type $FFi) (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/array/Array<f64>#sort|trampoline~anonymous|45 (; 109 ;) (type $FFi) (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   get_local $0
@@ -6713,7 +6717,7 @@
   i64.lt_s
   i32.sub
  )
- (func $~lib/array/Array<f64>#sort|trampoline (; 109 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f64>#sort|trampoline (; 110 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -6732,7 +6736,7 @@
   get_local $1
   call $~lib/array/Array<f64>#sort
  )
- (func $~lib/array/Array<f64>#__get (; 110 ;) (type $iiF) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__get (; 111 ;) (type $iiF) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local $3 i32)
   get_local $0
@@ -6759,12 +6763,12 @@
    unreachable
   end
  )
- (func $~lib/builtins/isNaN<f64> (; 111 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $~lib/builtins/isNaN<f64> (; 112 ;) (type $Fi) (param $0 f64) (result i32)
   get_local $0
   get_local $0
   f64.ne
  )
- (func $std/array/isArraysEqual<f64> (; 112 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<f64> (; 113 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   get_local $2
   i32.eqz
@@ -6839,7 +6843,7 @@
   end
   i32.const 1
  )
- (func $~lib/internal/sort/insertionSort<i32> (; 113 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<i32> (; 114 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -6951,7 +6955,7 @@
    unreachable
   end
  )
- (func $~lib/internal/sort/weakHeapSort<i32> (; 114 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/weakHeapSort<i32> (; 115 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -7364,7 +7368,7 @@
   get_local $12
   i32.store offset=8
  )
- (func $~lib/array/Array<i32>#sort (; 115 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#sort (; 116 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7489,12 +7493,12 @@
   end
   get_local $0
  )
- (func $~lib/array/Array<i32>#sort|trampoline~anonymous|46 (; 116 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#sort|trampoline~anonymous|46 (; 117 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   get_local $0
   get_local $1
   i32.sub
  )
- (func $~lib/array/Array<i32>#sort|trampoline (; 117 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#sort|trampoline (; 118 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -7513,7 +7517,7 @@
   get_local $1
   call $~lib/array/Array<i32>#sort
  )
- (func $~lib/internal/sort/insertionSort<u32> (; 118 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<u32> (; 119 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -7625,7 +7629,7 @@
    unreachable
   end
  )
- (func $~lib/internal/sort/weakHeapSort<u32> (; 119 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/weakHeapSort<u32> (; 120 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -8038,7 +8042,7 @@
   get_local $12
   i32.store offset=8
  )
- (func $~lib/array/Array<u32>#sort (; 120 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#sort (; 121 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8163,7 +8167,7 @@
   end
   get_local $0
  )
- (func $~lib/array/Array<u32>#sort|trampoline~anonymous|47 (; 121 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#sort|trampoline~anonymous|47 (; 122 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   get_local $0
   get_local $1
   i32.gt_u
@@ -8172,7 +8176,7 @@
   i32.lt_u
   i32.sub
  )
- (func $~lib/array/Array<u32>#sort|trampoline (; 122 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#sort|trampoline (; 123 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -8191,7 +8195,7 @@
   get_local $1
   call $~lib/array/Array<u32>#sort
  )
- (func $std/array/createReverseOrderedArray (; 123 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array/createReverseOrderedArray (; 124 ;) (type $ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
@@ -8232,7 +8236,7 @@
   end
   get_local $1
  )
- (func $~lib/math/NativeMath.random (; 124 ;) (type $F) (result f64)
+ (func $~lib/math/NativeMath.random (; 125 ;) (type $F) (result f64)
   (local $0 i64)
   (local $1 i64)
   (local $2 i64)
@@ -8289,7 +8293,7 @@
   f64.const 1
   f64.sub
  )
- (func $std/array/createRandomOrderedArray (; 125 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array/createRandomOrderedArray (; 126 ;) (type $ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
@@ -8330,12 +8334,12 @@
   end
   get_local $1
  )
- (func $std/array/assertSortedDefault<i32>~anonymous|48 (; 126 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/assertSortedDefault<i32>~anonymous|48 (; 127 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   get_local $0
   get_local $1
   i32.sub
  )
- (func $std/array/isSorted<i32> (; 127 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<i32> (; 128 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   block $break|0
@@ -8385,7 +8389,7 @@
   end
   i32.const 1
  )
- (func $std/array/assertSorted<i32> (; 128 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<i32> (; 129 ;) (type $iiv) (param $0 i32) (param $1 i32)
   get_local $0
   get_local $1
   call $~lib/array/Array<i32>#sort
@@ -8401,7 +8405,7 @@
    unreachable
   end
  )
- (func $std/array/assertSortedDefault<i32> (; 129 ;) (type $iv) (param $0 i32)
+ (func $std/array/assertSortedDefault<i32> (; 130 ;) (type $iv) (param $0 i32)
   get_local $0
   block $~lib/internal/sort/COMPARATOR<i32>|inlined.1 (result i32)
    i32.const 48
@@ -8409,27 +8413,27 @@
   end
   call $std/array/assertSorted<i32>
  )
- (func $start~anonymous|49 (; 130 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start~anonymous|49 (; 131 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   get_local $0
   get_local $1
   i32.sub
  )
- (func $start~anonymous|50 (; 131 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start~anonymous|50 (; 132 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   get_local $1
   get_local $0
   i32.sub
  )
- (func $start~anonymous|51 (; 132 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start~anonymous|51 (; 133 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   get_local $0
   get_local $1
   i32.sub
  )
- (func $start~anonymous|52 (; 133 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start~anonymous|52 (; 134 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   get_local $1
   get_local $0
   i32.sub
  )
- (func $~lib/array/Array<Array<i32>>#constructor (; 134 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Array<i32>>#constructor (; 135 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8452,25 +8456,22 @@
   get_local $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   set_local $3
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 8
     call $~lib/memory/memory.allocate
-    set_local $4
-    get_local $4
-    i32.const 0
-    i32.store
-    get_local $4
-    i32.const 0
-    i32.store offset=4
-    get_local $4
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
   end
-  tee_local $0
   get_local $3
   i32.store
   get_local $0
@@ -8488,7 +8489,7 @@
   call $~lib/internal/memory/memset
   get_local $0
  )
- (func $~lib/array/Array<Array<i32>>#__set (; 135 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<Array<i32>>#__set (; 136 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8544,7 +8545,7 @@
   get_local $2
   i32.store offset=8
  )
- (func $~lib/array/Array<Array<i32>>#__get (; 136 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Array<i32>>#__get (; 137 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   get_local $0
@@ -8571,7 +8572,7 @@
    unreachable
   end
  )
- (func $std/array/createReverseOrderedNestedArray (; 137 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array/createReverseOrderedNestedArray (; 138 ;) (type $ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
@@ -8622,7 +8623,7 @@
   end
   get_local $1
  )
- (func $start~anonymous|53 (; 138 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start~anonymous|53 (; 139 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   get_local $0
   i32.const 0
   call $~lib/array/Array<i32>#__get
@@ -8631,7 +8632,7 @@
   call $~lib/array/Array<i32>#__get
   i32.sub
  )
- (func $~lib/internal/sort/insertionSort<Array<i32>> (; 139 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<Array<i32>> (; 140 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -8743,7 +8744,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<Array<i32>>#sort (; 140 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Array<i32>>#sort (; 141 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8857,7 +8858,7 @@
   call $~lib/internal/sort/insertionSort<Array<i32>>
   get_local $0
  )
- (func $std/array/isSorted<Array<i32>> (; 141 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<Array<i32>> (; 142 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   block $break|0
@@ -8907,7 +8908,7 @@
   end
   i32.const 1
  )
- (func $std/array/assertSorted<Array<i32>> (; 142 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<Array<i32>> (; 143 ;) (type $iiv) (param $0 i32) (param $1 i32)
   get_local $0
   get_local $1
   call $~lib/array/Array<Array<i32>>#sort
@@ -8923,7 +8924,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<Proxy<i32>>#constructor (; 143 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Proxy<i32>>#constructor (; 144 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8946,25 +8947,22 @@
   get_local $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   set_local $3
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 8
     call $~lib/memory/memory.allocate
-    set_local $4
-    get_local $4
-    i32.const 0
-    i32.store
-    get_local $4
-    i32.const 0
-    i32.store offset=4
-    get_local $4
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
   end
-  tee_local $0
   get_local $3
   i32.store
   get_local $0
@@ -8982,26 +8980,20 @@
   call $~lib/internal/memory/memset
   get_local $0
  )
- (func $std/array/Proxy<i32>#constructor (; 144 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
+ (func $std/array/Proxy<i32>#constructor (; 145 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   get_local $0
-  if (result i32)
-   get_local $0
-  else   
-   block (result i32)
-    i32.const 4
-    call $~lib/memory/memory.allocate
-    set_local $2
-    get_local $2
-    get_local $1
-    i32.store
-    get_local $2
-   end
-   tee_local $0
+  i32.eqz
+  if
+   i32.const 4
+   call $~lib/memory/memory.allocate
+   set_local $0
   end
-  tee_local $0
+  get_local $0
+  get_local $1
+  i32.store
+  get_local $0
  )
- (func $~lib/array/Array<Proxy<i32>>#__set (; 145 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<Proxy<i32>>#__set (; 146 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9057,7 +9049,7 @@
   get_local $2
   i32.store offset=8
  )
- (func $std/array/createReverseOrderedElementsArray (; 146 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array/createReverseOrderedElementsArray (; 147 ;) (type $ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
@@ -9100,14 +9092,14 @@
   end
   get_local $1
  )
- (func $start~anonymous|54 (; 147 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start~anonymous|54 (; 148 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   get_local $0
   i32.load
   get_local $1
   i32.load
   i32.sub
  )
- (func $~lib/internal/sort/insertionSort<Proxy<i32>> (; 148 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<Proxy<i32>> (; 149 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -9219,7 +9211,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<Proxy<i32>>#sort (; 149 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Proxy<i32>>#sort (; 150 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9333,7 +9325,7 @@
   call $~lib/internal/sort/insertionSort<Proxy<i32>>
   get_local $0
  )
- (func $~lib/array/Array<Proxy<i32>>#__get (; 150 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Proxy<i32>>#__get (; 151 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   get_local $0
@@ -9360,7 +9352,7 @@
    unreachable
   end
  )
- (func $std/array/isSorted<Proxy<i32>> (; 151 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<Proxy<i32>> (; 152 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   block $break|0
@@ -9410,7 +9402,7 @@
   end
   i32.const 1
  )
- (func $std/array/assertSorted<Proxy<i32>> (; 152 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<Proxy<i32>> (; 153 ;) (type $iiv) (param $0 i32) (param $1 i32)
   get_local $0
   get_local $1
   call $~lib/array/Array<Proxy<i32>>#sort
@@ -9426,7 +9418,7 @@
    unreachable
   end
  )
- (func $~lib/internal/string/compareUnsafe (; 153 ;) (type $iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/internal/string/compareUnsafe (; 154 ;) (type $iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -9479,7 +9471,7 @@
   end
   get_local $5
  )
- (func $~lib/string/String.__gt (; 154 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__gt (; 155 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9544,7 +9536,7 @@
   i32.const 0
   i32.gt_s
  )
- (func $~lib/string/String.__lt (; 155 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__lt (; 156 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9609,7 +9601,7 @@
   i32.const 0
   i32.lt_s
  )
- (func $start~anonymous|55 (; 156 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start~anonymous|55 (; 157 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   get_local $0
   get_local $1
   call $~lib/string/String.__gt
@@ -9618,7 +9610,7 @@
   call $~lib/string/String.__lt
   i32.sub
  )
- (func $~lib/internal/sort/insertionSort<String> (; 157 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<String> (; 158 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -9730,7 +9722,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<String>#sort (; 158 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<String>#sort (; 159 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9844,7 +9836,7 @@
   call $~lib/internal/sort/insertionSort<String>
   get_local $0
  )
- (func $~lib/array/Array<String>#__get (; 159 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<String>#__get (; 160 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   get_local $0
@@ -9871,7 +9863,7 @@
    unreachable
   end
  )
- (func $std/array/isSorted<String> (; 160 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<String> (; 161 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   block $break|0
@@ -9921,7 +9913,7 @@
   end
   i32.const 1
  )
- (func $std/array/assertSorted<String> (; 161 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<String> (; 162 ;) (type $iiv) (param $0 i32) (param $1 i32)
   get_local $0
   get_local $1
   call $~lib/array/Array<String>#sort
@@ -9937,7 +9929,7 @@
    unreachable
   end
  )
- (func $~lib/string/String.__eq (; 162 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 163 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   get_local $0
@@ -9981,13 +9973,13 @@
   call $~lib/internal/string/compareUnsafe
   i32.eqz
  )
- (func $~lib/string/String.__ne (; 163 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__ne (; 164 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   get_local $0
   get_local $1
   call $~lib/string/String.__eq
   i32.eqz
  )
- (func $std/array/isArraysEqual<String> (; 164 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<String> (; 165 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   get_local $2
   i32.eqz
@@ -10046,7 +10038,7 @@
   end
   i32.const 1
  )
- (func $~lib/array/Array<String>#constructor (; 165 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<String>#constructor (; 166 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10069,25 +10061,22 @@
   get_local $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   set_local $3
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 8
     call $~lib/memory/memory.allocate
-    set_local $4
-    get_local $4
-    i32.const 0
-    i32.store
-    get_local $4
-    i32.const 0
-    i32.store offset=4
-    get_local $4
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
   end
-  tee_local $0
   get_local $3
   i32.store
   get_local $0
@@ -10105,7 +10094,7 @@
   call $~lib/internal/memory/memset
   get_local $0
  )
- (func $~lib/internal/string/allocateUnsafe (; 166 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/string/allocateUnsafe (; 167 ;) (type $ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   get_local $0
@@ -10145,7 +10134,7 @@
   i32.store
   get_local $2
  )
- (func $~lib/string/String#charAt (; 167 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#charAt (; 168 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   get_local $0
   i32.const 0
@@ -10180,7 +10169,7 @@
   i32.store16 offset=4
   get_local $2
  )
- (func $~lib/internal/string/copyUnsafe (; 168 ;) (type $iiiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
+ (func $~lib/internal/string/copyUnsafe (; 169 ;) (type $iiiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -10209,7 +10198,7 @@
   get_local $7
   call $~lib/internal/memory/memmove
  )
- (func $~lib/string/String#concat (; 169 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#concat (; 170 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10267,7 +10256,7 @@
   call $~lib/internal/string/copyUnsafe
   get_local $5
  )
- (func $~lib/string/String.__concat (; 170 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (; 171 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   get_local $0
   i32.eqz
   if
@@ -10278,7 +10267,7 @@
   get_local $1
   call $~lib/string/String#concat
  )
- (func $std/array/createRandomString (; 171 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array/createRandomString (; 172 ;) (type $ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -10320,7 +10309,7 @@
   end
   get_local $1
  )
- (func $~lib/array/Array<String>#__set (; 172 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<String>#__set (; 173 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -10376,7 +10365,7 @@
   get_local $2
   i32.store offset=8
  )
- (func $std/array/createRandomStringArray (; 173 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array/createRandomStringArray (; 174 ;) (type $ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
@@ -10414,7 +10403,7 @@
   end
   get_local $1
  )
- (func $start~anonymous|56 (; 174 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start~anonymous|56 (; 175 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   get_local $0
   get_local $1
   call $~lib/string/String.__gt
@@ -10423,7 +10412,7 @@
   call $~lib/string/String.__lt
   i32.sub
  )
- (func $~lib/string/String#substring (; 175 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substring (; 176 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -10533,7 +10522,7 @@
   call $~lib/internal/string/copyUnsafe
   get_local $10
  )
- (func $~lib/array/Array<bool>#join (; 176 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<bool>#join (; 177 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10746,7 +10735,7 @@
   get_local $12
   return
  )
- (func $~lib/internal/number/decimalCount32 (; 177 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/decimalCount32 (; 178 ;) (type $ii) (param $0 i32) (result i32)
   (local $1 i32)
   get_local $0
   i32.const 100000
@@ -10815,7 +10804,7 @@
   unreachable
   unreachable
  )
- (func $~lib/internal/number/utoa32_lut (; 178 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/number/utoa32_lut (; 179 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -10985,7 +10974,7 @@
    i32.store16 offset=4
   end
  )
- (func $~lib/internal/number/itoa32 (; 179 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/itoa32 (; 180 ;) (type $ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -11026,12 +11015,12 @@
   end
   get_local $3
  )
- (func $~lib/internal/number/itoa<i32> (; 180 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/itoa<i32> (; 181 ;) (type $ii) (param $0 i32) (result i32)
   get_local $0
   call $~lib/internal/number/itoa32
   return
  )
- (func $~lib/internal/number/itoa_stream<i32> (; 181 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/internal/number/itoa_stream<i32> (; 182 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   get_local $0
@@ -11079,7 +11068,7 @@
   end
   get_local $3
  )
- (func $~lib/array/Array<i32>#join (; 182 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#join (; 183 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11255,7 +11244,7 @@
   get_local $11
   return
  )
- (func $~lib/internal/number/utoa32 (; 183 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/utoa32 (; 184 ;) (type $ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   get_local $0
@@ -11276,12 +11265,12 @@
   call $~lib/internal/number/utoa32_lut
   get_local $2
  )
- (func $~lib/internal/number/itoa<u32> (; 184 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/itoa<u32> (; 185 ;) (type $ii) (param $0 i32) (result i32)
   get_local $0
   call $~lib/internal/number/utoa32
   return
  )
- (func $~lib/internal/number/itoa_stream<u32> (; 185 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/internal/number/itoa_stream<u32> (; 186 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   get_local $0
   get_local $1
@@ -11309,7 +11298,7 @@
   call $~lib/internal/number/utoa32_lut
   get_local $3
  )
- (func $~lib/array/Array<u32>#join (; 186 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#join (; 187 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11485,14 +11474,14 @@
   get_local $11
   return
  )
- (func $~lib/builtins/isFinite<f64> (; 187 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $~lib/builtins/isFinite<f64> (; 188 ;) (type $Fi) (param $0 f64) (result i32)
   get_local $0
   get_local $0
   f64.sub
   f64.const 0
   f64.eq
  )
- (func $~lib/internal/number/genDigits (; 188 ;) (type $iIiIiIii) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/internal/number/genDigits (; 189 ;) (type $iIiIiIii) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -12048,7 +12037,7 @@
   end
   get_local $15
  )
- (func $~lib/internal/number/prettify (; 189 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/internal/number/prettify (; 190 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12392,7 +12381,7 @@
   unreachable
   unreachable
  )
- (func $~lib/internal/number/dtoa_core (; 190 ;) (type $iFi) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/internal/number/dtoa_core (; 191 ;) (type $iFi) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 i64)
   (local $4 i32)
@@ -12831,7 +12820,7 @@
   get_local $2
   i32.add
  )
- (func $~lib/internal/number/dtoa (; 191 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $~lib/internal/number/dtoa (; 192 ;) (type $Fi) (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -12893,7 +12882,7 @@
   end
   get_local $3
  )
- (func $~lib/internal/number/dtoa_stream (; 192 ;) (type $iiFi) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
+ (func $~lib/internal/number/dtoa_stream (; 193 ;) (type $iiFi) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12980,7 +12969,7 @@
   get_local $2
   call $~lib/internal/number/dtoa_core
  )
- (func $~lib/array/Array<f64>#join (; 193 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f64>#join (; 194 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 f64)
@@ -13156,7 +13145,7 @@
   get_local $11
   return
  )
- (func $~lib/array/Array<String>#join (; 194 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<String>#join (; 195 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13352,23 +13341,17 @@
   get_local $8
   return
  )
- (func $std/array/Ref#constructor (; 195 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
+ (func $std/array/Ref#constructor (; 196 ;) (type $ii) (param $0 i32) (result i32)
   get_local $0
-  if (result i32)
-   get_local $0
-  else   
-   block (result i32)
-    i32.const 0
-    call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-   end
-   tee_local $0
+  i32.eqz
+  if
+   i32.const 0
+   call $~lib/memory/memory.allocate
+   set_local $0
   end
-  tee_local $0
+  get_local $0
  )
- (func $~lib/array/Array<Ref>#constructor (; 196 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Ref>#constructor (; 197 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13391,25 +13374,22 @@
   get_local $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   set_local $3
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 8
     call $~lib/memory/memory.allocate
-    set_local $4
-    get_local $4
-    i32.const 0
-    i32.store
-    get_local $4
-    i32.const 0
-    i32.store offset=4
-    get_local $4
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
   end
-  tee_local $0
   get_local $3
   i32.store
   get_local $0
@@ -13427,7 +13407,7 @@
   call $~lib/internal/memory/memset
   get_local $0
  )
- (func $~lib/array/Array<Ref>#__unchecked_set (; 197 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<Ref>#__unchecked_set (; 198 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   get_local $0
@@ -13445,7 +13425,7 @@
   get_local $2
   i32.store offset=8
  )
- (func $~lib/array/Array<Ref>#join (; 198 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Ref>#join (; 199 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13617,7 +13597,7 @@
   get_local $11
   return
  )
- (func $~lib/internal/number/itoa<i8> (; 199 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/itoa<i8> (; 200 ;) (type $ii) (param $0 i32) (result i32)
   get_local $0
   i32.const 24
   i32.shl
@@ -13626,7 +13606,7 @@
   call $~lib/internal/number/itoa32
   return
  )
- (func $~lib/internal/number/itoa_stream<i8> (; 200 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/internal/number/itoa_stream<i8> (; 201 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -13693,7 +13673,7 @@
   end
   get_local $3
  )
- (func $~lib/array/Array<i8>#join (; 201 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#join (; 202 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13869,14 +13849,14 @@
   get_local $11
   return
  )
- (func $~lib/internal/number/itoa<u16> (; 202 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/itoa<u16> (; 203 ;) (type $ii) (param $0 i32) (result i32)
   get_local $0
   i32.const 65535
   i32.and
   call $~lib/internal/number/utoa32
   return
  )
- (func $~lib/internal/number/itoa_stream<u16> (; 203 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/internal/number/itoa_stream<u16> (; 204 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   get_local $0
@@ -13913,7 +13893,7 @@
   call $~lib/internal/number/utoa32_lut
   get_local $3
  )
- (func $~lib/array/Array<u16>#join (; 204 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#join (; 205 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14089,7 +14069,7 @@
   get_local $11
   return
  )
- (func $~lib/internal/number/decimalCount64 (; 205 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/number/decimalCount64 (; 206 ;) (type $Ii) (param $0 i64) (result i32)
   (local $1 i32)
   get_local $0
   i64.const 1000000000000000
@@ -14158,7 +14138,7 @@
   unreachable
   unreachable
  )
- (func $~lib/internal/number/utoa64_lut (; 206 ;) (type $iIiv) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/internal/number/utoa64_lut (; 207 ;) (type $iIiv) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -14313,7 +14293,7 @@
   get_local $2
   call $~lib/internal/number/utoa32_lut
  )
- (func $~lib/internal/number/utoa64 (; 207 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/number/utoa64 (; 208 ;) (type $Ii) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -14355,12 +14335,12 @@
   end
   get_local $1
  )
- (func $~lib/internal/number/itoa<u64> (; 208 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/number/itoa<u64> (; 209 ;) (type $Ii) (param $0 i64) (result i32)
   get_local $0
   call $~lib/internal/number/utoa64
   return
  )
- (func $~lib/internal/number/itoa_stream<u64> (; 209 ;) (type $iiIi) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/internal/number/itoa_stream<u64> (; 210 ;) (type $iiIi) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   get_local $0
@@ -14406,7 +14386,7 @@
   end
   get_local $3
  )
- (func $~lib/array/Array<u64>#join (; 210 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u64>#join (; 211 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i64)
@@ -14582,7 +14562,7 @@
   get_local $11
   return
  )
- (func $~lib/internal/number/itoa64 (; 211 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/number/itoa64 (; 212 ;) (type $Ii) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -14646,12 +14626,12 @@
   end
   get_local $2
  )
- (func $~lib/internal/number/itoa<i64> (; 212 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/number/itoa<i64> (; 213 ;) (type $Ii) (param $0 i64) (result i32)
   get_local $0
   call $~lib/internal/number/itoa64
   return
  )
- (func $~lib/internal/number/itoa_stream<i64> (; 213 ;) (type $iiIi) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/internal/number/itoa_stream<i64> (; 214 ;) (type $iiIi) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -14719,7 +14699,7 @@
   end
   get_local $3
  )
- (func $~lib/array/Array<i64>#join (; 214 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i64>#join (; 215 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i64)
@@ -14895,7 +14875,7 @@
   get_local $11
   return
  )
- (func $~lib/array/Array<Array<i32>>#join (; 215 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Array<i32>>#join (; 216 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15030,14 +15010,14 @@
   get_local $3
   return
  )
- (func $~lib/internal/number/itoa<u8> (; 216 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/itoa<u8> (; 217 ;) (type $ii) (param $0 i32) (result i32)
   get_local $0
   i32.const 255
   i32.and
   call $~lib/internal/number/utoa32
   return
  )
- (func $~lib/internal/number/itoa_stream<u8> (; 217 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/internal/number/itoa_stream<u8> (; 218 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   get_local $0
@@ -15074,7 +15054,7 @@
   call $~lib/internal/number/utoa32_lut
   get_local $3
  )
- (func $~lib/array/Array<u8>#join (; 218 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#join (; 219 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15250,7 +15230,7 @@
   get_local $11
   return
  )
- (func $~lib/array/Array<Array<u8>>#join (; 219 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Array<u8>>#join (; 220 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15385,7 +15365,7 @@
   get_local $3
   return
  )
- (func $~lib/array/Array<Array<u32>>#join (; 220 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Array<u32>>#join (; 221 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15520,7 +15500,7 @@
   get_local $3
   return
  )
- (func $~lib/array/Array<Array<Array<u32>>>#join (; 221 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Array<Array<u32>>>#join (; 222 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15655,7 +15635,7 @@
   get_local $3
   return
  )
- (func $start (; 222 ;) (type $v)
+ (func $start (; 223 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -15700,12 +15680,8 @@
    call $~lib/env/abort
    unreachable
   end
-  block (result i32)
-   i32.const 0
-   call $~lib/memory/memory.allocate
-   set_local $0
-   get_local $0
-  end
+  i32.const 0
+  call $std/array/P#constructor
   call $~lib/array/Array.isArray<P>
   i32.const 0
   i32.eq
@@ -20124,6 +20100,6 @@
    unreachable
   end
  )
- (func $null (; 223 ;) (type $v)
+ (func $null (; 224 ;) (type $v)
  )
 )

--- a/tests/compiler/std/constructor.optimized.wat
+++ b/tests/compiler/std/constructor.optimized.wat
@@ -1,6 +1,7 @@
 (module
  (type $ii (func (param i32) (result i32)))
  (type $v (func))
+ (type $FUNCSIG$i (func (result i32)))
  (memory $0 0)
  (table $0 1 anyfunc)
  (elem (i32.const 0) $null)
@@ -82,7 +83,25 @@
   set_global $~lib/allocator/arena/offset
   get_local $1
  )
- (func $start (; 1 ;) (type $v)
+ (func $std/constructor/EmptyCtorWithFieldInit#constructor (; 1 ;) (type $FUNCSIG$i) (result i32)
+  (local $0 i32)
+  i32.const 4
+  call $~lib/allocator/arena/__memory_allocate
+  tee_local $0
+  i32.const 1
+  i32.store
+  get_local $0
+ )
+ (func $std/constructor/EmptyCtorWithFieldNoInit#constructor (; 2 ;) (type $FUNCSIG$i) (result i32)
+  (local $0 i32)
+  i32.const 4
+  call $~lib/allocator/arena/__memory_allocate
+  tee_local $0
+  i32.const 0
+  i32.store
+  get_local $0
+ )
+ (func $start (; 3 ;) (type $v)
   (local $0 i32)
   i32.const 8
   set_global $~lib/allocator/arena/startOffset
@@ -91,36 +110,16 @@
   i32.const 0
   call $~lib/allocator/arena/__memory_allocate
   set_global $std/constructor/emptyCtor
-  i32.const 4
-  call $~lib/allocator/arena/__memory_allocate
-  tee_local $0
-  i32.const 1
-  i32.store
-  get_local $0
+  call $std/constructor/EmptyCtorWithFieldInit#constructor
   set_global $std/constructor/emptyCtorWithFieldInit
-  i32.const 4
-  call $~lib/allocator/arena/__memory_allocate
-  tee_local $0
-  i32.const 0
-  i32.store
-  get_local $0
+  call $std/constructor/EmptyCtorWithFieldNoInit#constructor
   set_global $std/constructor/emptyCtorWithFieldNoInit
   i32.const 0
   call $~lib/allocator/arena/__memory_allocate
   set_global $std/constructor/none
-  i32.const 4
-  call $~lib/allocator/arena/__memory_allocate
-  tee_local $0
-  i32.const 1
-  i32.store
-  get_local $0
+  call $std/constructor/EmptyCtorWithFieldInit#constructor
   set_global $std/constructor/justFieldInit
-  i32.const 4
-  call $~lib/allocator/arena/__memory_allocate
-  tee_local $0
-  i32.const 0
-  i32.store
-  get_local $0
+  call $std/constructor/EmptyCtorWithFieldNoInit#constructor
   set_global $std/constructor/justFieldNoInit
   i32.const 0
   call $~lib/allocator/arena/__memory_allocate
@@ -139,8 +138,6 @@
   i32.const 0
   call $~lib/allocator/arena/__memory_allocate
   set_global $std/constructor/ctorAllocates
-  i32.const 0
-  set_local $0
   block (result i32)
    get_global $std/constructor/b
    if
@@ -151,15 +148,15 @@
    get_local $0
    i32.eqz
   end
-  if (result i32)
+  if
    i32.const 0
    call $~lib/allocator/arena/__memory_allocate
-  else   
-   get_local $0
+   set_local $0
   end
+  get_local $0
   set_global $std/constructor/ctorConditionallyAllocates
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 4 ;) (type $v)
   nop
  )
 )

--- a/tests/compiler/std/constructor.untouched.wat
+++ b/tests/compiler/std/constructor.untouched.wat
@@ -110,60 +110,78 @@
   return
  )
  (func $std/constructor/EmptyCtor#constructor (; 2 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
   get_local $0
-  if (result i32)
-   get_local $0
-  else   
-   block (result i32)
-    i32.const 0
-    call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-   end
-   tee_local $0
+  i32.eqz
+  if
+   i32.const 0
+   call $~lib/memory/memory.allocate
+   set_local $0
   end
-  tee_local $0
+  get_local $0
  )
  (func $std/constructor/EmptyCtorWithFieldInit#constructor (; 3 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
   get_local $0
-  if (result i32)
-   get_local $0
-  else   
-   block (result i32)
-    i32.const 4
-    call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 1
-    i32.store
-    get_local $1
-   end
-   tee_local $0
+  i32.eqz
+  if
+   i32.const 4
+   call $~lib/memory/memory.allocate
+   set_local $0
   end
-  tee_local $0
+  get_local $0
+  i32.const 1
+  i32.store
+  get_local $0
  )
  (func $std/constructor/EmptyCtorWithFieldNoInit#constructor (; 4 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
   get_local $0
-  if (result i32)
-   get_local $0
-  else   
-   block (result i32)
-    i32.const 4
-    call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 0
-    i32.store
-    get_local $1
-   end
-   tee_local $0
+  i32.eqz
+  if
+   i32.const 4
+   call $~lib/memory/memory.allocate
+   set_local $0
   end
-  tee_local $0
+  get_local $0
+  i32.const 0
+  i32.store
+  get_local $0
  )
- (func $std/constructor/CtorReturns#constructor (; 5 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/constructor/None#constructor (; 5 ;) (type $ii) (param $0 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 0
+   call $~lib/memory/memory.allocate
+   set_local $0
+  end
+  get_local $0
+ )
+ (func $std/constructor/JustFieldInit#constructor (; 6 ;) (type $ii) (param $0 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 4
+   call $~lib/memory/memory.allocate
+   set_local $0
+  end
+  get_local $0
+  i32.const 1
+  i32.store
+  get_local $0
+ )
+ (func $std/constructor/JustFieldNoInit#constructor (; 7 ;) (type $ii) (param $0 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 4
+   call $~lib/memory/memory.allocate
+   set_local $0
+  end
+  get_local $0
+  i32.const 0
+  i32.store
+  get_local $0
+ )
+ (func $std/constructor/CtorReturns#constructor (; 8 ;) (type $ii) (param $0 i32) (result i32)
   (local $1 i32)
   block $~lib/memory/memory.allocate|inlined.0 (result i32)
    i32.const 0
@@ -173,7 +191,7 @@
    br $~lib/memory/memory.allocate|inlined.0
   end
  )
- (func $std/constructor/CtorConditionallyReturns#constructor (; 6 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/constructor/CtorConditionallyReturns#constructor (; 9 ;) (type $ii) (param $0 i32) (result i32)
   (local $1 i32)
   get_global $std/constructor/b
   if
@@ -187,72 +205,53 @@
    return
   end
   get_local $0
-  if (result i32)
-   get_local $0
-  else   
-   block (result i32)
-    i32.const 0
-    call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-   end
-   tee_local $0
+  i32.eqz
+  if
+   i32.const 0
+   call $~lib/memory/memory.allocate
+   set_local $0
   end
-  tee_local $0
- )
- (func $std/constructor/CtorAllocates#constructor (; 7 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
   get_local $0
-  if (result i32)
+ )
+ (func $std/constructor/CtorAllocates#constructor (; 10 ;) (type $ii) (param $0 i32) (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 0
     call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
+    set_local $0
    end
-   tee_local $0
+   get_local $0
   end
-  tee_local $0
   drop
   get_local $0
  )
- (func $std/constructor/CtorConditionallyAllocates#constructor (; 8 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
+ (func $std/constructor/CtorConditionallyAllocates#constructor (; 11 ;) (type $ii) (param $0 i32) (result i32)
   get_global $std/constructor/b
   if
-   get_local $0
-   if (result i32)
+   block (result i32)
     get_local $0
-   else    
-    block (result i32)
+    i32.eqz
+    if
      i32.const 0
      call $~lib/memory/memory.allocate
-     set_local $1
-     get_local $1
+     set_local $0
     end
-    tee_local $0
+    get_local $0
    end
-   tee_local $0
    drop
   end
   get_local $0
-  if (result i32)
-   get_local $0
-  else   
-   block (result i32)
-    i32.const 0
-    call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-   end
-   tee_local $0
+  i32.eqz
+  if
+   i32.const 0
+   call $~lib/memory/memory.allocate
+   set_local $0
   end
-  tee_local $0
+  get_local $0
  )
- (func $start (; 9 ;) (type $v)
-  (local $0 i32)
+ (func $start (; 12 ;) (type $v)
   get_global $HEAP_BASE
   get_global $~lib/internal/allocator/AL_MASK
   i32.add
@@ -272,32 +271,14 @@
   i32.const 0
   call $std/constructor/EmptyCtorWithFieldNoInit#constructor
   set_global $std/constructor/emptyCtorWithFieldNoInit
-  block (result i32)
-   i32.const 0
-   call $~lib/memory/memory.allocate
-   set_local $0
-   get_local $0
-  end
+  i32.const 0
+  call $std/constructor/None#constructor
   set_global $std/constructor/none
-  block (result i32)
-   i32.const 4
-   call $~lib/memory/memory.allocate
-   set_local $0
-   get_local $0
-   i32.const 1
-   i32.store
-   get_local $0
-  end
+  i32.const 0
+  call $std/constructor/JustFieldInit#constructor
   set_global $std/constructor/justFieldInit
-  block (result i32)
-   i32.const 4
-   call $~lib/memory/memory.allocate
-   set_local $0
-   get_local $0
-   i32.const 0
-   i32.store
-   get_local $0
-  end
+  i32.const 0
+  call $std/constructor/JustFieldNoInit#constructor
   set_global $std/constructor/justFieldNoInit
   i32.const 0
   call $std/constructor/CtorReturns#constructor
@@ -312,6 +293,6 @@
   call $std/constructor/CtorConditionallyAllocates#constructor
   set_global $std/constructor/ctorConditionallyAllocates
  )
- (func $null (; 10 ;) (type $v)
+ (func $null (; 13 ;) (type $v)
  )
 )

--- a/tests/compiler/std/dataview.optimized.wat
+++ b/tests/compiler/std/dataview.optimized.wat
@@ -8,7 +8,6 @@
  (type $iiii (func (param i32 i32 i32) (result i32)))
  (type $v (func))
  (type $FUNCSIG$vii (func (param i32 i32)))
- (type $FUNCSIG$i (func (result i32)))
  (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
  (type $FUNCSIG$dii (func (param i32 i32) (result f64)))
  (type $FUNCSIG$jii (func (param i32 i32) (result i64)))
@@ -339,19 +338,34 @@
    end
   end
  )
- (func $~lib/internal/typedarray/TypedArray<u8>#constructor (; 4 ;) (type $FUNCSIG$i) (result i32)
-  (local $0 i32)
-  (local $1 i32)
-  i32.const 8
+ (func $~lib/internal/typedarray/TypedArray<u8>#constructor (; 4 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  get_local $1
+  i32.const 1073741816
+  i32.gt_u
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 23
+   i32.const 34
+   call $~lib/env/abort
+   unreachable
+  end
+  get_local $1
   call $~lib/internal/arraybuffer/allocateUnsafe
-  tee_local $1
+  tee_local $2
   i32.const 8
   i32.add
-  i32.const 8
+  get_local $1
   call $~lib/internal/memory/memset
-  i32.const 12
-  call $~lib/allocator/arena/__memory_allocate
-  tee_local $0
+  get_local $0
+  i32.eqz
+  if
+   i32.const 12
+   call $~lib/allocator/arena/__memory_allocate
+   set_local $0
+  end
+  get_local $0
   i32.const 0
   i32.store
   get_local $0
@@ -361,13 +375,13 @@
   i32.const 0
   i32.store offset=8
   get_local $0
-  get_local $1
+  get_local $2
   i32.store
   get_local $0
   i32.const 0
   i32.store offset=4
   get_local $0
-  i32.const 8
+  get_local $1
   i32.store offset=8
   get_local $0
  )
@@ -1082,6 +1096,9 @@
   set_global $~lib/allocator/arena/startOffset
   get_global $~lib/allocator/arena/startOffset
   set_global $~lib/allocator/arena/offset
+  i32.const 12
+  call $~lib/allocator/arena/__memory_allocate
+  i32.const 8
   call $~lib/internal/typedarray/TypedArray<u8>#constructor
   set_global $std/dataview/array
   get_global $std/dataview/array

--- a/tests/compiler/std/dataview.untouched.wat
+++ b/tests/compiler/std/dataview.untouched.wat
@@ -448,28 +448,25 @@
   get_local $5
   get_local $2
   call $~lib/internal/memory/memset
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 12
     call $~lib/memory/memory.allocate
-    set_local $5
-    get_local $5
-    i32.const 0
-    i32.store
-    get_local $5
-    i32.const 0
-    i32.store offset=4
-    get_local $5
-    i32.const 0
-    i32.store offset=8
-    get_local $5
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
   end
-  tee_local $0
   get_local $3
   i32.store
   get_local $0
@@ -480,7 +477,21 @@
   i32.store offset=8
   get_local $0
  )
- (func $~lib/internal/typedarray/TypedArray<u8>#__set (; 7 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#constructor (; 7 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 12
+   call $~lib/memory/memory.allocate
+   set_local $0
+  end
+  get_local $0
+  get_local $1
+  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  set_local $0
+  get_local $0
+ )
+ (func $~lib/internal/typedarray/TypedArray<u8>#__set (; 8 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   get_local $1
@@ -513,8 +524,7 @@
   get_local $2
   i32.store8 offset=8
  )
- (func $~lib/dataview/DataView#constructor (; 8 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
-  (local $4 i32)
+ (func $~lib/dataview/DataView#constructor (; 9 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $3
   get_global $~lib/builtins/i32.MIN_VALUE
   i32.eq
@@ -562,29 +572,24 @@
    unreachable
   end
   get_local $0
-  if (result i32)
-   get_local $0
-  else   
-   block (result i32)
-    i32.const 12
-    call $~lib/memory/memory.allocate
-    set_local $4
-    get_local $4
-    get_local $1
-    i32.store
-    get_local $4
-    get_local $2
-    i32.store offset=4
-    get_local $4
-    get_local $3
-    i32.store offset=8
-    get_local $4
-   end
-   tee_local $0
+  i32.eqz
+  if
+   i32.const 12
+   call $~lib/memory/memory.allocate
+   set_local $0
   end
-  tee_local $0
+  get_local $0
+  get_local $1
+  i32.store
+  get_local $0
+  get_local $2
+  i32.store offset=4
+  get_local $0
+  get_local $3
+  i32.store offset=8
+  get_local $0
  )
- (func $~lib/polyfills/bswap<u32> (; 9 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<u32> (; 10 ;) (type $ii) (param $0 i32) (result i32)
   get_local $0
   i32.const -16711936
   i32.and
@@ -598,7 +603,7 @@
   i32.or
   return
  )
- (func $~lib/dataview/DataView#getFloat32 (; 10 ;) (type $iiif) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
+ (func $~lib/dataview/DataView#getFloat32 (; 11 ;) (type $iiif) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -653,7 +658,7 @@
    f32.reinterpret/i32
   end
  )
- (func $~lib/polyfills/bswap<u64> (; 11 ;) (type $II) (param $0 i64) (result i64)
+ (func $~lib/polyfills/bswap<u64> (; 12 ;) (type $II) (param $0 i64) (result i64)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -692,7 +697,7 @@
   i64.rotr
   return
  )
- (func $~lib/dataview/DataView#getFloat64 (; 12 ;) (type $iiiF) (param $0 i32) (param $1 i32) (param $2 i32) (result f64)
+ (func $~lib/dataview/DataView#getFloat64 (; 13 ;) (type $iiiF) (param $0 i32) (param $1 i32) (param $2 i32) (result f64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -747,7 +752,7 @@
    f64.reinterpret/i64
   end
  )
- (func $~lib/dataview/DataView#getInt8 (; 13 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/dataview/DataView#getInt8 (; 14 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -786,7 +791,7 @@
   i32.add
   i32.load8_s offset=8
  )
- (func $~lib/polyfills/bswap<i16> (; 14 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<i16> (; 15 ;) (type $ii) (param $0 i32) (result i32)
   get_local $0
   i32.const 8
   i32.shl
@@ -802,7 +807,7 @@
   i32.or
   return
  )
- (func $~lib/dataview/DataView#getInt16 (; 15 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getInt16 (; 16 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -852,7 +857,7 @@
    call $~lib/polyfills/bswap<i16>
   end
  )
- (func $~lib/polyfills/bswap<i32> (; 16 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<i32> (; 17 ;) (type $ii) (param $0 i32) (result i32)
   get_local $0
   i32.const -16711936
   i32.and
@@ -866,7 +871,7 @@
   i32.or
   return
  )
- (func $~lib/dataview/DataView#getInt32 (; 17 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getInt32 (; 18 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -916,7 +921,7 @@
    call $~lib/polyfills/bswap<i32>
   end
  )
- (func $~lib/polyfills/bswap<i64> (; 18 ;) (type $II) (param $0 i64) (result i64)
+ (func $~lib/polyfills/bswap<i64> (; 19 ;) (type $II) (param $0 i64) (result i64)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -955,7 +960,7 @@
   i64.rotr
   return
  )
- (func $~lib/dataview/DataView#getInt64 (; 19 ;) (type $iiiI) (param $0 i32) (param $1 i32) (param $2 i32) (result i64)
+ (func $~lib/dataview/DataView#getInt64 (; 20 ;) (type $iiiI) (param $0 i32) (param $1 i32) (param $2 i32) (result i64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1005,7 +1010,7 @@
    call $~lib/polyfills/bswap<i64>
   end
  )
- (func $~lib/dataview/DataView#getUint8 (; 20 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/dataview/DataView#getUint8 (; 21 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1044,7 +1049,7 @@
   i32.add
   i32.load8_u offset=8
  )
- (func $~lib/polyfills/bswap<u16> (; 21 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<u16> (; 22 ;) (type $ii) (param $0 i32) (result i32)
   get_local $0
   i32.const 8
   i32.shl
@@ -1058,7 +1063,7 @@
   i32.or
   return
  )
- (func $~lib/dataview/DataView#getUint16 (; 22 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getUint16 (; 23 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1108,7 +1113,7 @@
    call $~lib/polyfills/bswap<u16>
   end
  )
- (func $~lib/dataview/DataView#getUint32 (; 23 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getUint32 (; 24 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1158,7 +1163,7 @@
    call $~lib/polyfills/bswap<u32>
   end
  )
- (func $~lib/dataview/DataView#getUint64 (; 24 ;) (type $iiiI) (param $0 i32) (param $1 i32) (param $2 i32) (result i64)
+ (func $~lib/dataview/DataView#getUint64 (; 25 ;) (type $iiiI) (param $0 i32) (param $1 i32) (param $2 i32) (result i64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1208,7 +1213,7 @@
    call $~lib/polyfills/bswap<u64>
   end
  )
- (func $~lib/dataview/DataView#setFloat32 (; 25 ;) (type $iifiv) (param $0 i32) (param $1 i32) (param $2 f32) (param $3 i32)
+ (func $~lib/dataview/DataView#setFloat32 (; 26 ;) (type $iifiv) (param $0 i32) (param $1 i32) (param $2 f32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1265,7 +1270,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/dataview/DataView#setFloat64 (; 26 ;) (type $iiFiv) (param $0 i32) (param $1 i32) (param $2 f64) (param $3 i32)
+ (func $~lib/dataview/DataView#setFloat64 (; 27 ;) (type $iiFiv) (param $0 i32) (param $1 i32) (param $2 f64) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1322,7 +1327,7 @@
    i64.store offset=8
   end
  )
- (func $~lib/dataview/DataView#setInt8 (; 27 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/dataview/DataView#setInt8 (; 28 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1362,7 +1367,7 @@
   get_local $2
   i32.store8 offset=8
  )
- (func $~lib/dataview/DataView#setInt16 (; 28 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/dataview/DataView#setInt16 (; 29 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1410,7 +1415,7 @@
   end
   i32.store16 offset=8
  )
- (func $~lib/dataview/DataView#setInt32 (; 29 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/dataview/DataView#setInt32 (; 30 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1458,7 +1463,7 @@
   end
   i32.store offset=8
  )
- (func $~lib/dataview/DataView#setInt64 (; 30 ;) (type $iiIiv) (param $0 i32) (param $1 i32) (param $2 i64) (param $3 i32)
+ (func $~lib/dataview/DataView#setInt64 (; 31 ;) (type $iiIiv) (param $0 i32) (param $1 i32) (param $2 i64) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1506,7 +1511,7 @@
   end
   i64.store offset=8
  )
- (func $~lib/dataview/DataView#setUint8 (; 31 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/dataview/DataView#setUint8 (; 32 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1546,7 +1551,7 @@
   get_local $2
   i32.store8 offset=8
  )
- (func $~lib/dataview/DataView#setUint16 (; 32 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/dataview/DataView#setUint16 (; 33 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1594,7 +1599,7 @@
   end
   i32.store16 offset=8
  )
- (func $~lib/dataview/DataView#setUint32 (; 33 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/dataview/DataView#setUint32 (; 34 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1642,7 +1647,7 @@
   end
   i32.store offset=8
  )
- (func $~lib/dataview/DataView#setUint64 (; 34 ;) (type $iiIiv) (param $0 i32) (param $1 i32) (param $2 i64) (param $3 i32)
+ (func $~lib/dataview/DataView#setUint64 (; 35 ;) (type $iiIiv) (param $0 i32) (param $1 i32) (param $2 i64) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1690,7 +1695,7 @@
   end
   i64.store offset=8
  )
- (func $start (; 35 ;) (type $v)
+ (func $start (; 36 ;) (type $v)
   get_global $HEAP_BASE
   get_global $~lib/internal/allocator/AL_MASK
   i32.add
@@ -1703,7 +1708,7 @@
   set_global $~lib/allocator/arena/offset
   i32.const 0
   i32.const 8
-  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  call $~lib/typedarray/Uint8Array#constructor
   set_global $std/dataview/array
   get_global $std/dataview/array
   i32.const 0
@@ -3383,6 +3388,6 @@
    unreachable
   end
  )
- (func $null (; 36 ;) (type $v)
+ (func $null (; 37 ;) (type $v)
  )
 )

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -111,23 +111,19 @@
   return
  )
  (func $~lib/date/Date#constructor (; 5 ;) (type $iIi) (param $0 i32) (param $1 i64) (result i32)
-  (local $2 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 8
     call $~lib/memory/memory.allocate
-    set_local $2
-    get_local $2
-    i64.const 0
-    i64.store
-    get_local $2
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i64.const 0
+   i64.store
+   get_local $0
   end
-  tee_local $0
   get_local $1
   i64.store
   get_local $0

--- a/tests/compiler/std/gc-object.optimized.wat
+++ b/tests/compiler/std/gc-object.optimized.wat
@@ -1,4 +1,5 @@
 (module
+ (type $iii (func (param i32 i32) (result i32)))
  (type $v (func))
  (type $ii (func (param i32) (result i32)))
  (type $iv (func (param i32)))
@@ -6,7 +7,7 @@
  (type $FUNCSIG$i (func (result i32)))
  (memory $0 0)
  (table $0 4 anyfunc)
- (elem (i32.const 0) $null $~lib/collector/itcm/__gc_mark $std/gc-object/Custom~gc $std/gc-object/Base~gc)
+ (elem (i32.const 0) $null $~lib/collector/itcm/__gc_mark $std/gc-object/Base~gc $std/gc-object/Custom~gc)
  (global $~lib/allocator/arena/startOffset (mut i32) (i32.const 0))
  (global $~lib/allocator/arena/offset (mut i32) (i32.const 0))
  (global $~lib/collector/itcm/state (mut i32) (i32.const 0))
@@ -302,26 +303,34 @@
    end
   end
  )
- (func $~lib/collector/itcm/__gc_allocate (; 5 ;) (type $FUNCSIG$i) (result i32)
-  (local $0 i32)
+ (func $~lib/collector/itcm/__gc_allocate (; 5 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  get_local $0
+  i32.const 1073741808
+  i32.gt_u
+  if
+   unreachable
+  end
   call $~lib/collector/itcm/step
-  i32.const 24
+  get_local $0
+  i32.const 16
+  i32.add
   call $~lib/allocator/arena/__memory_allocate
-  tee_local $0
-  i32.const 2
+  tee_local $2
+  get_local $1
   i32.store offset=8
-  get_local $0
+  get_local $2
   get_global $~lib/collector/itcm/white
-  get_local $0
+  get_local $2
   i32.load
   i32.const -4
   i32.and
   i32.or
   i32.store
   get_global $~lib/collector/itcm/fromSpace
-  get_local $0
+  get_local $2
   call $~lib/collector/itcm/ManagedObjectList#push
-  get_local $0
+  get_local $2
   i32.const 16
   i32.add
  )
@@ -341,7 +350,7 @@
    return
   end
   get_local $0
-  i32.const 3
+  i32.const 2
   call_indirect (type $iv)
   get_local $0
   i32.load
@@ -350,7 +359,28 @@
   i32.load offset=4
   call $~lib/collector/itcm/__gc_mark
  )
- (func $~lib/collector/itcm/__gc_collect (; 8 ;) (type $v)
+ (func $std/gc-object/Custom#constructor (; 8 ;) (type $FUNCSIG$i) (result i32)
+  (local $0 i32)
+  i32.const 8
+  i32.const 3
+  call $~lib/collector/itcm/__gc_allocate
+  tee_local $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 2
+   call $~lib/collector/itcm/__gc_allocate
+   set_local $0
+  end
+  get_local $0
+  i32.const 0
+  i32.store
+  get_local $0
+  i32.const 0
+  i32.store offset=4
+  get_local $0
+ )
+ (func $~lib/collector/itcm/__gc_collect (; 9 ;) (type $v)
   (local $0 i32)
   block $break|0
    block $case1|0
@@ -376,7 +406,7 @@
    end
   end
  )
- (func $std/gc-object/main (; 9 ;) (type $v)
+ (func $std/gc-object/main (; 10 ;) (type $v)
   get_global $~started
   i32.eqz
   if
@@ -385,7 +415,7 @@
    set_global $~started
   end
  )
- (func $start (; 10 ;) (type $v)
+ (func $start (; 11 ;) (type $v)
   (local $0 i32)
   i32.const 8
   set_global $~lib/allocator/arena/startOffset
@@ -393,14 +423,7 @@
   set_global $~lib/allocator/arena/offset
   i32.const 0
   set_global $~lib/collector/itcm/state
-  call $~lib/collector/itcm/__gc_allocate
-  tee_local $0
-  i32.const 0
-  i32.store
-  get_local $0
-  i32.const 0
-  i32.store offset=4
-  get_local $0
+  call $std/gc-object/Custom#constructor
   set_global $std/gc-object/obj
   call $~lib/collector/itcm/__gc_collect
   get_global $std/gc-object/obj
@@ -412,7 +435,7 @@
   set_global $std/gc-object/obj
   call $~lib/collector/itcm/__gc_collect
  )
- (func $null (; 11 ;) (type $v)
+ (func $null (; 12 ;) (type $v)
   nop
  )
 )

--- a/tests/compiler/std/gc-object.untouched.wat
+++ b/tests/compiler/std/gc-object.untouched.wat
@@ -6,7 +6,7 @@
  (type $iiv (func (param i32 i32)))
  (memory $0 0)
  (table $0 4 anyfunc)
- (elem (i32.const 0) $null $~lib/collector/itcm/__gc_mark $std/gc-object/Custom~gc $std/gc-object/Base~gc)
+ (elem (i32.const 0) $null $~lib/collector/itcm/__gc_mark $std/gc-object/Base~gc $std/gc-object/Custom~gc)
  (global $~lib/internal/allocator/AL_BITS i32 (i32.const 3))
  (global $~lib/internal/allocator/AL_SIZE i32 (i32.const 8))
  (global $~lib/internal/allocator/AL_MASK i32 (i32.const 7))
@@ -444,14 +444,25 @@
   get_local $0
   call $~lib/collector/itcm/__gc_mark
  )
- (func $std/gc-object/Custom~gc (; 14 ;) (type $iv) (param $0 i32)
+ (func $std/gc-object/Base#constructor (; 14 ;) (type $ii) (param $0 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 2
+   call $~lib/collector/itcm/__gc_allocate
+   set_local $0
+  end
+  get_local $0
+ )
+ (func $std/gc-object/Custom~gc (; 15 ;) (type $iv) (param $0 i32)
   get_local $0
   i32.eqz
   if
    return
   end
   get_local $0
-  i32.const 3
+  i32.const 2
   call_indirect (type $iv)
   get_local $0
   i32.load
@@ -460,7 +471,27 @@
   i32.load offset=4
   call $~lib/collector/itcm/__gc_mark
  )
- (func $~lib/collector/itcm/__gc_collect (; 15 ;) (type $v)
+ (func $std/gc-object/Custom#constructor (; 16 ;) (type $ii) (param $0 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 8
+   i32.const 3
+   call $~lib/collector/itcm/__gc_allocate
+   set_local $0
+  end
+  get_local $0
+  call $std/gc-object/Base#constructor
+  set_local $0
+  get_local $0
+  i32.const 0
+  i32.store
+  get_local $0
+  i32.const 0
+  i32.store offset=4
+  get_local $0
+ )
+ (func $~lib/collector/itcm/__gc_collect (; 17 ;) (type $v)
   (local $0 i32)
   block $break|0
    block $case1|0
@@ -492,11 +523,11 @@
    end
   end
  )
- (func $~lib/gc/gc.collect (; 16 ;) (type $v)
+ (func $~lib/gc/gc.collect (; 18 ;) (type $v)
   call $~lib/collector/itcm/__gc_collect
   return
  )
- (func $std/gc-object/main (; 17 ;) (type $v)
+ (func $std/gc-object/main (; 19 ;) (type $v)
   get_global $~started
   i32.eqz
   if
@@ -505,8 +536,7 @@
    set_global $~started
   end
  )
- (func $start (; 18 ;) (type $v)
-  (local $0 i32)
+ (func $start (; 20 ;) (type $v)
   get_global $HEAP_BASE
   get_global $~lib/internal/allocator/AL_MASK
   i32.add
@@ -519,19 +549,8 @@
   set_global $~lib/allocator/arena/offset
   get_global $~lib/collector/itcm/State.INIT
   set_global $~lib/collector/itcm/state
-  block (result i32)
-   i32.const 8
-   i32.const 2
-   call $~lib/collector/itcm/__gc_allocate
-   set_local $0
-   get_local $0
-   i32.const 0
-   i32.store
-   get_local $0
-   i32.const 0
-   i32.store offset=4
-   get_local $0
-  end
+  i32.const 0
+  call $std/gc-object/Custom#constructor
   set_global $std/gc-object/obj
   call $~lib/gc/gc.collect
   get_global $std/gc-object/obj
@@ -542,9 +561,9 @@
   set_global $std/gc-object/obj
   call $~lib/gc/gc.collect
  )
- (func $null (; 19 ;) (type $v)
+ (func $null (; 21 ;) (type $v)
  )
- (func $~iterateRoots (; 20 ;) (type $iv) (param $0 i32)
+ (func $~iterateRoots (; 22 ;) (type $iv) (param $0 i32)
   get_global $std/gc-object/obj
   get_local $0
   call_indirect (type $iv)

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -487,38 +487,34 @@
   i32.store offset=20
  )
  (func $~lib/map/Map<i8,i32>#constructor (; 8 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 24
     call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 0
-    i32.store
-    get_local $1
-    i32.const 0
-    i32.store offset=4
-    get_local $1
-    i32.const 0
-    i32.store offset=8
-    get_local $1
-    i32.const 0
-    i32.store offset=12
-    get_local $1
-    i32.const 0
-    i32.store offset=16
-    get_local $1
-    i32.const 0
-    i32.store offset=20
-    get_local $1
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
+   i32.const 0
+   i32.store offset=12
+   get_local $0
+   i32.const 0
+   i32.store offset=16
+   get_local $0
+   i32.const 0
+   i32.store offset=20
+   get_local $0
   end
-  tee_local $0
   call $~lib/map/Map<i8,i32>#clear
   get_local $0
  )
@@ -1363,38 +1359,34 @@
   i32.store offset=20
  )
  (func $~lib/map/Map<u8,i32>#constructor (; 19 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 24
     call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 0
-    i32.store
-    get_local $1
-    i32.const 0
-    i32.store offset=4
-    get_local $1
-    i32.const 0
-    i32.store offset=8
-    get_local $1
-    i32.const 0
-    i32.store offset=12
-    get_local $1
-    i32.const 0
-    i32.store offset=16
-    get_local $1
-    i32.const 0
-    i32.store offset=20
-    get_local $1
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
+   i32.const 0
+   i32.store offset=12
+   get_local $0
+   i32.const 0
+   i32.store offset=16
+   get_local $0
+   i32.const 0
+   i32.store offset=20
+   get_local $0
   end
-  tee_local $0
   call $~lib/map/Map<u8,i32>#clear
   get_local $0
  )
@@ -2208,38 +2200,34 @@
   i32.store offset=20
  )
  (func $~lib/map/Map<i16,i32>#constructor (; 29 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 24
     call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 0
-    i32.store
-    get_local $1
-    i32.const 0
-    i32.store offset=4
-    get_local $1
-    i32.const 0
-    i32.store offset=8
-    get_local $1
-    i32.const 0
-    i32.store offset=12
-    get_local $1
-    i32.const 0
-    i32.store offset=16
-    get_local $1
-    i32.const 0
-    i32.store offset=20
-    get_local $1
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
+   i32.const 0
+   i32.store offset=12
+   get_local $0
+   i32.const 0
+   i32.store offset=16
+   get_local $0
+   i32.const 0
+   i32.store offset=20
+   get_local $0
   end
-  tee_local $0
   call $~lib/map/Map<i16,i32>#clear
   get_local $0
  )
@@ -3099,38 +3087,34 @@
   i32.store offset=20
  )
  (func $~lib/map/Map<u16,i32>#constructor (; 40 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 24
     call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 0
-    i32.store
-    get_local $1
-    i32.const 0
-    i32.store offset=4
-    get_local $1
-    i32.const 0
-    i32.store offset=8
-    get_local $1
-    i32.const 0
-    i32.store offset=12
-    get_local $1
-    i32.const 0
-    i32.store offset=16
-    get_local $1
-    i32.const 0
-    i32.store offset=20
-    get_local $1
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
+   i32.const 0
+   i32.store offset=12
+   get_local $0
+   i32.const 0
+   i32.store offset=16
+   get_local $0
+   i32.const 0
+   i32.store offset=20
+   get_local $0
   end
-  tee_local $0
   call $~lib/map/Map<u16,i32>#clear
   get_local $0
  )
@@ -3944,38 +3928,34 @@
   i32.store offset=20
  )
  (func $~lib/map/Map<i32,i32>#constructor (; 50 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 24
     call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 0
-    i32.store
-    get_local $1
-    i32.const 0
-    i32.store offset=4
-    get_local $1
-    i32.const 0
-    i32.store offset=8
-    get_local $1
-    i32.const 0
-    i32.store offset=12
-    get_local $1
-    i32.const 0
-    i32.store offset=16
-    get_local $1
-    i32.const 0
-    i32.store offset=20
-    get_local $1
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
+   i32.const 0
+   i32.store offset=12
+   get_local $0
+   i32.const 0
+   i32.store offset=16
+   get_local $0
+   i32.const 0
+   i32.store offset=20
+   get_local $0
   end
-  tee_local $0
   call $~lib/map/Map<i32,i32>#clear
   get_local $0
  )
@@ -4807,38 +4787,34 @@
   i32.store offset=20
  )
  (func $~lib/map/Map<u32,i32>#constructor (; 61 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 24
     call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 0
-    i32.store
-    get_local $1
-    i32.const 0
-    i32.store offset=4
-    get_local $1
-    i32.const 0
-    i32.store offset=8
-    get_local $1
-    i32.const 0
-    i32.store offset=12
-    get_local $1
-    i32.const 0
-    i32.store offset=16
-    get_local $1
-    i32.const 0
-    i32.store offset=20
-    get_local $1
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
+   i32.const 0
+   i32.store offset=12
+   get_local $0
+   i32.const 0
+   i32.store offset=16
+   get_local $0
+   i32.const 0
+   i32.store offset=20
+   get_local $0
   end
-  tee_local $0
   call $~lib/map/Map<u32,i32>#clear
   get_local $0
  )
@@ -5628,38 +5604,34 @@
   i32.store offset=20
  )
  (func $~lib/map/Map<i64,i32>#constructor (; 71 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 24
     call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 0
-    i32.store
-    get_local $1
-    i32.const 0
-    i32.store offset=4
-    get_local $1
-    i32.const 0
-    i32.store offset=8
-    get_local $1
-    i32.const 0
-    i32.store offset=12
-    get_local $1
-    i32.const 0
-    i32.store offset=16
-    get_local $1
-    i32.const 0
-    i32.store offset=20
-    get_local $1
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
+   i32.const 0
+   i32.store offset=12
+   get_local $0
+   i32.const 0
+   i32.store offset=16
+   get_local $0
+   i32.const 0
+   i32.store offset=20
+   get_local $0
   end
-  tee_local $0
   call $~lib/map/Map<i64,i32>#clear
   get_local $0
  )
@@ -6545,38 +6517,34 @@
   i32.store offset=20
  )
  (func $~lib/map/Map<u64,i32>#constructor (; 82 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 24
     call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 0
-    i32.store
-    get_local $1
-    i32.const 0
-    i32.store offset=4
-    get_local $1
-    i32.const 0
-    i32.store offset=8
-    get_local $1
-    i32.const 0
-    i32.store offset=12
-    get_local $1
-    i32.const 0
-    i32.store offset=16
-    get_local $1
-    i32.const 0
-    i32.store offset=20
-    get_local $1
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
+   i32.const 0
+   i32.store offset=12
+   get_local $0
+   i32.const 0
+   i32.store offset=16
+   get_local $0
+   i32.const 0
+   i32.store offset=20
+   get_local $0
   end
-  tee_local $0
   call $~lib/map/Map<u64,i32>#clear
   get_local $0
  )
@@ -7374,38 +7342,34 @@
   i32.store offset=20
  )
  (func $~lib/map/Map<f32,i32>#constructor (; 92 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 24
     call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 0
-    i32.store
-    get_local $1
-    i32.const 0
-    i32.store offset=4
-    get_local $1
-    i32.const 0
-    i32.store offset=8
-    get_local $1
-    i32.const 0
-    i32.store offset=12
-    get_local $1
-    i32.const 0
-    i32.store offset=16
-    get_local $1
-    i32.const 0
-    i32.store offset=20
-    get_local $1
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
+   i32.const 0
+   i32.store offset=12
+   get_local $0
+   i32.const 0
+   i32.store offset=16
+   get_local $0
+   i32.const 0
+   i32.store offset=20
+   get_local $0
   end
-  tee_local $0
   call $~lib/map/Map<f32,i32>#clear
   get_local $0
  )
@@ -8208,38 +8172,34 @@
   i32.store offset=20
  )
  (func $~lib/map/Map<f64,i32>#constructor (; 102 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 24
     call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 0
-    i32.store
-    get_local $1
-    i32.const 0
-    i32.store offset=4
-    get_local $1
-    i32.const 0
-    i32.store offset=8
-    get_local $1
-    i32.const 0
-    i32.store offset=12
-    get_local $1
-    i32.const 0
-    i32.store offset=16
-    get_local $1
-    i32.const 0
-    i32.store offset=20
-    get_local $1
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
+   i32.const 0
+   i32.store offset=12
+   get_local $0
+   i32.const 0
+   i32.store offset=16
+   get_local $0
+   i32.const 0
+   i32.store offset=20
+   get_local $0
   end
-  tee_local $0
   call $~lib/map/Map<f64,i32>#clear
   get_local $0
  )

--- a/tests/compiler/std/new.untouched.wat
+++ b/tests/compiler/std/new.untouched.wat
@@ -101,27 +101,23 @@
   return
  )
  (func $std/new/AClass#constructor (; 2 ;) (type $ifi) (param $0 i32) (param $1 f32) (result i32)
-  (local $2 i32)
   get_local $0
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 8
     call $~lib/memory/memory.allocate
-    set_local $2
-    get_local $2
-    i32.const 1
-    i32.store
-    get_local $2
-    f32.const 2
-    f32.store offset=4
-    get_local $2
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 1
+   i32.store
+   get_local $0
+   f32.const 2
+   f32.store offset=4
+   get_local $0
   end
-  tee_local $0
   i32.load
   i32.const 1
   i32.add

--- a/tests/compiler/std/operator-overloading.untouched.wat
+++ b/tests/compiler/std/operator-overloading.untouched.wat
@@ -174,26 +174,20 @@
   return
  )
  (func $std/operator-overloading/Tester#constructor (; 3 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
   get_local $0
-  if (result i32)
-   get_local $0
-  else   
-   block (result i32)
-    i32.const 8
-    call $~lib/memory/memory.allocate
-    set_local $3
-    get_local $3
-    get_local $1
-    i32.store
-    get_local $3
-    get_local $2
-    i32.store offset=4
-    get_local $3
-   end
-   tee_local $0
+  i32.eqz
+  if
+   i32.const 8
+   call $~lib/memory/memory.allocate
+   set_local $0
   end
-  tee_local $0
+  get_local $0
+  get_local $1
+  i32.store
+  get_local $0
+  get_local $2
+  i32.store offset=4
+  get_local $0
  )
  (func $std/operator-overloading/Tester.add (; 4 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   i32.const 0
@@ -1751,48 +1745,36 @@
   call $std/operator-overloading/Tester#constructor
  )
  (func $std/operator-overloading/TesterInlineStatic#constructor (; 32 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
   get_local $0
-  if (result i32)
-   get_local $0
-  else   
-   block (result i32)
-    i32.const 8
-    call $~lib/memory/memory.allocate
-    set_local $3
-    get_local $3
-    get_local $1
-    i32.store
-    get_local $3
-    get_local $2
-    i32.store offset=4
-    get_local $3
-   end
-   tee_local $0
+  i32.eqz
+  if
+   i32.const 8
+   call $~lib/memory/memory.allocate
+   set_local $0
   end
-  tee_local $0
+  get_local $0
+  get_local $1
+  i32.store
+  get_local $0
+  get_local $2
+  i32.store offset=4
+  get_local $0
  )
  (func $std/operator-overloading/TesterInlineInstance#constructor (; 33 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
   get_local $0
-  if (result i32)
-   get_local $0
-  else   
-   block (result i32)
-    i32.const 8
-    call $~lib/memory/memory.allocate
-    set_local $3
-    get_local $3
-    get_local $1
-    i32.store
-    get_local $3
-    get_local $2
-    i32.store offset=4
-    get_local $3
-   end
-   tee_local $0
+  i32.eqz
+  if
+   i32.const 8
+   call $~lib/memory/memory.allocate
+   set_local $0
   end
-  tee_local $0
+  get_local $0
+  get_local $1
+  i32.store
+  get_local $0
+  get_local $2
+  i32.store offset=4
+  get_local $0
  )
  (func $start (; 34 ;) (type $v)
   (local $0 i32)

--- a/tests/compiler/std/pointer.untouched.wat
+++ b/tests/compiler/std/pointer.untouched.wat
@@ -1760,13 +1760,21 @@
   (local $0 i32)
   (local $1 i32)
   (local $2 f32)
-  i32.const 0
-  i32.const 8
-  call $std/pointer/Pointer<Entry>#constructor
+  block $std/pointer/Pointer<Entry>#constructor|inlined.0 (result i32)
+   i32.const 0
+   set_local $0
+   i32.const 8
+   set_local $1
+   get_local $1
+  end
   set_global $std/pointer/one
-  i32.const 0
-  i32.const 24
-  call $std/pointer/Pointer<Entry>#constructor
+  block $std/pointer/Pointer<Entry>#constructor|inlined.1 (result i32)
+   i32.const 0
+   set_local $1
+   i32.const 24
+   set_local $0
+   get_local $0
+  end
   set_global $std/pointer/two
   block $std/pointer/Pointer<Entry>#get:offset|inlined.0 (result i32)
    get_global $std/pointer/one
@@ -2108,9 +2116,13 @@
    call $~lib/env/abort
    unreachable
   end
-  i32.const 0
-  i32.const 0
-  call $std/pointer/Pointer<f32>#constructor
+  block $std/pointer/Pointer<f32>#constructor|inlined.0 (result i32)
+   i32.const 0
+   set_local $0
+   i32.const 0
+   set_local $1
+   get_local $1
+  end
   set_global $std/pointer/buf
   get_global $std/pointer/buf
   i32.const 0
@@ -2150,11 +2162,11 @@
   end
   block $std/pointer/Pointer<f32>#get|inlined.0 (result f32)
    get_global $std/pointer/buf
-   set_local $0
-   i32.const 0
    set_local $1
-   get_local $0
+   i32.const 0
+   set_local $0
    get_local $1
+   get_local $0
    i32.const 4
    i32.mul
    i32.add
@@ -2173,11 +2185,11 @@
   end
   block $std/pointer/Pointer<f32>#get|inlined.1 (result f32)
    get_global $std/pointer/buf
-   set_local $1
-   i32.const 1
    set_local $0
-   get_local $1
+   i32.const 1
+   set_local $1
    get_local $0
+   get_local $1
    i32.const 4
    i32.mul
    i32.add
@@ -2222,13 +2234,13 @@
   end
   block
    get_global $std/pointer/buf
-   set_local $0
-   i32.const 2
    set_local $1
+   i32.const 2
+   set_local $0
    f32.const 1.2999999523162842
    set_local $2
-   get_local $0
    get_local $1
+   get_local $0
    i32.const 4
    i32.mul
    i32.add
@@ -2251,11 +2263,11 @@
   end
   block $std/pointer/Pointer<f32>#get|inlined.2 (result f32)
    get_global $std/pointer/buf
-   set_local $1
-   i32.const 2
    set_local $0
-   get_local $1
+   i32.const 2
+   set_local $1
    get_local $0
+   get_local $1
    i32.const 4
    i32.mul
    i32.add
@@ -2290,8 +2302,8 @@
   call $std/pointer/Pointer<f32>#set:value
   block $std/pointer/Pointer<f32>#get:value|inlined.0 (result f32)
    get_global $std/pointer/buf
-   set_local $0
-   get_local $0
+   set_local $1
+   get_local $1
    f32.load
    br $std/pointer/Pointer<f32>#get:value|inlined.0
   end

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -489,38 +489,34 @@
   i32.store offset=20
  )
  (func $~lib/set/Set<i8>#constructor (; 8 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 24
     call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 0
-    i32.store
-    get_local $1
-    i32.const 0
-    i32.store offset=4
-    get_local $1
-    i32.const 0
-    i32.store offset=8
-    get_local $1
-    i32.const 0
-    i32.store offset=12
-    get_local $1
-    i32.const 0
-    i32.store offset=16
-    get_local $1
-    i32.const 0
-    i32.store offset=20
-    get_local $1
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
+   i32.const 0
+   i32.store offset=12
+   get_local $0
+   i32.const 0
+   i32.store offset=16
+   get_local $0
+   i32.const 0
+   i32.store offset=20
+   get_local $0
   end
-  tee_local $0
   call $~lib/set/Set<i8>#clear
   get_local $0
  )
@@ -1226,38 +1222,34 @@
   i32.store offset=20
  )
  (func $~lib/set/Set<u8>#constructor (; 19 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 24
     call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 0
-    i32.store
-    get_local $1
-    i32.const 0
-    i32.store offset=4
-    get_local $1
-    i32.const 0
-    i32.store offset=8
-    get_local $1
-    i32.const 0
-    i32.store offset=12
-    get_local $1
-    i32.const 0
-    i32.store offset=16
-    get_local $1
-    i32.const 0
-    i32.store offset=20
-    get_local $1
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
+   i32.const 0
+   i32.store offset=12
+   get_local $0
+   i32.const 0
+   i32.store offset=16
+   get_local $0
+   i32.const 0
+   i32.store offset=20
+   get_local $0
   end
-  tee_local $0
   call $~lib/set/Set<u8>#clear
   get_local $0
  )
@@ -1950,38 +1942,34 @@
   i32.store offset=20
  )
  (func $~lib/set/Set<i16>#constructor (; 29 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 24
     call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 0
-    i32.store
-    get_local $1
-    i32.const 0
-    i32.store offset=4
-    get_local $1
-    i32.const 0
-    i32.store offset=8
-    get_local $1
-    i32.const 0
-    i32.store offset=12
-    get_local $1
-    i32.const 0
-    i32.store offset=16
-    get_local $1
-    i32.const 0
-    i32.store offset=20
-    get_local $1
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
+   i32.const 0
+   i32.store offset=12
+   get_local $0
+   i32.const 0
+   i32.store offset=16
+   get_local $0
+   i32.const 0
+   i32.store offset=20
+   get_local $0
   end
-  tee_local $0
   call $~lib/set/Set<i16>#clear
   get_local $0
  )
@@ -2702,38 +2690,34 @@
   i32.store offset=20
  )
  (func $~lib/set/Set<u16>#constructor (; 40 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 24
     call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 0
-    i32.store
-    get_local $1
-    i32.const 0
-    i32.store offset=4
-    get_local $1
-    i32.const 0
-    i32.store offset=8
-    get_local $1
-    i32.const 0
-    i32.store offset=12
-    get_local $1
-    i32.const 0
-    i32.store offset=16
-    get_local $1
-    i32.const 0
-    i32.store offset=20
-    get_local $1
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
+   i32.const 0
+   i32.store offset=12
+   get_local $0
+   i32.const 0
+   i32.store offset=16
+   get_local $0
+   i32.const 0
+   i32.store offset=20
+   get_local $0
   end
-  tee_local $0
   call $~lib/set/Set<u16>#clear
   get_local $0
  )
@@ -3426,38 +3410,34 @@
   i32.store offset=20
  )
  (func $~lib/set/Set<i32>#constructor (; 50 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 24
     call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 0
-    i32.store
-    get_local $1
-    i32.const 0
-    i32.store offset=4
-    get_local $1
-    i32.const 0
-    i32.store offset=8
-    get_local $1
-    i32.const 0
-    i32.store offset=12
-    get_local $1
-    i32.const 0
-    i32.store offset=16
-    get_local $1
-    i32.const 0
-    i32.store offset=20
-    get_local $1
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
+   i32.const 0
+   i32.store offset=12
+   get_local $0
+   i32.const 0
+   i32.store offset=16
+   get_local $0
+   i32.const 0
+   i32.store offset=20
+   get_local $0
   end
-  tee_local $0
   call $~lib/set/Set<i32>#clear
   get_local $0
  )
@@ -4186,38 +4166,34 @@
   i32.store offset=20
  )
  (func $~lib/set/Set<u32>#constructor (; 61 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 24
     call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 0
-    i32.store
-    get_local $1
-    i32.const 0
-    i32.store offset=4
-    get_local $1
-    i32.const 0
-    i32.store offset=8
-    get_local $1
-    i32.const 0
-    i32.store offset=12
-    get_local $1
-    i32.const 0
-    i32.store offset=16
-    get_local $1
-    i32.const 0
-    i32.store offset=20
-    get_local $1
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
+   i32.const 0
+   i32.store offset=12
+   get_local $0
+   i32.const 0
+   i32.store offset=16
+   get_local $0
+   i32.const 0
+   i32.store offset=20
+   get_local $0
   end
-  tee_local $0
   call $~lib/set/Set<u32>#clear
   get_local $0
  )
@@ -4904,38 +4880,34 @@
   i32.store offset=20
  )
  (func $~lib/set/Set<i64>#constructor (; 71 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 24
     call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 0
-    i32.store
-    get_local $1
-    i32.const 0
-    i32.store offset=4
-    get_local $1
-    i32.const 0
-    i32.store offset=8
-    get_local $1
-    i32.const 0
-    i32.store offset=12
-    get_local $1
-    i32.const 0
-    i32.store offset=16
-    get_local $1
-    i32.const 0
-    i32.store offset=20
-    get_local $1
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
+   i32.const 0
+   i32.store offset=12
+   get_local $0
+   i32.const 0
+   i32.store offset=16
+   get_local $0
+   i32.const 0
+   i32.store offset=20
+   get_local $0
   end
-  tee_local $0
   call $~lib/set/Set<i64>#clear
   get_local $0
  )
@@ -5711,38 +5683,34 @@
   i32.store offset=20
  )
  (func $~lib/set/Set<u64>#constructor (; 82 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 24
     call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 0
-    i32.store
-    get_local $1
-    i32.const 0
-    i32.store offset=4
-    get_local $1
-    i32.const 0
-    i32.store offset=8
-    get_local $1
-    i32.const 0
-    i32.store offset=12
-    get_local $1
-    i32.const 0
-    i32.store offset=16
-    get_local $1
-    i32.const 0
-    i32.store offset=20
-    get_local $1
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
+   i32.const 0
+   i32.store offset=12
+   get_local $0
+   i32.const 0
+   i32.store offset=16
+   get_local $0
+   i32.const 0
+   i32.store offset=20
+   get_local $0
   end
-  tee_local $0
   call $~lib/set/Set<u64>#clear
   get_local $0
  )
@@ -6430,38 +6398,34 @@
   i32.store offset=20
  )
  (func $~lib/set/Set<f32>#constructor (; 92 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 24
     call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 0
-    i32.store
-    get_local $1
-    i32.const 0
-    i32.store offset=4
-    get_local $1
-    i32.const 0
-    i32.store offset=8
-    get_local $1
-    i32.const 0
-    i32.store offset=12
-    get_local $1
-    i32.const 0
-    i32.store offset=16
-    get_local $1
-    i32.const 0
-    i32.store offset=20
-    get_local $1
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
+   i32.const 0
+   i32.store offset=12
+   get_local $0
+   i32.const 0
+   i32.store offset=16
+   get_local $0
+   i32.const 0
+   i32.store offset=20
+   get_local $0
   end
-  tee_local $0
   call $~lib/set/Set<f32>#clear
   get_local $0
  )
@@ -7152,38 +7116,34 @@
   i32.store offset=20
  )
  (func $~lib/set/Set<f64>#constructor (; 102 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 24
     call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 0
-    i32.store
-    get_local $1
-    i32.const 0
-    i32.store offset=4
-    get_local $1
-    i32.const 0
-    i32.store offset=8
-    get_local $1
-    i32.const 0
-    i32.store offset=12
-    get_local $1
-    i32.const 0
-    i32.store offset=16
-    get_local $1
-    i32.const 0
-    i32.store offset=20
-    get_local $1
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
+   i32.const 0
+   i32.store offset=12
+   get_local $0
+   i32.const 0
+   i32.store offset=16
+   get_local $0
+   i32.const 0
+   i32.store offset=20
+   get_local $0
   end
-  tee_local $0
   call $~lib/set/Set<f64>#clear
   get_local $0
  )

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -4221,25 +4221,22 @@
   get_local $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   set_local $3
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 8
     call $~lib/memory/memory.allocate
-    set_local $4
-    get_local $4
-    i32.const 0
-    i32.store
-    get_local $4
-    i32.const 0
-    i32.store offset=4
-    get_local $4
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
   end
-  tee_local $0
   get_local $3
   i32.store
   get_local $0

--- a/tests/compiler/std/symbol.untouched.wat
+++ b/tests/compiler/std/symbol.untouched.wat
@@ -537,38 +537,34 @@
   i32.store offset=20
  )
  (func $~lib/map/Map<String,usize>#constructor (; 9 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 24
     call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 0
-    i32.store
-    get_local $1
-    i32.const 0
-    i32.store offset=4
-    get_local $1
-    i32.const 0
-    i32.store offset=8
-    get_local $1
-    i32.const 0
-    i32.store offset=12
-    get_local $1
-    i32.const 0
-    i32.store offset=16
-    get_local $1
-    i32.const 0
-    i32.store offset=20
-    get_local $1
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
+   i32.const 0
+   i32.store offset=12
+   get_local $0
+   i32.const 0
+   i32.store offset=16
+   get_local $0
+   i32.const 0
+   i32.store offset=20
+   get_local $0
   end
-  tee_local $0
   call $~lib/map/Map<String,usize>#clear
   get_local $0
  )
@@ -601,38 +597,34 @@
   i32.store offset=20
  )
  (func $~lib/map/Map<usize,String>#constructor (; 11 ;) (type $ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 24
     call $~lib/memory/memory.allocate
-    set_local $1
-    get_local $1
-    i32.const 0
-    i32.store
-    get_local $1
-    i32.const 0
-    i32.store offset=4
-    get_local $1
-    i32.const 0
-    i32.store offset=8
-    get_local $1
-    i32.const 0
-    i32.store offset=12
-    get_local $1
-    i32.const 0
-    i32.store offset=16
-    get_local $1
-    i32.const 0
-    i32.store offset=20
-    get_local $1
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
+   i32.const 0
+   i32.store offset=12
+   get_local $0
+   i32.const 0
+   i32.store offset=16
+   get_local $0
+   i32.const 0
+   i32.store offset=20
+   get_local $0
   end
-  tee_local $0
   call $~lib/map/Map<usize,String>#clear
   get_local $0
  )

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -408,10 +408,9 @@
    end
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i8>#constructor (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  (local $1 i32)
+ (func $~lib/internal/typedarray/TypedArray<i8>#constructor (; 4 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
-  get_local $0
+  get_local $1
   i32.const 1073741816
   i32.gt_u
   if
@@ -422,40 +421,61 @@
    call $~lib/env/abort
    unreachable
   end
-  get_local $0
+  get_local $1
   call $~lib/internal/arraybuffer/allocateUnsafe
   tee_local $2
   i32.const 8
   i32.add
   i32.const 0
-  get_local $0
+  get_local $1
   call $~lib/internal/memory/memset
-  i32.const 12
-  call $~lib/allocator/arena/__memory_allocate
-  tee_local $1
+  get_local $0
+  i32.eqz
+  if
+   i32.const 12
+   call $~lib/allocator/arena/__memory_allocate
+   set_local $0
+  end
+  get_local $0
   i32.const 0
   i32.store
-  get_local $1
+  get_local $0
   i32.const 0
   i32.store offset=4
-  get_local $1
+  get_local $0
   i32.const 0
   i32.store offset=8
-  get_local $1
+  get_local $0
   get_local $2
   i32.store
-  get_local $1
+  get_local $0
   i32.const 0
   i32.store offset=4
-  get_local $1
   get_local $0
+  get_local $1
   i32.store offset=8
-  get_local $1
- )
- (func $~lib/internal/typedarray/TypedArray<i16>#constructor (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
   get_local $0
+ )
+ (func $~lib/typedarray/Int8Array#constructor (; 5 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  get_local $0
+  if (result i32)
+   get_local $0
+  else   
+   i32.const 12
+   call $~lib/allocator/arena/__memory_allocate
+  end
+  get_local $1
+  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+ )
+ (func $~lib/typedarray/Uint8ClampedArray#constructor (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  i32.const 12
+  call $~lib/allocator/arena/__memory_allocate
+  get_local $0
+  call $~lib/typedarray/Int8Array#constructor
+ )
+ (func $~lib/internal/typedarray/TypedArray<i16>#constructor (; 7 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  get_local $1
   i32.const 536870908
   i32.gt_u
   if
@@ -466,43 +486,53 @@
    call $~lib/env/abort
    unreachable
   end
-  get_local $0
+  get_local $1
   i32.const 1
   i32.shl
-  tee_local $0
+  tee_local $1
   call $~lib/internal/arraybuffer/allocateUnsafe
   tee_local $2
   i32.const 8
   i32.add
   i32.const 0
-  get_local $0
+  get_local $1
   call $~lib/internal/memory/memset
-  i32.const 12
-  call $~lib/allocator/arena/__memory_allocate
-  tee_local $1
+  get_local $0
+  i32.eqz
+  if
+   i32.const 12
+   call $~lib/allocator/arena/__memory_allocate
+   set_local $0
+  end
+  get_local $0
   i32.const 0
   i32.store
-  get_local $1
+  get_local $0
   i32.const 0
   i32.store offset=4
-  get_local $1
+  get_local $0
   i32.const 0
   i32.store offset=8
-  get_local $1
+  get_local $0
   get_local $2
   i32.store
-  get_local $1
+  get_local $0
   i32.const 0
   i32.store offset=4
-  get_local $1
   get_local $0
+  get_local $1
   i32.store offset=8
-  get_local $1
- )
- (func $~lib/internal/typedarray/TypedArray<i32>#constructor (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
   get_local $0
+ )
+ (func $~lib/typedarray/Int16Array#constructor (; 8 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  i32.const 12
+  call $~lib/allocator/arena/__memory_allocate
+  get_local $0
+  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+ )
+ (func $~lib/internal/typedarray/TypedArray<i32>#constructor (; 9 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  get_local $1
   i32.const 268435454
   i32.gt_u
   if
@@ -513,43 +543,53 @@
    call $~lib/env/abort
    unreachable
   end
-  get_local $0
+  get_local $1
   i32.const 2
   i32.shl
-  tee_local $0
+  tee_local $1
   call $~lib/internal/arraybuffer/allocateUnsafe
   tee_local $2
   i32.const 8
   i32.add
   i32.const 0
-  get_local $0
+  get_local $1
   call $~lib/internal/memory/memset
-  i32.const 12
-  call $~lib/allocator/arena/__memory_allocate
-  tee_local $1
+  get_local $0
+  i32.eqz
+  if
+   i32.const 12
+   call $~lib/allocator/arena/__memory_allocate
+   set_local $0
+  end
+  get_local $0
   i32.const 0
   i32.store
-  get_local $1
+  get_local $0
   i32.const 0
   i32.store offset=4
-  get_local $1
+  get_local $0
   i32.const 0
   i32.store offset=8
-  get_local $1
+  get_local $0
   get_local $2
   i32.store
-  get_local $1
+  get_local $0
   i32.const 0
   i32.store offset=4
-  get_local $1
   get_local $0
+  get_local $1
   i32.store offset=8
-  get_local $1
- )
- (func $~lib/internal/typedarray/TypedArray<i64>#constructor (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
   get_local $0
+ )
+ (func $~lib/typedarray/Int32Array#constructor (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  i32.const 12
+  call $~lib/allocator/arena/__memory_allocate
+  get_local $0
+  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+ )
+ (func $~lib/internal/typedarray/TypedArray<i64>#constructor (; 11 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  get_local $1
   i32.const 134217727
   i32.gt_u
   if
@@ -560,43 +600,55 @@
    call $~lib/env/abort
    unreachable
   end
-  get_local $0
+  get_local $1
   i32.const 3
   i32.shl
-  tee_local $0
+  tee_local $1
   call $~lib/internal/arraybuffer/allocateUnsafe
   tee_local $2
   i32.const 8
   i32.add
   i32.const 0
-  get_local $0
+  get_local $1
   call $~lib/internal/memory/memset
-  i32.const 12
-  call $~lib/allocator/arena/__memory_allocate
-  tee_local $1
+  get_local $0
+  i32.eqz
+  if
+   i32.const 12
+   call $~lib/allocator/arena/__memory_allocate
+   set_local $0
+  end
+  get_local $0
   i32.const 0
   i32.store
-  get_local $1
+  get_local $0
   i32.const 0
   i32.store offset=4
-  get_local $1
+  get_local $0
   i32.const 0
   i32.store offset=8
-  get_local $1
+  get_local $0
   get_local $2
   i32.store
-  get_local $1
+  get_local $0
   i32.const 0
   i32.store offset=4
-  get_local $1
   get_local $0
+  get_local $1
   i32.store offset=8
-  get_local $1
- )
- (func $std/typedarray/testInstantiate (; 8 ;) (type $iv) (param $0 i32)
-  (local $1 i32)
   get_local $0
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+ )
+ (func $~lib/typedarray/Int64Array#constructor (; 12 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  i32.const 12
+  call $~lib/allocator/arena/__memory_allocate
+  get_local $0
+  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+ )
+ (func $std/typedarray/testInstantiate (; 13 ;) (type $iv) (param $0 i32)
+  (local $1 i32)
+  i32.const 0
+  get_local $0
+  call $~lib/typedarray/Int8Array#constructor
   tee_local $1
   i32.load offset=4
   if
@@ -631,8 +683,9 @@
    call $~lib/env/abort
    unreachable
   end
+  i32.const 0
   get_local $0
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   tee_local $1
   i32.load offset=4
   if
@@ -668,7 +721,7 @@
    unreachable
   end
   get_local $0
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Uint8ClampedArray#constructor
   tee_local $1
   i32.load offset=4
   if
@@ -704,7 +757,7 @@
    unreachable
   end
   get_local $0
-  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  call $~lib/typedarray/Int16Array#constructor
   tee_local $1
   i32.load offset=4
   if
@@ -744,7 +797,7 @@
    unreachable
   end
   get_local $0
-  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  call $~lib/typedarray/Int16Array#constructor
   tee_local $1
   i32.load offset=4
   if
@@ -784,7 +837,7 @@
    unreachable
   end
   get_local $0
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   tee_local $1
   i32.load offset=4
   if
@@ -824,7 +877,7 @@
    unreachable
   end
   get_local $0
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   tee_local $1
   i32.load offset=4
   if
@@ -864,7 +917,7 @@
    unreachable
   end
   get_local $0
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   tee_local $1
   i32.load offset=4
   if
@@ -904,7 +957,7 @@
    unreachable
   end
   get_local $0
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   tee_local $1
   i32.load offset=4
   if
@@ -944,7 +997,7 @@
    unreachable
   end
   get_local $0
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   tee_local $1
   i32.load offset=4
   if
@@ -984,7 +1037,7 @@
    unreachable
   end
   get_local $0
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   tee_local $1
   i32.load offset=4
   if
@@ -1024,7 +1077,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i32>#__set (; 9 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<i32>#__set (; 14 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   get_local $1
   get_local $0
   i32.load offset=8
@@ -1051,7 +1104,7 @@
   get_local $2
   i32.store offset=8
  )
- (func $~lib/internal/typedarray/TypedArray<i32>#__get (; 10 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<i32>#__get (; 15 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   get_local $1
   get_local $0
   i32.load offset=8
@@ -1077,7 +1130,7 @@
   i32.add
   i32.load offset=8
  )
- (func $~lib/typedarray/Int32Array#subarray (; 11 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#subarray (; 16 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 1
@@ -1142,7 +1195,7 @@
   i32.store offset=8
   get_local $2
  )
- (func $~lib/internal/typedarray/TypedArray<f64>#__set (; 12 ;) (type $iiFv) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/internal/typedarray/TypedArray<f64>#__set (; 17 ;) (type $iiFv) (param $0 i32) (param $1 i32) (param $2 f64)
   get_local $1
   get_local $0
   i32.load offset=8
@@ -1169,7 +1222,7 @@
   get_local $2
   f64.store offset=8
  )
- (func $~lib/typedarray/Float64Array#subarray (; 13 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#subarray (; 18 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1220,7 +1273,7 @@
   i32.store offset=8
   get_local $2
  )
- (func $~lib/internal/sort/insertionSort<f64> (; 14 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<f64> (; 19 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 f64)
@@ -1310,7 +1363,7 @@
    unreachable
   end
  )
- (func $~lib/internal/sort/weakHeapSort<f64> (; 15 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/weakHeapSort<f64> (; 20 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1595,7 +1648,7 @@
   get_local $7
   f64.store offset=8
  )
- (func $~lib/typedarray/Float64Array#sort (; 16 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#sort (; 21 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1675,7 +1728,7 @@
   end
   get_local $0
  )
- (func $~lib/typedarray/Float64Array#sort|trampoline~anonymous|1 (; 17 ;) (type $FFi) (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/typedarray/Float64Array#sort|trampoline~anonymous|1 (; 22 ;) (type $FFi) (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   get_local $0
@@ -1704,7 +1757,7 @@
   i64.lt_s
   i32.sub
  )
- (func $~lib/internal/typedarray/TypedArray<f64>#__get (; 18 ;) (type $iiF) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/internal/typedarray/TypedArray<f64>#__get (; 23 ;) (type $iiF) (param $0 i32) (param $1 i32) (result f64)
   get_local $1
   get_local $0
   i32.load offset=8
@@ -1730,7 +1783,7 @@
   i32.add
   f64.load offset=8
  )
- (func $~lib/internal/typedarray/TypedArray<u8>#__set (; 19 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<u8>#__set (; 24 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   get_local $1
   get_local $0
   i32.load offset=8
@@ -1753,7 +1806,7 @@
   get_local $2
   i32.store8 offset=8
  )
- (func $~lib/typedarray/Uint8ClampedArray#__set (; 20 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#__set (; 25 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   get_local $0
   get_local $1
@@ -1771,7 +1824,7 @@
   select
   call $~lib/internal/typedarray/TypedArray<u8>#__set
  )
- (func $~lib/internal/typedarray/TypedArray<u8>#__get (; 21 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<u8>#__get (; 26 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   get_local $1
   get_local $0
   i32.load offset=8
@@ -1793,7 +1846,7 @@
   i32.add
   i32.load8_u offset=8
  )
- (func $~lib/typedarray/Int8Array#fill (; 22 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#fill (; 27 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1868,7 +1921,7 @@
   end
   get_local $0
  )
- (func $~lib/internal/typedarray/TypedArray<i8>#__get (; 23 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<i8>#__get (; 28 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   get_local $1
   get_local $0
   i32.load offset=8
@@ -1890,7 +1943,7 @@
   i32.add
   i32.load8_s offset=8
  )
- (func $std/typedarray/isInt8ArrayEqual (; 24 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/typedarray/isInt8ArrayEqual (; 29 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1948,7 +2001,7 @@
   end
   i32.const 1
  )
- (func $~lib/typedarray/Int8Array#fill|trampoline (; 25 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#fill|trampoline (; 30 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   block $2of2
    block $1of2
@@ -1973,7 +2026,7 @@
   get_local $3
   call $~lib/typedarray/Int8Array#fill
  )
- (func $~lib/typedarray/Int8Array#subarray (; 26 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#subarray (; 31 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 1
@@ -2032,7 +2085,7 @@
   i32.store offset=8
   get_local $2
  )
- (func $~lib/typedarray/Int32Array#fill (; 27 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#fill (; 32 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -2116,7 +2169,7 @@
   end
   get_local $0
  )
- (func $std/typedarray/isInt32ArrayEqual (; 28 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/typedarray/isInt32ArrayEqual (; 33 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2178,7 +2231,7 @@
   end
   i32.const 1
  )
- (func $~lib/typedarray/Int32Array#fill|trampoline (; 29 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#fill|trampoline (; 34 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   block $2of2
    block $1of2
@@ -2203,12 +2256,12 @@
   get_local $3
   call $~lib/typedarray/Int32Array#fill
  )
- (func $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 (; 30 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 (; 35 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/typedarray/Int8Array#reduce<i8> (; 31 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#reduce<i8> (; 36 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2251,10 +2304,11 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduce<Int8Array,i8> (; 32 ;) (type $v)
+ (func $std/typedarray/testReduce<Int8Array,i8> (; 37 ;) (type $v)
   (local $0 i32)
+  i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -2282,7 +2336,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Uint8Array#reduce<u8> (; 33 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#reduce<u8> (; 38 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2325,10 +2379,11 @@
   end
   get_local $3
  )
- (func $std/typedarray/testReduce<Uint8Array,u8> (; 34 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint8Array,u8> (; 39 ;) (type $v)
   (local $0 i32)
+  i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -2357,10 +2412,10 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Uint8ClampedArray,u8> (; 35 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint8ClampedArray,u8> (; 40 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Uint8ClampedArray#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -2389,7 +2444,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i16>#__set (; 36 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<i16>#__set (; 41 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   get_local $1
   get_local $0
   i32.load offset=8
@@ -2416,7 +2471,7 @@
   get_local $2
   i32.store16 offset=8
  )
- (func $~lib/typedarray/Int16Array#reduce<i16> (; 37 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#reduce<i16> (; 42 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2463,10 +2518,10 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduce<Int16Array,i16> (; 38 ;) (type $v)
+ (func $std/typedarray/testReduce<Int16Array,i16> (; 43 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  call $~lib/typedarray/Int16Array#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -2494,7 +2549,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Uint16Array#reduce<u16> (; 39 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#reduce<u16> (; 44 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2541,10 +2596,10 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduce<Uint16Array,u16> (; 40 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint16Array,u16> (; 45 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  call $~lib/typedarray/Int16Array#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -2572,7 +2627,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Int32Array#reduce<i32> (; 41 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#reduce<i32> (; 46 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2619,10 +2674,10 @@
   end
   get_local $3
  )
- (func $std/typedarray/testReduce<Int32Array,i32> (; 42 ;) (type $v)
+ (func $std/typedarray/testReduce<Int32Array,i32> (; 47 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -2649,10 +2704,10 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Uint32Array,u32> (; 43 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint32Array,u32> (; 48 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -2679,7 +2734,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i64>#__set (; 44 ;) (type $iiIv) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/internal/typedarray/TypedArray<i64>#__set (; 49 ;) (type $iiIv) (param $0 i32) (param $1 i32) (param $2 i64)
   get_local $1
   get_local $0
   i32.load offset=8
@@ -2706,12 +2761,12 @@
   get_local $2
   i64.store offset=8
  )
- (func $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 (; 45 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 (; 50 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   get_local $0
   get_local $1
   i64.add
  )
- (func $~lib/typedarray/Int64Array#reduce<i64> (; 46 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/typedarray/Int64Array#reduce<i64> (; 51 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local $3 i64)
   (local $4 i32)
@@ -2758,10 +2813,10 @@
   end
   get_local $3
  )
- (func $std/typedarray/testReduce<Int64Array,i64> (; 47 ;) (type $v)
+ (func $std/typedarray/testReduce<Int64Array,i64> (; 52 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   tee_local $0
   i32.const 0
   i64.const 1
@@ -2788,10 +2843,10 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Uint64Array,u64> (; 48 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint64Array,u64> (; 53 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   tee_local $0
   i32.const 0
   i64.const 1
@@ -2818,7 +2873,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<f32>#__set (; 49 ;) (type $iifv) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/internal/typedarray/TypedArray<f32>#__set (; 54 ;) (type $iifv) (param $0 i32) (param $1 i32) (param $2 f32)
   get_local $1
   get_local $0
   i32.load offset=8
@@ -2845,12 +2900,12 @@
   get_local $2
   f32.store offset=8
  )
- (func $std/typedarray/testReduce<Float32Array,f32>~anonymous|11 (; 50 ;) (type $ffiif) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
+ (func $std/typedarray/testReduce<Float32Array,f32>~anonymous|11 (; 55 ;) (type $ffiif) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
   get_local $0
   get_local $1
   f32.add
  )
- (func $~lib/typedarray/Float32Array#reduce<f32> (; 51 ;) (type $FUNCSIG$fi) (param $0 i32) (result f32)
+ (func $~lib/typedarray/Float32Array#reduce<f32> (; 56 ;) (type $FUNCSIG$fi) (param $0 i32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 i32)
@@ -2897,10 +2952,10 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduce<Float32Array,f32> (; 52 ;) (type $v)
+ (func $std/typedarray/testReduce<Float32Array,f32> (; 57 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   tee_local $0
   i32.const 0
   f32.const 1
@@ -2926,12 +2981,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Float64Array,f64>~anonymous|12 (; 53 ;) (type $FFiiF) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
+ (func $std/typedarray/testReduce<Float64Array,f64>~anonymous|12 (; 58 ;) (type $FFiiF) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
   get_local $0
   get_local $1
   f64.add
  )
- (func $~lib/typedarray/Float64Array#reduce<f64> (; 54 ;) (type $FUNCSIG$di) (param $0 i32) (result f64)
+ (func $~lib/typedarray/Float64Array#reduce<f64> (; 59 ;) (type $FUNCSIG$di) (param $0 i32) (result f64)
   (local $1 i32)
   (local $2 f64)
   (local $3 i32)
@@ -2978,10 +3033,10 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduce<Float64Array,f64> (; 55 ;) (type $v)
+ (func $std/typedarray/testReduce<Float64Array,f64> (; 60 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   tee_local $0
   i32.const 0
   f64.const 1
@@ -3007,7 +3062,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Int8Array#reduceRight<i8> (; 56 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#reduceRight<i8> (; 61 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3051,10 +3106,11 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduceRight<Int8Array,i8> (; 57 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int8Array,i8> (; 62 ;) (type $v)
   (local $0 i32)
+  i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -3082,7 +3138,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Uint8Array#reduceRight<u8> (; 58 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#reduceRight<u8> (; 63 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3126,10 +3182,11 @@
   end
   get_local $3
  )
- (func $std/typedarray/testReduceRight<Uint8Array,u8> (; 59 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint8Array,u8> (; 64 ;) (type $v)
   (local $0 i32)
+  i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -3158,10 +3215,10 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8> (; 60 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8> (; 65 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Uint8ClampedArray#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -3190,7 +3247,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Int16Array#reduceRight<i16> (; 61 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#reduceRight<i16> (; 66 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3238,10 +3295,10 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduceRight<Int16Array,i16> (; 62 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int16Array,i16> (; 67 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  call $~lib/typedarray/Int16Array#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -3269,7 +3326,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Uint16Array#reduceRight<u16> (; 63 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#reduceRight<u16> (; 68 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3317,10 +3374,10 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduceRight<Uint16Array,u16> (; 64 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint16Array,u16> (; 69 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  call $~lib/typedarray/Int16Array#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -3348,7 +3405,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Int32Array#reduceRight<i32> (; 65 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#reduceRight<i32> (; 70 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3396,10 +3453,10 @@
   end
   get_local $3
  )
- (func $std/typedarray/testReduceRight<Int32Array,i32> (; 66 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int32Array,i32> (; 71 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -3426,10 +3483,10 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint32Array,u32> (; 67 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint32Array,u32> (; 72 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -3456,7 +3513,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Int64Array#reduceRight<i64> (; 68 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/typedarray/Int64Array#reduceRight<i64> (; 73 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local $3 i64)
   (local $4 i32)
@@ -3504,10 +3561,10 @@
   end
   get_local $3
  )
- (func $std/typedarray/testReduceRight<Int64Array,i64> (; 69 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int64Array,i64> (; 74 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   tee_local $0
   i32.const 0
   i64.const 1
@@ -3534,10 +3591,10 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint64Array,u64> (; 70 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint64Array,u64> (; 75 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   tee_local $0
   i32.const 0
   i64.const 1
@@ -3564,7 +3621,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Float32Array#reduceRight<f32> (; 71 ;) (type $FUNCSIG$fi) (param $0 i32) (result f32)
+ (func $~lib/typedarray/Float32Array#reduceRight<f32> (; 76 ;) (type $FUNCSIG$fi) (param $0 i32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 i32)
@@ -3612,10 +3669,10 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduceRight<Float32Array,f32> (; 72 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Float32Array,f32> (; 77 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   tee_local $0
   i32.const 0
   f32.const 1
@@ -3641,7 +3698,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Float64Array#reduceRight<f64> (; 73 ;) (type $FUNCSIG$di) (param $0 i32) (result f64)
+ (func $~lib/typedarray/Float64Array#reduceRight<f64> (; 78 ;) (type $FUNCSIG$di) (param $0 i32) (result f64)
   (local $1 i32)
   (local $2 f64)
   (local $3 i32)
@@ -3689,10 +3746,10 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduceRight<Float64Array,f64> (; 74 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Float64Array,f64> (; 79 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   tee_local $0
   i32.const 0
   f64.const 1
@@ -3718,12 +3775,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 (; 75 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 (; 80 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   get_local $0
   i32.mul
  )
- (func $~lib/typedarray/Int8Array#map (; 76 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#map (; 81 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3736,10 +3793,11 @@
   get_local $0
   i32.load offset=4
   set_local $3
+  i32.const 0
   get_local $0
   i32.load offset=8
   tee_local $4
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   tee_local $5
   i32.load
   set_local $6
@@ -3773,10 +3831,11 @@
   end
   get_local $5
  )
- (func $std/typedarray/testArrayMap<Int8Array,i8> (; 77 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int8Array,i8> (; 82 ;) (type $v)
   (local $0 i32)
+  i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -3837,61 +3896,62 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Uint8Array#map (; 78 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#map (; 83 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 i32)
   get_local $0
   i32.load
-  set_local $3
+  set_local $2
   get_local $0
   i32.load offset=4
-  set_local $4
+  set_local $3
+  i32.const 0
   get_local $0
   i32.load offset=8
+  tee_local $4
+  call $~lib/typedarray/Int8Array#constructor
   tee_local $5
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
-  tee_local $6
   i32.load
-  set_local $7
+  set_local $6
   loop $repeat|0
-   block $break|0
-    get_local $2
-    get_local $5
-    i32.ge_s
-    br_if $break|0
+   get_local $1
+   get_local $4
+   i32.lt_s
+   if
     i32.const 3
     set_global $~argc
-    get_local $2
-    get_local $7
+    get_local $1
+    get_local $6
     i32.add
+    get_local $1
     get_local $2
+    i32.add
     get_local $3
     i32.add
-    get_local $4
-    i32.add
     i32.load8_u offset=8
-    get_local $2
-    get_local $0
     get_local $1
+    get_local $0
+    i32.const 25
     call_indirect (type $iiii)
     i32.store8 offset=8
-    get_local $2
+    get_local $1
     i32.const 1
     i32.add
-    set_local $2
+    set_local $1
     br $repeat|0
    end
   end
-  get_local $6
+  get_local $5
  )
- (func $std/typedarray/testArrayMap<Uint8Array,u8> (; 79 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint8Array,u8> (; 84 ;) (type $v)
   (local $0 i32)
+  i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -3905,7 +3965,6 @@
   i32.const 3
   call $~lib/internal/typedarray/TypedArray<u8>#__set
   get_local $0
-  i32.const 25
   call $~lib/typedarray/Uint8Array#map
   tee_local $0
   i32.const 0
@@ -3953,10 +4012,60 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8> (; 80 ;) (type $v)
+ (func $~lib/typedarray/Uint8ClampedArray#map (; 85 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  get_local $0
+  i32.load
+  set_local $2
+  get_local $0
+  i32.load offset=4
+  set_local $3
+  get_local $0
+  i32.load offset=8
+  tee_local $4
+  call $~lib/typedarray/Uint8ClampedArray#constructor
+  tee_local $5
+  i32.load
+  set_local $6
+  loop $repeat|0
+   get_local $1
+   get_local $4
+   i32.lt_s
+   if
+    i32.const 3
+    set_global $~argc
+    get_local $1
+    get_local $6
+    i32.add
+    get_local $1
+    get_local $2
+    i32.add
+    get_local $3
+    i32.add
+    i32.load8_u offset=8
+    get_local $1
+    get_local $0
+    i32.const 26
+    call_indirect (type $iiii)
+    i32.store8 offset=8
+    get_local $1
+    i32.const 1
+    i32.add
+    set_local $1
+    br $repeat|0
+   end
+  end
+  get_local $5
+ )
+ (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8> (; 86 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Uint8ClampedArray#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -3970,8 +4079,7 @@
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#__set
   get_local $0
-  i32.const 26
-  call $~lib/typedarray/Uint8Array#map
+  call $~lib/typedarray/Uint8ClampedArray#map
   tee_local $0
   i32.const 0
   call $~lib/internal/typedarray/TypedArray<u8>#__get
@@ -4018,7 +4126,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Int16Array#map (; 81 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#map (; 87 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4037,7 +4145,7 @@
   i32.const 1
   i32.shr_u
   tee_local $4
-  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  call $~lib/typedarray/Int16Array#constructor
   tee_local $5
   i32.load
   set_local $6
@@ -4074,7 +4182,7 @@
   end
   get_local $5
  )
- (func $~lib/internal/typedarray/TypedArray<i16>#__get (; 82 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<i16>#__get (; 88 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   get_local $1
   get_local $0
   i32.load offset=8
@@ -4100,10 +4208,10 @@
   i32.add
   i32.load16_s offset=8
  )
- (func $std/typedarray/testArrayMap<Int16Array,i16> (; 83 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int16Array,i16> (; 89 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  call $~lib/typedarray/Int16Array#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -4164,7 +4272,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Uint16Array#map (; 84 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#map (; 90 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4183,7 +4291,7 @@
   i32.const 1
   i32.shr_u
   tee_local $4
-  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  call $~lib/typedarray/Int16Array#constructor
   tee_local $5
   i32.load
   set_local $6
@@ -4220,7 +4328,7 @@
   end
   get_local $5
  )
- (func $~lib/internal/typedarray/TypedArray<u16>#__get (; 85 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<u16>#__get (; 91 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   get_local $1
   get_local $0
   i32.load offset=8
@@ -4246,10 +4354,10 @@
   i32.add
   i32.load16_u offset=8
  )
- (func $std/typedarray/testArrayMap<Uint16Array,u16> (; 86 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint16Array,u16> (; 92 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  call $~lib/typedarray/Int16Array#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -4310,7 +4418,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Int32Array#map (; 87 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#map (; 93 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4328,7 +4436,7 @@
   i32.const 2
   i32.shr_u
   tee_local $5
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   tee_local $6
   i32.load
   set_local $7
@@ -4367,10 +4475,10 @@
   end
   get_local $6
  )
- (func $std/typedarray/testArrayMap<Int32Array,i32> (; 88 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int32Array,i32> (; 94 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -4426,10 +4534,10 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint32Array,u32> (; 89 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint32Array,u32> (; 95 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -4485,12 +4593,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 (; 90 ;) (type $IiiI) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+ (func $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 (; 96 ;) (type $IiiI) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
   get_local $0
   get_local $0
   i64.mul
  )
- (func $~lib/typedarray/Int64Array#map (; 91 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#map (; 97 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4508,7 +4616,7 @@
   i32.const 3
   i32.shr_u
   tee_local $5
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   tee_local $6
   i32.load
   set_local $7
@@ -4547,7 +4655,7 @@
   end
   get_local $6
  )
- (func $~lib/internal/typedarray/TypedArray<i64>#__get (; 92 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/internal/typedarray/TypedArray<i64>#__get (; 98 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
   get_local $1
   get_local $0
   i32.load offset=8
@@ -4573,10 +4681,10 @@
   i32.add
   i64.load offset=8
  )
- (func $std/typedarray/testArrayMap<Int64Array,i64> (; 93 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int64Array,i64> (; 99 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   tee_local $0
   i32.const 0
   i64.const 1
@@ -4632,10 +4740,10 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint64Array,u64> (; 94 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint64Array,u64> (; 100 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   tee_local $0
   i32.const 0
   i64.const 1
@@ -4691,12 +4799,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|33 (; 95 ;) (type $fiif) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
+ (func $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|33 (; 101 ;) (type $fiif) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
   get_local $0
   get_local $0
   f32.mul
  )
- (func $~lib/typedarray/Float32Array#map (; 96 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#map (; 102 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4715,7 +4823,7 @@
   i32.const 2
   i32.shr_u
   tee_local $4
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   tee_local $5
   i32.load
   set_local $6
@@ -4752,7 +4860,7 @@
   end
   get_local $5
  )
- (func $~lib/internal/typedarray/TypedArray<f32>#__get (; 97 ;) (type $iif) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/internal/typedarray/TypedArray<f32>#__get (; 103 ;) (type $iif) (param $0 i32) (param $1 i32) (result f32)
   get_local $1
   get_local $0
   i32.load offset=8
@@ -4778,10 +4886,10 @@
   i32.add
   f32.load offset=8
  )
- (func $std/typedarray/testArrayMap<Float32Array,f32> (; 98 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Float32Array,f32> (; 104 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   tee_local $0
   i32.const 0
   f32.const 1
@@ -4836,12 +4944,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|34 (; 99 ;) (type $FiiF) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
+ (func $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|34 (; 105 ;) (type $FiiF) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
   get_local $0
   get_local $0
   f64.mul
  )
- (func $~lib/typedarray/Float64Array#map (; 100 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#map (; 106 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4860,7 +4968,7 @@
   i32.const 3
   i32.shr_u
   tee_local $4
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   tee_local $5
   i32.load
   set_local $6
@@ -4897,10 +5005,10 @@
   end
   get_local $5
  )
- (func $std/typedarray/testArrayMap<Float64Array,f64> (; 101 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Float64Array,f64> (; 107 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   tee_local $0
   i32.const 0
   f64.const 1
@@ -4955,14 +5063,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 (; 102 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 (; 108 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 255
   i32.and
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Int8Array#some (; 103 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#some (; 109 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5008,16 +5116,17 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Int8Array,i8>~anonymous|36 (; 104 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int8Array,i8>~anonymous|36 (; 110 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 255
   i32.and
   i32.eqz
  )
- (func $std/typedarray/testArraySome<Int8Array,i8> (; 105 ;) (type $v)
+ (func $std/typedarray/testArraySome<Int8Array,i8> (; 111 ;) (type $v)
   (local $0 i32)
+  i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   tee_local $0
   i32.const 0
   i32.const 2
@@ -5054,7 +5163,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Uint8Array#some (; 106 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#some (; 112 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5100,10 +5209,11 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Uint8Array,u8> (; 107 ;) (type $v)
+ (func $std/typedarray/testArraySome<Uint8Array,u8> (; 113 ;) (type $v)
   (local $0 i32)
+  i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   tee_local $0
   i32.const 0
   i32.const 2
@@ -5140,10 +5250,10 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint8ClampedArray,u8> (; 108 ;) (type $v)
+ (func $std/typedarray/testArraySome<Uint8ClampedArray,u8> (; 114 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Uint8ClampedArray#constructor
   tee_local $0
   i32.const 0
   i32.const 2
@@ -5180,14 +5290,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 (; 109 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 (; 115 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 65535
   i32.and
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Int16Array#some (; 110 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#some (; 116 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5237,16 +5347,16 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Int16Array,i16>~anonymous|42 (; 111 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int16Array,i16>~anonymous|42 (; 117 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 65535
   i32.and
   i32.eqz
  )
- (func $std/typedarray/testArraySome<Int16Array,i16> (; 112 ;) (type $v)
+ (func $std/typedarray/testArraySome<Int16Array,i16> (; 118 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  call $~lib/typedarray/Int16Array#constructor
   tee_local $0
   i32.const 0
   i32.const 2
@@ -5283,7 +5393,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Uint16Array#some (; 113 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#some (; 119 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5333,10 +5443,10 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Uint16Array,u16> (; 114 ;) (type $v)
+ (func $std/typedarray/testArraySome<Uint16Array,u16> (; 120 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  call $~lib/typedarray/Int16Array#constructor
   tee_local $0
   i32.const 0
   i32.const 2
@@ -5373,12 +5483,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 (; 115 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 (; 121 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Int32Array#some (; 116 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#some (; 122 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5428,14 +5538,14 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Int32Array,i32>~anonymous|46 (; 117 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int32Array,i32>~anonymous|46 (; 123 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.eqz
  )
- (func $std/typedarray/testArraySome<Int32Array,i32> (; 118 ;) (type $v)
+ (func $std/typedarray/testArraySome<Int32Array,i32> (; 124 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   tee_local $0
   i32.const 0
   i32.const 2
@@ -5472,10 +5582,10 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint32Array,u32> (; 119 ;) (type $v)
+ (func $std/typedarray/testArraySome<Uint32Array,u32> (; 125 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   tee_local $0
   i32.const 0
   i32.const 2
@@ -5512,12 +5622,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 (; 120 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 (; 126 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i64.const 2
   i64.eq
  )
- (func $~lib/typedarray/Int64Array#some (; 121 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#some (; 127 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5567,15 +5677,15 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Int64Array,i64>~anonymous|50 (; 122 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int64Array,i64>~anonymous|50 (; 128 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i64.const 0
   i64.eq
  )
- (func $std/typedarray/testArraySome<Int64Array,i64> (; 123 ;) (type $v)
+ (func $std/typedarray/testArraySome<Int64Array,i64> (; 129 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   tee_local $0
   i32.const 0
   i64.const 2
@@ -5612,10 +5722,10 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint64Array,u64> (; 124 ;) (type $v)
+ (func $std/typedarray/testArraySome<Uint64Array,u64> (; 130 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   tee_local $0
   i32.const 0
   i64.const 2
@@ -5652,12 +5762,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Float32Array,f32>~anonymous|53 (; 125 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Float32Array,f32>~anonymous|53 (; 131 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   f32.const 2
   f32.eq
  )
- (func $~lib/typedarray/Float32Array#some (; 126 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#some (; 132 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5707,15 +5817,15 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Float32Array,f32>~anonymous|54 (; 127 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Float32Array,f32>~anonymous|54 (; 133 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   f32.const 0
   f32.eq
  )
- (func $std/typedarray/testArraySome<Float32Array,f32> (; 128 ;) (type $v)
+ (func $std/typedarray/testArraySome<Float32Array,f32> (; 134 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   tee_local $0
   i32.const 0
   f32.const 2
@@ -5752,12 +5862,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Float64Array,f64>~anonymous|55 (; 129 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Float64Array,f64>~anonymous|55 (; 135 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   f64.const 2
   f64.eq
  )
- (func $~lib/typedarray/Float64Array#some (; 130 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#some (; 136 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5807,15 +5917,15 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Float64Array,f64>~anonymous|56 (; 131 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Float64Array,f64>~anonymous|56 (; 137 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   f64.const 0
   f64.eq
  )
- (func $std/typedarray/testArraySome<Float64Array,f64> (; 132 ;) (type $v)
+ (func $std/typedarray/testArraySome<Float64Array,f64> (; 138 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   tee_local $0
   i32.const 0
   f64.const 2
@@ -5852,7 +5962,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Int8Array#findIndex (; 133 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#findIndex (; 139 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5898,17 +6008,18 @@
   end
   get_local $2
  )
- (func $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|58 (; 134 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|58 (; 140 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 255
   i32.and
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int8Array,i8> (; 135 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Int8Array,i8> (; 141 ;) (type $v)
   (local $0 i32)
+  i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -5948,7 +6059,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Uint8Array#findIndex (; 136 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#findIndex (; 142 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5994,10 +6105,11 @@
   end
   get_local $2
  )
- (func $std/typedarray/testArrayFindIndex<Uint8Array,u8> (; 137 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Uint8Array,u8> (; 143 ;) (type $v)
   (local $0 i32)
+  i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -6037,10 +6149,10 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8> (; 138 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8> (; 144 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Uint8ClampedArray#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -6080,7 +6192,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Int16Array#findIndex (; 139 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#findIndex (; 145 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6130,17 +6242,17 @@
   end
   get_local $2
  )
- (func $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|64 (; 140 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|64 (; 146 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 65535
   i32.and
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int16Array,i16> (; 141 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Int16Array,i16> (; 147 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  call $~lib/typedarray/Int16Array#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -6180,7 +6292,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Uint16Array#findIndex (; 142 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#findIndex (; 148 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6230,10 +6342,10 @@
   end
   get_local $2
  )
- (func $std/typedarray/testArrayFindIndex<Uint16Array,u16> (; 143 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Uint16Array,u16> (; 149 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  call $~lib/typedarray/Int16Array#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -6273,7 +6385,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Int32Array#findIndex (; 144 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#findIndex (; 150 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6323,15 +6435,15 @@
   end
   get_local $2
  )
- (func $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|68 (; 145 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|68 (; 151 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int32Array,i32> (; 146 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Int32Array,i32> (; 152 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -6371,10 +6483,10 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint32Array,u32> (; 147 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Uint32Array,u32> (; 153 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   tee_local $0
   i32.const 0
   i32.const 1
@@ -6414,7 +6526,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Int64Array#findIndex (; 148 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#findIndex (; 154 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6464,15 +6576,15 @@
   end
   get_local $2
  )
- (func $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|72 (; 149 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|72 (; 155 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i64.const 4
   i64.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int64Array,i64> (; 150 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Int64Array,i64> (; 156 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   tee_local $0
   i32.const 0
   i64.const 1
@@ -6512,10 +6624,10 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint64Array,u64> (; 151 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Uint64Array,u64> (; 157 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   tee_local $0
   i32.const 0
   i64.const 1
@@ -6555,7 +6667,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Float32Array#findIndex (; 152 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#findIndex (; 158 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6605,15 +6717,15 @@
   end
   get_local $2
  )
- (func $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|76 (; 153 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|76 (; 159 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   f32.const 4
   f32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Float32Array,f32> (; 154 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Float32Array,f32> (; 160 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   tee_local $0
   i32.const 0
   f32.const 1
@@ -6653,7 +6765,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Float64Array#findIndex (; 155 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#findIndex (; 161 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6703,15 +6815,15 @@
   end
   get_local $2
  )
- (func $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|78 (; 156 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|78 (; 162 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   f64.const 4
   f64.eq
  )
- (func $std/typedarray/testArrayFindIndex<Float64Array,f64> (; 157 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Float64Array,f64> (; 163 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   tee_local $0
   i32.const 0
   f64.const 1
@@ -6751,7 +6863,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|79 (; 158 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|79 (; 164 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 24
   i32.shl
@@ -6761,7 +6873,7 @@
   i32.rem_s
   i32.eqz
  )
- (func $~lib/typedarray/Int8Array#every (; 159 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#every (; 165 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6809,10 +6921,11 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int8Array,i8> (; 160 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Int8Array,i8> (; 166 ;) (type $v)
   (local $0 i32)
+  i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   tee_local $0
   i32.const 0
   i32.const 2
@@ -6849,13 +6962,13 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|81 (; 161 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|81 (; 167 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 1
   i32.and
   i32.eqz
  )
- (func $~lib/typedarray/Uint8Array#every (; 162 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#every (; 168 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6903,10 +7016,11 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Uint8Array,u8> (; 163 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Uint8Array,u8> (; 169 ;) (type $v)
   (local $0 i32)
+  i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   tee_local $0
   i32.const 0
   i32.const 2
@@ -6943,10 +7057,10 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8> (; 164 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8> (; 170 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Uint8ClampedArray#constructor
   tee_local $0
   i32.const 0
   i32.const 2
@@ -6983,7 +7097,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|85 (; 165 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|85 (; 171 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 16
   i32.shl
@@ -6993,7 +7107,7 @@
   i32.rem_s
   i32.eqz
  )
- (func $~lib/typedarray/Int16Array#every (; 166 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#every (; 172 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7045,10 +7159,10 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int16Array,i16> (; 167 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Int16Array,i16> (; 173 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  call $~lib/typedarray/Int16Array#constructor
   tee_local $0
   i32.const 0
   i32.const 2
@@ -7085,7 +7199,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Uint16Array#every (; 168 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#every (; 174 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7137,10 +7251,10 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Uint16Array,u16> (; 169 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Uint16Array,u16> (; 175 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  call $~lib/typedarray/Int16Array#constructor
   tee_local $0
   i32.const 0
   i32.const 2
@@ -7177,13 +7291,13 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|89 (; 170 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|89 (; 176 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 2
   i32.rem_s
   i32.eqz
  )
- (func $~lib/typedarray/Int32Array#every (; 171 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#every (; 177 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7235,10 +7349,10 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int32Array,i32> (; 172 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Int32Array,i32> (; 178 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   tee_local $0
   i32.const 0
   i32.const 2
@@ -7275,10 +7389,10 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint32Array,u32> (; 173 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Uint32Array,u32> (; 179 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   tee_local $0
   i32.const 0
   i32.const 2
@@ -7315,14 +7429,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|93 (; 174 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|93 (; 180 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i64.const 2
   i64.rem_s
   i64.const 0
   i64.eq
  )
- (func $~lib/typedarray/Int64Array#every (; 175 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#every (; 181 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7374,10 +7488,10 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int64Array,i64> (; 176 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Int64Array,i64> (; 182 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   tee_local $0
   i32.const 0
   i64.const 2
@@ -7414,17 +7528,17 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|95 (; 177 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|95 (; 183 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i64.const 2
   i64.rem_u
   i64.const 0
   i64.eq
  )
- (func $std/typedarray/testArrayEvery<Uint64Array,u64> (; 178 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Uint64Array,u64> (; 184 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   tee_local $0
   i32.const 0
   i64.const 2
@@ -7461,7 +7575,7 @@
    unreachable
   end
  )
- (func $~lib/math/NativeMathf.mod (; 179 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (; 185 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7612,13 +7726,13 @@
   get_local $0
   f32.mul
  )
- (func $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|97 (; 180 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|97 (; 186 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   call $~lib/math/NativeMathf.mod
   f32.const 0
   f32.eq
  )
- (func $~lib/typedarray/Float32Array#every (; 181 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#every (; 187 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7670,10 +7784,10 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Float32Array,f32> (; 182 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Float32Array,f32> (; 188 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   tee_local $0
   i32.const 0
   f32.const 2
@@ -7710,7 +7824,7 @@
    unreachable
   end
  )
- (func $~lib/math/NativeMath.mod (; 183 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (; 189 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -7869,13 +7983,13 @@
   get_local $0
   f64.mul
  )
- (func $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|99 (; 184 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|99 (; 190 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   call $~lib/math/NativeMath.mod
   f64.const 0
   f64.eq
  )
- (func $~lib/typedarray/Float64Array#every (; 185 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#every (; 191 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7927,10 +8041,10 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Float64Array,f64> (; 186 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Float64Array,f64> (; 192 ;) (type $v)
   (local $0 i32)
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   tee_local $0
   i32.const 0
   f64.const 2
@@ -7967,7 +8081,7 @@
    unreachable
   end
  )
- (func $start (; 187 ;) (type $v)
+ (func $start (; 193 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 624
@@ -7979,7 +8093,7 @@
   i32.const 5
   call $std/typedarray/testInstantiate
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   set_global $std/typedarray/arr
   get_global $std/typedarray/arr
   i32.const 0
@@ -8124,7 +8238,7 @@
    unreachable
   end
   i32.const 8
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   set_global $std/typedarray/af64
   get_global $std/typedarray/af64
   i32.const 0
@@ -8265,7 +8379,7 @@
    unreachable
   end
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Uint8ClampedArray#constructor
   set_global $std/typedarray/clampedArr
   get_global $std/typedarray/clampedArr
   i32.const 0
@@ -8322,8 +8436,9 @@
    call $~lib/env/abort
    unreachable
   end
+  i32.const 0
   i32.const 5
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   set_global $std/typedarray/arr8
   get_global $std/typedarray/arr8
   i32.const 0
@@ -8509,7 +8624,7 @@
    unreachable
   end
   i32.const 5
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   set_global $std/typedarray/arr32
   get_global $std/typedarray/arr32
   i32.const 0
@@ -8697,10 +8812,11 @@
    unreachable
   end
   i32.const 134217727
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   drop
+  i32.const 0
   i32.const 6
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   set_global $std/typedarray/multisubarr
   get_global $std/typedarray/multisubarr
   i32.const 0
@@ -8958,7 +9074,7 @@
   call $std/typedarray/testArrayEvery<Float32Array,f32>
   call $std/typedarray/testArrayEvery<Float64Array,f64>
  )
- (func $null (; 188 ;) (type $v)
+ (func $null (; 194 ;) (type $v)
   nop
  )
 )

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -512,28 +512,25 @@
   get_local $5
   get_local $2
   call $~lib/internal/memory/memset
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 12
     call $~lib/memory/memory.allocate
-    set_local $5
-    get_local $5
-    i32.const 0
-    i32.store
-    get_local $5
-    i32.const 0
-    i32.store offset=4
-    get_local $5
-    i32.const 0
-    i32.store offset=8
-    get_local $5
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
   end
-  tee_local $0
   get_local $3
   i32.store
   get_local $0
@@ -544,7 +541,21 @@
   i32.store offset=8
   get_local $0
  )
- (func $~lib/internal/typedarray/TypedArray<u8>#constructor (; 7 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#constructor (; 7 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 12
+   call $~lib/memory/memory.allocate
+   set_local $0
+  end
+  get_local $0
+  get_local $1
+  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  set_local $0
+  get_local $0
+ )
+ (func $~lib/internal/typedarray/TypedArray<u8>#constructor (; 8 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -577,28 +588,25 @@
   get_local $5
   get_local $2
   call $~lib/internal/memory/memset
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 12
     call $~lib/memory/memory.allocate
-    set_local $5
-    get_local $5
-    i32.const 0
-    i32.store
-    get_local $5
-    i32.const 0
-    i32.store offset=4
-    get_local $5
-    i32.const 0
-    i32.store offset=8
-    get_local $5
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
   end
-  tee_local $0
   get_local $3
   i32.store
   get_local $0
@@ -609,7 +617,35 @@
   i32.store offset=8
   get_local $0
  )
- (func $~lib/internal/typedarray/TypedArray<i16>#constructor (; 8 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#constructor (; 9 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 12
+   call $~lib/memory/memory.allocate
+   set_local $0
+  end
+  get_local $0
+  get_local $1
+  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  set_local $0
+  get_local $0
+ )
+ (func $~lib/typedarray/Uint8ClampedArray#constructor (; 10 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 12
+   call $~lib/memory/memory.allocate
+   set_local $0
+  end
+  get_local $0
+  get_local $1
+  call $~lib/typedarray/Uint8Array#constructor
+  set_local $0
+  get_local $0
+ )
+ (func $~lib/internal/typedarray/TypedArray<i16>#constructor (; 11 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -642,28 +678,25 @@
   get_local $5
   get_local $2
   call $~lib/internal/memory/memset
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 12
     call $~lib/memory/memory.allocate
-    set_local $5
-    get_local $5
-    i32.const 0
-    i32.store
-    get_local $5
-    i32.const 0
-    i32.store offset=4
-    get_local $5
-    i32.const 0
-    i32.store offset=8
-    get_local $5
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
   end
-  tee_local $0
   get_local $3
   i32.store
   get_local $0
@@ -674,7 +707,21 @@
   i32.store offset=8
   get_local $0
  )
- (func $~lib/internal/typedarray/TypedArray<u16>#constructor (; 9 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#constructor (; 12 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 12
+   call $~lib/memory/memory.allocate
+   set_local $0
+  end
+  get_local $0
+  get_local $1
+  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  set_local $0
+  get_local $0
+ )
+ (func $~lib/internal/typedarray/TypedArray<u16>#constructor (; 13 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -707,28 +754,25 @@
   get_local $5
   get_local $2
   call $~lib/internal/memory/memset
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 12
     call $~lib/memory/memory.allocate
-    set_local $5
-    get_local $5
-    i32.const 0
-    i32.store
-    get_local $5
-    i32.const 0
-    i32.store offset=4
-    get_local $5
-    i32.const 0
-    i32.store offset=8
-    get_local $5
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
   end
-  tee_local $0
   get_local $3
   i32.store
   get_local $0
@@ -739,7 +783,21 @@
   i32.store offset=8
   get_local $0
  )
- (func $~lib/internal/typedarray/TypedArray<i32>#constructor (; 10 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#constructor (; 14 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 12
+   call $~lib/memory/memory.allocate
+   set_local $0
+  end
+  get_local $0
+  get_local $1
+  call $~lib/internal/typedarray/TypedArray<u16>#constructor
+  set_local $0
+  get_local $0
+ )
+ (func $~lib/internal/typedarray/TypedArray<i32>#constructor (; 15 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -772,28 +830,25 @@
   get_local $5
   get_local $2
   call $~lib/internal/memory/memset
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 12
     call $~lib/memory/memory.allocate
-    set_local $5
-    get_local $5
-    i32.const 0
-    i32.store
-    get_local $5
-    i32.const 0
-    i32.store offset=4
-    get_local $5
-    i32.const 0
-    i32.store offset=8
-    get_local $5
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
   end
-  tee_local $0
   get_local $3
   i32.store
   get_local $0
@@ -804,7 +859,21 @@
   i32.store offset=8
   get_local $0
  )
- (func $~lib/internal/typedarray/TypedArray<u32>#constructor (; 11 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#constructor (; 16 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 12
+   call $~lib/memory/memory.allocate
+   set_local $0
+  end
+  get_local $0
+  get_local $1
+  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  set_local $0
+  get_local $0
+ )
+ (func $~lib/internal/typedarray/TypedArray<u32>#constructor (; 17 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -837,28 +906,25 @@
   get_local $5
   get_local $2
   call $~lib/internal/memory/memset
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 12
     call $~lib/memory/memory.allocate
-    set_local $5
-    get_local $5
-    i32.const 0
-    i32.store
-    get_local $5
-    i32.const 0
-    i32.store offset=4
-    get_local $5
-    i32.const 0
-    i32.store offset=8
-    get_local $5
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
   end
-  tee_local $0
   get_local $3
   i32.store
   get_local $0
@@ -869,7 +935,21 @@
   i32.store offset=8
   get_local $0
  )
- (func $~lib/internal/typedarray/TypedArray<i64>#constructor (; 12 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#constructor (; 18 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 12
+   call $~lib/memory/memory.allocate
+   set_local $0
+  end
+  get_local $0
+  get_local $1
+  call $~lib/internal/typedarray/TypedArray<u32>#constructor
+  set_local $0
+  get_local $0
+ )
+ (func $~lib/internal/typedarray/TypedArray<i64>#constructor (; 19 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -902,28 +982,25 @@
   get_local $5
   get_local $2
   call $~lib/internal/memory/memset
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 12
     call $~lib/memory/memory.allocate
-    set_local $5
-    get_local $5
-    i32.const 0
-    i32.store
-    get_local $5
-    i32.const 0
-    i32.store offset=4
-    get_local $5
-    i32.const 0
-    i32.store offset=8
-    get_local $5
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
   end
-  tee_local $0
   get_local $3
   i32.store
   get_local $0
@@ -934,7 +1011,21 @@
   i32.store offset=8
   get_local $0
  )
- (func $~lib/internal/typedarray/TypedArray<u64>#constructor (; 13 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#constructor (; 20 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 12
+   call $~lib/memory/memory.allocate
+   set_local $0
+  end
+  get_local $0
+  get_local $1
+  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  set_local $0
+  get_local $0
+ )
+ (func $~lib/internal/typedarray/TypedArray<u64>#constructor (; 21 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -967,28 +1058,25 @@
   get_local $5
   get_local $2
   call $~lib/internal/memory/memset
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 12
     call $~lib/memory/memory.allocate
-    set_local $5
-    get_local $5
-    i32.const 0
-    i32.store
-    get_local $5
-    i32.const 0
-    i32.store offset=4
-    get_local $5
-    i32.const 0
-    i32.store offset=8
-    get_local $5
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
   end
-  tee_local $0
   get_local $3
   i32.store
   get_local $0
@@ -999,7 +1087,21 @@
   i32.store offset=8
   get_local $0
  )
- (func $~lib/internal/typedarray/TypedArray<f32>#constructor (; 14 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#constructor (; 22 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 12
+   call $~lib/memory/memory.allocate
+   set_local $0
+  end
+  get_local $0
+  get_local $1
+  call $~lib/internal/typedarray/TypedArray<u64>#constructor
+  set_local $0
+  get_local $0
+ )
+ (func $~lib/internal/typedarray/TypedArray<f32>#constructor (; 23 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1032,28 +1134,25 @@
   get_local $5
   get_local $2
   call $~lib/internal/memory/memset
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 12
     call $~lib/memory/memory.allocate
-    set_local $5
-    get_local $5
-    i32.const 0
-    i32.store
-    get_local $5
-    i32.const 0
-    i32.store offset=4
-    get_local $5
-    i32.const 0
-    i32.store offset=8
-    get_local $5
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
   end
-  tee_local $0
   get_local $3
   i32.store
   get_local $0
@@ -1064,7 +1163,21 @@
   i32.store offset=8
   get_local $0
  )
- (func $~lib/internal/typedarray/TypedArray<f64>#constructor (; 15 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#constructor (; 24 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 12
+   call $~lib/memory/memory.allocate
+   set_local $0
+  end
+  get_local $0
+  get_local $1
+  call $~lib/internal/typedarray/TypedArray<f32>#constructor
+  set_local $0
+  get_local $0
+ )
+ (func $~lib/internal/typedarray/TypedArray<f64>#constructor (; 25 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1097,28 +1210,25 @@
   get_local $5
   get_local $2
   call $~lib/internal/memory/memset
-  get_local $0
-  if (result i32)
+  block (result i32)
    get_local $0
-  else   
-   block (result i32)
+   i32.eqz
+   if
     i32.const 12
     call $~lib/memory/memory.allocate
-    set_local $5
-    get_local $5
-    i32.const 0
-    i32.store
-    get_local $5
-    i32.const 0
-    i32.store offset=4
-    get_local $5
-    i32.const 0
-    i32.store offset=8
-    get_local $5
+    set_local $0
    end
-   tee_local $0
+   get_local $0
+   i32.const 0
+   i32.store
+   get_local $0
+   i32.const 0
+   i32.store offset=4
+   get_local $0
+   i32.const 0
+   i32.store offset=8
+   get_local $0
   end
-  tee_local $0
   get_local $3
   i32.store
   get_local $0
@@ -1129,7 +1239,21 @@
   i32.store offset=8
   get_local $0
  )
- (func $std/typedarray/testInstantiate (; 16 ;) (type $iv) (param $0 i32)
+ (func $~lib/typedarray/Float64Array#constructor (; 26 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  get_local $0
+  i32.eqz
+  if
+   i32.const 12
+   call $~lib/memory/memory.allocate
+   set_local $0
+  end
+  get_local $0
+  get_local $1
+  call $~lib/internal/typedarray/TypedArray<f64>#constructor
+  set_local $0
+  get_local $0
+ )
+ (func $std/typedarray/testInstantiate (; 27 ;) (type $iv) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1143,7 +1267,7 @@
   (local $11 i32)
   i32.const 0
   get_local $0
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   set_local $1
   get_local $1
   i32.load offset=4
@@ -1192,7 +1316,7 @@
   end
   i32.const 0
   get_local $0
-  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  call $~lib/typedarray/Uint8Array#constructor
   set_local $2
   get_local $2
   i32.load offset=4
@@ -1241,7 +1365,7 @@
   end
   i32.const 0
   get_local $0
-  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  call $~lib/typedarray/Uint8ClampedArray#constructor
   set_local $3
   get_local $3
   i32.load offset=4
@@ -1290,7 +1414,7 @@
   end
   i32.const 0
   get_local $0
-  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  call $~lib/typedarray/Int16Array#constructor
   set_local $4
   get_local $4
   i32.load offset=4
@@ -1339,7 +1463,7 @@
   end
   i32.const 0
   get_local $0
-  call $~lib/internal/typedarray/TypedArray<u16>#constructor
+  call $~lib/typedarray/Uint16Array#constructor
   set_local $5
   get_local $5
   i32.load offset=4
@@ -1388,7 +1512,7 @@
   end
   i32.const 0
   get_local $0
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   set_local $6
   get_local $6
   i32.load offset=4
@@ -1437,7 +1561,7 @@
   end
   i32.const 0
   get_local $0
-  call $~lib/internal/typedarray/TypedArray<u32>#constructor
+  call $~lib/typedarray/Uint32Array#constructor
   set_local $7
   get_local $7
   i32.load offset=4
@@ -1486,7 +1610,7 @@
   end
   i32.const 0
   get_local $0
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   set_local $8
   get_local $8
   i32.load offset=4
@@ -1535,7 +1659,7 @@
   end
   i32.const 0
   get_local $0
-  call $~lib/internal/typedarray/TypedArray<u64>#constructor
+  call $~lib/typedarray/Uint64Array#constructor
   set_local $9
   get_local $9
   i32.load offset=4
@@ -1584,7 +1708,7 @@
   end
   i32.const 0
   get_local $0
-  call $~lib/internal/typedarray/TypedArray<f32>#constructor
+  call $~lib/typedarray/Float32Array#constructor
   set_local $10
   get_local $10
   i32.load offset=4
@@ -1633,7 +1757,7 @@
   end
   i32.const 0
   get_local $0
-  call $~lib/internal/typedarray/TypedArray<f64>#constructor
+  call $~lib/typedarray/Float64Array#constructor
   set_local $11
   get_local $11
   i32.load offset=4
@@ -1681,7 +1805,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i32>#__set (; 17 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<i32>#__set (; 28 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   get_local $1
@@ -1714,7 +1838,7 @@
   get_local $2
   i32.store offset=8
  )
- (func $~lib/internal/typedarray/TypedArray<i32>#__get (; 18 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<i32>#__get (; 29 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   get_local $1
@@ -1748,7 +1872,7 @@
    i32.load offset=8
   end
  )
- (func $~lib/typedarray/Int32Array#subarray (; 19 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#subarray (; 30 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1847,7 +1971,7 @@
   i32.store offset=8
   get_local $4
  )
- (func $~lib/internal/typedarray/TypedArray<f64>#__set (; 20 ;) (type $iiFv) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/internal/typedarray/TypedArray<f64>#__set (; 31 ;) (type $iiFv) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (local $4 i32)
   get_local $1
@@ -1880,7 +2004,7 @@
   get_local $2
   f64.store offset=8
  )
- (func $~lib/typedarray/Float64Array#subarray (; 21 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#subarray (; 32 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1979,7 +2103,7 @@
   i32.store offset=8
   get_local $4
  )
- (func $~lib/internal/sort/insertionSort<f64> (; 22 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<f64> (; 33 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 f64)
   (local $6 i32)
@@ -2091,10 +2215,10 @@
    unreachable
   end
  )
- (func $~lib/allocator/arena/__memory_free (; 23 ;) (type $iv) (param $0 i32)
+ (func $~lib/allocator/arena/__memory_free (; 34 ;) (type $iv) (param $0 i32)
   nop
  )
- (func $~lib/internal/sort/weakHeapSort<f64> (; 24 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/weakHeapSort<f64> (; 35 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -2507,7 +2631,7 @@
   get_local $12
   f64.store offset=8
  )
- (func $~lib/typedarray/Float64Array#sort (; 25 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#sort (; 36 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2621,7 +2745,7 @@
    get_local $0
   end
  )
- (func $~lib/typedarray/Float64Array#sort|trampoline~anonymous|1 (; 26 ;) (type $FFi) (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/typedarray/Float64Array#sort|trampoline~anonymous|1 (; 37 ;) (type $FFi) (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   get_local $0
@@ -2654,7 +2778,7 @@
   i64.lt_s
   i32.sub
  )
- (func $~lib/typedarray/Float64Array#sort|trampoline (; 27 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#sort|trampoline (; 38 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -2673,7 +2797,7 @@
   get_local $1
   call $~lib/typedarray/Float64Array#sort
  )
- (func $~lib/internal/typedarray/TypedArray<f64>#__get (; 28 ;) (type $iiF) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/internal/typedarray/TypedArray<f64>#__get (; 39 ;) (type $iiF) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local $3 i32)
   get_local $1
@@ -2707,7 +2831,7 @@
    f64.load offset=8
   end
  )
- (func $~lib/internal/typedarray/TypedArray<u8>#__set (; 29 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<u8>#__set (; 40 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   get_local $1
@@ -2740,7 +2864,7 @@
   get_local $2
   i32.store8 offset=8
  )
- (func $~lib/typedarray/Uint8ClampedArray#__set (; 30 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#__set (; 41 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   get_local $0
@@ -2762,7 +2886,7 @@
   select
   call $~lib/internal/typedarray/TypedArray<u8>#__set
  )
- (func $~lib/internal/typedarray/TypedArray<u8>#__get (; 31 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<u8>#__get (; 42 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   get_local $1
@@ -2796,7 +2920,7 @@
    i32.load8_u offset=8
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i8>#__set (; 32 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<i8>#__set (; 43 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   get_local $1
@@ -2829,7 +2953,7 @@
   get_local $2
   i32.store8 offset=8
  )
- (func $~lib/typedarray/Int8Array#fill (; 33 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#fill (; 44 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -2921,7 +3045,7 @@
   end
   get_local $0
  )
- (func $~lib/internal/typedarray/TypedArray<i8>#__get (; 34 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<i8>#__get (; 45 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   get_local $1
@@ -2955,7 +3079,7 @@
    i32.load8_s offset=8
   end
  )
- (func $~lib/array/Array<i8>#__get (; 35 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__get (; 46 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   get_local $0
@@ -2982,7 +3106,7 @@
    unreachable
   end
  )
- (func $std/typedarray/isInt8ArrayEqual (; 36 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/typedarray/isInt8ArrayEqual (; 47 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   block $~lib/internal/typedarray/TypedArray<i8>#get:length|inlined.3 (result i32)
@@ -3048,7 +3172,7 @@
   end
   i32.const 1
  )
- (func $~lib/typedarray/Int8Array#fill|trampoline (; 37 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#fill|trampoline (; 48 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -3072,7 +3196,7 @@
   get_local $3
   call $~lib/typedarray/Int8Array#fill
  )
- (func $~lib/typedarray/Int8Array#subarray (; 38 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#subarray (; 49 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3171,7 +3295,7 @@
   i32.store offset=8
   get_local $4
  )
- (func $~lib/typedarray/Int32Array#fill (; 39 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#fill (; 50 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3267,7 +3391,7 @@
   end
   get_local $0
  )
- (func $~lib/array/Array<i32>#__get (; 40 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (; 51 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   get_local $0
@@ -3294,7 +3418,7 @@
    unreachable
   end
  )
- (func $std/typedarray/isInt32ArrayEqual (; 41 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/typedarray/isInt32ArrayEqual (; 52 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   block $~lib/internal/typedarray/TypedArray<i32>#get:length|inlined.6 (result i32)
@@ -3352,7 +3476,7 @@
   end
   i32.const 1
  )
- (func $~lib/typedarray/Int32Array#fill|trampoline (; 42 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#fill|trampoline (; 53 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -3376,12 +3500,12 @@
   get_local $3
   call $~lib/typedarray/Int32Array#fill
  )
- (func $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 (; 43 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 (; 54 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/typedarray/Int8Array#reduce<i8> (; 44 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#reduce<i8> (; 55 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3439,12 +3563,12 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduce<Int8Array,i8> (; 45 ;) (type $v)
+ (func $std/typedarray/testReduce<Int8Array,i8> (; 56 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -3480,12 +3604,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Uint8Array,u8>~anonymous|3 (; 46 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Uint8Array,u8>~anonymous|3 (; 57 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/typedarray/Uint8Array#reduce<u8> (; 47 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#reduce<u8> (; 58 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3543,12 +3667,12 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduce<Uint8Array,u8> (; 48 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint8Array,u8> (; 59 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  call $~lib/typedarray/Uint8Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -3582,17 +3706,17 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Uint8ClampedArray,u8>~anonymous|4 (; 49 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Uint8ClampedArray,u8>~anonymous|4 (; 60 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $std/typedarray/testReduce<Uint8ClampedArray,u8> (; 50 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint8ClampedArray,u8> (; 61 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  call $~lib/typedarray/Uint8ClampedArray#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -3626,7 +3750,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i16>#__set (; 51 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<i16>#__set (; 62 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   get_local $1
@@ -3659,12 +3783,12 @@
   get_local $2
   i32.store16 offset=8
  )
- (func $std/typedarray/testReduce<Int16Array,i16>~anonymous|5 (; 52 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Int16Array,i16>~anonymous|5 (; 63 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/typedarray/Int16Array#reduce<i16> (; 53 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#reduce<i16> (; 64 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3722,12 +3846,12 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduce<Int16Array,i16> (; 54 ;) (type $v)
+ (func $std/typedarray/testReduce<Int16Array,i16> (; 65 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  call $~lib/typedarray/Int16Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -3763,7 +3887,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<u16>#__set (; 55 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<u16>#__set (; 66 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   get_local $1
@@ -3796,12 +3920,12 @@
   get_local $2
   i32.store16 offset=8
  )
- (func $std/typedarray/testReduce<Uint16Array,u16>~anonymous|6 (; 56 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Uint16Array,u16>~anonymous|6 (; 67 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/typedarray/Uint16Array#reduce<u16> (; 57 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#reduce<u16> (; 68 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3859,12 +3983,12 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduce<Uint16Array,u16> (; 58 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint16Array,u16> (; 69 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u16>#constructor
+  call $~lib/typedarray/Uint16Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -3898,12 +4022,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Int32Array,i32>~anonymous|7 (; 59 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Int32Array,i32>~anonymous|7 (; 70 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/typedarray/Int32Array#reduce<i32> (; 60 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#reduce<i32> (; 71 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3961,12 +4085,12 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduce<Int32Array,i32> (; 61 ;) (type $v)
+ (func $std/typedarray/testReduce<Int32Array,i32> (; 72 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -3998,7 +4122,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<u32>#__set (; 62 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<u32>#__set (; 73 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   get_local $1
@@ -4031,12 +4155,12 @@
   get_local $2
   i32.store offset=8
  )
- (func $std/typedarray/testReduce<Uint32Array,u32>~anonymous|8 (; 63 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Uint32Array,u32>~anonymous|8 (; 74 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/typedarray/Uint32Array#reduce<u32> (; 64 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#reduce<u32> (; 75 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4094,12 +4218,12 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduce<Uint32Array,u32> (; 65 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint32Array,u32> (; 76 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u32>#constructor
+  call $~lib/typedarray/Uint32Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -4131,7 +4255,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i64>#__set (; 66 ;) (type $iiIv) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/internal/typedarray/TypedArray<i64>#__set (; 77 ;) (type $iiIv) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local $4 i32)
   get_local $1
@@ -4164,12 +4288,12 @@
   get_local $2
   i64.store offset=8
  )
- (func $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 (; 67 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 (; 78 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   get_local $0
   get_local $1
   i64.add
  )
- (func $~lib/typedarray/Int64Array#reduce<i64> (; 68 ;) (type $iiII) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
+ (func $~lib/typedarray/Int64Array#reduce<i64> (; 79 ;) (type $iiII) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4227,12 +4351,12 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduce<Int64Array,i64> (; 69 ;) (type $v)
+ (func $std/typedarray/testReduce<Int64Array,i64> (; 80 ;) (type $v)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -4264,7 +4388,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<u64>#__set (; 70 ;) (type $iiIv) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/internal/typedarray/TypedArray<u64>#__set (; 81 ;) (type $iiIv) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local $4 i32)
   get_local $1
@@ -4297,12 +4421,12 @@
   get_local $2
   i64.store offset=8
  )
- (func $std/typedarray/testReduce<Uint64Array,u64>~anonymous|10 (; 71 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduce<Uint64Array,u64>~anonymous|10 (; 82 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   get_local $0
   get_local $1
   i64.add
  )
- (func $~lib/typedarray/Uint64Array#reduce<u64> (; 72 ;) (type $iiII) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
+ (func $~lib/typedarray/Uint64Array#reduce<u64> (; 83 ;) (type $iiII) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4360,12 +4484,12 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduce<Uint64Array,u64> (; 73 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint64Array,u64> (; 84 ;) (type $v)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u64>#constructor
+  call $~lib/typedarray/Uint64Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -4397,7 +4521,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<f32>#__set (; 74 ;) (type $iifv) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/internal/typedarray/TypedArray<f32>#__set (; 85 ;) (type $iifv) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (local $4 i32)
   get_local $1
@@ -4430,12 +4554,12 @@
   get_local $2
   f32.store offset=8
  )
- (func $std/typedarray/testReduce<Float32Array,f32>~anonymous|11 (; 75 ;) (type $ffiif) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
+ (func $std/typedarray/testReduce<Float32Array,f32>~anonymous|11 (; 86 ;) (type $ffiif) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
   get_local $0
   get_local $1
   f32.add
  )
- (func $~lib/typedarray/Float32Array#reduce<f32> (; 76 ;) (type $iiff) (param $0 i32) (param $1 i32) (param $2 f32) (result f32)
+ (func $~lib/typedarray/Float32Array#reduce<f32> (; 87 ;) (type $iiff) (param $0 i32) (param $1 i32) (param $2 f32) (result f32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4493,12 +4617,12 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduce<Float32Array,f32> (; 77 ;) (type $v)
+ (func $std/typedarray/testReduce<Float32Array,f32> (; 88 ;) (type $v)
   (local $0 i32)
   (local $1 f32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<f32>#constructor
+  call $~lib/typedarray/Float32Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -4530,12 +4654,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Float64Array,f64>~anonymous|12 (; 78 ;) (type $FFiiF) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
+ (func $std/typedarray/testReduce<Float64Array,f64>~anonymous|12 (; 89 ;) (type $FFiiF) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
   get_local $0
   get_local $1
   f64.add
  )
- (func $~lib/typedarray/Float64Array#reduce<f64> (; 79 ;) (type $iiFF) (param $0 i32) (param $1 i32) (param $2 f64) (result f64)
+ (func $~lib/typedarray/Float64Array#reduce<f64> (; 90 ;) (type $iiFF) (param $0 i32) (param $1 i32) (param $2 f64) (result f64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4593,12 +4717,12 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduce<Float64Array,f64> (; 80 ;) (type $v)
+ (func $std/typedarray/testReduce<Float64Array,f64> (; 91 ;) (type $v)
   (local $0 i32)
   (local $1 f64)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<f64>#constructor
+  call $~lib/typedarray/Float64Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -4630,12 +4754,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Int8Array,i8>~anonymous|13 (; 81 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Int8Array,i8>~anonymous|13 (; 92 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/typedarray/Int8Array#reduceRight<i8> (; 82 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#reduceRight<i8> (; 93 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4692,12 +4816,12 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduceRight<Int8Array,i8> (; 83 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int8Array,i8> (; 94 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -4733,12 +4857,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint8Array,u8>~anonymous|14 (; 84 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Uint8Array,u8>~anonymous|14 (; 95 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/typedarray/Uint8Array#reduceRight<u8> (; 85 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#reduceRight<u8> (; 96 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4795,12 +4919,12 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduceRight<Uint8Array,u8> (; 86 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint8Array,u8> (; 97 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  call $~lib/typedarray/Uint8Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -4834,17 +4958,17 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8>~anonymous|15 (; 87 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8>~anonymous|15 (; 98 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8> (; 88 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8> (; 99 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  call $~lib/typedarray/Uint8ClampedArray#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -4878,12 +5002,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Int16Array,i16>~anonymous|16 (; 89 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Int16Array,i16>~anonymous|16 (; 100 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/typedarray/Int16Array#reduceRight<i16> (; 90 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#reduceRight<i16> (; 101 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4940,12 +5064,12 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduceRight<Int16Array,i16> (; 91 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int16Array,i16> (; 102 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  call $~lib/typedarray/Int16Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -4981,12 +5105,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint16Array,u16>~anonymous|17 (; 92 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Uint16Array,u16>~anonymous|17 (; 103 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/typedarray/Uint16Array#reduceRight<u16> (; 93 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#reduceRight<u16> (; 104 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5043,12 +5167,12 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduceRight<Uint16Array,u16> (; 94 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint16Array,u16> (; 105 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u16>#constructor
+  call $~lib/typedarray/Uint16Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -5082,12 +5206,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Int32Array,i32>~anonymous|18 (; 95 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Int32Array,i32>~anonymous|18 (; 106 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/typedarray/Int32Array#reduceRight<i32> (; 96 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#reduceRight<i32> (; 107 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5144,12 +5268,12 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduceRight<Int32Array,i32> (; 97 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int32Array,i32> (; 108 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -5181,12 +5305,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint32Array,u32>~anonymous|19 (; 98 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Uint32Array,u32>~anonymous|19 (; 109 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   get_local $0
   get_local $1
   i32.add
  )
- (func $~lib/typedarray/Uint32Array#reduceRight<u32> (; 99 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#reduceRight<u32> (; 110 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5243,12 +5367,12 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduceRight<Uint32Array,u32> (; 100 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint32Array,u32> (; 111 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u32>#constructor
+  call $~lib/typedarray/Uint32Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -5280,12 +5404,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Int64Array,i64>~anonymous|20 (; 101 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduceRight<Int64Array,i64>~anonymous|20 (; 112 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   get_local $0
   get_local $1
   i64.add
  )
- (func $~lib/typedarray/Int64Array#reduceRight<i64> (; 102 ;) (type $iiII) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
+ (func $~lib/typedarray/Int64Array#reduceRight<i64> (; 113 ;) (type $iiII) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5342,12 +5466,12 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduceRight<Int64Array,i64> (; 103 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int64Array,i64> (; 114 ;) (type $v)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -5379,12 +5503,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint64Array,u64>~anonymous|21 (; 104 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduceRight<Uint64Array,u64>~anonymous|21 (; 115 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   get_local $0
   get_local $1
   i64.add
  )
- (func $~lib/typedarray/Uint64Array#reduceRight<u64> (; 105 ;) (type $iiII) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
+ (func $~lib/typedarray/Uint64Array#reduceRight<u64> (; 116 ;) (type $iiII) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5441,12 +5565,12 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduceRight<Uint64Array,u64> (; 106 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint64Array,u64> (; 117 ;) (type $v)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u64>#constructor
+  call $~lib/typedarray/Uint64Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -5478,12 +5602,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Float32Array,f32>~anonymous|22 (; 107 ;) (type $ffiif) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
+ (func $std/typedarray/testReduceRight<Float32Array,f32>~anonymous|22 (; 118 ;) (type $ffiif) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
   get_local $0
   get_local $1
   f32.add
  )
- (func $~lib/typedarray/Float32Array#reduceRight<f32> (; 108 ;) (type $iiff) (param $0 i32) (param $1 i32) (param $2 f32) (result f32)
+ (func $~lib/typedarray/Float32Array#reduceRight<f32> (; 119 ;) (type $iiff) (param $0 i32) (param $1 i32) (param $2 f32) (result f32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5540,12 +5664,12 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduceRight<Float32Array,f32> (; 109 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Float32Array,f32> (; 120 ;) (type $v)
   (local $0 i32)
   (local $1 f32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<f32>#constructor
+  call $~lib/typedarray/Float32Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -5577,12 +5701,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Float64Array,f64>~anonymous|23 (; 110 ;) (type $FFiiF) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
+ (func $std/typedarray/testReduceRight<Float64Array,f64>~anonymous|23 (; 121 ;) (type $FFiiF) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
   get_local $0
   get_local $1
   f64.add
  )
- (func $~lib/typedarray/Float64Array#reduceRight<f64> (; 111 ;) (type $iiFF) (param $0 i32) (param $1 i32) (param $2 f64) (result f64)
+ (func $~lib/typedarray/Float64Array#reduceRight<f64> (; 122 ;) (type $iiFF) (param $0 i32) (param $1 i32) (param $2 f64) (result f64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5639,12 +5763,12 @@
   end
   get_local $2
  )
- (func $std/typedarray/testReduceRight<Float64Array,f64> (; 112 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Float64Array,f64> (; 123 ;) (type $v)
   (local $0 i32)
   (local $1 f64)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<f64>#constructor
+  call $~lib/typedarray/Float64Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -5676,12 +5800,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 (; 113 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 (; 124 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   get_local $0
   i32.mul
  )
- (func $~lib/typedarray/Int8Array#map (; 114 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#map (; 125 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5705,7 +5829,7 @@
   set_local $4
   i32.const 0
   get_local $2
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   set_local $5
   get_local $5
   i32.load
@@ -5766,12 +5890,12 @@
   end
   get_local $5
  )
- (func $std/typedarray/testArrayMap<Int8Array,i8> (; 115 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int8Array,i8> (; 126 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -5844,12 +5968,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint8Array,u8>~anonymous|25 (; 116 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Uint8Array,u8>~anonymous|25 (; 127 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   get_local $0
   i32.mul
  )
- (func $~lib/typedarray/Uint8Array#map (; 117 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#map (; 128 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5873,7 +5997,7 @@
   set_local $4
   i32.const 0
   get_local $2
-  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  call $~lib/typedarray/Uint8Array#constructor
   set_local $5
   get_local $5
   i32.load
@@ -5932,12 +6056,12 @@
   end
   get_local $5
  )
- (func $std/typedarray/testArrayMap<Uint8Array,u8> (; 118 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint8Array,u8> (; 129 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  call $~lib/typedarray/Uint8Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -6004,12 +6128,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8>~anonymous|26 (; 119 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8>~anonymous|26 (; 130 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   get_local $0
   i32.mul
  )
- (func $~lib/typedarray/Uint8ClampedArray#map (; 120 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#map (; 131 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6033,7 +6157,7 @@
   set_local $4
   i32.const 0
   get_local $2
-  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  call $~lib/typedarray/Uint8ClampedArray#constructor
   set_local $5
   get_local $5
   i32.load
@@ -6092,12 +6216,12 @@
   end
   get_local $5
  )
- (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8> (; 121 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8> (; 132 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  call $~lib/typedarray/Uint8ClampedArray#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -6164,12 +6288,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int16Array,i16>~anonymous|27 (; 122 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Int16Array,i16>~anonymous|27 (; 133 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   get_local $0
   i32.mul
  )
- (func $~lib/typedarray/Int16Array#map (; 123 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#map (; 134 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6193,7 +6317,7 @@
   set_local $4
   i32.const 0
   get_local $2
-  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  call $~lib/typedarray/Int16Array#constructor
   set_local $5
   get_local $5
   i32.load
@@ -6254,7 +6378,7 @@
   end
   get_local $5
  )
- (func $~lib/internal/typedarray/TypedArray<i16>#__get (; 124 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<i16>#__get (; 135 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   get_local $1
@@ -6288,12 +6412,12 @@
    i32.load16_s offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Int16Array,i16> (; 125 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int16Array,i16> (; 136 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  call $~lib/typedarray/Int16Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -6366,12 +6490,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint16Array,u16>~anonymous|28 (; 126 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Uint16Array,u16>~anonymous|28 (; 137 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   get_local $0
   i32.mul
  )
- (func $~lib/typedarray/Uint16Array#map (; 127 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#map (; 138 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6395,7 +6519,7 @@
   set_local $4
   i32.const 0
   get_local $2
-  call $~lib/internal/typedarray/TypedArray<u16>#constructor
+  call $~lib/typedarray/Uint16Array#constructor
   set_local $5
   get_local $5
   i32.load
@@ -6454,7 +6578,7 @@
   end
   get_local $5
  )
- (func $~lib/internal/typedarray/TypedArray<u16>#__get (; 128 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<u16>#__get (; 139 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   get_local $1
@@ -6488,12 +6612,12 @@
    i32.load16_u offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Uint16Array,u16> (; 129 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint16Array,u16> (; 140 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u16>#constructor
+  call $~lib/typedarray/Uint16Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -6560,12 +6684,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int32Array,i32>~anonymous|29 (; 130 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Int32Array,i32>~anonymous|29 (; 141 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   get_local $0
   i32.mul
  )
- (func $~lib/typedarray/Int32Array#map (; 131 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#map (; 142 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6589,7 +6713,7 @@
   set_local $4
   i32.const 0
   get_local $2
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   set_local $5
   get_local $5
   i32.load
@@ -6646,12 +6770,12 @@
   end
   get_local $5
  )
- (func $std/typedarray/testArrayMap<Int32Array,i32> (; 132 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int32Array,i32> (; 143 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -6712,12 +6836,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint32Array,u32>~anonymous|30 (; 133 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Uint32Array,u32>~anonymous|30 (; 144 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   get_local $0
   i32.mul
  )
- (func $~lib/typedarray/Uint32Array#map (; 134 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#map (; 145 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6741,7 +6865,7 @@
   set_local $4
   i32.const 0
   get_local $2
-  call $~lib/internal/typedarray/TypedArray<u32>#constructor
+  call $~lib/typedarray/Uint32Array#constructor
   set_local $5
   get_local $5
   i32.load
@@ -6798,7 +6922,7 @@
   end
   get_local $5
  )
- (func $~lib/internal/typedarray/TypedArray<u32>#__get (; 135 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<u32>#__get (; 146 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   get_local $1
@@ -6832,12 +6956,12 @@
    i32.load offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Uint32Array,u32> (; 136 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint32Array,u32> (; 147 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u32>#constructor
+  call $~lib/typedarray/Uint32Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -6898,12 +7022,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 (; 137 ;) (type $IiiI) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+ (func $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 (; 148 ;) (type $IiiI) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
   get_local $0
   get_local $0
   i64.mul
  )
- (func $~lib/typedarray/Int64Array#map (; 138 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#map (; 149 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6927,7 +7051,7 @@
   set_local $4
   i32.const 0
   get_local $2
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   set_local $5
   get_local $5
   i32.load
@@ -6984,7 +7108,7 @@
   end
   get_local $5
  )
- (func $~lib/internal/typedarray/TypedArray<i64>#__get (; 139 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/internal/typedarray/TypedArray<i64>#__get (; 150 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local $3 i32)
   get_local $1
@@ -7018,12 +7142,12 @@
    i64.load offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Int64Array,i64> (; 140 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int64Array,i64> (; 151 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -7084,12 +7208,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint64Array,u64>~anonymous|32 (; 141 ;) (type $IiiI) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+ (func $std/typedarray/testArrayMap<Uint64Array,u64>~anonymous|32 (; 152 ;) (type $IiiI) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
   get_local $0
   get_local $0
   i64.mul
  )
- (func $~lib/typedarray/Uint64Array#map (; 142 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#map (; 153 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7113,7 +7237,7 @@
   set_local $4
   i32.const 0
   get_local $2
-  call $~lib/internal/typedarray/TypedArray<u64>#constructor
+  call $~lib/typedarray/Uint64Array#constructor
   set_local $5
   get_local $5
   i32.load
@@ -7170,7 +7294,7 @@
   end
   get_local $5
  )
- (func $~lib/internal/typedarray/TypedArray<u64>#__get (; 143 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/internal/typedarray/TypedArray<u64>#__get (; 154 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local $3 i32)
   get_local $1
@@ -7204,12 +7328,12 @@
    i64.load offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Uint64Array,u64> (; 144 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint64Array,u64> (; 155 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u64>#constructor
+  call $~lib/typedarray/Uint64Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -7270,12 +7394,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|33 (; 145 ;) (type $fiif) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
+ (func $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|33 (; 156 ;) (type $fiif) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
   get_local $0
   get_local $0
   f32.mul
  )
- (func $~lib/typedarray/Float32Array#map (; 146 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#map (; 157 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7299,7 +7423,7 @@
   set_local $4
   i32.const 0
   get_local $2
-  call $~lib/internal/typedarray/TypedArray<f32>#constructor
+  call $~lib/typedarray/Float32Array#constructor
   set_local $5
   get_local $5
   i32.load
@@ -7356,7 +7480,7 @@
   end
   get_local $5
  )
- (func $~lib/internal/typedarray/TypedArray<f32>#__get (; 147 ;) (type $iif) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/internal/typedarray/TypedArray<f32>#__get (; 158 ;) (type $iif) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (local $3 i32)
   get_local $1
@@ -7390,12 +7514,12 @@
    f32.load offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Float32Array,f32> (; 148 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Float32Array,f32> (; 159 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<f32>#constructor
+  call $~lib/typedarray/Float32Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -7456,12 +7580,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|34 (; 149 ;) (type $FiiF) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
+ (func $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|34 (; 160 ;) (type $FiiF) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
   get_local $0
   get_local $0
   f64.mul
  )
- (func $~lib/typedarray/Float64Array#map (; 150 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#map (; 161 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7485,7 +7609,7 @@
   set_local $4
   i32.const 0
   get_local $2
-  call $~lib/internal/typedarray/TypedArray<f64>#constructor
+  call $~lib/typedarray/Float64Array#constructor
   set_local $5
   get_local $5
   i32.load
@@ -7542,12 +7666,12 @@
   end
   get_local $5
  )
- (func $std/typedarray/testArrayMap<Float64Array,f64> (; 151 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Float64Array,f64> (; 162 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<f64>#constructor
+  call $~lib/typedarray/Float64Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -7608,7 +7732,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 (; 152 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 (; 163 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 24
   i32.shl
@@ -7617,7 +7741,7 @@
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Int8Array#some (; 153 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#some (; 164 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7681,7 +7805,7 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Int8Array,i8>~anonymous|36 (; 154 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int8Array,i8>~anonymous|36 (; 165 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 24
   i32.shl
@@ -7690,13 +7814,13 @@
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Int8Array,i8> (; 155 ;) (type $v)
+ (func $std/typedarray/testArraySome<Int8Array,i8> (; 166 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -7744,14 +7868,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint8Array,u8>~anonymous|37 (; 156 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Uint8Array,u8>~anonymous|37 (; 167 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 255
   i32.and
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Uint8Array#some (; 157 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#some (; 168 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7815,20 +7939,20 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Uint8Array,u8>~anonymous|38 (; 158 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Uint8Array,u8>~anonymous|38 (; 169 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 255
   i32.and
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Uint8Array,u8> (; 159 ;) (type $v)
+ (func $std/typedarray/testArraySome<Uint8Array,u8> (; 170 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  call $~lib/typedarray/Uint8Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -7876,14 +8000,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint8ClampedArray,u8>~anonymous|39 (; 160 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Uint8ClampedArray,u8>~anonymous|39 (; 171 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 255
   i32.and
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Uint8ClampedArray#some (; 161 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#some (; 172 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7947,20 +8071,20 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Uint8ClampedArray,u8>~anonymous|40 (; 162 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Uint8ClampedArray,u8>~anonymous|40 (; 173 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 255
   i32.and
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Uint8ClampedArray,u8> (; 163 ;) (type $v)
+ (func $std/typedarray/testArraySome<Uint8ClampedArray,u8> (; 174 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  call $~lib/typedarray/Uint8ClampedArray#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -8008,7 +8132,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 (; 164 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 (; 175 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 16
   i32.shl
@@ -8017,7 +8141,7 @@
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Int16Array#some (; 165 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#some (; 176 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8081,7 +8205,7 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Int16Array,i16>~anonymous|42 (; 166 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int16Array,i16>~anonymous|42 (; 177 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 16
   i32.shl
@@ -8090,13 +8214,13 @@
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Int16Array,i16> (; 167 ;) (type $v)
+ (func $std/typedarray/testArraySome<Int16Array,i16> (; 178 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  call $~lib/typedarray/Int16Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -8144,14 +8268,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint16Array,u16>~anonymous|43 (; 168 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Uint16Array,u16>~anonymous|43 (; 179 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 65535
   i32.and
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Uint16Array#some (; 169 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#some (; 180 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8215,20 +8339,20 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Uint16Array,u16>~anonymous|44 (; 170 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Uint16Array,u16>~anonymous|44 (; 181 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 65535
   i32.and
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Uint16Array,u16> (; 171 ;) (type $v)
+ (func $std/typedarray/testArraySome<Uint16Array,u16> (; 182 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u16>#constructor
+  call $~lib/typedarray/Uint16Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -8276,12 +8400,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 (; 172 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 (; 183 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Int32Array#some (; 173 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#some (; 184 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8345,18 +8469,18 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Int32Array,i32>~anonymous|46 (; 174 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int32Array,i32>~anonymous|46 (; 185 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Int32Array,i32> (; 175 ;) (type $v)
+ (func $std/typedarray/testArraySome<Int32Array,i32> (; 186 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -8404,12 +8528,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint32Array,u32>~anonymous|47 (; 176 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Uint32Array,u32>~anonymous|47 (; 187 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Uint32Array#some (; 177 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#some (; 188 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8473,18 +8597,18 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Uint32Array,u32>~anonymous|48 (; 178 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Uint32Array,u32>~anonymous|48 (; 189 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Uint32Array,u32> (; 179 ;) (type $v)
+ (func $std/typedarray/testArraySome<Uint32Array,u32> (; 190 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u32>#constructor
+  call $~lib/typedarray/Uint32Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -8532,12 +8656,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 (; 180 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 (; 191 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i64.const 2
   i64.eq
  )
- (func $~lib/typedarray/Int64Array#some (; 181 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#some (; 192 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8601,18 +8725,18 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Int64Array,i64>~anonymous|50 (; 182 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int64Array,i64>~anonymous|50 (; 193 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i64.const 0
   i64.eq
  )
- (func $std/typedarray/testArraySome<Int64Array,i64> (; 183 ;) (type $v)
+ (func $std/typedarray/testArraySome<Int64Array,i64> (; 194 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -8660,12 +8784,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint64Array,u64>~anonymous|51 (; 184 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Uint64Array,u64>~anonymous|51 (; 195 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i64.const 2
   i64.eq
  )
- (func $~lib/typedarray/Uint64Array#some (; 185 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#some (; 196 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8729,18 +8853,18 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Uint64Array,u64>~anonymous|52 (; 186 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Uint64Array,u64>~anonymous|52 (; 197 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i64.const 0
   i64.eq
  )
- (func $std/typedarray/testArraySome<Uint64Array,u64> (; 187 ;) (type $v)
+ (func $std/typedarray/testArraySome<Uint64Array,u64> (; 198 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u64>#constructor
+  call $~lib/typedarray/Uint64Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -8788,12 +8912,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Float32Array,f32>~anonymous|53 (; 188 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Float32Array,f32>~anonymous|53 (; 199 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   f32.const 2
   f32.eq
  )
- (func $~lib/typedarray/Float32Array#some (; 189 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#some (; 200 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8857,18 +8981,18 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Float32Array,f32>~anonymous|54 (; 190 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Float32Array,f32>~anonymous|54 (; 201 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   f32.const 0
   f32.eq
  )
- (func $std/typedarray/testArraySome<Float32Array,f32> (; 191 ;) (type $v)
+ (func $std/typedarray/testArraySome<Float32Array,f32> (; 202 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<f32>#constructor
+  call $~lib/typedarray/Float32Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -8916,12 +9040,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Float64Array,f64>~anonymous|55 (; 192 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Float64Array,f64>~anonymous|55 (; 203 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   f64.const 2
   f64.eq
  )
- (func $~lib/typedarray/Float64Array#some (; 193 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#some (; 204 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8985,18 +9109,18 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Float64Array,f64>~anonymous|56 (; 194 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Float64Array,f64>~anonymous|56 (; 205 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   f64.const 0
   f64.eq
  )
- (func $std/typedarray/testArraySome<Float64Array,f64> (; 195 ;) (type $v)
+ (func $std/typedarray/testArraySome<Float64Array,f64> (; 206 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<f64>#constructor
+  call $~lib/typedarray/Float64Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -9044,7 +9168,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|57 (; 196 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|57 (; 207 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 24
   i32.shl
@@ -9053,7 +9177,7 @@
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Int8Array#findIndex (; 197 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#findIndex (; 208 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9117,7 +9241,7 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|58 (; 198 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|58 (; 209 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 24
   i32.shl
@@ -9126,13 +9250,13 @@
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int8Array,i8> (; 199 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Int8Array,i8> (; 210 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -9179,14 +9303,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint8Array,u8>~anonymous|59 (; 200 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Uint8Array,u8>~anonymous|59 (; 211 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 255
   i32.and
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Uint8Array#findIndex (; 201 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#findIndex (; 212 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9250,20 +9374,20 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint8Array,u8>~anonymous|60 (; 202 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Uint8Array,u8>~anonymous|60 (; 213 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 255
   i32.and
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Uint8Array,u8> (; 203 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Uint8Array,u8> (; 214 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  call $~lib/typedarray/Uint8Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -9310,14 +9434,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8>~anonymous|61 (; 204 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8>~anonymous|61 (; 215 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 255
   i32.and
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Uint8ClampedArray#findIndex (; 205 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#findIndex (; 216 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9381,20 +9505,20 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8>~anonymous|62 (; 206 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8>~anonymous|62 (; 217 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 255
   i32.and
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8> (; 207 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8> (; 218 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  call $~lib/typedarray/Uint8ClampedArray#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -9441,7 +9565,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|63 (; 208 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|63 (; 219 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 16
   i32.shl
@@ -9450,7 +9574,7 @@
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Int16Array#findIndex (; 209 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#findIndex (; 220 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9514,7 +9638,7 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|64 (; 210 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|64 (; 221 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 16
   i32.shl
@@ -9523,13 +9647,13 @@
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int16Array,i16> (; 211 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Int16Array,i16> (; 222 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  call $~lib/typedarray/Int16Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -9576,14 +9700,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint16Array,u16>~anonymous|65 (; 212 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Uint16Array,u16>~anonymous|65 (; 223 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 65535
   i32.and
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Uint16Array#findIndex (; 213 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#findIndex (; 224 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9647,20 +9771,20 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint16Array,u16>~anonymous|66 (; 214 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Uint16Array,u16>~anonymous|66 (; 225 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 65535
   i32.and
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Uint16Array,u16> (; 215 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Uint16Array,u16> (; 226 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u16>#constructor
+  call $~lib/typedarray/Uint16Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -9707,12 +9831,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|67 (; 216 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|67 (; 227 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Int32Array#findIndex (; 217 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#findIndex (; 228 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9776,18 +9900,18 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|68 (; 218 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|68 (; 229 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int32Array,i32> (; 219 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Int32Array,i32> (; 230 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -9834,12 +9958,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint32Array,u32>~anonymous|69 (; 220 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Uint32Array,u32>~anonymous|69 (; 231 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Uint32Array#findIndex (; 221 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#findIndex (; 232 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9903,18 +10027,18 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint32Array,u32>~anonymous|70 (; 222 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Uint32Array,u32>~anonymous|70 (; 233 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Uint32Array,u32> (; 223 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Uint32Array,u32> (; 234 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u32>#constructor
+  call $~lib/typedarray/Uint32Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -9961,12 +10085,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|71 (; 224 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|71 (; 235 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i64.const 2
   i64.eq
  )
- (func $~lib/typedarray/Int64Array#findIndex (; 225 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#findIndex (; 236 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10030,18 +10154,18 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|72 (; 226 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|72 (; 237 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i64.const 4
   i64.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int64Array,i64> (; 227 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Int64Array,i64> (; 238 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -10088,12 +10212,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint64Array,u64>~anonymous|73 (; 228 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Uint64Array,u64>~anonymous|73 (; 239 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i64.const 2
   i64.eq
  )
- (func $~lib/typedarray/Uint64Array#findIndex (; 229 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#findIndex (; 240 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10157,18 +10281,18 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint64Array,u64>~anonymous|74 (; 230 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Uint64Array,u64>~anonymous|74 (; 241 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i64.const 4
   i64.eq
  )
- (func $std/typedarray/testArrayFindIndex<Uint64Array,u64> (; 231 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Uint64Array,u64> (; 242 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u64>#constructor
+  call $~lib/typedarray/Uint64Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -10215,12 +10339,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|75 (; 232 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|75 (; 243 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   f32.const 2
   f32.eq
  )
- (func $~lib/typedarray/Float32Array#findIndex (; 233 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#findIndex (; 244 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10284,18 +10408,18 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|76 (; 234 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|76 (; 245 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   f32.const 4
   f32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Float32Array,f32> (; 235 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Float32Array,f32> (; 246 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<f32>#constructor
+  call $~lib/typedarray/Float32Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -10342,12 +10466,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|77 (; 236 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|77 (; 247 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   f64.const 2
   f64.eq
  )
- (func $~lib/typedarray/Float64Array#findIndex (; 237 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#findIndex (; 248 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10411,18 +10535,18 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|78 (; 238 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|78 (; 249 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   f64.const 4
   f64.eq
  )
- (func $std/typedarray/testArrayFindIndex<Float64Array,f64> (; 239 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Float64Array,f64> (; 250 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<f64>#constructor
+  call $~lib/typedarray/Float64Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -10469,7 +10593,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|79 (; 240 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|79 (; 251 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 24
   i32.shl
@@ -10480,7 +10604,7 @@
   i32.const 0
   i32.eq
  )
- (func $~lib/typedarray/Int8Array#every (; 241 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#every (; 252 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10551,7 +10675,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|80 (; 242 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|80 (; 253 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 24
   i32.shl
@@ -10560,13 +10684,13 @@
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Int8Array,i8> (; 243 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Int8Array,i8> (; 254 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -10614,7 +10738,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|81 (; 244 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|81 (; 255 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 255
   i32.and
@@ -10623,7 +10747,7 @@
   i32.const 0
   i32.eq
  )
- (func $~lib/typedarray/Uint8Array#every (; 245 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#every (; 256 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10694,20 +10818,20 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|82 (; 246 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|82 (; 257 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 255
   i32.and
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Uint8Array,u8> (; 247 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Uint8Array,u8> (; 258 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  call $~lib/typedarray/Uint8Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -10755,7 +10879,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8>~anonymous|83 (; 248 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8>~anonymous|83 (; 259 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 255
   i32.and
@@ -10764,7 +10888,7 @@
   i32.const 0
   i32.eq
  )
- (func $~lib/typedarray/Uint8ClampedArray#every (; 249 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#every (; 260 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10835,20 +10959,20 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8>~anonymous|84 (; 250 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8>~anonymous|84 (; 261 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 255
   i32.and
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8> (; 251 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8> (; 262 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  call $~lib/typedarray/Uint8ClampedArray#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -10896,7 +11020,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|85 (; 252 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|85 (; 263 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 16
   i32.shl
@@ -10907,7 +11031,7 @@
   i32.const 0
   i32.eq
  )
- (func $~lib/typedarray/Int16Array#every (; 253 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#every (; 264 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10978,7 +11102,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|86 (; 254 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|86 (; 265 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 16
   i32.shl
@@ -10987,13 +11111,13 @@
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Int16Array,i16> (; 255 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Int16Array,i16> (; 266 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i16>#constructor
+  call $~lib/typedarray/Int16Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -11041,7 +11165,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint16Array,u16>~anonymous|87 (; 256 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Uint16Array,u16>~anonymous|87 (; 267 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 65535
   i32.and
@@ -11050,7 +11174,7 @@
   i32.const 0
   i32.eq
  )
- (func $~lib/typedarray/Uint16Array#every (; 257 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#every (; 268 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11121,20 +11245,20 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Uint16Array,u16>~anonymous|88 (; 258 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Uint16Array,u16>~anonymous|88 (; 269 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 65535
   i32.and
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Uint16Array,u16> (; 259 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Uint16Array,u16> (; 270 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u16>#constructor
+  call $~lib/typedarray/Uint16Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -11182,14 +11306,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|89 (; 260 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|89 (; 271 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 2
   i32.rem_s
   i32.const 0
   i32.eq
  )
- (func $~lib/typedarray/Int32Array#every (; 261 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#every (; 272 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11260,18 +11384,18 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|90 (; 262 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|90 (; 273 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Int32Array,i32> (; 263 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Int32Array,i32> (; 274 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -11319,14 +11443,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint32Array,u32>~anonymous|91 (; 264 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Uint32Array,u32>~anonymous|91 (; 275 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 2
   i32.rem_u
   i32.const 0
   i32.eq
  )
- (func $~lib/typedarray/Uint32Array#every (; 265 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#every (; 276 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11397,18 +11521,18 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Uint32Array,u32>~anonymous|92 (; 266 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Uint32Array,u32>~anonymous|92 (; 277 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Uint32Array,u32> (; 267 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Uint32Array,u32> (; 278 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u32>#constructor
+  call $~lib/typedarray/Uint32Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -11456,14 +11580,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|93 (; 268 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|93 (; 279 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i64.const 2
   i64.rem_s
   i64.const 0
   i64.eq
  )
- (func $~lib/typedarray/Int64Array#every (; 269 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#every (; 280 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11534,18 +11658,18 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|94 (; 270 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|94 (; 281 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i64.const 2
   i64.eq
  )
- (func $std/typedarray/testArrayEvery<Int64Array,i64> (; 271 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Int64Array,i64> (; 282 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i64>#constructor
+  call $~lib/typedarray/Int64Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -11593,14 +11717,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|95 (; 272 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|95 (; 283 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i64.const 2
   i64.rem_u
   i64.const 0
   i64.eq
  )
- (func $~lib/typedarray/Uint64Array#every (; 273 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#every (; 284 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11671,18 +11795,18 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|96 (; 274 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|96 (; 285 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   i64.const 2
   i64.eq
  )
- (func $std/typedarray/testArrayEvery<Uint64Array,u64> (; 275 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Uint64Array,u64> (; 286 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u64>#constructor
+  call $~lib/typedarray/Uint64Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -11730,7 +11854,7 @@
    unreachable
   end
  )
- (func $~lib/math/NativeMathf.mod (; 276 ;) (type $fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (; 287 ;) (type $fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11984,14 +12108,14 @@
   get_local $2
   f32.reinterpret/i32
  )
- (func $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|97 (; 277 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|97 (; 288 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   f32.const 2
   call $~lib/math/NativeMathf.mod
   f32.const 0
   f32.eq
  )
- (func $~lib/typedarray/Float32Array#every (; 278 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#every (; 289 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12062,18 +12186,18 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|98 (; 279 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|98 (; 290 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   f32.const 2
   f32.eq
  )
- (func $std/typedarray/testArrayEvery<Float32Array,f32> (; 280 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Float32Array,f32> (; 291 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<f32>#constructor
+  call $~lib/typedarray/Float32Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -12121,7 +12245,7 @@
    unreachable
   end
  )
- (func $~lib/math/NativeMath.mod (; 281 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (; 292 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -12377,14 +12501,14 @@
   get_local $2
   f64.reinterpret/i64
  )
- (func $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|99 (; 282 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|99 (; 293 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   f64.const 2
   call $~lib/math/NativeMath.mod
   f64.const 0
   f64.eq
  )
- (func $~lib/typedarray/Float64Array#every (; 283 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#every (; 294 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12455,18 +12579,18 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|100 (; 284 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|100 (; 295 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   get_local $0
   f64.const 2
   f64.eq
  )
- (func $std/typedarray/testArrayEvery<Float64Array,f64> (; 285 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Float64Array,f64> (; 296 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<f64>#constructor
+  call $~lib/typedarray/Float64Array#constructor
   set_local $0
   get_local $0
   i32.const 0
@@ -12514,7 +12638,7 @@
    unreachable
   end
  )
- (func $start (; 286 ;) (type $v)
+ (func $start (; 297 ;) (type $v)
   (local $0 i32)
   get_global $~lib/typedarray/Int8Array.BYTES_PER_ELEMENT
   i32.const 1
@@ -12664,7 +12788,7 @@
   call $std/typedarray/testInstantiate
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   set_global $std/typedarray/arr
   get_global $std/typedarray/arr
   i32.const 0
@@ -12837,7 +12961,7 @@
   end
   i32.const 0
   i32.const 8
-  call $~lib/internal/typedarray/TypedArray<f64>#constructor
+  call $~lib/typedarray/Float64Array#constructor
   set_global $std/typedarray/af64
   get_global $std/typedarray/af64
   i32.const 0
@@ -12979,7 +13103,7 @@
   end
   i32.const 0
   i32.const 3
-  call $~lib/internal/typedarray/TypedArray<u8>#constructor
+  call $~lib/typedarray/Uint8ClampedArray#constructor
   set_global $std/typedarray/clampedArr
   get_global $std/typedarray/clampedArr
   i32.const 0
@@ -13043,7 +13167,7 @@
   end
   i32.const 0
   i32.const 5
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   set_global $std/typedarray/arr8
   get_global $std/typedarray/arr8
   i32.const 0
@@ -13249,7 +13373,7 @@
   end
   i32.const 0
   i32.const 5
-  call $~lib/internal/typedarray/TypedArray<i32>#constructor
+  call $~lib/typedarray/Int32Array#constructor
   set_global $std/typedarray/arr32
   get_global $std/typedarray/arr32
   i32.const 0
@@ -13459,11 +13583,11 @@
   end
   i32.const 0
   get_global $std/typedarray/MAX_F64LENGTH
-  call $~lib/internal/typedarray/TypedArray<f64>#constructor
+  call $~lib/typedarray/Float64Array#constructor
   drop
   i32.const 0
   i32.const 6
-  call $~lib/internal/typedarray/TypedArray<i8>#constructor
+  call $~lib/typedarray/Int8Array#constructor
   set_global $std/typedarray/multisubarr
   get_global $std/typedarray/multisubarr
   i32.const 0
@@ -13760,6 +13884,6 @@
   call $std/typedarray/testArrayEvery<Float32Array,f32>
   call $std/typedarray/testArrayEvery<Float64Array,f64>
  )
- (func $null (; 287 ;) (type $v)
+ (func $null (; 298 ;) (type $v)
  )
 )


### PR DESCRIPTION
As a follow-up to https://github.com/AssemblyScript/assemblyscript/pull/445 this PR aims at reworking constructor handling. Currently, whenever a `new` is encountered, it calls the constructor if it is present and if it isn't, inlines a bare allocation with field initializers at that place. While we could get away with this, generating actual constructors for classes that don't explicitly define one would simplify fixing some remaining issues, while also reducing code size (inlined allocation and initializers quickly accumulate), instead of just working around them.