### PR TITLE
Rework inlining logic

### DIFF
--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -154,7 +154,7 @@ export function compileCall(
       }
       let element = compiler.resolver.resolveExpression(
         operands[0],
-        compiler.currentFunction,
+        compiler.currentFlow,
         Type.void,
         ReportMode.SWALLOW
       );
@@ -639,11 +639,12 @@ export function compileCall(
         case TypeKind.I8:
         case TypeKind.I16:
         case TypeKind.I32: {
-          let currentFunction = compiler.currentFunction;
+          let flow = compiler.currentFlow;
+          let parentFunction = flow.parentFunction;
 
           // possibly overflows, e.g. abs<i8>(-128) == 128
-          let tempLocal1 = currentFunction.getTempLocal(Type.i32, false);
-          let tempLocalIndex2 = currentFunction.getAndFreeTempLocal(Type.i32, false).index;
+          let tempLocal1 = parentFunction.getTempLocal(Type.i32, false);
+          let tempLocalIndex2 = parentFunction.getAndFreeTempLocal(Type.i32, false).index;
           let tempLocalIndex1 = tempLocal1.index;
 
           // (x + (x >> 31)) ^ (x >> 31)
@@ -661,16 +662,17 @@ export function compileCall(
             module.createGetLocal(tempLocalIndex2, NativeType.I32)
           );
 
-          currentFunction.freeTempLocal(tempLocal1);
+          parentFunction.freeTempLocal(tempLocal1);
           break;
         }
         case TypeKind.ISIZE: {
           let options = compiler.options;
-          let currentFunction = compiler.currentFunction;
+          let flow = compiler.currentFlow;
+          let parentFunction = flow.parentFunction;
           let wasm64 = options.isWasm64;
 
-          let tempLocal1 = currentFunction.getTempLocal(options.usizeType, false);
-          let tempLocalIndex2 = currentFunction.getAndFreeTempLocal(options.usizeType, false).index;
+          let tempLocal1 = parentFunction.getTempLocal(options.usizeType, false);
+          let tempLocalIndex2 = parentFunction.getAndFreeTempLocal(options.usizeType, false).index;
           let tempLocalIndex1 = tempLocal1.index;
 
           ret = module.createBinary(wasm64 ? BinaryOp.XorI64 : BinaryOp.XorI32,
@@ -687,14 +689,15 @@ export function compileCall(
             module.createGetLocal(tempLocalIndex2, options.nativeSizeType)
           );
 
-          currentFunction.freeTempLocal(tempLocal1);
+          parentFunction.freeTempLocal(tempLocal1);
           break;
         }
         case TypeKind.I64: {
-          let currentFunction = compiler.currentFunction;
+          let flow = compiler.currentFlow;
+          let parentFunction = flow.parentFunction;
 
-          let tempLocal1 = currentFunction.getTempLocal(Type.i64, false);
-          let tempLocalIndex2 = currentFunction.getAndFreeTempLocal(Type.i64, false).index;
+          let tempLocal1 = parentFunction.getTempLocal(Type.i64, false);
+          let tempLocalIndex2 = parentFunction.getAndFreeTempLocal(Type.i64, false).index;
           let tempLocalIndex1 = tempLocal1.index;
 
           // (x + (x >> 63)) ^ (x >> 63)
@@ -712,7 +715,7 @@ export function compileCall(
             module.createGetLocal(tempLocalIndex2, NativeType.I64)
           );
 
-          currentFunction.freeTempLocal(tempLocal1);
+          parentFunction.freeTempLocal(tempLocal1);
           break;
         }
         case TypeKind.USIZE: {
@@ -792,16 +795,17 @@ export function compileCall(
         case TypeKind.I8:
         case TypeKind.I16:
         case TypeKind.I32: {
-          let flow = compiler.currentFunction.flow;
-          let tempLocal0 = compiler.currentFunction.getTempLocal(
+          let flow = compiler.currentFlow;
+          let parentFunction = flow.parentFunction;
+          let tempLocal0 = parentFunction.getTempLocal(
             compiler.currentType,
             !flow.canOverflow(arg0, compiler.currentType)
           );
-          let tempLocal1 = compiler.currentFunction.getAndFreeTempLocal(
+          let tempLocal1 = parentFunction.getAndFreeTempLocal(
             compiler.currentType,
             !flow.canOverflow(arg1, compiler.currentType)
           );
-          compiler.currentFunction.freeTempLocal(tempLocal0);
+          parentFunction.freeTempLocal(tempLocal0);
           ret = module.createSelect(
             module.createTeeLocal(tempLocal0.index, arg0),
             module.createTeeLocal(tempLocal1.index, arg1),
@@ -816,16 +820,17 @@ export function compileCall(
         case TypeKind.U16:
         case TypeKind.U32:
         case TypeKind.BOOL: {
-          let flow = compiler.currentFunction.flow;
-          let tempLocal0 = compiler.currentFunction.getTempLocal(
+          let flow = compiler.currentFlow;
+          let parentFunction = flow.parentFunction;
+          let tempLocal0 = parentFunction.getTempLocal(
             compiler.currentType,
             !flow.canOverflow(arg0, compiler.currentType)
           );
-          let tempLocal1 = compiler.currentFunction.getAndFreeTempLocal(
+          let tempLocal1 = parentFunction.getAndFreeTempLocal(
             compiler.currentType,
             !flow.canOverflow(arg1, compiler.currentType)
           );
-          compiler.currentFunction.freeTempLocal(tempLocal0);
+          parentFunction.freeTempLocal(tempLocal0);
           ret = module.createSelect(
             module.createTeeLocal(tempLocal0.index, arg0),
             module.createTeeLocal(tempLocal1.index, arg1),
@@ -837,9 +842,11 @@ export function compileCall(
           break;
         }
         case TypeKind.I64: {
-          let tempLocal0 = compiler.currentFunction.getTempLocal(Type.i64, false);
-          let tempLocal1 = compiler.currentFunction.getAndFreeTempLocal(Type.i64, false);
-          compiler.currentFunction.freeTempLocal(tempLocal0);
+          let flow = compiler.currentFlow;
+          let parentFunction = flow.parentFunction;
+          let tempLocal0 = parentFunction.getTempLocal(Type.i64, false);
+          let tempLocal1 = parentFunction.getAndFreeTempLocal(Type.i64, false);
+          parentFunction.freeTempLocal(tempLocal0);
           ret = module.createSelect(
             module.createTeeLocal(tempLocal0.index, arg0),
             module.createTeeLocal(tempLocal1.index, arg1),
@@ -851,9 +858,11 @@ export function compileCall(
           break;
         }
         case TypeKind.U64: {
-          let tempLocal0 = compiler.currentFunction.getTempLocal(Type.i64, false);
-          let tempLocal1 = compiler.currentFunction.getAndFreeTempLocal(Type.i64, false);
-          compiler.currentFunction.freeTempLocal(tempLocal0);
+          let flow = compiler.currentFlow;
+          let parentFunction = flow.parentFunction;
+          let tempLocal0 = parentFunction.getTempLocal(Type.i64, false);
+          let tempLocal1 = parentFunction.getAndFreeTempLocal(Type.i64, false);
+          parentFunction.freeTempLocal(tempLocal0);
           ret = module.createSelect(
             module.createTeeLocal(tempLocal0.index, arg0),
             module.createTeeLocal(tempLocal1.index, arg1),
@@ -865,9 +874,11 @@ export function compileCall(
           break;
         }
         case TypeKind.ISIZE: {
-          let tempLocal0 = compiler.currentFunction.getTempLocal(compiler.options.usizeType, false);
-          let tempLocal1 = compiler.currentFunction.getAndFreeTempLocal(compiler.options.usizeType, false);
-          compiler.currentFunction.freeTempLocal(tempLocal0);
+          let flow = compiler.currentFlow;
+          let parentFunction = flow.parentFunction;
+          let tempLocal0 = parentFunction.getTempLocal(compiler.options.usizeType, false);
+          let tempLocal1 = parentFunction.getAndFreeTempLocal(compiler.options.usizeType, false);
+          parentFunction.freeTempLocal(tempLocal0);
           ret = module.createSelect(
             module.createTeeLocal(tempLocal0.index, arg0),
             module.createTeeLocal(tempLocal1.index, arg1),
@@ -890,9 +901,11 @@ export function compileCall(
             ret = module.createUnreachable();
             break;
           }
-          let tempLocal0 = compiler.currentFunction.getTempLocal(compiler.options.usizeType, false);
-          let tempLocal1 = compiler.currentFunction.getAndFreeTempLocal(compiler.options.usizeType, false);
-          compiler.currentFunction.freeTempLocal(tempLocal0);
+          let flow = compiler.currentFlow;
+          let parentFunction = flow.parentFunction;
+          let tempLocal0 = parentFunction.getTempLocal(compiler.options.usizeType, false);
+          let tempLocal1 = parentFunction.getAndFreeTempLocal(compiler.options.usizeType, false);
+          parentFunction.freeTempLocal(tempLocal0);
           ret = module.createSelect(
             module.createTeeLocal(tempLocal0.index, arg0),
             module.createTeeLocal(tempLocal1.index, arg1),
@@ -960,16 +973,17 @@ export function compileCall(
         case TypeKind.I8:
         case TypeKind.I16:
         case TypeKind.I32: {
-          let flow = compiler.currentFunction.flow;
-          let tempLocal0 = compiler.currentFunction.getTempLocal(
+          let flow = compiler.currentFlow;
+          let parentFunction = flow.parentFunction;
+          let tempLocal0 = parentFunction.getTempLocal(
             compiler.currentType,
             !flow.canOverflow(arg0, compiler.currentType)
           );
-          let tempLocal1 = compiler.currentFunction.getAndFreeTempLocal(
+          let tempLocal1 = parentFunction.getAndFreeTempLocal(
             compiler.currentType,
             !flow.canOverflow(arg1, compiler.currentType)
           );
-          compiler.currentFunction.freeTempLocal(tempLocal0);
+          parentFunction.freeTempLocal(tempLocal0);
           ret = module.createSelect(
             module.createTeeLocal(tempLocal0.index, arg0),
             module.createTeeLocal(tempLocal1.index, arg1),
@@ -984,16 +998,17 @@ export function compileCall(
         case TypeKind.U16:
         case TypeKind.U32:
         case TypeKind.BOOL: {
-          let flow = compiler.currentFunction.flow;
-          let tempLocal0 = compiler.currentFunction.getTempLocal(
+          let flow = compiler.currentFlow;
+          let parentFunction = flow.parentFunction;
+          let tempLocal0 = parentFunction.getTempLocal(
             compiler.currentType,
             !flow.canOverflow(arg0, compiler.currentType)
           );
-          let tempLocal1 = compiler.currentFunction.getAndFreeTempLocal(
+          let tempLocal1 = parentFunction.getAndFreeTempLocal(
             compiler.currentType,
             !flow.canOverflow(arg1, compiler.currentType)
           );
-          compiler.currentFunction.freeTempLocal(tempLocal0);
+          parentFunction.freeTempLocal(tempLocal0);
           ret = module.createSelect(
             module.createTeeLocal(tempLocal0.index, arg0),
             module.createTeeLocal(tempLocal1.index, arg1),
@@ -1005,9 +1020,10 @@ export function compileCall(
           break;
         }
         case TypeKind.I64: {
-          let tempLocal0 = compiler.currentFunction.getTempLocal(Type.i64, false);
-          let tempLocal1 = compiler.currentFunction.getAndFreeTempLocal(Type.i64, false);
-          compiler.currentFunction.freeTempLocal(tempLocal0);
+          let parentFunction = compiler.currentFlow.parentFunction;
+          let tempLocal0 = parentFunction.getTempLocal(Type.i64, false);
+          let tempLocal1 = parentFunction.getAndFreeTempLocal(Type.i64, false);
+          parentFunction.freeTempLocal(tempLocal0);
           ret = module.createSelect(
             module.createTeeLocal(tempLocal0.index, arg0),
             module.createTeeLocal(tempLocal1.index, arg1),
@@ -1019,9 +1035,10 @@ export function compileCall(
           break;
         }
         case TypeKind.U64: {
-          let tempLocal0 = compiler.currentFunction.getTempLocal(Type.i64, false);
-          let tempLocal1 = compiler.currentFunction.getAndFreeTempLocal(Type.i64, false);
-          compiler.currentFunction.freeTempLocal(tempLocal0);
+          let parentFunction = compiler.currentFlow.parentFunction;
+          let tempLocal0 = parentFunction.getTempLocal(Type.i64, false);
+          let tempLocal1 = parentFunction.getAndFreeTempLocal(Type.i64, false);
+          parentFunction.freeTempLocal(tempLocal0);
           ret = module.createSelect(
             module.createTeeLocal(tempLocal0.index, arg0),
             module.createTeeLocal(tempLocal1.index, arg1),
@@ -1033,9 +1050,10 @@ export function compileCall(
           break;
         }
         case TypeKind.ISIZE: {
-          let tempLocal0 = compiler.currentFunction.getTempLocal(compiler.options.usizeType, false);
-          let tempLocal1 = compiler.currentFunction.getAndFreeTempLocal(compiler.options.usizeType, false);
-          compiler.currentFunction.freeTempLocal(tempLocal0);
+          let parentFunction = compiler.currentFlow.parentFunction;
+          let tempLocal0 = parentFunction.getTempLocal(compiler.options.usizeType, false);
+          let tempLocal1 = parentFunction.getAndFreeTempLocal(compiler.options.usizeType, false);
+          parentFunction.freeTempLocal(tempLocal0);
           ret = module.createSelect(
             module.createTeeLocal(tempLocal0.index, arg0),
             module.createTeeLocal(tempLocal1.index, arg1),
@@ -1058,9 +1076,10 @@ export function compileCall(
             ret = module.createUnreachable();
             break;
           }
-          let tempLocal0 = compiler.currentFunction.getTempLocal(compiler.options.usizeType, false);
-          let tempLocal1 = compiler.currentFunction.getAndFreeTempLocal(compiler.options.usizeType, false);
-          compiler.currentFunction.freeTempLocal(tempLocal0);
+          let parentFunction = compiler.currentFlow.parentFunction;
+          let tempLocal0 = parentFunction.getTempLocal(compiler.options.usizeType, false);
+          let tempLocal1 = parentFunction.getAndFreeTempLocal(compiler.options.usizeType, false);
+          parentFunction.freeTempLocal(tempLocal0);
           ret = module.createSelect(
             module.createTeeLocal(tempLocal0.index, arg0),
             module.createTeeLocal(tempLocal1.index, arg1),
@@ -2186,8 +2205,8 @@ export function compileCall(
           case TypeKind.U8:
           case TypeKind.U16:
           case TypeKind.BOOL: {
-            let flow = compiler.currentFunction.flow;
-            let tempLocal = compiler.currentFunction.getAndFreeTempLocal(
+            let flow = compiler.currentFlow;
+            let tempLocal = flow.parentFunction.getAndFreeTempLocal(
               compiler.currentType,
               !flow.canOverflow(arg0, compiler.currentType)
             );
@@ -2201,7 +2220,7 @@ export function compileCall(
           case TypeKind.I32:
           case TypeKind.U32:
           default: {
-            let tempLocal = compiler.currentFunction.getAndFreeTempLocal(Type.i32, false);
+            let tempLocal = compiler.currentFlow.parentFunction.getAndFreeTempLocal(Type.i32, false);
             ret = module.createIf(
               module.createTeeLocal(tempLocal.index, arg0),
               module.createGetLocal(tempLocal.index, NativeType.I32),
@@ -2211,7 +2230,7 @@ export function compileCall(
           }
           case TypeKind.I64:
           case TypeKind.U64: {
-            let tempLocal = compiler.currentFunction.getAndFreeTempLocal(Type.i64, false);
+            let tempLocal = compiler.currentFlow.parentFunction.getAndFreeTempLocal(Type.i64, false);
             ret = module.createIf(
               module.createUnary(UnaryOp.EqzI64,
                 module.createTeeLocal(tempLocal.index, arg0)
@@ -2223,7 +2242,7 @@ export function compileCall(
           }
           case TypeKind.ISIZE:
           case TypeKind.USIZE: {
-            let tempLocal = compiler.currentFunction.getAndFreeTempLocal(compiler.options.usizeType, false);
+            let tempLocal = compiler.currentFlow.parentFunction.getAndFreeTempLocal(compiler.options.usizeType, false);
             ret = module.createIf(
               module.createUnary(
                 compiler.options.isWasm64
@@ -2237,7 +2256,7 @@ export function compileCall(
             break;
           }
           case TypeKind.F32: {
-            let tempLocal = compiler.currentFunction.getAndFreeTempLocal(Type.f32, false);
+            let tempLocal = compiler.currentFlow.parentFunction.getAndFreeTempLocal(Type.f32, false);
             ret = module.createIf(
               module.createBinary(BinaryOp.EqF32,
                 module.createTeeLocal(tempLocal.index, arg0),
@@ -2249,7 +2268,7 @@ export function compileCall(
             break;
           }
           case TypeKind.F64: {
-            let tempLocal = compiler.currentFunction.getAndFreeTempLocal(Type.f64, false);
+            let tempLocal = compiler.currentFlow.parentFunction.getAndFreeTempLocal(Type.f64, false);
             ret = module.createIf(
               module.createBinary(BinaryOp.EqF64,
                 module.createTeeLocal(tempLocal.index, arg0),
@@ -2286,7 +2305,7 @@ export function compileCall(
         );
         return module.createUnreachable();
       }
-      let flow = compiler.currentFunction.flow;
+      let flow = compiler.currentFlow;
       flow.set(FlowFlags.UNCHECKED_CONTEXT);
       ret = compiler.compileExpressionRetainType(operands[0], contextualType, WrapMode.NONE);
       flow.unset(FlowFlags.UNCHECKED_CONTEXT);

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -140,7 +140,6 @@ import {
   StringLiteralExpression,
   UnaryPostfixExpression,
   UnaryPrefixExpression,
-  FieldDeclaration,
 
   nodeIsConstantValue,
   isLastStatement,
@@ -266,10 +265,8 @@ export class Compiler extends DiagnosticEmitter {
   options: Options;
   /** Module instance being compiled. */
   module: Module;
-  /** Current function in compilation. */
-  currentFunction: Function;
-  /** Current outer function in compilation, if compiling a function expression. */
-  currentOuterFunction: Function | null = null;
+  /** Current control flow. */
+  currentFlow: Flow;
   /** Current inline functions stack. */
   currentInlineFunctions: Function[] = [];
   /** Current enum in compilation. */
@@ -329,7 +326,7 @@ export class Compiler extends DiagnosticEmitter {
     this.startFunctionInstance = startFunctionInstance;
     var startFunctionBody = new Array<ExpressionRef>();
     this.startFunctionBody = startFunctionBody;
-    this.currentFunction = startFunctionInstance;
+    this.currentFlow = startFunctionInstance.flow;
 
     // add a mutable heap base dummy
     if (options.isWasm64) {
@@ -670,10 +667,12 @@ export class Compiler extends DiagnosticEmitter {
           break;
         }
         default: { // otherwise a top-level statement that is part of the start function's body
-          let previousFunction = this.currentFunction;
-          this.currentFunction = startFunctionInstance;
-          startFunctionBody.push(this.compileStatement(statement));
-          this.currentFunction = previousFunction;
+          let previousFlow = this.currentFlow;
+          this.currentFlow = startFunctionInstance.flow;
+          startFunctionBody.push(
+            this.compileStatement(statement)
+          );
+          this.currentFlow = previousFlow;
           break;
         }
       }
@@ -1022,18 +1021,28 @@ export class Compiler extends DiagnosticEmitter {
     return typeRef;
   }
 
-  /** Compiles just the body of a function in whatever is the current context. */
+  /** Compiles the body of a function within the specified flow. */
   private compileFunctionBody(instance: Function): ExpressionRef[] {
+    var module = this.module;
     var declaration = instance.prototype.declaration;
     var body = assert(declaration.body);
+    var returnType = instance.signature.returnType;
+    var flow = this.currentFlow;
+
+    // compile statements
+    var stmts: BinaryenExportRef[];
     if (body.kind == NodeKind.BLOCK) {
-      return this.compileStatements((<BlockStatement>body).statements);
+      stmts = this.compileStatements((<BlockStatement>body).statements);
     } else {
+      // must be an expression statement if not a block
       assert(body.kind == NodeKind.EXPRESSION);
+
+      // must be an arrow function
       assert(instance.is(CommonFlags.ARROW));
+
+      // none of the following can be an arrow function
       assert(!instance.isAny(CommonFlags.CONSTRUCTOR | CommonFlags.GET | CommonFlags.SET | CommonFlags.MAIN));
-      let returnType = instance.signature.returnType;
-      let flow = instance.flow;
+
       let stmt = this.compileExpression(
         (<ExpressionStatement>body).expression,
         returnType,
@@ -1042,8 +1051,80 @@ export class Compiler extends DiagnosticEmitter {
       );
       flow.set(FlowFlags.RETURNS);
       if (!flow.canOverflow(stmt, returnType)) flow.set(FlowFlags.RETURNS_WRAPPED);
-      return [ stmt ];
+      stmts = [ stmt ];
     }
+
+    // make the main function call `start` implicitly, but only once
+    if (instance.is(CommonFlags.MAIN)) {
+      module.addGlobal("~started", NativeType.I32, true, module.createI32(0));
+      stmts.unshift(
+        module.createIf(
+          module.createUnary(
+            UnaryOp.EqzI32,
+            module.createGetGlobal("~started", NativeType.I32)
+          ),
+          module.createBlock(null, [
+            module.createCall("start", null, NativeType.None),
+            module.createSetGlobal("~started", module.createI32(1))
+          ])
+        )
+      );
+    }
+
+    // make constructors return their instance pointer
+    if (instance.is(CommonFlags.CONSTRUCTOR)) {
+      let nativeSizeType = this.options.nativeSizeType;
+      assert(instance.is(CommonFlags.INSTANCE));
+      let classInstance = assert(instance.parent); assert(classInstance.kind == ElementKind.CLASS);
+
+      if (!flow.isAny(FlowFlags.ANY_TERMINATING)) {
+        let thisLocalIndex = flow.is(FlowFlags.INLINE_CONTEXT)
+          ? assert(flow.getScopedLocal("this")).index
+          : 0;
+
+        // if `this` wasn't accessed before, allocate if necessary and initialize `this`
+        if (!flow.is(FlowFlags.ALLOCATES)) {
+          // {
+          //   if (!this) this = <ALLOC>
+          //   this.a = X
+          //   this.b = Y
+          // }
+          stmts.push(
+            module.createIf(
+              module.createUnary(nativeSizeType == NativeType.I64 ? UnaryOp.EqzI64 : UnaryOp.EqzI32,
+                module.createGetLocal(thisLocalIndex, nativeSizeType)
+              ),
+              module.createSetLocal(thisLocalIndex,
+                this.makeAllocation(<Class>classInstance)
+              )
+            )
+          );
+          this.makeFieldInitialization(<Class>classInstance, stmts);
+        }
+
+        // implicitly return `this`
+        stmts.push(
+          module.createGetLocal(thisLocalIndex, nativeSizeType)
+        );
+      }
+
+      // check that super has been called if this is a derived class
+      if ((<Class>classInstance).base && !flow.is(FlowFlags.CALLS_SUPER)) {
+        this.error(
+          DiagnosticCode.Constructors_for_derived_classes_must_contain_a_super_call,
+          instance.prototype.declaration.range
+        );
+      }
+
+    // if this is a normal function, make sure that all branches return
+    } else if (returnType != Type.void && !flow.is(FlowFlags.RETURNS)) {
+      this.error(
+        DiagnosticCode.A_function_whose_declared_type_is_not_void_must_return_a_value,
+        declaration.signature.returnType.range
+      );
+    }
+
+    return stmts;
   }
 
   /** Compiles a readily resolved function instance. */
@@ -1081,81 +1162,11 @@ export class Compiler extends DiagnosticEmitter {
       }
 
       // compile body in this function's context
-      let previousFunction = this.currentFunction;
-      this.currentFunction = instance;
-      let flow = instance.flow;
-      let returnType = instance.signature.returnType;
+      let previousFlow = this.currentFlow;
+      this.currentFlow = instance.flow;
       let stmts = this.compileFunctionBody(instance);
-      flow.finalize();
-
-      // make the main function call `start` implicitly once
-      if (instance.is(CommonFlags.MAIN)) {
-        module.addGlobal("~started", NativeType.I32, true, module.createI32(0));
-        stmts.unshift(
-          module.createIf(
-            module.createUnary(
-              UnaryOp.EqzI32,
-              module.createGetGlobal("~started", NativeType.I32)
-            ),
-            module.createBlock(null, [
-              module.createCall("start", null, NativeType.None),
-              module.createSetGlobal("~started", module.createI32(1))
-            ])
-          )
-        );
-      }
-
-      // make constructors return their instance pointer
-      if (instance.is(CommonFlags.CONSTRUCTOR)) {
-        let nativeSizeType = this.options.nativeSizeType;
-        assert(instance.is(CommonFlags.INSTANCE));
-        let classInstance = assert(instance.parent); assert(classInstance.kind == ElementKind.CLASS);
-
-        if (!flow.isAny(FlowFlags.ANY_TERMINATING)) {
-
-          // if `this` wasn't accessed before, allocate if necessary and initialize `this`
-          if (!flow.is(FlowFlags.ALLOCATES)) {
-            // {
-            //   if (!this) this = <ALLOC>
-            //   this.a = X
-            //   this.b = Y
-            // }
-            stmts.push(
-              module.createIf(
-                module.createUnary(nativeSizeType == NativeType.I64 ? UnaryOp.EqzI64 : UnaryOp.EqzI32,
-                  module.createGetLocal(0, nativeSizeType)
-                ),
-                module.createSetLocal(0,
-                  this.makeAllocation(<Class>classInstance)
-                )
-              )
-            );
-            this.makeFieldInitialization(<Class>classInstance, stmts);
-          }
-
-          // implicitly return `this`
-          stmts.push(
-            module.createGetLocal(0, nativeSizeType)
-          );
-        }
-
-        // check that super has been called if this is a derived class
-        if ((<Class>classInstance).base && !flow.is(FlowFlags.CALLS_SUPER)) {
-          this.error(
-            DiagnosticCode.Constructors_for_derived_classes_must_contain_a_super_call,
-            instance.prototype.declaration.range
-          );
-        }
-
-      // if this is a normal function, make sure that all branches return
-      } else if (returnType != Type.void && !flow.is(FlowFlags.RETURNS)) {
-        this.error(
-          DiagnosticCode.A_function_whose_declared_type_is_not_void_must_return_a_value,
-          declaration.signature.returnType.range
-        );
-      }
-
-      this.currentFunction = previousFunction;
+      instance.flow.finalize();
+      this.currentFlow = previousFlow;
 
       // create the function
       funcRef = module.addFunction(
@@ -1165,7 +1176,7 @@ export class Compiler extends DiagnosticEmitter {
         stmts.length
           ? stmts.length == 1
             ? stmts[0]
-            : module.createBlock(null, stmts, returnType.toNativeType())
+            : module.createBlock(null, stmts, instance.signature.returnType.toNativeType())
           : module.createNop()
       );
 
@@ -1611,7 +1622,7 @@ export class Compiler extends DiagnosticEmitter {
       case NodeKind.TYPEDECLARATION: {
         // type declarations must be top-level because function bodies are evaluated when
         // reachaable only.
-        if (this.currentFunction == this.startFunctionInstance) {
+        if (this.currentFlow.parentFunction == this.startFunctionInstance) {
           return module.createNop();
         }
         // otherwise fall-through
@@ -1629,7 +1640,7 @@ export class Compiler extends DiagnosticEmitter {
     var numStatements = statements.length;
     var stmts = new Array<ExpressionRef>(numStatements);
     stmts.length = 0;
-    var flow = this.currentFunction.flow;
+    var flow = this.currentFlow;
     for (let i = 0; i < numStatements; ++i) {
       let stmt = this.compileStatement(statements[i]);
       switch (getExpressionId(stmt)) {
@@ -1653,9 +1664,9 @@ export class Compiler extends DiagnosticEmitter {
 
   compileBlockStatement(statement: BlockStatement): ExpressionRef {
     var statements = statement.statements;
-    var parentFlow = this.currentFunction.flow;
-    var flow = parentFlow.fork();
-    this.currentFunction.flow = flow;
+    var outerFlow = this.currentFlow;
+    var innerFlow = outerFlow.fork();
+    this.currentFlow = innerFlow;
 
     var stmts = this.compileStatements(statements);
     var stmt = stmts.length == 0
@@ -1664,8 +1675,9 @@ export class Compiler extends DiagnosticEmitter {
         ? stmts[0]
         : this.module.createBlock(null, stmts,getExpressionType(stmts[stmts.length - 1]));
 
-    this.currentFunction.flow = flow.free();
-    parentFlow.inherit(flow);
+    innerFlow.free();
+    outerFlow.inherit(innerFlow);
+    this.currentFlow = outerFlow;
     return stmt;
   }
 
@@ -1678,7 +1690,7 @@ export class Compiler extends DiagnosticEmitter {
       );
       return module.createUnreachable();
     }
-    var flow = this.currentFunction.flow;
+    var flow = this.currentFlow;
     var breakLabel = flow.breakLabel;
     if (breakLabel == null) {
       this.error(
@@ -1702,7 +1714,7 @@ export class Compiler extends DiagnosticEmitter {
       return module.createUnreachable();
     }
     // Check if 'continue' is allowed here
-    var flow = this.currentFunction.flow;
+    var flow = this.currentFlow;
     var continueLabel = flow.continueLabel;
     if (continueLabel == null) {
       this.error(
@@ -1716,17 +1728,16 @@ export class Compiler extends DiagnosticEmitter {
   }
 
   compileDoStatement(statement: DoStatement): ExpressionRef {
-    var currentFunction = this.currentFunction;
     var module = this.module;
 
-    var label = currentFunction.enterBreakContext();
-    var parentFlow = currentFunction.flow;
-    var flow = parentFlow.fork();
-    currentFunction.flow = flow;
+    var outerFlow = this.currentFlow;
+    var label = outerFlow.parentFunction.enterBreakContext();
+    var innerFlow = outerFlow.fork();
+    this.currentFlow = innerFlow;
     var breakLabel = "break|" + label;
-    flow.breakLabel = breakLabel;
+    innerFlow.breakLabel = breakLabel;
     var continueLabel = "continue|" + label;
-    flow.continueLabel = continueLabel;
+    innerFlow.continueLabel = continueLabel;
 
     var body = this.compileStatement(statement.statement);
     var condExpr = this.makeIsTrueish(
@@ -1736,16 +1747,17 @@ export class Compiler extends DiagnosticEmitter {
     // TODO: check if condition is always false and if so, omit it (just a block)
 
     // Switch back to the parent flow
-    currentFunction.flow = flow.free();
-    currentFunction.leaveBreakContext();
-    var terminated = flow.isAny(FlowFlags.ANY_TERMINATING);
-    flow.unset(
+    innerFlow.free();
+    this.currentFlow = outerFlow;
+    outerFlow.parentFunction.leaveBreakContext();
+    var terminated = innerFlow.isAny(FlowFlags.ANY_TERMINATING);
+    innerFlow.unset(
       FlowFlags.BREAKS |
       FlowFlags.CONDITIONALLY_BREAKS |
       FlowFlags.CONTINUES |
       FlowFlags.CONDITIONALLY_CONTINUES
     );
-    parentFlow.inherit(flow);
+    outerFlow.inherit(innerFlow);
 
     var block: ExpressionRef[] = [
       module.createLoop(continueLabel,
@@ -1777,15 +1789,14 @@ export class Compiler extends DiagnosticEmitter {
   compileForStatement(statement: ForStatement): ExpressionRef {
     // A for statement initiates a new branch with its own scoped variables
     // possibly declared in its initializer, and break context.
-    var currentFunction = this.currentFunction;
-    var label = currentFunction.enterBreakContext();
-    var parentFlow = currentFunction.flow;
-    var flow = parentFlow.fork();
-    currentFunction.flow = flow;
-    var breakLabel = flow.breakLabel = "break|" + label;
-    flow.breakLabel = breakLabel;
+    var outerFlow = this.currentFlow;
+    var label = outerFlow.parentFunction.enterBreakContext();
+    var innerFlow = outerFlow.fork();
+    this.currentFlow = innerFlow;
+    var breakLabel = innerFlow.breakLabel = "break|" + label;
+    innerFlow.breakLabel = breakLabel;
     var continueLabel = "continue|" + label;
-    flow.continueLabel = continueLabel;
+    innerFlow.continueLabel = continueLabel;
     var repeatLabel = "repeat|" + label;
 
     // Compile in correct order
@@ -1827,17 +1838,18 @@ export class Compiler extends DiagnosticEmitter {
       : this.compileStatement(bodyStatement);
 
     // Switch back to the parent flow
-    currentFunction.flow = flow.free();
-    currentFunction.leaveBreakContext();
-    var usesContinue = flow.isAny(FlowFlags.CONTINUES | FlowFlags.CONDITIONALLY_CONTINUES);
-    flow.unset(
+    innerFlow.free();
+    this.currentFlow = outerFlow;
+    outerFlow.parentFunction.leaveBreakContext();
+    var usesContinue = innerFlow.isAny(FlowFlags.CONTINUES | FlowFlags.CONDITIONALLY_CONTINUES);
+    innerFlow.unset(
       FlowFlags.BREAKS |
       FlowFlags.CONDITIONALLY_BREAKS |
       FlowFlags.CONTINUES |
       FlowFlags.CONDITIONALLY_CONTINUES
     );
-    if (alwaysTrue) parentFlow.inherit(flow);
-    else parentFlow.inheritConditional(flow);
+    if (alwaysTrue) outerFlow.inherit(innerFlow);
+    else outerFlow.inheritConditional(innerFlow);
 
     var breakBlock = new Array<ExpressionRef>(); // outer 'break' block
     if (initExpr) breakBlock.push(initExpr);
@@ -1870,9 +1882,10 @@ export class Compiler extends DiagnosticEmitter {
 
   compileIfStatement(statement: IfStatement): ExpressionRef {
     var module = this.module;
-    var currentFunction = this.currentFunction;
     var ifTrue = statement.ifTrue;
     var ifFalse = statement.ifFalse;
+    var outerFlow = this.currentFlow;
+    var actualFunction = outerFlow.actualFunction;
 
     // The condition doesn't initiate a branch yet
     var condExpr = this.makeIsTrueish(
@@ -1882,7 +1895,7 @@ export class Compiler extends DiagnosticEmitter {
 
     if (
       !this.options.noTreeShaking ||
-      this.currentFunction.isAny(CommonFlags.GENERIC | CommonFlags.GENERIC_CONTEXT)
+      actualFunction.isAny(CommonFlags.GENERIC | CommonFlags.GENERIC_CONTEXT)
     ) {
       // Try to eliminate unnecesssary branches if the condition is constant
       let condExprPrecomp = module.precomputeExpression(condExpr);
@@ -1906,30 +1919,30 @@ export class Compiler extends DiagnosticEmitter {
     }
 
     // Each arm initiates a branch
-    var parentFlow = currentFunction.flow;
-    var ifTrueFlow = parentFlow.fork();
-    currentFunction.flow = ifTrueFlow;
+    var ifTrueFlow = outerFlow.fork();
+    this.currentFlow = ifTrueFlow;
     var ifTrueExpr = this.compileStatement(ifTrue);
-    currentFunction.flow = ifTrueFlow.free();
+    ifTrueFlow.free();
+    this.currentFlow = outerFlow;
 
     var ifFalseExpr: ExpressionRef = 0;
     if (ifFalse) {
-      let ifFalseFlow = parentFlow.fork();
-      currentFunction.flow = ifFalseFlow;
+      let ifFalseFlow = outerFlow.fork();
+      this.currentFlow = ifFalseFlow;
       ifFalseExpr = this.compileStatement(ifFalse);
-      currentFunction.flow = ifFalseFlow.free();
-      parentFlow.inheritMutual(ifTrueFlow, ifFalseFlow);
+      ifFalseFlow.free();
+      this.currentFlow = outerFlow;
+      outerFlow.inheritMutual(ifTrueFlow, ifFalseFlow);
     } else {
-      parentFlow.inheritConditional(ifTrueFlow);
+      outerFlow.inheritConditional(ifTrueFlow);
     }
     return module.createIf(condExpr, ifTrueExpr, ifFalseExpr);
   }
 
   compileReturnStatement(statement: ReturnStatement): ExpressionRef {
     var module = this.module;
-    var currentFunction = this.currentFunction;
     var expr: ExpressionRef = 0;
-    var flow = currentFunction.flow;
+    var flow = this.currentFlow;
 
     // Remember that this flow returns
     flow.set(FlowFlags.RETURNS);
@@ -1949,7 +1962,7 @@ export class Compiler extends DiagnosticEmitter {
         statement.value,
         returnType,
         ConversionKind.IMPLICIT,
-        currentFunction.is(CommonFlags.MODULE_EXPORT)
+        flow.actualFunction.is(CommonFlags.MODULE_EXPORT)
           ? WrapMode.WRAP
           : WrapMode.NONE
       );
@@ -1962,14 +1975,13 @@ export class Compiler extends DiagnosticEmitter {
     if (isLastStatement(statement)) return expr ? expr : module.createNop();
 
     // When inlining, break to the end of the inlined function's block (no need to wrap)
-    return flow.is(FlowFlags.INLINE_CONTEXT)
-      ? module.createBreak(assert(flow.returnLabel), 0, expr)
-      : module.createReturn(expr);
+    if (flow.is(FlowFlags.INLINE_CONTEXT)) return module.createBreak(assert(flow.inlineReturnLabel), 0, expr)
+
+    return module.createReturn(expr);
   }
 
   compileSwitchStatement(statement: SwitchStatement): ExpressionRef {
     var module = this.module;
-    var currentFunction = this.currentFunction;
 
     var cases = statement.cases;
     var numCases = cases.length;
@@ -1978,11 +1990,12 @@ export class Compiler extends DiagnosticEmitter {
     }
 
     // Everything within a switch uses the same break context
-    var context = currentFunction.enterBreakContext();
-    var parentFlow = currentFunction.flow;
+    var outerFlow = this.currentFlow;
+    var parentFunction = outerFlow.parentFunction;
+    var context = parentFunction.enterBreakContext();
 
     // introduce a local for evaluating the condition (exactly once)
-    var tempLocal = currentFunction.getTempLocal(Type.u32, false);
+    var tempLocal = parentFunction.getTempLocal(Type.u32, false);
     var tempLocalIndex = tempLocal.index;
 
     // Prepend initializer to inner block. Does not initiate a new branch, yet.
@@ -2010,7 +2023,7 @@ export class Compiler extends DiagnosticEmitter {
       }
     }
 
-    currentFunction.freeTempLocal(tempLocal);
+    parentFunction.freeTempLocal(tempLocal);
 
     // otherwise br to default respectively out of the switch if there is no default case
     breaks[breakIndex] = module.createBreak((defaultIndex >= 0
@@ -2030,10 +2043,10 @@ export class Compiler extends DiagnosticEmitter {
       let numStatements = statements.length;
 
       // Each switch case initiates a new branch
-      let flow = parentFlow.fork();
-      currentFunction.flow = flow;
+      let innerFlow = outerFlow.fork();
+      this.currentFlow = innerFlow;
       let breakLabel = "break|" + context;
-      flow.breakLabel = breakLabel;
+      innerFlow.breakLabel = breakLabel;
 
       let isLast = i == numCases - 1;
       let nextLabel = isLast ? breakLabel : "case" + (i + 1).toString(10) + "|" + context;
@@ -2045,7 +2058,7 @@ export class Compiler extends DiagnosticEmitter {
         let stmt = this.compileStatement(statements[j]);
         if (getExpressionId(stmt) != ExpressionId.Nop) {
           stmts[count++] = stmt;
-          if (flow.isAny(FlowFlags.ANY_TERMINATING)) {
+          if (innerFlow.isAny(FlowFlags.ANY_TERMINATING)) {
             terminated = true;
             break;
           }
@@ -2053,34 +2066,35 @@ export class Compiler extends DiagnosticEmitter {
       }
       stmts.length = count;
       if (terminated || isLast) {
-        if (!flow.is(FlowFlags.RETURNS)) alwaysReturns = false;
-        if (!flow.is(FlowFlags.RETURNS_WRAPPED)) alwaysReturnsWrapped = false;
-        if (!flow.is(FlowFlags.THROWS)) alwaysThrows = false;
-        if (!flow.is(FlowFlags.ALLOCATES)) alwaysAllocates = false;
+        if (!innerFlow.is(FlowFlags.RETURNS)) alwaysReturns = false;
+        if (!innerFlow.is(FlowFlags.RETURNS_WRAPPED)) alwaysReturnsWrapped = false;
+        if (!innerFlow.is(FlowFlags.THROWS)) alwaysThrows = false;
+        if (!innerFlow.is(FlowFlags.ALLOCATES)) alwaysAllocates = false;
       }
 
       // Switch back to the parent flow
-      flow.unset(
+      innerFlow.unset(
         FlowFlags.BREAKS |
         FlowFlags.CONDITIONALLY_BREAKS
       );
-      currentFunction.flow = flow.free();
+      innerFlow.free();
+      this.currentFlow = outerFlow;
       currentBlock = module.createBlock(nextLabel, stmts, NativeType.None); // must be a labeled block
     }
-    currentFunction.leaveBreakContext();
+    parentFunction.leaveBreakContext();
 
     // If the switch has a default (guaranteed to handle any value), propagate common flags
     if (defaultIndex >= 0) {
-      if (alwaysReturns) parentFlow.set(FlowFlags.RETURNS);
-      if (alwaysReturnsWrapped) parentFlow.set(FlowFlags.RETURNS_WRAPPED);
-      if (alwaysThrows) parentFlow.set(FlowFlags.THROWS);
-      if (alwaysAllocates) parentFlow.set(FlowFlags.ALLOCATES);
+      if (alwaysReturns) outerFlow.set(FlowFlags.RETURNS);
+      if (alwaysReturnsWrapped) outerFlow.set(FlowFlags.RETURNS_WRAPPED);
+      if (alwaysThrows) outerFlow.set(FlowFlags.THROWS);
+      if (alwaysAllocates) outerFlow.set(FlowFlags.ALLOCATES);
     }
     return currentBlock;
   }
 
   compileThrowStatement(statement: ThrowStatement): ExpressionRef {
-    var flow = this.currentFunction.flow;
+    var flow = this.currentFlow;
 
     // Remember that this branch throws
     flow.set(FlowFlags.THROWS);
@@ -2109,13 +2123,13 @@ export class Compiler extends DiagnosticEmitter {
    */
   compileVariableStatement(statement: VariableStatement, isKnownGlobal: bool = false): ExpressionRef {
     var program = this.program;
-    var currentFunction = this.currentFunction;
     var declarations = statement.declarations;
     var numDeclarations = declarations.length;
+    var flow = this.currentFlow;
 
     // top-level variables and constants become globals
     if (isKnownGlobal || (
-      currentFunction == this.startFunctionInstance &&
+      flow.parentFunction == this.startFunctionInstance &&
       statement.parent && statement.parent.kind == NodeKind.SOURCE
     )) {
       // NOTE that the above condition also covers top-level variables declared with 'let', even
@@ -2131,7 +2145,6 @@ export class Compiler extends DiagnosticEmitter {
 
     // other variables become locals
     var initializers = new Array<ExpressionRef>();
-    var flow = this.currentFunction.flow;
     var resolver = this.resolver;
     for (let i = 0; i < numDeclarations; ++i) {
       let declaration = declarations[i];
@@ -2212,8 +2225,8 @@ export class Compiler extends DiagnosticEmitter {
               }
             }
             // Create a virtual local that doesn't actually exist in WebAssembly
-            let scopedLocals = currentFunction.flow.scopedLocals;
-            if (!scopedLocals) currentFunction.flow.scopedLocals = scopedLocals = new Map();
+            let scopedLocals = flow.scopedLocals;
+            if (!scopedLocals) flow.scopedLocals = scopedLocals = new Map();
             else if (scopedLocals.has(name)) {
               this.error(
                 DiagnosticCode.Duplicate_identifier_0,
@@ -2244,17 +2257,19 @@ export class Compiler extends DiagnosticEmitter {
         ) { // here: not top-level
           local = flow.addScopedLocal(type, name, false, declaration); // reports
         } else {
-          if (currentFunction.flow.getScopedLocal(name)) {
+          if (flow.getScopedLocal(name)) {
             this.error(
               DiagnosticCode.Duplicate_identifier_0,
               declaration.name.range, name
             );
             continue;
           }
-          local = currentFunction.addLocal(type, name, declaration);
+          local = flow.parentFunction.addLocal(type, name, declaration);
         }
         if (initExpr) {
-          initializers.push(this.compileAssignmentWithValue(declaration.name, initExpr));
+          initializers.push(
+            this.compileAssignmentWithValue(declaration.name, initExpr)
+          );
           if (local.type.is(TypeFlags.SHORT | TypeFlags.INTEGER)) {
             flow.setLocalWrapped(local.index, !flow.canOverflow(initExpr, type));
           }
@@ -2276,6 +2291,7 @@ export class Compiler extends DiagnosticEmitter {
 
   compileWhileStatement(statement: WhileStatement): ExpressionRef {
     var module = this.module;
+    var outerFlow = this.currentFlow;
 
     // The condition does not yet initialize a branch
     var condExpr = this.makeIsTrueish(
@@ -2285,7 +2301,7 @@ export class Compiler extends DiagnosticEmitter {
 
     if (
       !this.options.noTreeShaking ||
-      this.currentFunction.isAny(CommonFlags.GENERIC | CommonFlags.GENERIC_CONTEXT)
+      outerFlow.actualFunction.isAny(CommonFlags.GENERIC | CommonFlags.GENERIC_CONTEXT)
     ) {
       // Try to eliminate unnecesssary loops if the condition is constant
       let condExprPrecomp = module.precomputeExpression(condExpr);
@@ -2305,31 +2321,30 @@ export class Compiler extends DiagnosticEmitter {
     }
 
     // Statements initiate a new branch with its own break context
-    var currentFunction = this.currentFunction;
-    var label = currentFunction.enterBreakContext();
-    var parentFlow = currentFunction.flow;
-    var flow = parentFlow.fork();
-    currentFunction.flow = flow;
+    var label = outerFlow.parentFunction.enterBreakContext();
+    var innerFlow = outerFlow.fork();
+    this.currentFlow = innerFlow;
     var breakLabel = "break|" + label;
-    flow.breakLabel = breakLabel;
+    innerFlow.breakLabel = breakLabel;
     var continueLabel = "continue|" + label;
-    flow.continueLabel = continueLabel;
+    innerFlow.continueLabel = continueLabel;
 
     var body = this.compileStatement(statement.statement);
     var alwaysTrue = false; // TODO
-    var terminated = flow.isAny(FlowFlags.ANY_TERMINATING);
+    var terminated = innerFlow.isAny(FlowFlags.ANY_TERMINATING);
 
     // Switch back to the parent flow
-    currentFunction.flow = flow.free();
-    currentFunction.leaveBreakContext();
-    flow.unset(
+    innerFlow.free();
+    this.currentFlow = outerFlow;
+    outerFlow.parentFunction.leaveBreakContext();
+    innerFlow.unset(
       FlowFlags.BREAKS |
       FlowFlags.CONDITIONALLY_BREAKS |
       FlowFlags.CONTINUES |
       FlowFlags.CONDITIONALLY_CONTINUES
     );
-    if (alwaysTrue) parentFlow.inherit(flow);
-    else parentFlow.inheritConditional(flow);
+    if (alwaysTrue) outerFlow.inherit(innerFlow);
+    else outerFlow.inheritConditional(innerFlow);
 
     return module.createBlock(breakLabel, [
       module.createLoop(continueLabel,
@@ -2749,7 +2764,7 @@ export class Compiler extends DiagnosticEmitter {
       case AssertionKind.AS: {
         let toType = this.resolver.resolveType( // reports
           assert(expression.toType),
-          this.currentFunction.flow.contextualTypeArguments
+          this.currentFlow.contextualTypeArguments
         );
         if (!toType) return this.module.createUnreachable();
         return this.compileExpression(expression.expression, toType, ConversionKind.EXPLICIT, WrapMode.NONE);
@@ -4609,8 +4624,8 @@ export class Compiler extends DiagnosticEmitter {
 
         // if not possible, tee left to a temp. local
         } else {
-          let flow = this.currentFunction.flow;
-          let tempLocal = this.currentFunction.getAndFreeTempLocal(
+          let flow = this.currentFlow;
+          let tempLocal = flow.parentFunction.getAndFreeTempLocal(
             this.currentType,
             !flow.canOverflow(leftExpr, this.currentType)
           );
@@ -4644,8 +4659,8 @@ export class Compiler extends DiagnosticEmitter {
 
         // if not possible, tee left to a temp. local
         } else {
-          let flow = this.currentFunction.flow;
-          let tempLocal = this.currentFunction.getAndFreeTempLocal(
+          let flow = this.currentFlow;
+          let tempLocal = flow.parentFunction.getAndFreeTempLocal(
             this.currentType,
             !flow.canOverflow(leftExpr, this.currentType)
           );
@@ -4691,8 +4706,7 @@ export class Compiler extends DiagnosticEmitter {
       operatorInstance,
       argumentExpressions,
       reportNode,
-      thisArg,
-      operatorInstance.hasDecorator(DecoratorFlags.INLINE)
+      thisArg
     );
   }
 
@@ -4716,8 +4730,7 @@ export class Compiler extends DiagnosticEmitter {
       operatorInstance,
       argumentExpressions,
       reportNode,
-      thisArg,
-      operatorInstance.hasDecorator(DecoratorFlags.INLINE)
+      thisArg
     );
     return ret;
   }
@@ -4725,8 +4738,8 @@ export class Compiler extends DiagnosticEmitter {
   compileAssignment(expression: Expression, valueExpression: Expression, contextualType: Type): ExpressionRef {
     var program = this.program;
     var resolver = program.resolver;
-    var currentFunction = this.currentFunction;
-    var target = resolver.resolveExpression(expression, currentFunction); // reports
+    var flow = this.currentFlow;
+    var target = resolver.resolveExpression(expression, flow); // reports
     if (!target) return this.module.createUnreachable();
 
     // to compile just the value, we need to know the target's type
@@ -4761,7 +4774,7 @@ export class Compiler extends DiagnosticEmitter {
       }
       case ElementKind.CLASS: {
         if (resolver.currentElementExpression) { // indexed access
-          let isUnchecked = currentFunction.flow.is(FlowFlags.UNCHECKED_CONTEXT);
+          let isUnchecked = flow.is(FlowFlags.UNCHECKED_CONTEXT);
           let indexedSet = (<Class>target).lookupOverload(OperatorKind.INDEXED_SET, isUnchecked);
           if (!indexedSet) {
             let indexedGet = (<Class>target).lookupOverload(OperatorKind.INDEXED_GET, isUnchecked);
@@ -4809,7 +4822,8 @@ export class Compiler extends DiagnosticEmitter {
     tee: bool = false
   ): ExpressionRef {
     var module = this.module;
-    var target = this.resolver.resolveExpression(expression, this.currentFunction); // reports
+    var flow = this.currentFlow;
+    var target = this.resolver.resolveExpression(expression, flow); // reports
     if (!target) return module.createUnreachable();
 
     switch (target.kind) {
@@ -4824,7 +4838,6 @@ export class Compiler extends DiagnosticEmitter {
           );
           return module.createUnreachable();
         }
-        let flow = this.currentFunction.flow;
         if (type.is(TypeFlags.SHORT | TypeFlags.INTEGER)) {
           flow.setLocalWrapped((<Local>target).index, !flow.canOverflow(valueWithCorrectType, type));
         }
@@ -4862,7 +4875,7 @@ export class Compiler extends DiagnosticEmitter {
         if (
           (<Field>target).is(CommonFlags.READONLY) &&
           !(
-            this.currentFunction.is(CommonFlags.CONSTRUCTOR) ||
+            flow.actualFunction.is(CommonFlags.CONSTRUCTOR) ||
             declaration == null ||
             declaration.initializer != null
           )
@@ -4887,9 +4900,8 @@ export class Compiler extends DiagnosticEmitter {
           valueWithCorrectType = this.ensureSmallIntegerWrap(valueWithCorrectType, type);
         }
         if (tee) {
-          let currentFunction = this.currentFunction;
-          let flow = currentFunction.flow;
-          let tempLocal = currentFunction.getAndFreeTempLocal(
+          let flow = this.currentFlow;
+          let tempLocal = flow.parentFunction.getAndFreeTempLocal(
             type,
             !flow.canOverflow(valueWithCorrectType, type)
           );
@@ -4953,7 +4965,7 @@ export class Compiler extends DiagnosticEmitter {
               this.options.usizeType,
               WrapMode.NONE
             );
-            let tempLocal = this.currentFunction.getAndFreeTempLocal(returnType, false);
+            let tempLocal = flow.parentFunction.getAndFreeTempLocal(returnType, false);
             let tempLocalIndex = tempLocal.index;
             return module.createBlock(null, [
               this.makeCallDirect(setterInstance, [ // set and remember the target
@@ -4982,7 +4994,7 @@ export class Compiler extends DiagnosticEmitter {
       case ElementKind.CLASS: {
         let elementExpression = this.resolver.currentElementExpression;
         if (elementExpression) {
-          let isUnchecked = this.currentFunction.flow.is(FlowFlags.UNCHECKED_CONTEXT);
+          let isUnchecked = flow.is(FlowFlags.UNCHECKED_CONTEXT);
           let indexedGet = (<Class>target).lookupOverload(OperatorKind.INDEXED_GET, isUnchecked);
           if (!indexedGet) {
             this.error(
@@ -5014,11 +5026,11 @@ export class Compiler extends DiagnosticEmitter {
             WrapMode.NONE
           );
           if (tee) {
-            let currentFunction = this.currentFunction;
-            let tempLocalTarget = currentFunction.getTempLocal(targetType, false);
-            let tempLocalElement = currentFunction.getAndFreeTempLocal(this.currentType, false);
+            let parentFunction = flow.parentFunction;
+            let tempLocalTarget = parentFunction.getTempLocal(targetType, false);
+            let tempLocalElement = parentFunction.getAndFreeTempLocal(this.currentType, false);
             let returnType = indexedGet.signature.returnType;
-            this.currentFunction.freeTempLocal(tempLocalTarget);
+            parentFunction.freeTempLocal(tempLocalTarget);
             return module.createBlock(null, [
               this.makeCallDirect(indexedSet, [
                 module.createTeeLocal(tempLocalTarget.index, thisExpr),
@@ -5050,8 +5062,8 @@ export class Compiler extends DiagnosticEmitter {
 
   compileCallExpression(expression: CallExpression, contextualType: Type): ExpressionRef {
     var module = this.module;
-    var currentFunction = this.currentFunction;
-    var target = this.resolver.resolveExpression(expression.expression, currentFunction); // reports
+    var flow = this.currentFlow;
+    var target = this.resolver.resolveExpression(expression.expression, flow); // reports
     if (!target) return module.createUnreachable();
 
     var signature: Signature | null;
@@ -5082,7 +5094,7 @@ export class Compiler extends DiagnosticEmitter {
           instance = this.resolver.resolveFunctionInclTypeArguments(
             prototype,
             typeArguments,
-            makeMap<string,Type>(this.currentFunction.flow.contextualTypeArguments),
+            makeMap<string,Type>(flow.contextualTypeArguments),
             expression
           );
 
@@ -5137,7 +5149,7 @@ export class Compiler extends DiagnosticEmitter {
             } else {
               let concreteType = this.resolver.resolveType(
                 parameterTypes[i].type,
-                this.currentFunction.flow.contextualTypeArguments
+                flow.contextualTypeArguments
               );
               if (!concreteType) return module.createUnreachable();
               argumentExprs[i] = this.compileExpression(
@@ -5156,7 +5168,7 @@ export class Compiler extends DiagnosticEmitter {
           instance = this.resolver.resolveFunction(
             prototype,
             resolvedTypeArguments,
-            makeMap<string,Type>(this.currentFunction.flow.contextualTypeArguments)
+            makeMap<string,Type>(flow.contextualTypeArguments)
           );
           if (!instance) return this.module.createUnreachable();
           return this.makeCallDirect(instance, argumentExprs);
@@ -5184,8 +5196,7 @@ export class Compiler extends DiagnosticEmitter {
           instance,
           expression.arguments,
           expression,
-          thisExpr,
-          instance.hasDecorator(DecoratorFlags.INLINE)
+          thisExpr
         );
       }
 
@@ -5269,10 +5280,12 @@ export class Compiler extends DiagnosticEmitter {
       }
 
       case ElementKind.CLASS: {
+        let flow = this.currentFlow;
+        let actualFunction = flow.actualFunction;
 
         // call to `super()`
         if (expression.expression.kind == NodeKind.SUPER) {
-          if (!currentFunction.is(CommonFlags.CONSTRUCTOR)) {
+          if (!actualFunction.is(CommonFlags.CONSTRUCTOR)) {
             this.error(
               DiagnosticCode.Super_calls_are_not_permitted_outside_constructors_or_in_nested_functions_inside_constructors,
               expression.range
@@ -5280,9 +5293,9 @@ export class Compiler extends DiagnosticEmitter {
             return module.createUnreachable();
           }
 
-          let classInstance = assert(currentFunction.parent); assert(classInstance.kind == ElementKind.CLASS);
+          let classInstance = assert(actualFunction.parent); assert(classInstance.kind == ElementKind.CLASS);
           let baseClassInstance = assert((<Class>classInstance).base);
-          let thisLocal = assert(currentFunction.flow.getScopedLocal("this"));
+          let thisLocal = assert(flow.getScopedLocal("this"));
           let nativeSizeType = this.options.nativeSizeType;
 
           // {
@@ -5307,7 +5320,6 @@ export class Compiler extends DiagnosticEmitter {
           this.makeFieldInitialization(<Class>classInstance, stmts);
 
           // check that super had been called before accessing allocating `this`
-          let flow = currentFunction.flow;
           if (flow.isAny(
             FlowFlags.ALLOCATES |
             FlowFlags.CONDITIONALLY_ALLOCATES
@@ -5362,7 +5374,7 @@ export class Compiler extends DiagnosticEmitter {
       typeArguments = this.resolver.resolveTypeArguments(
         assert(prototype.declaration.typeParameters),
         typeArgumentNodes,
-        makeMap<string,Type>(this.currentFunction.flow.contextualTypeArguments),
+        makeMap<string,Type>(this.currentFlow.contextualTypeArguments),
         expression
       );
     }
@@ -5448,8 +5460,7 @@ export class Compiler extends DiagnosticEmitter {
     instance: Function,
     argumentExpressions: Expression[],
     reportNode: Node,
-    thisArg: ExpressionRef = 0,
-    inline: bool = false
+    thisArg: ExpressionRef = 0
   ): ExpressionRef {
     var numArguments = argumentExpressions.length;
     var signature = instance.signature;
@@ -5464,7 +5475,7 @@ export class Compiler extends DiagnosticEmitter {
     }
 
     // Inline if explicitly requested
-    if (inline) {
+    if (instance.hasDecorator(DecoratorFlags.INLINE)) {
       assert(!instance.is(CommonFlags.TRAMPOLINE)); // doesn't make sense
       if (this.currentInlineFunctions.includes(instance)) {
         this.warning(
@@ -5507,45 +5518,29 @@ export class Compiler extends DiagnosticEmitter {
     reportNode: Node,
     thisArg: ExpressionRef = 0
   ): ExpressionRef {
-    var numArguments = argumentExpressions.length;
-    var signature = instance.signature;
-    var currentFunction = this.currentFunction;
     var module = this.module;
-    var declaration = instance.prototype.declaration;
 
     // Create an empty child flow with its own scope and mark it for inlining
-    var previousFlow = currentFunction.flow;
-    var returnLabel = instance.internalName + "|inlined." + (instance.nextInlineId++).toString(10);
-    var returnType = instance.signature.returnType;
-    var flow = Flow.create(currentFunction);
-    flow.set(FlowFlags.INLINE_CONTEXT);
-    flow.returnLabel = returnLabel;
-    flow.returnType = returnType;
-    flow.contextualTypeArguments = instance.contextualTypeArguments;
+    var previousFlow = this.currentFlow;
+    var flow = Flow.createInline(previousFlow.parentFunction, instance);
 
     // Convert provided call arguments to temporary locals. It is important that these are compiled
     // here, with their respective locals being blocked. There is no 'makeCallInline'.
     var body = [];
+
     if (thisArg) {
       let classInstance = assert(instance.parent); assert(classInstance.kind == ElementKind.CLASS);
       let thisType = assert(instance.signature.thisType);
-      let classType = thisType.classReference;
-      let superType = classType
-        ? classType.base
-          ? classType.base.type
-          : null
-        : null;
-      if (getExpressionId(thisArg) == ExpressionId.GetLocal) { // reuse this var
-        flow.addScopedLocalAlias(getGetLocalIndex(thisArg), thisType, "this");
-        if (superType) flow.addScopedLocalAlias(getGetLocalIndex(thisArg), superType, "super");
-      } else { // use a temp var
-        let thisLocal = flow.addScopedLocal(thisType, "this", false);
-        body.push(
-          module.createSetLocal(thisLocal.index, thisArg)
-        );
-        if (superType) flow.addScopedLocalAlias(thisLocal.index, superType, "super");
-      }
+      let thisLocal = flow.addScopedLocal(thisType, "this", false);
+      body.push(
+        module.createSetLocal(thisLocal.index, thisArg)
+      );
+      let baseInstance = (<Class>classInstance).base;
+      if (baseInstance) flow.addScopedLocalAlias(thisLocal.index, baseInstance.type, "super");
     }
+
+    var numArguments = argumentExpressions.length;
+    var signature = instance.signature;
     var parameterTypes = signature.parameterTypes;
     for (let i = 0; i < numArguments; ++i) {
       let paramExpr = this.compileExpression(
@@ -5554,27 +5549,19 @@ export class Compiler extends DiagnosticEmitter {
         ConversionKind.IMPLICIT,
         WrapMode.NONE
       );
-      if (getExpressionId(paramExpr) == ExpressionId.GetLocal) {
-        flow.addScopedLocalAlias(
-          getGetLocalIndex(paramExpr),
-          parameterTypes[i],
-          signature.getParameterName(i)
-        );
-        // inherits wrap status
-      } else {
-        let argumentLocal = flow.addScopedLocal(
-          parameterTypes[i],
-          signature.getParameterName(i),
-          !flow.canOverflow(paramExpr, parameterTypes[i])
-        );
-        body.push(
-          module.createSetLocal(argumentLocal.index, paramExpr)
-        );
-      }
+      let argumentLocal = flow.addScopedLocal(
+        parameterTypes[i],
+        signature.getParameterName(i),
+        !previousFlow.canOverflow(paramExpr, parameterTypes[i])
+      );
+      body.push(
+        module.createSetLocal(argumentLocal.index, paramExpr)
+      );
     }
 
     // Compile optional parameter initializers in the scope of the inlined flow
-    currentFunction.flow = flow;
+    this.currentFlow = flow;
+    var declaration = instance.prototype.declaration;
     var numParameters = signature.parameterTypes.length;
     for (let i = numArguments; i < numParameters; ++i) {
       let initExpr = this.compileExpression(
@@ -5594,49 +5581,32 @@ export class Compiler extends DiagnosticEmitter {
     }
 
     // Compile the called function's body in the scope of the inlined flow
-    var bodyStatement = assert(declaration.body);
-    if (bodyStatement.kind == NodeKind.BLOCK) {
-      let statements = (<BlockStatement>bodyStatement).statements;
-      for (let i = 0, k = statements.length; i < k; ++i) {
-        let stmt = this.compileStatement(statements[i]);
-        if (getExpressionId(stmt) != ExpressionId.Nop) {
-          body.push(stmt);
-          if (flow.isAny(FlowFlags.ANY_TERMINATING)) break;
-        }
-      }
-    } else {
-      body.push(this.compileStatement(bodyStatement));
-    }
+    var stmts = this.compileFunctionBody(instance);
+    for (let i = 0, k = stmts.length; i < k; ++i) body.push(stmts[i]);
 
     // Free any new scoped locals and reset to the original flow
     var scopedLocals = flow.scopedLocals;
     if (scopedLocals) {
       for (let scopedLocal of scopedLocals.values()) {
         if (scopedLocal.is(CommonFlags.SCOPED)) { // otherwise an alias
-          currentFunction.freeTempLocal(scopedLocal);
+          flow.parentFunction.freeTempLocal(scopedLocal);
         }
       }
       flow.scopedLocals = null;
     }
+    var inlineReturnLabel = flow.inlineReturnLabel;
+    var returnType = flow.returnType;
     flow.finalize();
-    this.currentFunction.flow = previousFlow;
+    this.currentFlow = previousFlow;
     this.currentType = returnType;
-
-    // Check that all branches are terminated
-    if (returnType != Type.void && !flow.isAny(FlowFlags.ANY_TERMINATING)) {
-      this.error(
-        DiagnosticCode.A_function_whose_declared_type_is_not_void_must_return_a_value,
-        declaration.signature.returnType.range
-      );
-      return module.createUnreachable();
-    }
-    return flow.is(FlowFlags.RETURNS)
-      ? module.createBlock(returnLabel, body, returnType.toNativeType())
-      : body.length > 1
-        ? module.createBlock(null, body, returnType.toNativeType())
-        : body.length
-          ? body[0]
-          : module.createNop();
+    return module.createBlock(inlineReturnLabel, body, returnType.toNativeType());
+    // return flow.is(FlowFlags.RETURNS)
+    //   ? module.createBlock(inlineReturnLabel, body, returnType.toNativeType())
+    //   : body.length > 1
+    //     ? module.createBlock(null, body, returnType.toNativeType())
+    //     : body.length
+    //       ? body[0]
+    //       : module.createNop();
   }
 
   /** Gets the trampoline for the specified function. */
@@ -5702,8 +5672,8 @@ export class Compiler extends DiagnosticEmitter {
 
     // compile initializers of omitted arguments in scope of the trampoline function
     // this is necessary because initializers might need additional locals and a proper this context
-    var previousFunction = this.currentFunction;
-    this.currentFunction = trampoline;
+    var previousFlow = this.currentFlow;
+    this.currentFlow = trampoline.flow;
 
     // create a br_table switching over the number of optional parameters provided
     var numNames = numOptional + 1; // incl. outer block
@@ -5755,7 +5725,7 @@ export class Compiler extends DiagnosticEmitter {
       ]);
       forwardedOperands[operandIndex] = module.createGetLocal(operandIndex, type.toNativeType());
     }
-    this.currentFunction = previousFunction;
+    this.currentFlow = previousFlow;
     assert(operandIndex == maxOperands);
 
     var funcRef = module.addFunction(
@@ -5991,11 +5961,15 @@ export class Compiler extends DiagnosticEmitter {
   }
 
   compileElementAccessExpression(expression: ElementAccessExpression, contextualType: Type): ExpressionRef {
-    var target = this.resolver.resolveElementAccess(expression, this.currentFunction, contextualType); // reports
+    var target = this.resolver.resolveElementAccess(
+      expression,
+      this.currentFlow,
+      contextualType
+    ); // reports
     if (!target) return this.module.createUnreachable();
     switch (target.kind) {
       case ElementKind.CLASS: {
-        let isUnchecked = this.currentFunction.flow.is(FlowFlags.UNCHECKED_CONTEXT);
+        let isUnchecked = this.currentFlow.is(FlowFlags.UNCHECKED_CONTEXT);
         let indexedGet = (<Class>target).lookupOverload(OperatorKind.INDEXED_GET, isUnchecked);
         if (!indexedGet) {
           this.error(
@@ -6028,16 +6002,15 @@ export class Compiler extends DiagnosticEmitter {
     var simpleName = (name.text.length
       ? name.text
       : "anonymous") + "|" + this.functionTable.length.toString(10);
-    var currentFunction = this.currentFunction;
+    var flow = this.currentFlow;
     var prototype = new FunctionPrototype(
       this.program,
       simpleName,
-      currentFunction.internalName + INNER_DELIMITER + simpleName,
+      flow.actualFunction.internalName + INNER_DELIMITER + simpleName,
       declaration,
       null,
       DecoratorFlags.NONE
     );
-    var flow = currentFunction.flow;
     var instance = this.compileFunctionUsingTypeArguments(
       prototype,
       [],
@@ -6066,7 +6039,8 @@ export class Compiler extends DiagnosticEmitter {
     retainConstantType: bool
   ): ExpressionRef {
     var module = this.module;
-    var currentFunction = this.currentFunction;
+    var flow = this.currentFlow;
+    var actualFunction = flow.actualFunction;
 
     // check special keywords first
     switch (expression.kind) {
@@ -6088,19 +6062,11 @@ export class Compiler extends DiagnosticEmitter {
         return module.createI32(0);
       }
       case NodeKind.THIS: {
-        let flow = currentFunction.flow;
-        if (flow.is(FlowFlags.INLINE_CONTEXT)) {
+        if (actualFunction.is(CommonFlags.INSTANCE)) {
           let thisLocal = assert(flow.getScopedLocal("this"));
-          if (thisLocal) {
-            this.currentType = thisLocal.type;
-            return module.createGetLocal(thisLocal.index, thisLocal.type.toNativeType());
-          }
-        }
-        if (currentFunction.is(CommonFlags.INSTANCE)) {
-          let thisLocal = assert(flow.getScopedLocal("this"));
-          let classInstance = assert(currentFunction.parent); assert(classInstance.kind == ElementKind.CLASS);
+          let classInstance = assert(actualFunction.parent); assert(classInstance.kind == ElementKind.CLASS);
           let nativeSizeType = this.options.nativeSizeType;
-          if (currentFunction.is(CommonFlags.CONSTRUCTOR)) {
+          if (actualFunction.is(CommonFlags.CONSTRUCTOR)) {
             if (!flow.is(FlowFlags.ALLOCATES)) {
               flow.set(FlowFlags.ALLOCATES);
               // {
@@ -6128,9 +6094,9 @@ export class Compiler extends DiagnosticEmitter {
             }
           }
           // if not a constructor, `this` type can differ
-          let thisType = assert(currentFunction.signature.thisType);
+          let thisType = assert(actualFunction.signature.thisType);
           this.currentType = thisType;
-          return module.createGetLocal(0, thisType.toNativeType());
+          return module.createGetLocal(thisLocal.index, thisType.toNativeType());
         }
         this.error(
           DiagnosticCode._this_cannot_be_referenced_in_current_location,
@@ -6140,8 +6106,10 @@ export class Compiler extends DiagnosticEmitter {
         return module.createUnreachable();
       }
       case NodeKind.SUPER: {
-        if (currentFunction.is(CommonFlags.CONSTRUCTOR)) {
-          if (!currentFunction.flow.is(FlowFlags.CALLS_SUPER)) {
+        let flow = this.currentFlow;
+        let actualFunction = flow.actualFunction;
+        if (actualFunction.is(CommonFlags.CONSTRUCTOR)) {
+          if (!flow.is(FlowFlags.CALLS_SUPER)) {
             // TS1034 in the parser effectively limits this to property accesses
             this.error(
               DiagnosticCode._super_must_be_called_before_accessing_a_property_of_super_in_the_constructor_of_a_derived_class,
@@ -6149,7 +6117,6 @@ export class Compiler extends DiagnosticEmitter {
             );
           }
         }
-        let flow = currentFunction.flow;
         if (flow.is(FlowFlags.INLINE_CONTEXT)) {
           let scopedThis = flow.getScopedLocal("this");
           if (scopedThis) {
@@ -6161,8 +6128,8 @@ export class Compiler extends DiagnosticEmitter {
             }
           }
         }
-        if (currentFunction.is(CommonFlags.INSTANCE)) {
-          let classInstance = assert(currentFunction.parent); assert(classInstance.kind == ElementKind.CLASS);
+        if (actualFunction.is(CommonFlags.INSTANCE)) {
+          let classInstance = assert(actualFunction.parent); assert(classInstance.kind == ElementKind.CLASS);
           let baseClassInstance = (<Class>classInstance).base;
           if (baseClassInstance) {
             let superType = baseClassInstance.type;
@@ -6182,7 +6149,8 @@ export class Compiler extends DiagnosticEmitter {
     // otherwise resolve
     var target = this.resolver.resolveIdentifier( // reports
       expression,
-      this.currentEnum || currentFunction
+      flow,
+      this.currentEnum || actualFunction
     );
     if (!target) return module.createUnreachable();
 
@@ -6229,7 +6197,7 @@ export class Compiler extends DiagnosticEmitter {
         let instance = this.resolver.resolveFunction(
           <FunctionPrototype>target,
           null,
-          makeMap<string,Type>(currentFunction.flow.contextualTypeArguments)
+          makeMap<string,Type>(flow.contextualTypeArguments)
         );
         if (!(instance && this.compileFunction(instance))) return module.createUnreachable();
         let index = this.ensureFunctionTableEntry(instance);
@@ -6596,8 +6564,9 @@ export class Compiler extends DiagnosticEmitter {
       return module.createUnreachable();
     }
     var nativeArrayType = arrayType.toNativeType();
-    var currentFunction = this.currentFunction;
-    var tempLocal = currentFunction.addLocal(arrayType); // can't reuse a temp (used in compiledValues)
+    var flow = this.currentFlow;
+    var parentFunction = flow.parentFunction;
+    var tempLocal = parentFunction.addLocal(arrayType); // can't reuse a temp (used in compiledValues)
     var stmts = new Array<ExpressionRef>(2 + length);
     var index = 0;
     stmts[index++] = module.createSetLocal(tempLocal.index,
@@ -6615,7 +6584,7 @@ export class Compiler extends DiagnosticEmitter {
     }
     assert(index + 1 == stmts.length);
     stmts[index] = module.createGetLocal(tempLocal.index, nativeArrayType);
-    currentFunction.freeTempLocal(tempLocal); // but can be reused now
+    parentFunction.freeTempLocal(tempLocal); // but can be reused now
     this.currentType = arrayType;
     return module.createBlock(null, stmts, nativeArrayType);
   }
@@ -6668,7 +6637,8 @@ export class Compiler extends DiagnosticEmitter {
     var members = classReference.members;
     var hasErrors = false;
     var exprs = new Array<ExpressionRef>(numNames + 2);
-    var tempLocal = this.currentFunction.getTempLocal(this.options.usizeType);
+    var flow = this.currentFlow;
+    var tempLocal = flow.parentFunction.getTempLocal(this.options.usizeType);
     assert(numNames == values.length);
     for (let i = 0, k = numNames; i < k; ++i) {
       let member = members ? members.get(names[i].text) : null;
@@ -6706,13 +6676,12 @@ export class Compiler extends DiagnosticEmitter {
 
   compileNewExpression(expression: NewExpression, contextualType: Type): ExpressionRef {
     var module = this.module;
-    var options = this.options;
-    var currentFunction = this.currentFunction;
+    var flow = this.currentFlow;
 
     // obtain the class being instantiated
     var target = this.resolver.resolveExpression( // reports
       expression.expression,
-      currentFunction
+      flow
     );
     if (!target) return module.createUnreachable();
     if (target.kind != ElementKind.CLASS_PROTOTYPE) {
@@ -6734,13 +6703,13 @@ export class Compiler extends DiagnosticEmitter {
       classInstance = this.resolver.resolveClass(
         classPrototype,
         classReference.typeArguments,
-        makeMap<string,Type>(currentFunction.flow.contextualTypeArguments)
+        makeMap<string,Type>(flow.contextualTypeArguments)
       );
     } else {
       classInstance = this.resolver.resolveClassInclTypeArguments(
         classPrototype,
         typeArguments,
-        makeMap<string,Type>(currentFunction.flow.contextualTypeArguments),
+        makeMap<string,Type>(flow.contextualTypeArguments),
         expression
       );
     }
@@ -6776,8 +6745,8 @@ export class Compiler extends DiagnosticEmitter {
     );
     ctorInstance.set(CommonFlags.INSTANCE | CommonFlags.CONSTRUCTOR | CommonFlags.COMPILED);
     classInstance.constructorInstance = ctorInstance;
-    var previousFunction = this.currentFunction;
-    this.currentFunction = ctorInstance;
+    var previousFlow = this.currentFlow;
+    this.currentFlow = ctorInstance.flow;
 
     // generate body
     var module = this.module;
@@ -6829,7 +6798,7 @@ export class Compiler extends DiagnosticEmitter {
         : module.createBlock(null, stmts, nativeSizeType)
     );
     ctorInstance.finalize(module, funcRef);
-    this.currentFunction = previousFunction;
+    this.currentFlow = previousFlow;
     return ctorInstance;
   }
 
@@ -6839,9 +6808,7 @@ export class Compiler extends DiagnosticEmitter {
       ctor,
       argumentExpressions,
       reportNode,
-      this.options.usizeType.toNativeZero(this.module),
-      ctor.hasDecorator(DecoratorFlags.INLINE)
-      // FIXME: trying to inline a constructor that doesn't return a custom value doesn't work
+      this.options.usizeType.toNativeZero(this.module)
     );
     this.currentType = classInstance.type;
     return expr;
@@ -6871,8 +6838,9 @@ export class Compiler extends DiagnosticEmitter {
     retainConstantType: bool
   ): ExpressionRef {
     var module = this.module;
+    var flow = this.currentFlow;
 
-    var target = this.resolver.resolvePropertyAccess(propertyAccess, this.currentFunction, contextualType); // reports
+    var target = this.resolver.resolvePropertyAccess(propertyAccess, flow, contextualType); // reports
     if (!target) return module.createUnreachable();
 
     switch (target.kind) {
@@ -6949,7 +6917,6 @@ export class Compiler extends DiagnosticEmitter {
       )) {
         return this.module.createUnreachable();
       }
-      let inline = (instance.decoratorFlags & DecoratorFlags.INLINE) != 0;
       if (instance.is(CommonFlags.INSTANCE)) {
         let classInstance = assert(instance.parent); assert(classInstance.kind == ElementKind.CLASS);
         let thisExpression = assert(this.resolver.currentThisExpression); //!!!
@@ -6959,10 +6926,10 @@ export class Compiler extends DiagnosticEmitter {
           WrapMode.NONE
         );
         this.currentType = signature.returnType;
-        return this.compileCallDirect(instance, [], reportNode, thisExpr, inline);
+        return this.compileCallDirect(instance, [], reportNode, thisExpr);
       } else {
         this.currentType = signature.returnType;
-        return this.compileCallDirect(instance, [], reportNode, 0, inline);
+        return this.compileCallDirect(instance, [], reportNode, 0);
       }
     } else {
       this.error(
@@ -6976,8 +6943,7 @@ export class Compiler extends DiagnosticEmitter {
   compileTernaryExpression(expression: TernaryExpression, contextualType: Type): ExpressionRef {
     var ifThen = expression.ifThen;
     var ifElse = expression.ifElse;
-    var currentFunction = this.currentFunction;
-    var parentFlow = currentFunction.flow;
+    var outerFlow = this.currentFlow;
 
     var condExpr = this.makeIsTrueish(
       this.compileExpressionRetainType(expression.condition, Type.bool, WrapMode.NONE),
@@ -6986,7 +6952,7 @@ export class Compiler extends DiagnosticEmitter {
 
     if (
       !this.options.noTreeShaking ||
-      this.currentFunction.isAny(CommonFlags.GENERIC | CommonFlags.GENERIC_CONTEXT)
+      outerFlow.actualFunction.isAny(CommonFlags.GENERIC | CommonFlags.GENERIC_CONTEXT)
     ) {
       // Try to eliminate unnecesssary branches if the condition is constant
       let condExprPrecomp = this.module.precomputeExpression(condExpr);
@@ -7007,19 +6973,20 @@ export class Compiler extends DiagnosticEmitter {
       }
     }
 
-    var ifThenFlow = parentFlow.fork();
-    currentFunction.flow = ifThenFlow;
+    var ifThenFlow = outerFlow.fork();
+    this.currentFlow = ifThenFlow;
     var ifThenExpr = this.compileExpressionRetainType(ifThen, contextualType, WrapMode.NONE);
     var ifThenType = this.currentType;
     ifThenFlow.free();
 
-    var ifElseFlow = parentFlow.fork();
-    currentFunction.flow = ifElseFlow;
+    var ifElseFlow = outerFlow.fork();
+    this.currentFlow = ifElseFlow;
     var ifElseExpr = this.compileExpressionRetainType(ifElse, contextualType, WrapMode.NONE);
     var ifElseType = this.currentType;
-    currentFunction.flow = ifElseFlow.free();
+    ifElseFlow.free();
+    this.currentFlow = outerFlow;
 
-    parentFlow.inheritMutual(ifThenFlow, ifElseFlow);
+    outerFlow.inheritMutual(ifThenFlow, ifElseFlow);
 
     var commonType = Type.commonCompatible(ifThenType, ifElseType, false);
     if (!commonType) {
@@ -7052,7 +7019,7 @@ export class Compiler extends DiagnosticEmitter {
 
   compileUnaryPostfixExpression(expression: UnaryPostfixExpression, contextualType: Type): ExpressionRef {
     var module = this.module;
-    var currentFunction = this.currentFunction;
+    var flow = this.currentFlow;
 
     // make a getter for the expression (also obtains the type)
     var getValue = this.compileExpression( // reports
@@ -7072,7 +7039,7 @@ export class Compiler extends DiagnosticEmitter {
     // if the value isn't dropped, a temp. local is required to remember the original value
     var tempLocal: Local | null = null;
     if (contextualType != Type.void) {
-      tempLocal = currentFunction.getTempLocal(currentType, false);
+      tempLocal = flow.parentFunction.getTempLocal(currentType, false);
       getValue = module.createTeeLocal(
         tempLocal.index,
         getValue
@@ -7258,7 +7225,7 @@ export class Compiler extends DiagnosticEmitter {
     );
 
     this.currentType = tempLocal.type;
-    currentFunction.freeTempLocal(tempLocal);
+    flow.parentFunction.freeTempLocal(tempLocal);
     var nativeType = tempLocal.type.toNativeType();
 
     return module.createBlock(null, [
@@ -7643,7 +7610,7 @@ export class Compiler extends DiagnosticEmitter {
   /** Makes sure that a 32-bit integer value is wrapped to a valid value of the specified type. */
   ensureSmallIntegerWrap(expr: ExpressionRef, type: Type): ExpressionRef {
     var module = this.module;
-    var flow = this.currentFunction.flow;
+    var flow = this.currentFlow;
     switch (type.kind) {
       case TypeKind.I8: {
         if (flow.canOverflow(expr, type)) {
@@ -7823,47 +7790,59 @@ export class Compiler extends DiagnosticEmitter {
 
   /** Makes the initializers for a class's fields. */
   makeFieldInitialization(classInstance: Class, stmts: ExpressionRef[] = []): ExpressionRef[] {
+    var members = classInstance.members;
+    if (!members) return [];
 
-    // must not be used in an inline context as it makes assumptions about local indexes
-    assert(!this.currentFunction.flow.is(FlowFlags.INLINE_CONTEXT));
+    var module = this.module;
+    var flow = this.currentFlow;
+    var isInline = flow.is(FlowFlags.INLINE_CONTEXT);
+    var thisLocalIndex = isInline
+      ? assert(flow.getScopedLocal("this")).index
+      : 0;
+    var nativeSizeType = this.options.nativeSizeType;
 
-    if (classInstance.members) {
-      let module = this.module;
-      let nativeSizeType = this.options.nativeSizeType;
-      for (let member of classInstance.members.values()) {
-        if (member.parent != classInstance) continue;
-        if (member.kind == ElementKind.FIELD) {
-          let field = <Field>member;
-          let fieldType = field.type;
-          let nativeFieldType = fieldType.toNativeType();
-          let fieldDeclaration = field.prototype.declaration;
-          assert(!field.isAny(CommonFlags.CONST));
-          if (fieldDeclaration.initializer) { // use initializer
-            stmts.push(module.createStore(fieldType.byteSize,
-              module.createGetLocal(0, nativeSizeType),
-              this.compileExpression( // reports
-                fieldDeclaration.initializer,
-                fieldType,
-                ConversionKind.IMPLICIT,
-                WrapMode.NONE
-              ),
-              nativeFieldType,
-              field.memoryOffset
-            ));
-          } else {
-            // NOTE: if all fields have initializers then this way is best, but if they don't,
-            // it would be more efficient to categorically zero memory on allocation.
-            let parameterIndex = (<FieldDeclaration>field.prototype.declaration).parameterIndex;
-            stmts.push(module.createStore(fieldType.byteSize,
-              module.createGetLocal(0, nativeSizeType),
-              parameterIndex >= 0 // initialized via parameter
-                ? module.createGetLocal(1 + parameterIndex, nativeFieldType)
-                : fieldType.toNativeZero(module),
-                nativeFieldType,
-              field.memoryOffset
-            ));
-          }
-        }
+    for (let member of members.values()) {
+      if (
+        member.kind != ElementKind.FIELD || // not a field
+        member.parent != classInstance      // inherited field
+      ) continue;
+
+      let field = <Field>member; assert(!field.isAny(CommonFlags.CONST));
+      let fieldType = field.type;
+      let nativeFieldType = fieldType.toNativeType();
+      let fieldDeclaration = field.prototype.declaration;
+      let initializer = fieldDeclaration.initializer;
+      if (initializer) { // use initializer
+        stmts.push(
+          module.createStore(fieldType.byteSize,
+            module.createGetLocal(thisLocalIndex, nativeSizeType),
+            this.compileExpression( // reports
+              initializer,
+              fieldType,
+              ConversionKind.IMPLICIT,
+              WrapMode.NONE
+            ),
+            nativeFieldType,
+            field.memoryOffset
+          )
+        );
+      } else {
+        let parameterIndex = fieldDeclaration.parameterIndex;
+        stmts.push(
+          module.createStore(fieldType.byteSize,
+            module.createGetLocal(thisLocalIndex, nativeSizeType),
+            parameterIndex >= 0 // initialized via parameter (here: a local)
+              ? module.createGetLocal(
+                  isInline
+                    ? assert(flow.getScopedLocal(field.simpleName)).index
+                    : 1 + parameterIndex, // this is local 0
+                  nativeFieldType
+                )
+              : fieldType.toNativeZero(module),
+            nativeFieldType,
+            field.memoryOffset
+          )
+        );
       }
     }
     return stmts;
@@ -7871,11 +7850,11 @@ export class Compiler extends DiagnosticEmitter {
 
   /** Adds the debug location of the specified expression at the specified range to the source map. */
   addDebugLocation(expr: ExpressionRef, range: Range): void {
-    var currentFunction = this.currentFunction;
+    var parentFunction = this.currentFlow.parentFunction;
     var source = range.source;
     if (source.debugInfoIndex < 0) source.debugInfoIndex = this.module.addDebugInfoFile(source.normalizedPath);
     range.debugInfoRef = expr;
-    currentFunction.debugLocations.push(range);
+    parentFunction.debugLocations.push(range);
   }
 }
 

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -249,8 +249,8 @@ export abstract class DiagnosticEmitter {
   ): void {
     var message = DiagnosticMessage.create(code, category, arg0, arg1, arg2).withRange(range);
     this.diagnostics.push(message);
-    // console.log(formatDiagnosticMessage(message, true, true) + "\n"); // temporary
-    // console.log(<string>new Error("stack").stack);
+    console.log(formatDiagnosticMessage(message, true, true) + "\n"); // temporary
+    console.log(<string>new Error("stack").stack);
   }
 
   /** Emits an informatory diagnostic message. */

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -25,7 +25,8 @@ import {
   DecoratorFlags,
   FieldPrototype,
   Field,
-  Global
+  Global,
+  Flow
 } from "./program";
 
 import {
@@ -355,22 +356,26 @@ export class Resolver extends DiagnosticEmitter {
   /** Resolves an identifier to the element it refers to. */
   resolveIdentifier(
     identifier: IdentifierExpression,
+    flow: Flow | null,
     context: Element | null,
     reportMode: ReportMode = ReportMode.REPORT
   ): Element | null {
     var name = identifier.text;
     var element: Element | null;
 
+    if (flow) {
+      let local = flow.getScopedLocal(name);
+      if (local) {
+        this.currentThisExpression = null;
+        this.currentElementExpression = null;
+        return local;
+      }
+    }
+
     if (context) {
 
       switch (context.kind) {
-        case ElementKind.FUNCTION: { // search locals, use prototype
-          element = (<Function>context).flow.getScopedLocal(name);
-          if (element) {
-            this.currentThisExpression = null;
-            this.currentElementExpression = null;
-            return element;
-          }
+        case ElementKind.FUNCTION: { // use prototype
           context = (<Function>context).prototype.parent;
           break;
         }
@@ -433,13 +438,13 @@ export class Resolver extends DiagnosticEmitter {
   /** Resolves a property access to the element it refers to. */
   resolvePropertyAccess(
     propertyAccess: PropertyAccessExpression,
-    contextualFunction: Function,
+    flow: Flow,
     contextualType: Type,
     reportMode: ReportMode = ReportMode.REPORT
   ): Element | null {
     // start by resolving the lhs target (expression before the last dot)
     var targetExpression = propertyAccess.expression;
-    var target = this.resolveExpression(targetExpression, contextualFunction, contextualType, reportMode); // reports
+    var target = this.resolveExpression(targetExpression, flow, contextualType, reportMode); // reports
     if (!target) return null;
 
     // at this point we know exactly what the target is, so look up the element within
@@ -565,12 +570,12 @@ export class Resolver extends DiagnosticEmitter {
 
   resolveElementAccess(
     elementAccess: ElementAccessExpression,
-    contextualFunction: Function,
+    flow: Flow,
     contextualType: Type,
     reportMode: ReportMode = ReportMode.REPORT
   ): Element | null {
     var targetExpression = elementAccess.expression;
-    var target = this.resolveExpression(targetExpression, contextualFunction, contextualType, reportMode);
+    var target = this.resolveExpression(targetExpression, flow, contextualType, reportMode);
     if (!target) return null;
     switch (target.kind) {
       case ElementKind.GLOBAL: if (!this.ensureResolvedLazyGlobal(<Global>target, reportMode)) return null;
@@ -685,7 +690,7 @@ export class Resolver extends DiagnosticEmitter {
 
   resolveExpression(
     expression: Expression,
-    contextualFunction: Function,
+    flow: Flow,
     contextualType: Type = Type.void,
     reportMode: ReportMode = ReportMode.REPORT
   ): Element | null {
@@ -697,14 +702,14 @@ export class Resolver extends DiagnosticEmitter {
         if ((<AssertionExpression>expression).assertionKind == AssertionKind.NONNULL) {
           return this.resolveExpression(
             (<AssertionExpression>expression).expression,
-            contextualFunction,
+            flow,
             contextualType,
             reportMode
           );
         }
         let type = this.resolveType(
           assert((<AssertionExpression>expression).toType),
-          contextualFunction.flow.contextualTypeArguments,
+          flow.contextualTypeArguments,
           reportMode
         );
         if (!type) return null;
@@ -733,7 +738,7 @@ export class Resolver extends DiagnosticEmitter {
             }
             return this.resolveExpression(
               operand,
-              contextualFunction,
+              flow,
               contextualType,
               reportMode
             );
@@ -743,7 +748,7 @@ export class Resolver extends DiagnosticEmitter {
           case Token.MINUS_MINUS: {
             return this.resolveExpression(
               (<UnaryPrefixExpression>expression).operand,
-              contextualFunction,
+              flow,
               contextualType,
               reportMode
             );
@@ -754,7 +759,7 @@ export class Resolver extends DiagnosticEmitter {
           case Token.TILDE: {
             let resolvedOperand = this.resolveExpression(
               (<UnaryPrefixExpression>expression).operand,
-              contextualFunction,
+              flow,
               contextualType,
               reportMode
             );
@@ -772,7 +777,7 @@ export class Resolver extends DiagnosticEmitter {
           case Token.MINUS_MINUS: {
             return this.resolveExpression(
               (<UnaryPostfixExpression>expression).operand,
-              contextualFunction,
+              flow,
               contextualType,
               reportMode
             );
@@ -788,15 +793,15 @@ export class Resolver extends DiagnosticEmitter {
         throw new Error("not implemented");
       }
       case NodeKind.THIS: { // -> Class / ClassPrototype
-        if (contextualFunction.flow.is(FlowFlags.INLINE_CONTEXT)) {
-          let explicitLocal = contextualFunction.flow.getScopedLocal("this");
+        if (flow.is(FlowFlags.INLINE_CONTEXT)) {
+          let explicitLocal = flow.getScopedLocal("this");
           if (explicitLocal) {
             this.currentThisExpression = null;
             this.currentElementExpression = null;
             return explicitLocal;
           }
         }
-        let parent = contextualFunction.parent;
+        let parent = flow.parentFunction.parent;
         if (parent) {
           this.currentThisExpression = null;
           this.currentElementExpression = null;
@@ -811,15 +816,15 @@ export class Resolver extends DiagnosticEmitter {
         return null;
       }
       case NodeKind.SUPER: { // -> Class
-        if (contextualFunction.flow.is(FlowFlags.INLINE_CONTEXT)) {
-          let explicitLocal = contextualFunction.flow.getScopedLocal("super");
+        if (flow.is(FlowFlags.INLINE_CONTEXT)) {
+          let explicitLocal = flow.getScopedLocal("super");
           if (explicitLocal) {
             this.currentThisExpression = null;
             this.currentElementExpression = null;
             return explicitLocal;
           }
         }
-        let parent = contextualFunction.parent;
+        let parent = flow.parentFunction.parent;
         if (parent && parent.kind == ElementKind.CLASS && (parent = (<Class>parent).base)) {
           this.currentThisExpression = null;
           this.currentElementExpression = null;
@@ -834,7 +839,7 @@ export class Resolver extends DiagnosticEmitter {
         return null;
       }
       case NodeKind.IDENTIFIER: {
-        return this.resolveIdentifier(<IdentifierExpression>expression, contextualFunction, reportMode);
+        return this.resolveIdentifier(<IdentifierExpression>expression, flow, flow.actualFunction, reportMode);
       }
       case NodeKind.LITERAL: {
         switch ((<LiteralExpression>expression).literalKind) {
@@ -871,7 +876,7 @@ export class Resolver extends DiagnosticEmitter {
       case NodeKind.PROPERTYACCESS: {
         return this.resolvePropertyAccess(
           <PropertyAccessExpression>expression,
-          contextualFunction,
+          flow,
           contextualType,
           reportMode
         );
@@ -879,20 +884,20 @@ export class Resolver extends DiagnosticEmitter {
       case NodeKind.ELEMENTACCESS: {
         return this.resolveElementAccess(
           <ElementAccessExpression>expression,
-          contextualFunction,
+          flow,
           contextualType,
           reportMode
         );
       }
       case NodeKind.CALL: {
         let targetExpression = (<CallExpression>expression).expression;
-        let target = this.resolveExpression(targetExpression, contextualFunction, contextualType, reportMode);
+        let target = this.resolveExpression(targetExpression, flow, contextualType, reportMode);
         if (!target) return null;
         if (target.kind == ElementKind.FUNCTION_PROTOTYPE) {
           let instance = this.resolveFunctionInclTypeArguments(
             <FunctionPrototype>target,
             (<CallExpression>expression).typeArguments,
-            makeMap<string,Type>(contextualFunction.flow.contextualTypeArguments),
+            makeMap<string,Type>(flow.contextualTypeArguments),
             expression,
             reportMode
           );

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -824,7 +824,7 @@ export class Resolver extends DiagnosticEmitter {
             return explicitLocal;
           }
         }
-        let parent = flow.parentFunction.parent;
+        let parent = flow.actualFunction.parent;
         if (parent && parent.kind == ElementKind.CLASS && (parent = (<Class>parent).base)) {
           this.currentThisExpression = null;
           this.currentElementExpression = null;

--- a/tests/compiler/binary.untouched.wat
+++ b/tests/compiler/binary.untouched.wat
@@ -403,6 +403,8 @@
     i32.eq
    end
    local.tee $14
+   i32.const 0
+   i32.ne
    if (result i32)
     local.get $14
    else    
@@ -410,6 +412,8 @@
     i32.const 1072693248
     i32.eq
    end
+   i32.const 0
+   i32.ne
    if
     local.get $15
     local.set $16
@@ -1249,7 +1253,9 @@
    local.get $8
   else   
    local.get $1
-   local.get $1
+   local.set $9
+   local.get $9
+   local.get $9
    f32.ne
   end
   i32.const 0
@@ -2531,7 +2537,9 @@
    local.get $8
   else   
    local.get $1
-   local.get $1
+   local.set $9
+   local.get $9
+   local.get $9
    f64.ne
   end
   i32.const 0

--- a/tests/compiler/inlining-recursive.untouched.wat
+++ b/tests/compiler/inlining-recursive.untouched.wat
@@ -16,7 +16,9 @@
   call $inlining-recursive/bar
  )
  (func $inlining-recursive/bar (; 2 ;) (type $v)
-  call $inlining-recursive/baz
+  block $inlining-recursive/bar|inlined.0
+   call $inlining-recursive/baz
+  end
  )
  (func $null (; 3 ;) (type $v)
  )

--- a/tests/compiler/inlining.optimized.wat
+++ b/tests/compiler/inlining.optimized.wat
@@ -7,7 +7,7 @@
  (memory $0 1)
  (data (i32.const 8) "\0b\00\00\00i\00n\00l\00i\00n\00i\00n\00g\00.\00t\00s")
  (table $0 2 funcref)
- (elem (i32.const 0) $null $inlining/test_funcs~anonymous|1)
+ (elem (i32.const 0) $null $inlining/func_fe~anonymous|1)
  (global $~argc (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (export "table" (table $0))
@@ -16,7 +16,7 @@
  (func $inlining/test (; 1 ;) (type $i) (result i32)
   i32.const 3
  )
- (func $inlining/test_funcs~anonymous|1 (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $inlining/func_fe~anonymous|1 (; 2 ;) (type $ii) (param $0 i32) (result i32)
   local.get $0
  )
  (func $inlining/test_funcs (; 3 ;) (type $v)

--- a/tests/compiler/inlining.optimized.wat
+++ b/tests/compiler/inlining.optimized.wat
@@ -9,6 +9,8 @@
  (table $0 2 funcref)
  (elem (i32.const 0) $null $inlining/func_fe~anonymous|1)
  (global $~argc (mut i32) (i32.const 0))
+ (global $~lib/allocator/arena/startOffset (mut i32) (i32.const 0))
+ (global $~lib/allocator/arena/offset (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "test" (func $inlining/test))
@@ -36,10 +38,155 @@
    unreachable
   end
  )
- (func $start (; 4 ;) (type $v)
-  call $inlining/test_funcs
+ (func $~lib/allocator/arena/__memory_allocate (; 4 ;) (type $ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  i32.const 1073741824
+  i32.gt_u
+  if
+   unreachable
+  end
+  global.get $~lib/allocator/arena/offset
+  local.tee $1
+  local.get $0
+  i32.const 1
+  local.get $0
+  i32.const 1
+  i32.gt_u
+  select
+  i32.add
+  i32.const 7
+  i32.add
+  i32.const -8
+  i32.and
+  local.tee $2
+  current_memory
+  local.tee $3
+  i32.const 16
+  i32.shl
+  i32.gt_u
+  if
+   local.get $3
+   local.get $2
+   local.get $1
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const -65536
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.tee $0
+   local.get $3
+   local.get $0
+   i32.gt_s
+   select
+   grow_memory
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $0
+    grow_memory
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $2
+  global.set $~lib/allocator/arena/offset
+  local.get $1
  )
- (func $null (; 5 ;) (type $v)
+ (func $inlining/test_ctor (; 5 ;) (type $v)
+  (local $0 i32)
+  i32.const 16
+  call $~lib/allocator/arena/__memory_allocate
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 8
+   call $~lib/allocator/arena/__memory_allocate
+   local.set $0
+  end
+  local.get $0
+  i32.const 1
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 2
+  i32.store offset=4
+  local.get $0
+  i32.const 3
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.load
+  i32.const 1
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 97
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  i32.const 2
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 98
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=8
+  i32.const 3
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 99
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=12
+  i32.const 4
+  i32.ne
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 100
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $start (; 6 ;) (type $v)
+  call $inlining/test_funcs
+  i32.const 40
+  global.set $~lib/allocator/arena/startOffset
+  global.get $~lib/allocator/arena/startOffset
+  global.set $~lib/allocator/arena/offset
+  call $inlining/test_ctor
+ )
+ (func $null (; 7 ;) (type $v)
   nop
  )
 )

--- a/tests/compiler/inlining.ts
+++ b/tests/compiler/inlining.ts
@@ -72,3 +72,32 @@ function test_funcs(): void {
 }
 
 test_funcs();
+
+import "allocator/arena";
+
+class Baz {
+  a: i32 = 1;
+  b: i32;
+  @inline constructor(c: i32) {
+    this.b = c;
+  }
+}
+
+class Bar extends Baz {
+  d: i32 = 3;
+  e: i32;
+  @inline constructor(f: i32) {
+    super(2);
+    this.e = f;
+  }
+}
+
+function test_ctor(): void {
+  var bar = new Bar(4);
+  assert(bar.a == 1);
+  assert(bar.b == 2);
+  assert(bar.d == 3);
+  assert(bar.e == 4);
+}
+
+test_ctor();

--- a/tests/compiler/inlining.untouched.wat
+++ b/tests/compiler/inlining.untouched.wat
@@ -7,7 +7,7 @@
  (memory $0 1)
  (data (i32.const 8) "\0b\00\00\00i\00n\00l\00i\00n\00i\00n\00g\00.\00t\00s\00")
  (table $0 2 funcref)
- (elem (i32.const 0) $null $inlining/test_funcs~anonymous|1)
+ (elem (i32.const 0) $null $inlining/func_fe~anonymous|1)
  (global $inlining/constantGlobal i32 (i32.const 1))
  (global $~argc (mut i32) (i32.const 0))
  (global $HEAP_BASE i32 (i32.const 36))
@@ -20,7 +20,7 @@
   i32.const 2
   i32.add
  )
- (func $inlining/test_funcs~anonymous|1 (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $inlining/func_fe~anonymous|1 (; 2 ;) (type $ii) (param $0 i32) (result i32)
   local.get $0
  )
  (func $inlining/test_funcs (; 3 ;) (type $v)
@@ -163,16 +163,14 @@
    local.set $2
    local.get $2
    local.set $3
-   block
-    local.get $3
-    local.set $5
-    local.get $5
-    local.set $6
-    local.get $6
-    i32.const 1
-    i32.add
-    local.set $4
-   end
+   local.get $3
+   local.set $5
+   local.get $5
+   local.set $6
+   local.get $6
+   i32.const 1
+   i32.add
+   local.set $4
    local.get $4
   end
   i32.const 3
@@ -191,16 +189,14 @@
    local.set $4
    local.get $4
    local.set $3
-   block
-    local.get $3
-    local.set $6
-    local.get $6
-    local.set $5
-    local.get $5
-    i32.const 1
-    i32.add
-    local.set $2
-   end
+   local.get $3
+   local.set $6
+   local.get $6
+   local.set $5
+   local.get $5
+   i32.const 1
+   i32.add
+   local.set $2
    local.get $2
   end
   i32.const 4
@@ -214,8 +210,10 @@
    call $~lib/env/abort
    unreachable
   end
-  i32.const 0
-  local.set $2
+  block $inlining/func_iv|inlined.0
+   i32.const 0
+   local.set $2
+  end
   block (result i32)
    i32.const 1
    global.set $~argc
@@ -259,11 +257,13 @@
   i32.const 123
   local.set $7
   block $inlining/Foo#method_this|inlined.0 (result i32)
-   i32.const 43
-   local.set $3
-   i32.const 3
-   local.set $2
    local.get $7
+   local.set $3
+   i32.const 43
+   local.set $2
+   i32.const 3
+   local.set $4
+   local.get $3
   end
   i32.const 123
   i32.eq

--- a/tests/compiler/inlining.untouched.wat
+++ b/tests/compiler/inlining.untouched.wat
@@ -10,6 +10,12 @@
  (elem (i32.const 0) $null $inlining/func_fe~anonymous|1)
  (global $inlining/constantGlobal i32 (i32.const 1))
  (global $~argc (mut i32) (i32.const 0))
+ (global $~lib/internal/allocator/AL_BITS i32 (i32.const 3))
+ (global $~lib/internal/allocator/AL_SIZE i32 (i32.const 8))
+ (global $~lib/internal/allocator/AL_MASK i32 (i32.const 7))
+ (global $~lib/internal/allocator/MAX_SIZE_32 i32 (i32.const 1073741824))
+ (global $~lib/allocator/arena/startOffset (mut i32) (i32.const 0))
+ (global $~lib/allocator/arena/offset (mut i32) (i32.const 0))
  (global $HEAP_BASE i32 (i32.const 36))
  (export "memory" (memory $0))
  (export "table" (table $0))
@@ -277,7 +283,199 @@
    unreachable
   end
  )
- (func $start (; 4 ;) (type $v)
+ (func $~lib/allocator/arena/__memory_allocate (; 4 ;) (type $ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  global.get $~lib/internal/allocator/MAX_SIZE_32
+  i32.gt_u
+  if
+   unreachable
+  end
+  global.get $~lib/allocator/arena/offset
+  local.set $1
+  local.get $1
+  local.get $0
+  local.tee $2
+  i32.const 1
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_u
+  select
+  i32.add
+  global.get $~lib/internal/allocator/AL_MASK
+  i32.add
+  global.get $~lib/internal/allocator/AL_MASK
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $4
+  current_memory
+  local.set $5
+  local.get $4
+  local.get $5
+  i32.const 16
+  i32.shl
+  i32.gt_u
+  if
+   local.get $4
+   local.get $1
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const 65535
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.set $2
+   local.get $5
+   local.tee $3
+   local.get $2
+   local.tee $6
+   local.get $3
+   local.get $6
+   i32.gt_s
+   select
+   local.set $3
+   local.get $3
+   grow_memory
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $2
+    grow_memory
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $4
+  global.set $~lib/allocator/arena/offset
+  local.get $1
+ )
+ (func $~lib/memory/memory.allocate (; 5 ;) (type $ii) (param $0 i32) (result i32)
+  local.get $0
+  call $~lib/allocator/arena/__memory_allocate
+  return
+ )
+ (func $inlining/test_ctor (; 6 ;) (type $v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  block $inlining/Bar#constructor|inlined.0 (result i32)
+   i32.const 0
+   local.set $0
+   i32.const 4
+   local.set $1
+   block $inlining/Baz#constructor|inlined.0 (result i32)
+    local.get $0
+    if (result i32)
+     local.get $0
+    else     
+     i32.const 16
+     call $~lib/memory/memory.allocate
+    end
+    local.set $2
+    i32.const 2
+    local.set $3
+    block (result i32)
+     local.get $2
+     i32.eqz
+     if
+      i32.const 8
+      call $~lib/memory/memory.allocate
+      local.set $2
+     end
+     local.get $2
+     i32.const 1
+     i32.store
+     local.get $2
+     i32.const 0
+     i32.store offset=4
+     local.get $2
+    end
+    local.get $3
+    i32.store offset=4
+    local.get $2
+   end
+   local.set $0
+   local.get $0
+   i32.const 3
+   i32.store offset=8
+   local.get $0
+   i32.const 0
+   i32.store offset=12
+   local.get $0
+   local.get $1
+   i32.store offset=12
+   local.get $0
+  end
+  local.set $4
+  local.get $4
+  i32.load
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 97
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  local.get $4
+  i32.load offset=4
+  i32.const 2
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 98
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  local.get $4
+  i32.load offset=8
+  i32.const 3
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 99
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+  local.get $4
+  i32.load offset=12
+  i32.const 4
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 8
+   i32.const 100
+   i32.const 2
+   call $~lib/env/abort
+   unreachable
+  end
+ )
+ (func $start (; 7 ;) (type $v)
   call $inlining/test
   i32.const 3
   i32.eq
@@ -291,7 +489,18 @@
    unreachable
   end
   call $inlining/test_funcs
+  global.get $HEAP_BASE
+  global.get $~lib/internal/allocator/AL_MASK
+  i32.add
+  global.get $~lib/internal/allocator/AL_MASK
+  i32.const -1
+  i32.xor
+  i32.and
+  global.set $~lib/allocator/arena/startOffset
+  global.get $~lib/allocator/arena/startOffset
+  global.set $~lib/allocator/arena/offset
+  call $inlining/test_ctor
  )
- (func $null (; 5 ;) (type $v)
+ (func $null (; 8 ;) (type $v)
  )
 )

--- a/tests/compiler/nonNullAssertion.untouched.wat
+++ b/tests/compiler/nonNullAssertion.untouched.wat
@@ -44,6 +44,8 @@
  (func $~lib/array/Array<Foo>#__get (; 3 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.load
   local.set $2
@@ -54,14 +56,18 @@
   i32.shr_u
   i32.lt_u
   if (result i32)
-   i32.const 0
-   local.set $3
    local.get $2
+   local.set $3
    local.get $1
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 2
    i32.shl
    i32.add
-   local.get $3
+   local.get $5
    i32.add
    i32.load offset=8
   else   
@@ -76,6 +82,8 @@
  (func $~lib/array/Array<Foo | null>#__get (; 5 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.load
   local.set $2
@@ -86,14 +94,18 @@
   i32.shr_u
   i32.lt_u
   if (result i32)
-   i32.const 0
-   local.set $3
    local.get $2
+   local.set $3
    local.get $1
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 2
    i32.shl
    i32.add
-   local.get $3
+   local.get $5
    i32.add
    i32.load offset=8
   else   

--- a/tests/compiler/number.optimized.wat
+++ b/tests/compiler/number.optimized.wat
@@ -423,32 +423,32 @@
   (local $7 i32)
   (local $8 i64)
   (local $9 i32)
-  (local $10 i64)
+  (local $10 i32)
   (local $11 i32)
-  (local $12 i32)
+  (local $12 i64)
   (local $13 i64)
   (local $14 i64)
   local.get $3
   local.get $1
   i64.sub
-  local.set $8
+  local.set $12
   i64.const 1
   i32.const 0
   local.get $4
   i32.sub
   local.tee $11
   i64.extend_i32_s
-  local.tee $13
+  local.tee $1
   i64.shl
-  local.tee $10
+  local.tee $13
   i64.const 1
   i64.sub
   local.tee $14
   local.get $3
   i64.and
-  local.set $1
+  local.set $8
   local.get $3
-  local.get $13
+  local.get $1
   i64.shr_u
   i32.wrap_i64
   local.tee $7
@@ -456,7 +456,7 @@
   local.set $9
   i32.const 2064
   i32.load
-  local.set $12
+  local.set $10
   loop $continue|0
    local.get $9
    i32.const 0
@@ -612,9 +612,9 @@
     local.get $11
     i64.extend_i32_s
     i64.shl
-    local.get $1
+    local.get $8
     i64.add
-    local.tee $3
+    local.tee $1
     local.get $5
     i64.le_u
     if
@@ -622,7 +622,9 @@
      local.get $9
      i32.add
      global.set $~lib/internal/number/_K
-     local.get $12
+     local.get $5
+     local.set $3
+     local.get $10
      local.get $9
      i32.const 2
      i32.shl
@@ -631,7 +633,9 @@
      local.get $11
      i64.extend_i32_s
      i64.shl
-     local.set $1
+     local.set $8
+     local.get $12
+     local.set $5
      local.get $6
      i32.const 1
      i32.sub
@@ -641,37 +645,37 @@
      i32.add
      local.tee $2
      i32.load16_u offset=4
-     local.set $7
+     local.set $10
      loop $continue|2
-      local.get $3
-      local.get $8
+      local.get $1
+      local.get $5
       i64.lt_u
       local.tee $0
       if
-       local.get $5
        local.get $3
-       i64.sub
        local.get $1
+       i64.sub
+       local.get $8
        i64.ge_u
        local.set $0
       end
       local.get $0
       if
        local.get $1
-       local.get $3
-       i64.add
        local.get $8
+       i64.add
+       local.get $5
        i64.lt_u
        local.tee $0
        i32.eqz
        if
-        local.get $8
-        local.get $3
+        local.get $5
+        local.get $1
         i64.sub
         local.get $1
-        local.get $3
-        i64.add
         local.get $8
+        i64.add
+        local.get $5
         i64.sub
         i64.gt_u
         local.set $0
@@ -679,19 +683,19 @@
       end
       local.get $0
       if
-       local.get $7
+       local.get $10
        i32.const 1
        i32.sub
-       local.set $7
+       local.set $10
        local.get $1
-       local.get $3
+       local.get $8
        i64.add
-       local.set $3
+       local.set $1
        br $continue|2
       end
      end
      local.get $2
-     local.get $7
+     local.get $10
      i32.store16 offset=4
      local.get $6
      return
@@ -704,14 +708,14 @@
    i64.const 10
    i64.mul
    local.set $5
-   local.get $1
+   local.get $8
    i64.const 10
    i64.mul
-   local.tee $1
+   local.tee $8
    local.get $11
    i64.extend_i32_s
    i64.shr_u
-   local.tee $3
+   local.tee $1
    local.get $6
    i64.extend_i32_s
    i64.or
@@ -728,7 +732,7 @@
     i32.shl
     local.get $0
     i32.add
-    local.get $3
+    local.get $1
     i32.wrap_i64
     i32.const 65535
     i32.and
@@ -740,10 +744,10 @@
    i32.const 1
    i32.sub
    local.set $9
-   local.get $1
+   local.get $8
    local.get $14
    i64.and
-   local.tee $1
+   local.tee $8
    local.get $5
    i64.ge_u
    br_if $continue|3
@@ -751,7 +755,9 @@
    local.get $9
    i32.add
    global.set $~lib/internal/number/_K
-   local.get $12
+   local.get $13
+   local.set $1
+   local.get $10
    i32.const 0
    local.get $9
    i32.sub
@@ -759,49 +765,50 @@
    i32.shl
    i32.add
    i64.load32_u offset=8
-   local.get $8
+   local.get $12
    i64.mul
-   local.set $8
+   local.set $3
    local.get $6
+   local.tee $10
    i32.const 1
    i32.sub
    i32.const 1
    i32.shl
    local.get $0
    i32.add
-   local.tee $7
+   local.tee $4
    i32.load16_u offset=4
-   local.set $4
+   local.set $6
    loop $continue|4
-    local.get $1
     local.get $8
+    local.get $3
     i64.lt_u
     local.tee $2
     if
      local.get $5
-     local.get $1
+     local.get $8
      i64.sub
-     local.get $10
+     local.get $1
      i64.ge_u
      local.set $2
     end
     local.get $2
     if
      local.get $1
-     local.get $10
-     i64.add
      local.get $8
+     i64.add
+     local.get $3
      i64.lt_u
      local.tee $2
      i32.eqz
      if
+      local.get $3
       local.get $8
-      local.get $1
       i64.sub
       local.get $1
-      local.get $10
-      i64.add
       local.get $8
+      i64.add
+      local.get $3
       i64.sub
       i64.gt_u
       local.set $2
@@ -809,21 +816,21 @@
     end
     local.get $2
     if
-     local.get $4
+     local.get $6
      i32.const 1
      i32.sub
-     local.set $4
+     local.set $6
      local.get $1
-     local.get $10
+     local.get $8
      i64.add
-     local.set $1
+     local.set $8
      br $continue|4
     end
    end
-   local.get $7
    local.get $4
-   i32.store16 offset=4
    local.get $6
+   i32.store16 offset=4
+   local.get $10
   end
  )
  (func $~lib/internal/memory/memcpy (; 9 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
@@ -1944,74 +1951,73 @@
   local.get $1
   local.get $2
   i32.add
-  local.tee $5
-  i32.le_s
   local.tee $3
+  i32.le_s
+  local.tee $4
   if
-   local.get $5
+   local.get $3
    i32.const 21
    i32.le_s
-   local.set $3
+   local.set $4
   end
-  local.get $3
+  local.get $4
   if (result i32)
    local.get $1
-   local.set $3
+   local.set $4
    loop $repeat|0
     block $break|0
+     local.get $4
      local.get $3
-     local.get $5
      i32.ge_s
      br_if $break|0
-     local.get $3
+     local.get $4
      i32.const 1
      i32.shl
      local.get $0
      i32.add
      i32.const 48
      i32.store16 offset=4
-     local.get $3
+     local.get $4
      i32.const 1
      i32.add
-     local.set $3
+     local.set $4
      br $repeat|0
     end
    end
-   local.get $5
+   local.get $3
    i32.const 1
    i32.shl
    local.get $0
    i32.add
    i32.const 3145774
    i32.store offset=4
-   local.get $5
+   local.get $3
    i32.const 2
    i32.add
   else   
-   local.get $5
+   local.get $3
    i32.const 0
    i32.gt_s
-   local.tee $3
+   local.tee $4
    if
-    local.get $5
+    local.get $3
     i32.const 21
     i32.le_s
-    local.set $3
+    local.set $4
    end
-   local.get $3
+   local.get $4
    if (result i32)
-    local.get $5
+    local.get $3
     i32.const 1
     i32.shl
     local.get $0
     i32.add
-    local.tee $3
     i32.const 4
     i32.add
-    local.tee $0
+    local.tee $4
     i32.const 2
     i32.add
-    local.get $0
+    local.get $4
     i32.const 0
     local.get $2
     i32.sub
@@ -2019,6 +2025,10 @@
     i32.shl
     call $~lib/internal/memory/memmove
     local.get $3
+    i32.const 1
+    i32.shl
+    local.get $0
+    i32.add
     i32.const 46
     i32.store16 offset=4
     local.get $1
@@ -2026,25 +2036,25 @@
     i32.add
    else    
     i32.const -6
-    local.get $5
+    local.get $3
     i32.lt_s
-    local.tee $3
+    local.tee $4
     if
-     local.get $5
+     local.get $3
      i32.const 0
      i32.le_s
-     local.set $3
+     local.set $4
     end
-    local.get $3
+    local.get $4
     if (result i32)
      local.get $0
      i32.const 4
      i32.add
      local.tee $2
      i32.const 2
-     local.get $5
+     local.get $3
      i32.sub
-     local.tee $3
+     local.tee $4
      i32.const 1
      i32.shl
      i32.add
@@ -2057,29 +2067,29 @@
      i32.const 3014704
      i32.store offset=4
      i32.const 2
-     local.set $4
+     local.set $3
      loop $repeat|1
       block $break|1
-       local.get $4
        local.get $3
+       local.get $4
        i32.ge_s
        br_if $break|1
-       local.get $4
+       local.get $3
        i32.const 1
        i32.shl
        local.get $0
        i32.add
        i32.const 48
        i32.store16 offset=4
-       local.get $4
+       local.get $3
        i32.const 1
        i32.add
-       local.set $4
+       local.set $3
        br $repeat|1
       end
      end
      local.get $1
-     local.get $3
+     local.get $4
      i32.add
     else     
      local.get $1
@@ -2092,52 +2102,52 @@
       local.get $0
       i32.const 4
       i32.add
-      local.tee $3
+      local.tee $4
       block (result i32)
-       local.get $5
+       local.get $3
        i32.const 1
        i32.sub
-       local.tee $4
+       local.tee $3
        i32.const 0
        i32.lt_s
        local.tee $2
        if
         i32.const 0
-        local.get $4
+        local.get $3
         i32.sub
-        local.set $4
+        local.set $3
        end
-       local.get $4
+       local.get $3
       end
-      local.get $4
+      local.get $3
       call $~lib/internal/number/decimalCount32
       i32.const 1
       i32.add
-      local.tee $4
+      local.tee $5
       call $~lib/internal/number/utoa32_lut
-      local.get $3
+      local.get $4
       i32.const 45
       i32.const 43
       local.get $2
       select
       i32.store16 offset=4
-      local.get $4
+      local.get $5
       i32.const 2
       i32.add
      else      
       local.get $0
       i32.const 4
       i32.add
-      local.tee $3
+      local.tee $4
       i32.const 4
       i32.add
-      local.get $3
+      local.get $4
       i32.const 2
       i32.add
       local.get $1
       i32.const 1
       i32.shl
-      local.tee $4
+      local.tee $5
       i32.const 2
       i32.sub
       call $~lib/internal/memory/memmove
@@ -2145,7 +2155,7 @@
       i32.const 46
       i32.store16 offset=6
       local.get $0
-      local.get $4
+      local.get $5
       i32.add
       local.tee $0
       i32.const 101
@@ -2153,30 +2163,30 @@
       local.get $0
       i32.const 4
       i32.add
-      local.tee $3
+      local.tee $4
       block (result i32)
-       local.get $5
+       local.get $3
        i32.const 1
        i32.sub
-       local.tee $4
+       local.tee $3
        i32.const 0
        i32.lt_s
        local.tee $2
        if
         i32.const 0
-        local.get $4
+        local.get $3
         i32.sub
-        local.set $4
+        local.set $3
        end
-       local.get $4
+       local.get $3
       end
-      local.get $4
+      local.get $3
       call $~lib/internal/number/decimalCount32
       i32.const 1
       i32.add
       local.tee $0
       call $~lib/internal/number/utoa32_lut
-      local.get $3
+      local.get $4
       i32.const 45
       i32.const 43
       local.get $2
@@ -2198,19 +2208,18 @@
   (local $4 i32)
   (local $5 i64)
   (local $6 i32)
-  (local $7 i64)
-  (local $8 i32)
+  (local $7 i32)
+  (local $8 i64)
   (local $9 i64)
   (local $10 i64)
   (local $11 i64)
-  (local $12 i64)
-  (local $13 i32)
+  (local $12 i32)
+  (local $13 i64)
   (local $14 i32)
-  (local $15 i64)
   local.get $1
   f64.const 0
   f64.lt
-  local.tee $13
+  local.tee $12
   if (result f64)
    local.get $0
    i32.const 45
@@ -2221,32 +2230,32 @@
    local.get $1
   end
   i64.reinterpret_f64
-  local.tee $2
+  local.tee $13
   i64.const 9218868437227405312
   i64.and
   i64.const 52
   i64.shr_u
   i32.wrap_i64
-  local.set $8
-  local.get $2
+  local.set $7
+  local.get $13
   i64.const 4503599627370495
   i64.and
-  local.get $8
+  local.get $7
   i32.const 0
   i32.ne
-  local.tee $6
+  local.tee $4
   i64.extend_i32_u
   i64.const 52
   i64.shl
   i64.add
   local.set $2
-  local.get $8
+  local.get $7
   i32.const 1
-  local.get $6
+  local.get $4
   select
   i32.const 1075
   i32.sub
-  local.tee $8
+  local.tee $7
   i32.const 1
   i32.sub
   local.set $6
@@ -2275,7 +2284,7 @@
   i64.shl
   i64.const 1
   i64.sub
-  local.get $8
+  local.get $7
   local.get $14
   i32.sub
   local.get $6
@@ -2342,27 +2351,27 @@
   local.tee $2
   i64.const 4294967295
   i64.and
-  local.tee $7
+  local.tee $8
   global.get $~lib/internal/number/_frc_pow
   local.tee $5
   i64.const 4294967295
   i64.and
   local.tee $9
   i64.mul
-  local.set $10
+  local.set $3
   local.get $5
   i64.const 32
   i64.shr_u
-  local.tee $11
-  local.get $7
+  local.tee $10
+  local.get $8
   i64.mul
   local.get $2
   i64.const 32
   i64.shr_u
-  local.tee $12
+  local.tee $2
   local.get $9
   i64.mul
-  local.get $10
+  local.get $3
   i64.const 32
   i64.shr_u
   i64.add
@@ -2374,43 +2383,43 @@
   i64.add
   i64.const 32
   i64.shr_u
-  local.get $11
-  local.get $12
+  local.get $2
+  local.get $10
   i64.mul
   local.get $3
   i64.const 32
   i64.shr_u
   i64.add
   i64.add
-  local.set $2
+  local.set $13
   local.get $5
   i64.const 4294967295
   i64.and
-  local.tee $11
+  local.tee $2
   global.get $~lib/internal/number/_frc_plus
   local.tee $3
   i64.const 4294967295
   i64.and
   local.tee $10
   i64.mul
-  local.set $7
+  local.set $11
   local.get $10
   local.get $5
+  i64.const 32
+  i64.shr_u
+  local.tee $8
+  i64.mul
+  local.get $2
+  local.get $3
   i64.const 32
   i64.shr_u
   local.tee $9
   i64.mul
   local.get $11
-  local.get $3
-  i64.const 32
-  i64.shr_u
-  local.tee $12
-  i64.mul
-  local.get $7
   i64.const 32
   i64.shr_u
   i64.add
-  local.tee $3
+  local.tee $2
   i64.const 4294967295
   i64.and
   i64.add
@@ -2418,97 +2427,95 @@
   i64.add
   i64.const 32
   i64.shr_u
+  local.get $8
   local.get $9
-  local.get $12
   i64.mul
-  local.get $3
+  local.get $2
   i64.const 32
   i64.shr_u
   i64.add
   i64.add
-  local.set $15
+  local.set $11
   global.get $~lib/internal/number/_frc_minus
-  local.tee $3
+  local.tee $2
   i64.const 4294967295
   i64.and
-  local.tee $7
+  local.tee $8
   local.get $5
   i64.const 4294967295
   i64.and
   local.tee $9
   i64.mul
-  local.set $10
-  local.get $5
-  i64.const 32
-  i64.shr_u
-  local.tee $11
-  local.get $7
-  i64.mul
-  local.get $3
-  i64.const 32
-  i64.shr_u
-  local.tee $12
-  local.get $9
-  i64.mul
-  local.get $10
-  i64.const 32
-  i64.shr_u
-  i64.add
-  local.tee $3
-  i64.const 4294967295
-  i64.and
-  i64.add
-  local.set $5
-  local.get $15
+  local.set $3
+  local.get $11
   i64.const 1
   i64.sub
-  local.tee $7
-  local.get $11
-  local.get $12
+  local.tee $11
+  local.get $5
+  i64.const 32
+  i64.shr_u
+  local.tee $10
+  local.get $8
+  i64.mul
+  local.get $2
+  i64.const 32
+  i64.shr_u
+  local.tee $2
+  local.get $9
   i64.mul
   local.get $3
   i64.const 32
   i64.shr_u
   i64.add
-  local.get $5
+  local.tee $3
+  i64.const 4294967295
+  i64.and
+  i64.add
   i64.const 2147483647
   i64.add
   i64.const 32
   i64.shr_u
+  local.get $2
+  local.get $10
+  i64.mul
+  local.get $3
+  i64.const 32
+  i64.shr_u
+  i64.add
   i64.add
   i64.const 1
   i64.add
   i64.sub
   local.set $3
-  local.get $13
+  local.get $12
   i32.const 1
   i32.shl
   local.get $0
   i32.add
   local.get $0
-  local.get $2
-  local.get $8
+  local.get $13
+  global.get $~lib/internal/number/_exp_pow
+  local.tee $14
+  local.get $7
   local.get $4
   i32.sub
-  global.get $~lib/internal/number/_exp_pow
-  local.tee $4
   i32.add
   i32.const -64
   i32.sub
-  local.get $7
-  local.get $4
+  local.get $11
   global.get $~lib/internal/number/_exp
+  local.get $14
   i32.add
   i32.const -64
   i32.sub
   local.get $3
-  local.get $13
+  local.get $12
   call $~lib/internal/number/genDigits
-  local.get $13
+  local.get $12
   i32.sub
   global.get $~lib/internal/number/_K
   call $~lib/internal/number/prettify
-  local.get $13
+  local.get $12
   i32.add
  )
  (func $~lib/string/String#substring (; 13 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)

--- a/tests/compiler/number.untouched.wat
+++ b/tests/compiler/number.untouched.wat
@@ -295,8 +295,10 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 i64)
-  (local $10 i64)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i64)
+  (local $12 i64)
   block $~lib/internal/number/DIGITS|inlined.0 (result i32)
    i32.const 584
   end
@@ -328,23 +330,31 @@
       i32.rem_u
       local.set $7
       block $~lib/internal/arraybuffer/LOAD<u32,u64>|inlined.0 (result i64)
-       i32.const 0
-       local.set $8
        local.get $3
+       local.set $8
        local.get $6
+       local.set $9
+       i32.const 0
+       local.set $10
+       local.get $8
+       local.get $9
        i32.const 2
        i32.shl
        i32.add
-       local.get $8
+       local.get $10
        i32.add
        i64.load32_u offset=8
       end
-      local.set $9
+      local.set $11
       block $~lib/internal/arraybuffer/LOAD<u32,u64>|inlined.1 (result i64)
+       local.get $3
+       local.set $10
+       local.get $7
+       local.set $9
        i32.const 0
        local.set $8
-       local.get $3
-       local.get $7
+       local.get $10
+       local.get $9
        i32.const 2
        i32.shl
        i32.add
@@ -352,7 +362,7 @@
        i32.add
        i64.load32_u offset=8
       end
-      local.set $10
+      local.set $12
       local.get $2
       i32.const 4
       i32.sub
@@ -362,8 +372,8 @@
       i32.const 1
       i32.shl
       i32.add
-      local.get $9
-      local.get $10
+      local.get $11
+      local.get $12
       i64.const 32
       i64.shl
       i64.or
@@ -392,24 +402,28 @@
    i32.sub
    local.set $2
    block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.0 (result i32)
-    i32.const 0
-    local.set $5
     local.get $3
+    local.set $5
     local.get $6
+    local.set $4
+    i32.const 0
+    local.set $8
+    local.get $5
+    local.get $4
     i32.const 2
     i32.shl
     i32.add
-    local.get $5
+    local.get $8
     i32.add
     i32.load offset=8
    end
-   local.set $5
+   local.set $8
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $5
+   local.get $8
    i32.store offset=4
   end
   local.get $1
@@ -421,24 +435,28 @@
    i32.sub
    local.set $2
    block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.1 (result i32)
-    i32.const 0
-    local.set $5
     local.get $3
+    local.set $8
     local.get $1
+    local.set $6
+    i32.const 0
+    local.set $7
+    local.get $8
+    local.get $6
     i32.const 2
     i32.shl
     i32.add
-    local.get $5
+    local.get $7
     i32.add
     i32.load offset=8
    end
-   local.set $5
+   local.set $7
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $5
+   local.get $7
    i32.store offset=4
   else   
    local.get $2
@@ -448,13 +466,13 @@
    global.get $~lib/internal/string/CharCode._0
    local.get $1
    i32.add
-   local.set $5
+   local.set $7
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $5
+   local.get $7
    i32.store16 offset=4
   end
  )
@@ -462,6 +480,9 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.eqz
   if
@@ -487,10 +508,18 @@
   local.get $2
   call $~lib/internal/string/allocateUnsafe
   local.set $3
-  local.get $3
-  local.get $0
-  local.get $2
-  call $~lib/internal/number/utoa32_lut
+  block $~lib/internal/number/utoa32_core|inlined.0
+   local.get $3
+   local.set $4
+   local.get $0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/number/utoa32_lut
+  end
   local.get $1
   if
    local.get $3
@@ -631,9 +660,14 @@
   (local $17 i32)
   (local $18 i32)
   (local $19 i64)
-  (local $20 i64)
-  (local $21 i32)
-  (local $22 i32)
+  (local $20 i32)
+  (local $21 i64)
+  (local $22 i64)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i64)
+  (local $27 i64)
   i32.const 0
   local.get $4
   i32.sub
@@ -923,90 +957,110 @@
        local.get $14
        i32.add
        global.set $~lib/internal/number/_K
-       block $~lib/internal/arraybuffer/LOAD<u32,u64>|inlined.2 (result i64)
-        i32.const 0
+       block $~lib/internal/number/grisuRound|inlined.0
+        local.get $0
         local.set $18
-        local.get $16
-        local.get $14
-        i32.const 2
+        local.get $15
+        local.set $20
+        local.get $5
+        local.set $21
+        local.get $19
+        local.set $22
+        block $~lib/internal/arraybuffer/LOAD<u32,u64>|inlined.2 (result i64)
+         local.get $16
+         local.set $23
+         local.get $14
+         local.set $24
+         i32.const 0
+         local.set $25
+         local.get $23
+         local.get $24
+         i32.const 2
+         i32.shl
+         i32.add
+         local.get $25
+         i32.add
+         i64.load32_u offset=8
+        end
+        local.get $7
+        i64.extend_i32_s
+        i64.shl
+        local.set $26
+        local.get $10
+        local.set $27
+        local.get $18
+        local.get $20
+        i32.const 1
+        i32.sub
+        i32.const 1
         i32.shl
         i32.add
-        local.get $18
-        i32.add
-        i64.load32_u offset=8
-       end
-       local.get $7
-       i64.extend_i32_s
-       i64.shl
-       local.set $20
-       local.get $0
-       local.get $15
-       i32.const 1
-       i32.sub
-       i32.const 1
-       i32.shl
-       i32.add
-       local.set $18
-       local.get $18
-       i32.load16_u offset=4
-       local.set $21
-       block $break|2
-        loop $continue|2
-         local.get $19
-         local.get $10
-         i64.lt_u
-         local.tee $22
-         if (result i32)
-          local.get $5
-          local.get $19
-          i64.sub
-          local.get $20
-          i64.ge_u
-         else          
+        local.set $25
+        local.get $25
+        i32.load16_u offset=4
+        local.set $24
+        block $break|2
+         loop $continue|2
           local.get $22
-         end
-         local.tee $22
-         if (result i32)
-          local.get $19
-          local.get $20
-          i64.add
-          local.get $10
+          local.get $27
           i64.lt_u
-          local.tee $22
+          local.tee $23
+          if (result i32)
+           local.get $21
+           local.get $22
+           i64.sub
+           local.get $26
+           i64.ge_u
+          else           
+           local.get $23
+          end
+          local.tee $23
+          i32.const 0
+          i32.ne
           if (result i32)
            local.get $22
+           local.get $26
+           i64.add
+           local.get $27
+           i64.lt_u
+           local.tee $23
+           if (result i32)
+            local.get $23
+           else            
+            local.get $27
+            local.get $22
+            i64.sub
+            local.get $22
+            local.get $26
+            i64.add
+            local.get $27
+            i64.sub
+            i64.gt_u
+           end
           else           
-           local.get $10
-           local.get $19
-           i64.sub
-           local.get $19
-           local.get $20
-           i64.add
-           local.get $10
-           i64.sub
-           i64.gt_u
+           local.get $23
           end
-         else          
-          local.get $22
-         end
-         if
-          block
-           local.get $21
-           i32.const 1
-           i32.sub
-           local.set $21
-           local.get $19
-           local.get $20
-           i64.add
-           local.set $19
+          i32.const 0
+          i32.ne
+          if
+           block
+            local.get $24
+            i32.const 1
+            i32.sub
+            local.set $24
+            local.get $22
+            local.get $26
+            i64.add
+            local.set $22
+           end
+           br $continue|2
           end
-          br $continue|2
          end
         end
+        local.get $25
+        local.get $24
+        i32.store16 offset=4
        end
-       local.get $18
-       local.get $21
-       i32.store16 offset=4
        local.get $15
        return
       end
@@ -1078,91 +1132,111 @@
        global.set $~lib/internal/number/_K
        local.get $10
        block $~lib/internal/arraybuffer/LOAD<u32,u64>|inlined.3 (result i64)
+        local.get $16
+        local.set $17
         i32.const 0
         local.get $14
         i32.sub
-        local.set $17
+        local.set $24
         i32.const 0
-        local.set $21
-        local.get $16
+        local.set $25
         local.get $17
+        local.get $24
         i32.const 2
         i32.shl
         i32.add
-        local.get $21
+        local.get $25
         i32.add
         i64.load32_u offset=8
        end
        i64.mul
        local.set $10
-       local.get $0
-       local.get $15
-       i32.const 1
-       i32.sub
-       i32.const 1
-       i32.shl
-       i32.add
-       local.set $21
-       local.get $21
-       i32.load16_u offset=4
-       local.set $17
-       block $break|4
-        loop $continue|4
-         local.get $13
-         local.get $10
-         i64.lt_u
-         local.tee $18
-         if (result i32)
-          local.get $5
-          local.get $13
-          i64.sub
-          local.get $8
-          i64.ge_u
-         else          
-          local.get $18
-         end
-         local.tee $18
-         if (result i32)
-          local.get $13
-          local.get $8
-          i64.add
-          local.get $10
+       block $~lib/internal/number/grisuRound|inlined.1
+        local.get $0
+        local.set $25
+        local.get $15
+        local.set $24
+        local.get $5
+        local.set $27
+        local.get $13
+        local.set $26
+        local.get $8
+        local.set $22
+        local.get $10
+        local.set $21
+        local.get $25
+        local.get $24
+        i32.const 1
+        i32.sub
+        i32.const 1
+        i32.shl
+        i32.add
+        local.set $17
+        local.get $17
+        i32.load16_u offset=4
+        local.set $20
+        block $break|4
+         loop $continue|4
+          local.get $26
+          local.get $21
           i64.lt_u
           local.tee $18
           if (result i32)
-           local.get $18
+           local.get $27
+           local.get $26
+           i64.sub
+           local.get $22
+           i64.ge_u
           else           
-           local.get $10
-           local.get $13
-           i64.sub
-           local.get $13
-           local.get $8
-           i64.add
-           local.get $10
-           i64.sub
-           i64.gt_u
+           local.get $18
           end
-         else          
-          local.get $18
-         end
-         if
-          block
-           local.get $17
-           i32.const 1
-           i32.sub
-           local.set $17
-           local.get $13
-           local.get $8
+          local.tee $18
+          i32.const 0
+          i32.ne
+          if (result i32)
+           local.get $26
+           local.get $22
            i64.add
-           local.set $13
+           local.get $21
+           i64.lt_u
+           local.tee $18
+           if (result i32)
+            local.get $18
+           else            
+            local.get $21
+            local.get $26
+            i64.sub
+            local.get $26
+            local.get $22
+            i64.add
+            local.get $21
+            i64.sub
+            i64.gt_u
+           end
+          else           
+           local.get $18
           end
-          br $continue|4
+          i32.const 0
+          i32.ne
+          if
+           block
+            local.get $20
+            i32.const 1
+            i32.sub
+            local.set $20
+            local.get $26
+            local.get $22
+            i64.add
+            local.set $26
+           end
+           br $continue|4
+          end
          end
         end
+        local.get $17
+        local.get $20
+        i32.store16 offset=4
        end
-       local.get $21
-       local.get $17
-       i32.store16 offset=4
        local.get $15
        return
       end
@@ -2608,6 +2682,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   local.get $2
   i32.eqz
   if
@@ -2702,26 +2779,28 @@
     i32.shl
     i32.add
     local.set $4
-    local.get $4
-    global.get $~lib/internal/string/HEADER_SIZE
-    i32.add
-    i32.const 2
-    i32.add
-    local.set $5
-    local.get $4
-    global.get $~lib/internal/string/HEADER_SIZE
-    i32.add
-    local.set $6
-    i32.const 0
-    local.get $2
-    i32.sub
-    i32.const 1
-    i32.shl
-    local.set $7
-    local.get $5
-    local.get $6
-    local.get $7
-    call $~lib/internal/memory/memmove
+    block $~lib/memory/memory.copy|inlined.0
+     local.get $4
+     global.get $~lib/internal/string/HEADER_SIZE
+     i32.add
+     i32.const 2
+     i32.add
+     local.set $5
+     local.get $4
+     global.get $~lib/internal/string/HEADER_SIZE
+     i32.add
+     local.set $6
+     i32.const 0
+     local.get $2
+     i32.sub
+     i32.const 1
+     i32.shl
+     local.set $7
+     local.get $5
+     local.get $6
+     local.get $7
+     call $~lib/internal/memory/memmove
+    end
     local.get $0
     local.get $3
     i32.const 1
@@ -2750,26 +2829,28 @@
      local.get $3
      i32.sub
      local.set $4
-     local.get $0
-     global.get $~lib/internal/string/HEADER_SIZE
-     i32.add
-     local.get $4
-     i32.const 1
-     i32.shl
-     i32.add
-     local.set $7
-     local.get $0
-     global.get $~lib/internal/string/HEADER_SIZE
-     i32.add
-     local.set $6
-     local.get $1
-     i32.const 1
-     i32.shl
-     local.set $5
-     local.get $7
-     local.get $6
-     local.get $5
-     call $~lib/internal/memory/memmove
+     block $~lib/memory/memory.copy|inlined.1
+      local.get $0
+      global.get $~lib/internal/string/HEADER_SIZE
+      i32.add
+      local.get $4
+      i32.const 1
+      i32.shl
+      i32.add
+      local.set $7
+      local.get $0
+      global.get $~lib/internal/string/HEADER_SIZE
+      i32.add
+      local.set $6
+      local.get $1
+      i32.const 1
+      i32.shl
+      local.set $5
+      local.get $7
+      local.get $6
+      local.get $5
+      call $~lib/internal/memory/memmove
+     end
      local.get $0
      global.get $~lib/internal/string/CharCode._0
      global.get $~lib/internal/string/CharCode.DOT
@@ -2839,10 +2920,18 @@
        i32.const 1
        i32.add
        local.set $7
-       local.get $4
-       local.get $5
-       local.get $7
-       call $~lib/internal/number/utoa32_lut
+       block $~lib/internal/number/utoa32_core|inlined.1
+        local.get $4
+        local.set $8
+        local.get $5
+        local.set $9
+        local.get $7
+        local.set $10
+        local.get $8
+        local.get $9
+        local.get $10
+        call $~lib/internal/number/utoa32_lut
+       end
        local.get $4
        global.get $~lib/internal/string/CharCode.MINUS
        global.get $~lib/internal/string/CharCode.PLUS
@@ -2861,26 +2950,28 @@
       i32.const 1
       i32.shl
       local.set $7
-      local.get $0
-      global.get $~lib/internal/string/HEADER_SIZE
-      i32.add
-      i32.const 4
-      i32.add
-      local.set $6
-      local.get $0
-      global.get $~lib/internal/string/HEADER_SIZE
-      i32.add
-      i32.const 2
-      i32.add
-      local.set $5
-      local.get $7
-      i32.const 2
-      i32.sub
-      local.set $4
-      local.get $6
-      local.get $5
-      local.get $4
-      call $~lib/internal/memory/memmove
+      block $~lib/memory/memory.copy|inlined.2
+       local.get $0
+       global.get $~lib/internal/string/HEADER_SIZE
+       i32.add
+       i32.const 4
+       i32.add
+       local.set $6
+       local.get $0
+       global.get $~lib/internal/string/HEADER_SIZE
+       i32.add
+       i32.const 2
+       i32.add
+       local.set $5
+       local.get $7
+       i32.const 2
+       i32.sub
+       local.set $4
+       local.get $6
+       local.get $5
+       local.get $4
+       call $~lib/internal/memory/memmove
+      end
       local.get $0
       global.get $~lib/internal/string/CharCode.DOT
       i32.store16 offset=6
@@ -2916,18 +3007,26 @@
        call $~lib/internal/number/decimalCount32
        i32.const 1
        i32.add
-       local.set $8
-       local.get $4
-       local.get $5
-       local.get $8
-       call $~lib/internal/number/utoa32_lut
+       local.set $10
+       block $~lib/internal/number/utoa32_core|inlined.2
+        local.get $4
+        local.set $9
+        local.get $5
+        local.set $8
+        local.get $10
+        local.set $11
+        local.get $9
+        local.get $8
+        local.get $11
+        call $~lib/internal/number/utoa32_lut
+       end
        local.get $4
        global.get $~lib/internal/string/CharCode.MINUS
        global.get $~lib/internal/string/CharCode.PLUS
        local.get $6
        select
        i32.store16 offset=4
-       local.get $8
+       local.get $10
       end
       i32.add
       local.set $1
@@ -2947,29 +3046,35 @@
  )
  (func $~lib/internal/number/dtoa_core (; 16 ;) (type $iFi) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
-  (local $3 i64)
+  (local $3 f64)
   (local $4 i32)
-  (local $5 i64)
+  (local $5 i32)
   (local $6 i64)
-  (local $7 i64)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 f64)
-  (local $12 i32)
+  (local $7 i32)
+  (local $8 i64)
+  (local $9 i64)
+  (local $10 i64)
+  (local $11 i32)
+  (local $12 i64)
   (local $13 i32)
   (local $14 i32)
-  (local $15 i64)
-  (local $16 i64)
-  (local $17 i64)
-  (local $18 i64)
-  (local $19 i64)
-  (local $20 i64)
+  (local $15 i32)
+  (local $16 f64)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   (local $21 i64)
   (local $22 i64)
   (local $23 i64)
   (local $24 i64)
-  (local $25 i32)
+  (local $25 i64)
+  (local $26 i64)
+  (local $27 i64)
+  (local $28 i64)
+  (local $29 i64)
+  (local $30 i64)
+  (local $31 i32)
   local.get $1
   f64.const 0
   f64.lt
@@ -2985,31 +3090,37 @@
   end
   block $~lib/internal/number/grisu2|inlined.0 (result i32)
    local.get $1
-   i64.reinterpret_f64
    local.set $3
+   local.get $0
+   local.set $4
+   local.get $2
+   local.set $5
    local.get $3
+   i64.reinterpret_f64
+   local.set $6
+   local.get $6
    i64.const 9218868437227405312
    i64.and
    i64.const 52
    i64.shr_u
    i32.wrap_i64
-   local.set $4
-   local.get $3
+   local.set $7
+   local.get $6
    i64.const 4503599627370495
    i64.and
-   local.set $5
-   local.get $4
+   local.set $8
+   local.get $7
    i32.const 0
    i32.ne
    i64.extend_i32_u
    i64.const 52
    i64.shl
-   local.get $5
+   local.get $8
    i64.add
-   local.set $6
-   local.get $4
+   local.set $9
+   local.get $7
    i32.const 1
-   local.get $4
+   local.get $7
    i32.const 0
    i32.ne
    select
@@ -3017,86 +3128,90 @@
    i32.const 52
    i32.add
    i32.sub
-   local.set $4
-   block
-    local.get $6
+   local.set $7
+   block $~lib/internal/number/normalizedBoundaries|inlined.0
+    local.get $9
+    local.set $10
+    local.get $7
+    local.set $11
+    local.get $10
     i64.const 1
     i64.shl
     i64.const 1
     i64.add
-    local.set $7
-    local.get $4
+    local.set $12
+    local.get $11
     i32.const 1
     i32.sub
-    local.set $8
-    local.get $7
+    local.set $13
+    local.get $12
     i64.clz
     i32.wrap_i64
-    local.set $9
-    local.get $7
-    local.get $9
+    local.set $14
+    local.get $12
+    local.get $14
     i64.extend_i32_s
     i64.shl
-    local.set $7
-    local.get $8
-    local.get $9
+    local.set $12
+    local.get $13
+    local.get $14
     i32.sub
-    local.set $8
+    local.set $13
     i32.const 1
-    local.get $6
+    local.get $10
     i64.const 4503599627370496
     i64.eq
     i32.add
-    local.set $10
-    local.get $7
+    local.set $15
+    local.get $12
     global.set $~lib/internal/number/_frc_plus
-    local.get $6
     local.get $10
+    local.get $15
     i64.extend_i32_s
     i64.shl
     i64.const 1
     i64.sub
-    local.get $4
-    local.get $10
+    local.get $11
+    local.get $15
     i32.sub
-    local.get $8
+    local.get $13
     i32.sub
     i64.extend_i32_s
     i64.shl
     global.set $~lib/internal/number/_frc_minus
-    local.get $8
+    local.get $13
     global.set $~lib/internal/number/_exp
    end
-   block
+   block $~lib/internal/number/getCachedPower|inlined.0
     global.get $~lib/internal/number/_exp
-    local.set $10
+    local.set $15
     i32.const -61
-    local.get $10
+    local.get $15
     i32.sub
     f64.convert_i32_s
     f64.const 0.30102999566398114
     f64.mul
     f64.const 347
     f64.add
-    local.set $11
-    local.get $11
+    local.set $16
+    local.get $16
     i32.trunc_f64_s
-    local.set $9
-    local.get $9
-    local.get $9
+    local.set $14
+    local.get $14
+    local.get $14
     f64.convert_i32_s
-    local.get $11
+    local.get $16
     f64.ne
     i32.add
-    local.set $9
-    local.get $9
+    local.set $14
+    local.get $14
     i32.const 3
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $8
+    local.set $13
     i32.const 348
-    local.get $8
+    local.get $13
     i32.const 3
     i32.shl
     i32.sub
@@ -3105,282 +3220,304 @@
      i32.const 1728
     end
     i32.load
-    local.set $12
+    local.set $11
     block $~lib/internal/number/EXP_POWERS|inlined.0 (result i32)
      i32.const 1992
     end
     i32.load
-    local.set $13
+    local.set $17
     block $~lib/internal/arraybuffer/LOAD<u64,u64>|inlined.0 (result i64)
+     local.get $11
+     local.set $18
+     local.get $13
+     local.set $19
      i32.const 0
-     local.set $14
-     local.get $12
-     local.get $8
+     local.set $20
+     local.get $18
+     local.get $19
      i32.const 3
      i32.shl
      i32.add
-     local.get $14
+     local.get $20
      i32.add
      i64.load offset=8
     end
     global.set $~lib/internal/number/_frc_pow
     block $~lib/internal/arraybuffer/LOAD<i16,i32>|inlined.0 (result i32)
-     i32.const 0
-     local.set $14
+     local.get $17
+     local.set $20
      local.get $13
-     local.get $8
+     local.set $19
+     i32.const 0
+     local.set $18
+     local.get $20
+     local.get $19
      i32.const 1
      i32.shl
      i32.add
-     local.get $14
+     local.get $18
      i32.add
      i32.load16_s offset=8
     end
     global.set $~lib/internal/number/_exp_pow
    end
-   local.get $6
+   local.get $9
    i64.clz
    i32.wrap_i64
-   local.set $13
-   local.get $6
-   local.get $13
+   local.set $17
+   local.get $9
+   local.get $17
    i64.extend_i32_s
    i64.shl
-   local.set $6
-   local.get $4
-   local.get $13
+   local.set $9
+   local.get $7
+   local.get $17
    i32.sub
-   local.set $4
-   global.get $~lib/internal/number/_frc_pow
    local.set $7
-   global.get $~lib/internal/number/_exp_pow
+   global.get $~lib/internal/number/_frc_pow
    local.set $12
+   global.get $~lib/internal/number/_exp_pow
+   local.set $11
    block $~lib/internal/number/umul64f|inlined.0 (result i64)
-    local.get $6
-    i64.const 4294967295
-    i64.and
-    local.set $15
-    local.get $7
-    i64.const 4294967295
-    i64.and
-    local.set $16
-    local.get $6
-    i64.const 32
-    i64.shr_u
-    local.set $17
-    local.get $7
-    i64.const 32
-    i64.shr_u
-    local.set $18
-    local.get $15
-    local.get $16
-    i64.mul
-    local.set $19
-    local.get $17
-    local.get $16
-    i64.mul
-    local.get $19
-    i64.const 32
-    i64.shr_u
-    i64.add
-    local.set $20
-    local.get $15
-    local.get $18
-    i64.mul
-    local.get $20
-    i64.const 4294967295
-    i64.and
-    i64.add
+    local.get $9
+    local.set $10
+    local.get $12
     local.set $21
+    local.get $10
+    i64.const 4294967295
+    i64.and
+    local.set $22
     local.get $21
+    i64.const 4294967295
+    i64.and
+    local.set $23
+    local.get $10
+    i64.const 32
+    i64.shr_u
+    local.set $24
+    local.get $21
+    i64.const 32
+    i64.shr_u
+    local.set $25
+    local.get $22
+    local.get $23
+    i64.mul
+    local.set $26
+    local.get $24
+    local.get $23
+    i64.mul
+    local.get $26
+    i64.const 32
+    i64.shr_u
+    i64.add
+    local.set $27
+    local.get $22
+    local.get $25
+    i64.mul
+    local.get $27
+    i64.const 4294967295
+    i64.and
+    i64.add
+    local.set $28
+    local.get $28
     i64.const 2147483647
     i64.add
-    local.set $21
-    local.get $20
+    local.set $28
+    local.get $27
     i64.const 32
     i64.shr_u
-    local.set $20
-    local.get $21
+    local.set $27
+    local.get $28
     i64.const 32
     i64.shr_u
-    local.set $21
-    local.get $17
-    local.get $18
+    local.set $28
+    local.get $24
+    local.get $25
     i64.mul
-    local.get $20
+    local.get $27
     i64.add
-    local.get $21
+    local.get $28
     i64.add
    end
-   local.set $21
+   local.set $28
    block $~lib/internal/number/umul64e|inlined.0 (result i32)
-    local.get $4
-    local.get $12
+    local.get $7
+    local.set $13
+    local.get $11
+    local.set $14
+    local.get $13
+    local.get $14
     i32.add
     i32.const 64
     i32.add
    end
-   local.set $8
+   local.set $14
    block $~lib/internal/number/umul64f|inlined.1 (result i64)
     global.get $~lib/internal/number/_frc_plus
-    local.set $20
-    local.get $20
+    local.set $27
+    local.get $12
+    local.set $26
+    local.get $27
     i64.const 4294967295
     i64.and
-    local.set $19
-    local.get $7
+    local.set $25
+    local.get $26
     i64.const 4294967295
     i64.and
-    local.set $18
-    local.get $20
+    local.set $24
+    local.get $27
     i64.const 32
     i64.shr_u
-    local.set $17
-    local.get $7
-    i64.const 32
-    i64.shr_u
-    local.set $16
-    local.get $19
-    local.get $18
-    i64.mul
-    local.set $15
-    local.get $17
-    local.get $18
-    i64.mul
-    local.get $15
-    i64.const 32
-    i64.shr_u
-    i64.add
-    local.set $22
-    local.get $19
-    local.get $16
-    i64.mul
-    local.get $22
-    i64.const 4294967295
-    i64.and
-    i64.add
     local.set $23
+    local.get $26
+    i64.const 32
+    i64.shr_u
+    local.set $22
+    local.get $25
+    local.get $24
+    i64.mul
+    local.set $21
     local.get $23
+    local.get $24
+    i64.mul
+    local.get $21
+    i64.const 32
+    i64.shr_u
+    i64.add
+    local.set $10
+    local.get $25
+    local.get $22
+    i64.mul
+    local.get $10
+    i64.const 4294967295
+    i64.and
+    i64.add
+    local.set $29
+    local.get $29
     i64.const 2147483647
     i64.add
-    local.set $23
-    local.get $22
+    local.set $29
+    local.get $10
     i64.const 32
     i64.shr_u
-    local.set $22
+    local.set $10
+    local.get $29
+    i64.const 32
+    i64.shr_u
+    local.set $29
     local.get $23
-    i64.const 32
-    i64.shr_u
-    local.set $23
-    local.get $17
-    local.get $16
+    local.get $22
     i64.mul
-    local.get $22
+    local.get $10
     i64.add
-    local.get $23
+    local.get $29
     i64.add
    end
    i64.const 1
    i64.sub
-   local.set $23
+   local.set $29
    block $~lib/internal/number/umul64e|inlined.1 (result i32)
     global.get $~lib/internal/number/_exp
-    local.set $9
-    local.get $9
-    local.get $12
+    local.set $13
+    local.get $11
+    local.set $15
+    local.get $13
+    local.get $15
     i32.add
     i32.const 64
     i32.add
    end
-   local.set $9
+   local.set $15
    block $~lib/internal/number/umul64f|inlined.2 (result i64)
     global.get $~lib/internal/number/_frc_minus
+    local.set $10
+    local.get $12
+    local.set $21
+    local.get $10
+    i64.const 4294967295
+    i64.and
     local.set $22
-    local.get $22
+    local.get $21
     i64.const 4294967295
     i64.and
-    local.set $15
-    local.get $7
-    i64.const 4294967295
-    i64.and
-    local.set $16
-    local.get $22
+    local.set $23
+    local.get $10
     i64.const 32
     i64.shr_u
-    local.set $17
-    local.get $7
-    i64.const 32
-    i64.shr_u
-    local.set $18
-    local.get $15
-    local.get $16
-    i64.mul
-    local.set $19
-    local.get $17
-    local.get $16
-    i64.mul
-    local.get $19
-    i64.const 32
-    i64.shr_u
-    i64.add
-    local.set $20
-    local.get $15
-    local.get $18
-    i64.mul
-    local.get $20
-    i64.const 4294967295
-    i64.and
-    i64.add
     local.set $24
+    local.get $21
+    i64.const 32
+    i64.shr_u
+    local.set $25
+    local.get $22
+    local.get $23
+    i64.mul
+    local.set $26
     local.get $24
+    local.get $23
+    i64.mul
+    local.get $26
+    i64.const 32
+    i64.shr_u
+    i64.add
+    local.set $27
+    local.get $22
+    local.get $25
+    i64.mul
+    local.get $27
+    i64.const 4294967295
+    i64.and
+    i64.add
+    local.set $30
+    local.get $30
     i64.const 2147483647
     i64.add
-    local.set $24
-    local.get $20
+    local.set $30
+    local.get $27
     i64.const 32
     i64.shr_u
-    local.set $20
+    local.set $27
+    local.get $30
+    i64.const 32
+    i64.shr_u
+    local.set $30
     local.get $24
-    i64.const 32
-    i64.shr_u
-    local.set $24
-    local.get $17
-    local.get $18
+    local.get $25
     i64.mul
-    local.get $20
+    local.get $27
     i64.add
-    local.get $24
+    local.get $30
     i64.add
    end
    i64.const 1
    i64.add
-   local.set $24
-   local.get $23
-   local.get $24
+   local.set $30
+   local.get $29
+   local.get $30
    i64.sub
-   local.set $20
-   local.get $0
-   local.get $21
-   local.get $8
-   local.get $23
-   local.get $9
-   local.get $20
-   local.get $2
+   local.set $27
+   local.get $4
+   local.get $28
+   local.get $14
+   local.get $29
+   local.get $15
+   local.get $27
+   local.get $5
    call $~lib/internal/number/genDigits
   end
-  local.set $25
+  local.set $31
   local.get $0
   local.get $2
   i32.const 1
   i32.shl
   i32.add
-  local.get $25
+  local.get $31
   local.get $2
   i32.sub
   global.get $~lib/internal/number/_K
   call $~lib/internal/number/prettify
-  local.set $25
-  local.get $25
+  local.set $31
+  local.get $31
   local.get $2
   i32.add
  )
@@ -3530,6 +3667,8 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   f64.const 0
   f64.eq
@@ -3567,24 +3706,26 @@
   local.get $2
   call $~lib/string/String#substring
   local.set $3
-  local.get $1
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 16
-   i32.const 28
-   i32.const 4
-   call $~lib/env/abort
-   unreachable
-  end
-  block $~lib/memory/memory.free|inlined.0
-   block
-    local.get $1
-    call $~lib/allocator/arena/__memory_free
-    br $~lib/memory/memory.free|inlined.0
+  block $~lib/internal/string/freeUnsafe|inlined.0
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 16
+    i32.const 28
+    i32.const 4
+    call $~lib/env/abort
     unreachable
    end
-   unreachable
+   block $~lib/memory/memory.free|inlined.0
+    local.get $4
+    local.set $5
+    local.get $5
+    call $~lib/allocator/arena/__memory_free
+    br $~lib/memory/memory.free|inlined.0
+   end
   end
   local.get $3
  )
@@ -3619,15 +3760,18 @@
   end
  )
  (func $~lib/number/F32.isInteger (; 24 ;) (type $fi) (param $0 f32) (result i32)
-  (local $1 i32)
+  (local $1 f32)
+  (local $2 i32)
   block $~lib/builtins/isFinite<f32>|inlined.0 (result i32)
    local.get $0
-   local.get $0
+   local.set $1
+   local.get $1
+   local.get $1
    f32.sub
    f32.const 0
    f32.eq
   end
-  local.tee $1
+  local.tee $2
   i32.const 0
   i32.ne
   if (result i32)
@@ -3636,7 +3780,7 @@
    local.get $0
    f32.eq
   else   
-   local.get $1
+   local.get $2
   end
  )
  (func $~lib/number/F64.isSafeInteger (; 25 ;) (type $Fi) (param $0 f64) (result i32)
@@ -3656,15 +3800,18 @@
   end
  )
  (func $~lib/number/F64.isInteger (; 26 ;) (type $Fi) (param $0 f64) (result i32)
-  (local $1 i32)
+  (local $1 f64)
+  (local $2 i32)
   block $~lib/builtins/isFinite<f64>|inlined.0 (result i32)
    local.get $0
-   local.get $0
+   local.set $1
+   local.get $1
+   local.get $1
    f64.sub
    f64.const 0
    f64.eq
   end
-  local.tee $1
+  local.tee $2
   i32.const 0
   i32.ne
   if (result i32)
@@ -3673,7 +3820,7 @@
    local.get $0
    f64.eq
   else   
-   local.get $1
+   local.get $2
   end
  )
  (func $start (; 27 ;) (type $v)

--- a/tests/compiler/std/allocator_arena.untouched.wat
+++ b/tests/compiler/std/allocator_arena.untouched.wat
@@ -1888,7 +1888,7 @@
    call $~lib/env/abort
    unreachable
   end
-  block
+  block $~lib/memory/memory.fill|inlined.0
    global.get $std/allocator_arena/ptr1
    local.set $0
    i32.const 18
@@ -1933,7 +1933,7 @@
    end
    unreachable
   end
-  block
+  block $~lib/memory/memory.copy|inlined.0
    global.get $std/allocator_arena/ptr2
    local.set $2
    global.get $std/allocator_arena/ptr1
@@ -2004,32 +2004,20 @@
   block $~lib/memory/memory.free|inlined.0
    global.get $std/allocator_arena/ptr1
    local.set $2
-   block
-    local.get $2
-    call $~lib/allocator/arena/__memory_free
-    br $~lib/memory/memory.free|inlined.0
-    unreachable
-   end
-   unreachable
+   local.get $2
+   call $~lib/allocator/arena/__memory_free
+   br $~lib/memory/memory.free|inlined.0
   end
   block $~lib/memory/memory.free|inlined.1
    global.get $std/allocator_arena/ptr2
    local.set $2
-   block
-    local.get $2
-    call $~lib/allocator/arena/__memory_free
-    br $~lib/memory/memory.free|inlined.1
-    unreachable
-   end
-   unreachable
+   local.get $2
+   call $~lib/allocator/arena/__memory_free
+   br $~lib/memory/memory.free|inlined.1
   end
   block $~lib/memory/memory.reset|inlined.0
-   block
-    call $~lib/allocator/arena/__memory_reset
-    br $~lib/memory/memory.reset|inlined.0
-    unreachable
-   end
-   unreachable
+   call $~lib/allocator/arena/__memory_reset
+   br $~lib/memory/memory.reset|inlined.0
   end
   block $~lib/memory/memory.allocate|inlined.2 (result i32)
    global.get $std/allocator_arena/size

--- a/tests/compiler/std/array-access.untouched.wat
+++ b/tests/compiler/std/array-access.untouched.wat
@@ -28,6 +28,8 @@
  (func $~lib/array/Array<Array<i32>>#__get (; 1 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.load
   local.set $2
@@ -38,14 +40,18 @@
   i32.shr_u
   i32.lt_u
   if (result i32)
-   i32.const 0
-   local.set $3
    local.get $2
+   local.set $3
    local.get $1
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 2
    i32.shl
    i32.add
-   local.get $3
+   local.get $5
    i32.add
    i32.load offset=8
   else   
@@ -55,6 +61,8 @@
  (func $~lib/array/Array<i32>#__get (; 2 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.load
   local.set $2
@@ -65,14 +73,18 @@
   i32.shr_u
   i32.lt_u
   if (result i32)
-   i32.const 0
-   local.set $3
    local.get $2
+   local.set $3
    local.get $1
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 2
    i32.shl
    i32.add
-   local.get $3
+   local.get $5
    i32.add
    i32.load offset=8
   else   
@@ -89,6 +101,8 @@
  (func $~lib/array/Array<String>#__get (; 4 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.load
   local.set $2
@@ -99,14 +113,18 @@
   i32.shr_u
   i32.lt_u
   if (result i32)
-   i32.const 0
-   local.set $3
    local.get $2
+   local.set $3
    local.get $1
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 2
    i32.shl
    i32.add
-   local.get $3
+   local.get $5
    i32.add
    i32.load offset=8
   else   
@@ -250,6 +268,8 @@
  (func $~lib/array/Array<Array<String>>#__get (; 9 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.load
   local.set $2
@@ -260,14 +280,18 @@
   i32.shr_u
   i32.lt_u
   if (result i32)
-   i32.const 0
-   local.set $3
    local.get $2
+   local.set $3
    local.get $1
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 2
    i32.shl
    i32.add
-   local.get $3
+   local.get $5
    i32.add
    i32.load offset=8
   else   

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -40,6 +40,8 @@
  (func $~lib/array/Array<i8>#__get (; 1 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.load
   local.set $2
@@ -50,14 +52,18 @@
   i32.shr_u
   i32.lt_u
   if (result i32)
-   i32.const 0
-   local.set $3
    local.get $2
+   local.set $3
    local.get $1
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 0
    i32.shl
    i32.add
-   local.get $3
+   local.get $5
    i32.add
    i32.load8_s offset=8
   else   
@@ -67,6 +73,8 @@
  (func $~lib/array/Array<i32>#__get (; 2 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.load
   local.set $2
@@ -77,14 +85,18 @@
   i32.shr_u
   i32.lt_u
   if (result i32)
-   i32.const 0
-   local.set $3
    local.get $2
+   local.set $3
    local.get $1
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 2
    i32.shl
    i32.add
-   local.get $3
+   local.get $5
    i32.add
    i32.load offset=8
   else   
@@ -475,6 +487,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.const 1073741816
   i32.gt_u
@@ -514,34 +527,44 @@
   local.get $0
   local.get $1
   i32.store offset=4
-  local.get $3
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  i32.const 0
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $2
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.0
+   local.get $3
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/memory/memset
+  end
   local.get $0
  )
  (func $~lib/array/Array<i8>#__unchecked_set (; 9 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.load
   local.set $3
-  i32.const 0
-  local.set $4
-  local.get $3
   local.get $1
+  local.set $4
+  local.get $2
+  local.set $5
+  i32.const 0
+  local.set $6
+  local.get $3
+  local.get $4
   i32.const 0
   i32.shl
   i32.add
-  local.get $4
+  local.get $6
   i32.add
-  local.get $2
+  local.get $5
   i32.store8 offset=8
  )
  (func $~lib/array/Array<i32>#constructor (; 10 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
@@ -549,6 +572,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.const 268435454
   i32.gt_u
@@ -588,34 +612,44 @@
   local.get $0
   local.get $1
   i32.store offset=4
-  local.get $3
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  i32.const 0
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $2
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.1
+   local.get $3
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/memory/memset
+  end
   local.get $0
  )
  (func $~lib/array/Array<i32>#__unchecked_set (; 11 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.load
   local.set $3
-  i32.const 0
-  local.set $4
-  local.get $3
   local.get $1
+  local.set $4
+  local.get $2
+  local.set $5
+  i32.const 0
+  local.set $6
+  local.get $3
+  local.get $4
   i32.const 2
   i32.shl
   i32.add
-  local.get $4
+  local.get $6
   i32.add
-  local.get $2
+  local.get $5
   i32.store offset=8
  )
  (func $std/array-literal/Ref#constructor (; 12 ;) (type $ii) (param $0 i32) (result i32)
@@ -633,6 +667,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.const 268435454
   i32.gt_u
@@ -672,34 +707,44 @@
   local.get $0
   local.get $1
   i32.store offset=4
-  local.get $3
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  i32.const 0
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $2
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.2
+   local.get $3
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/memory/memset
+  end
   local.get $0
  )
  (func $~lib/array/Array<Ref>#__unchecked_set (; 14 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.load
   local.set $3
-  i32.const 0
-  local.set $4
-  local.get $3
   local.get $1
+  local.set $4
+  local.get $2
+  local.set $5
+  i32.const 0
+  local.set $6
+  local.get $3
+  local.get $4
   i32.const 2
   i32.shl
   i32.add
-  local.get $4
+  local.get $6
   i32.add
-  local.get $2
+  local.get $5
   i32.store offset=8
  )
  (func $std/array-literal/RefWithCtor#constructor (; 15 ;) (type $ii) (param $0 i32) (result i32)
@@ -717,6 +762,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.const 268435454
   i32.gt_u
@@ -756,34 +802,44 @@
   local.get $0
   local.get $1
   i32.store offset=4
-  local.get $3
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  i32.const 0
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $2
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.3
+   local.get $3
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/memory/memset
+  end
   local.get $0
  )
  (func $~lib/array/Array<RefWithCtor>#__unchecked_set (; 17 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.load
   local.set $3
-  i32.const 0
-  local.set $4
-  local.get $3
   local.get $1
+  local.set $4
+  local.get $2
+  local.set $5
+  i32.const 0
+  local.set $6
+  local.get $3
+  local.get $4
   i32.const 2
   i32.shl
   i32.add
-  local.get $4
+  local.get $6
   i32.add
-  local.get $2
+  local.get $5
   i32.store offset=8
  )
  (func $start (; 18 ;) (type $v)

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -338,7 +338,7 @@
  (data (i32.const 8408) "\04\00\00\00\00\00\00\00\d0 ")
  (data (i32.const 8424) "\d8 \00\00\01")
  (table $0 57 funcref)
- (elem (i32.const 0) $null $start~anonymous|1 $start~anonymous|2 $start~anonymous|3 $start~anonymous|4 $start~anonymous|3 $start~anonymous|6 $start~anonymous|7 $start~anonymous|8 $start~anonymous|9 $start~anonymous|10 $start~anonymous|11 $start~anonymous|12 $start~anonymous|13 $start~anonymous|14 $start~anonymous|15 $start~anonymous|16 $start~anonymous|17 $start~anonymous|18 $start~anonymous|17 $start~anonymous|20 $start~anonymous|21 $start~anonymous|22 $start~anonymous|23 $start~anonymous|24 $start~anonymous|25 $start~anonymous|26 $start~anonymous|27 $start~anonymous|28 $start~anonymous|29 $start~anonymous|30 $start~anonymous|30 $start~anonymous|32 $start~anonymous|33 $start~anonymous|34 $start~anonymous|30 $start~anonymous|36 $start~anonymous|30 $start~anonymous|30 $start~anonymous|32 $start~anonymous|33 $start~anonymous|34 $start~anonymous|30 $start~anonymous|36 $~lib/array/Array<f32>#sort|trampoline~anonymous|44 $~lib/array/Array<f64>#sort|trampoline~anonymous|45 $~lib/array/Array<i32>#sort|trampoline~anonymous|46 $~lib/array/Array<u32>#sort|trampoline~anonymous|47 $~lib/array/Array<i32>#sort|trampoline~anonymous|46 $~lib/array/Array<i32>#sort|trampoline~anonymous|46 $start~anonymous|50 $~lib/array/Array<i32>#sort|trampoline~anonymous|46 $start~anonymous|50 $start~anonymous|53 $start~anonymous|54 $start~anonymous|55 $start~anonymous|55)
+ (elem (i32.const 0) $null $start~anonymous|1 $start~anonymous|2 $start~anonymous|3 $start~anonymous|4 $start~anonymous|3 $start~anonymous|6 $start~anonymous|7 $start~anonymous|8 $start~anonymous|9 $start~anonymous|10 $start~anonymous|11 $start~anonymous|12 $start~anonymous|13 $start~anonymous|14 $start~anonymous|15 $start~anonymous|16 $start~anonymous|17 $start~anonymous|18 $start~anonymous|17 $start~anonymous|20 $start~anonymous|21 $start~anonymous|22 $start~anonymous|23 $start~anonymous|24 $start~anonymous|25 $start~anonymous|26 $start~anonymous|27 $start~anonymous|28 $start~anonymous|29 $start~anonymous|30 $start~anonymous|30 $start~anonymous|32 $start~anonymous|33 $start~anonymous|34 $start~anonymous|30 $start~anonymous|36 $start~anonymous|30 $start~anonymous|30 $start~anonymous|32 $start~anonymous|33 $start~anonymous|34 $start~anonymous|30 $start~anonymous|36 $~lib/internal/sort/COMPARATOR<f32>~anonymous|44 $~lib/internal/sort/COMPARATOR<f64>~anonymous|45 $~lib/internal/sort/COMPARATOR<i32>~anonymous|46 $~lib/internal/sort/COMPARATOR<u32>~anonymous|47 $~lib/internal/sort/COMPARATOR<i32>~anonymous|46 $~lib/internal/sort/COMPARATOR<i32>~anonymous|46 $start~anonymous|50 $~lib/internal/sort/COMPARATOR<i32>~anonymous|46 $start~anonymous|50 $start~anonymous|53 $start~anonymous|54 $start~anonymous|55 $start~anonymous|55)
  (global $~lib/allocator/arena/startOffset (mut i32) (i32.const 0))
  (global $~lib/allocator/arena/offset (mut i32) (i32.const 0))
  (global $~lib/internal/number/_K (mut i32) (i32.const 0))
@@ -2479,9 +2479,10 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load
-  local.set $6
+  local.set $7
   local.get $3
   local.tee $4
   local.get $0
@@ -2514,7 +2515,7 @@
    i32.lt_s
    select
   end
-  local.set $1
+  local.set $6
   local.get $2
   i32.const 0
   i32.lt_s
@@ -2530,9 +2531,8 @@
    select
   else   
    local.get $2
-   local.tee $4
    local.get $5
-   local.get $4
+   local.get $2
    local.get $5
    i32.lt_s
    select
@@ -2553,9 +2553,8 @@
    select
   else   
    local.get $3
-   local.tee $4
    local.get $5
-   local.get $4
+   local.get $3
    local.get $5
    i32.lt_s
    select
@@ -2564,20 +2563,20 @@
   i32.sub
   local.tee $4
   local.get $5
-  local.get $1
+  local.get $6
   i32.sub
-  local.tee $5
+  local.tee $1
   local.get $4
-  local.get $5
+  local.get $1
   i32.lt_s
   select
   local.set $3
   local.get $2
-  local.get $1
+  local.get $6
   i32.lt_s
   local.tee $4
   if
-   local.get $1
+   local.get $6
    local.get $2
    local.get $3
    i32.add
@@ -2589,23 +2588,23 @@
    local.get $3
    i32.const 1
    i32.sub
-   local.tee $4
+   local.tee $1
    local.get $2
    i32.add
    local.set $2
    local.get $1
-   local.get $4
+   local.get $6
    i32.add
-   local.set $1
+   local.set $6
    loop $continue|0
     local.get $3
     if
+     local.get $7
      local.get $6
-     local.get $1
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $7
      local.get $2
      i32.const 2
      i32.shl
@@ -2616,10 +2615,10 @@
      i32.const 1
      i32.sub
      local.set $2
-     local.get $1
+     local.get $6
      i32.const 1
      i32.sub
-     local.set $1
+     local.set $6
      local.get $3
      i32.const 1
      i32.sub
@@ -2628,11 +2627,11 @@
     end
    end
   else   
-   local.get $6
+   local.get $7
    i32.const 8
    i32.add
    local.tee $4
-   local.get $1
+   local.get $6
    i32.const 2
    i32.shl
    i32.add
@@ -2744,7 +2743,7 @@
   (local $5 i32)
   local.get $0
   i32.load offset=4
-  local.tee $1
+  local.tee $3
   i32.const 1
   i32.lt_s
   if
@@ -2757,33 +2756,34 @@
   end
   local.get $0
   i32.load
-  local.tee $3
+  local.tee $2
   i32.load offset=8
   local.set $4
-  local.get $3
+  local.get $2
   i32.const 8
   i32.add
   local.tee $5
   i32.const 4
   i32.add
-  local.set $2
+  local.set $1
   local.get $5
-  local.get $2
-  local.get $1
-  i32.const 1
-  i32.sub
-  local.tee $2
-  i32.const 2
-  i32.shl
-  local.tee $1
-  call $~lib/internal/memory/memmove
   local.get $1
   local.get $3
+  i32.const 1
+  i32.sub
+  local.tee $1
+  i32.const 2
+  i32.shl
+  call $~lib/internal/memory/memmove
+  local.get $2
+  local.get $1
+  i32.const 2
+  i32.shl
   i32.add
   i32.const 0
   i32.store offset=8
   local.get $0
-  local.get $2
+  local.get $1
   i32.store offset=4
   local.get $4
  )
@@ -2915,60 +2915,61 @@
   (local $5 i32)
   (local $6 i32)
   local.get $0
-  i32.load
-  local.set $5
-  local.get $2
-  local.get $0
   i32.load offset=4
-  local.tee $4
+  local.set $3
+  local.get $0
+  i32.load
+  local.tee $6
+  i32.const 8
+  i32.add
   local.get $1
   i32.const 0
   i32.lt_s
   if (result i32)
    local.get $1
-   local.get $4
-   i32.add
-   local.tee $3
-   i32.const 0
    local.get $3
+   i32.add
+   local.tee $4
+   i32.const 0
+   local.get $4
    i32.const 0
    i32.gt_s
    select
   else   
    local.get $1
-   local.get $4
+   local.get $3
    local.get $1
-   local.get $4
+   local.get $3
    i32.lt_s
    select
   end
   local.tee $1
-  i32.sub
-  local.tee $3
+  i32.const 2
+  i32.shl
+  i32.add
+  local.set $5
   local.get $2
   local.get $3
+  local.get $1
+  i32.sub
+  local.tee $4
+  local.get $2
+  local.get $4
   i32.lt_s
   select
-  local.tee $3
+  local.tee $4
   i32.const 0
-  local.get $3
+  local.get $4
   i32.const 0
   i32.gt_s
   select
   local.tee $2
   call $~lib/array/Array<i32>#constructor
-  local.tee $6
+  local.tee $4
   i32.load
   i32.const 8
   i32.add
   local.get $5
-  i32.const 8
-  i32.add
-  local.get $1
-  i32.const 2
-  i32.shl
-  i32.add
-  local.tee $3
   local.get $2
   i32.const 2
   i32.shl
@@ -2977,18 +2978,18 @@
   local.get $2
   i32.add
   local.tee $1
-  local.get $4
+  local.get $3
   i32.ne
   if
-   local.get $3
    local.get $5
+   local.get $6
    i32.const 8
    i32.add
    local.get $1
    i32.const 2
    i32.shl
    i32.add
-   local.get $4
+   local.get $3
    local.get $1
    i32.sub
    i32.const 2
@@ -2996,11 +2997,11 @@
    call $~lib/internal/memory/memmove
   end
   local.get $0
-  local.get $4
+  local.get $3
   local.get $2
   i32.sub
   i32.store offset=4
-  local.get $6
+  local.get $4
  )
  (func $~lib/array/Array<i32>#splice|trampoline (; 26 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -3078,16 +3079,16 @@
   (local $4 i32)
   local.get $0
   i32.load offset=4
-  local.set $3
+  local.set $4
   loop $repeat|0
    block $break|0
-    local.get $2
-    local.get $3
-    local.get $0
-    i32.load offset=4
-    local.tee $4
     local.get $3
     local.get $4
+    local.get $0
+    i32.load offset=4
+    local.tee $2
+    local.get $4
+    local.get $2
     i32.lt_s
     select
     i32.ge_s
@@ -3096,7 +3097,8 @@
     global.set $~argc
     local.get $0
     i32.load
-    local.get $2
+    local.get $3
+    local.tee $2
     i32.const 2
     i32.shl
     i32.add
@@ -3112,7 +3114,7 @@
      local.get $2
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $repeat|0
     end
     unreachable
@@ -3158,16 +3160,16 @@
   (local $4 i32)
   local.get $0
   i32.load offset=4
-  local.set $3
+  local.set $4
   loop $repeat|0
    block $break|0
-    local.get $2
-    local.get $3
-    local.get $0
-    i32.load offset=4
-    local.tee $4
     local.get $3
     local.get $4
+    local.get $0
+    i32.load offset=4
+    local.tee $2
+    local.get $4
+    local.get $2
     i32.lt_s
     select
     i32.ge_s
@@ -3176,7 +3178,8 @@
     global.set $~argc
     local.get $0
     i32.load
-    local.get $2
+    local.get $3
+    local.tee $2
     i32.const 2
     i32.shl
     i32.add
@@ -3189,7 +3192,7 @@
      local.get $2
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $repeat|0
     else     
      i32.const 0
@@ -3238,16 +3241,16 @@
   (local $4 i32)
   local.get $0
   i32.load offset=4
-  local.set $3
+  local.set $4
   loop $repeat|0
    block $break|0
-    local.get $2
-    local.get $3
-    local.get $0
-    i32.load offset=4
-    local.tee $4
     local.get $3
     local.get $4
+    local.get $0
+    i32.load offset=4
+    local.tee $2
+    local.get $4
+    local.get $2
     i32.lt_s
     select
     i32.ge_s
@@ -3256,7 +3259,8 @@
     global.set $~argc
     local.get $0
     i32.load
-    local.get $2
+    local.get $3
+    local.tee $2
     i32.const 2
     i32.shl
     i32.add
@@ -3272,7 +3276,7 @@
      local.get $2
      i32.const 1
      i32.add
-     local.set $2
+     local.set $3
      br $repeat|0
     end
     unreachable
@@ -3320,15 +3324,15 @@
   block $break|0
    local.get $0
    i32.load offset=4
-   local.set $3
+   local.set $4
    loop $repeat|0
-    local.get $2
-    local.get $3
-    local.get $0
-    i32.load offset=4
-    local.tee $4
     local.get $3
     local.get $4
+    local.get $0
+    i32.load offset=4
+    local.tee $2
+    local.get $4
+    local.get $2
     i32.lt_s
     select
     i32.ge_s
@@ -3337,7 +3341,8 @@
     global.set $~argc
     local.get $0
     i32.load
-    local.get $2
+    local.get $3
+    local.tee $2
     i32.const 2
     i32.shl
     i32.add
@@ -3349,7 +3354,7 @@
     local.get $2
     i32.const 1
     i32.add
-    local.set $2
+    local.set $3
     br $repeat|0
     unreachable
    end
@@ -3506,22 +3511,23 @@
     i32.const 3
     global.set $~argc
     local.get $1
+    local.tee $2
     i32.const 2
     i32.shl
-    local.tee $2
+    local.tee $1
     local.get $5
     i32.add
     local.get $0
     i32.load
-    local.get $2
+    local.get $1
     i32.add
     i32.load offset=8
-    local.get $1
+    local.get $2
     local.get $0
     i32.const 22
     call_indirect (type $iiif)
     f32.store offset=8
-    local.get $1
+    local.get $2
     i32.const 1
     i32.add
     local.set $1
@@ -3549,28 +3555,29 @@
   (local $6 i32)
   local.get $0
   i32.load offset=4
-  local.tee $3
-  call $~lib/array/Array<i32>#constructor
   local.tee $4
+  call $~lib/array/Array<i32>#constructor
+  local.tee $5
   i32.load
-  local.set $5
+  local.set $6
   loop $repeat|0
    block $break|0
-    local.get $2
     local.get $3
+    local.get $4
     local.get $0
     i32.load offset=4
-    local.tee $6
-    local.get $3
-    local.get $6
+    local.tee $2
+    local.get $4
+    local.get $2
     i32.lt_s
     select
     i32.ge_s
     br_if $break|0
     i32.const 3
     global.set $~argc
-    local.get $5
-    local.get $2
+    local.get $6
+    local.get $3
+    local.tee $2
     i32.const 2
     i32.shl
     i32.add
@@ -3589,11 +3596,11 @@
     local.get $2
     i32.const 1
     i32.add
-    local.set $2
+    local.set $3
     br $repeat|0
    end
   end
-  local.get $4
+  local.get $5
  )
  (func $start~anonymous|24 (; 55 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   global.get $std/array/i
@@ -3644,25 +3651,26 @@
     local.get $0
     i32.load
     local.get $2
+    local.tee $3
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=8
-    local.set $3
+    local.set $2
     i32.const 3
     global.set $~argc
-    local.get $3
     local.get $2
+    local.get $3
     local.get $0
     local.get $1
     call_indirect (type $iiii)
     if
      local.get $4
-     local.get $3
+     local.get $2
      call $~lib/array/Array<i32>#push
      drop
     end
-    local.get $2
+    local.get $3
     i32.const 1
     i32.add
     local.set $2
@@ -3714,12 +3722,16 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  local.get $2
+  local.set $3
+  i32.const 0
+  local.set $2
   local.get $0
   i32.load offset=4
   local.set $4
   loop $repeat|0
    block $break|0
-    local.get $3
+    local.get $2
     local.get $4
     local.get $0
     i32.load offset=4
@@ -3732,27 +3744,27 @@
     br_if $break|0
     i32.const 4
     global.set $~argc
-    local.get $2
+    local.get $3
     local.get $0
     i32.load
-    local.get $3
+    local.get $2
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=8
-    local.get $3
+    local.get $2
     local.get $0
     local.get $1
     call_indirect (type $iiiii)
-    local.set $2
-    local.get $3
+    local.set $3
+    local.get $2
     i32.const 1
     i32.add
-    local.set $3
+    local.set $2
     br $repeat|0
    end
   end
-  local.get $2
+  local.get $3
  )
  (func $start~anonymous|32 (; 64 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
@@ -4004,9 +4016,9 @@
  (func $~lib/internal/sort/weakHeapSort<f32> (; 72 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
+  (local $5 f32)
   (local $6 f32)
-  (local $7 f32)
+  (local $7 i32)
   (local $8 i32)
   local.get $1
   i32.const 31
@@ -4015,36 +4027,36 @@
   i32.shr_s
   i32.const 2
   i32.shl
-  local.tee $5
+  local.tee $3
   call $~lib/allocator/arena/__memory_allocate
-  local.tee $8
+  local.tee $7
   i32.const 0
-  local.get $5
+  local.get $3
   call $~lib/internal/memory/memset
   local.get $1
   i32.const 1
   i32.sub
-  local.set $3
+  local.set $4
   loop $repeat|0
-   local.get $3
+   local.get $4
    i32.const 0
    i32.gt_s
    if
-    local.get $3
-    local.set $5
+    local.get $4
+    local.set $3
     loop $continue|1
-     local.get $5
+     local.get $3
      i32.const 1
      i32.and
-     local.get $5
+     local.get $3
      i32.const 6
      i32.shr_s
      i32.const 2
      i32.shl
-     local.get $8
+     local.get $7
      i32.add
      i32.load
-     local.get $5
+     local.get $3
      i32.const 1
      i32.shr_s
      i32.const 31
@@ -4054,63 +4066,56 @@
      i32.and
      i32.eq
      if
-      local.get $5
+      local.get $3
       i32.const 1
       i32.shr_s
-      local.set $5
+      local.set $3
       br $continue|1
      end
     end
-    local.get $5
+    local.get $3
     i32.const 1
     i32.shr_s
-    local.tee $4
-    i32.const 2
-    i32.shl
-    local.get $0
-    i32.add
-    f32.load offset=8
-    local.set $7
-    local.get $3
+    local.tee $3
     i32.const 2
     i32.shl
     local.get $0
     i32.add
     f32.load offset=8
     local.set $6
+    local.get $4
+    i32.const 2
+    i32.shl
+    local.get $0
+    i32.add
+    f32.load offset=8
+    local.set $5
     i32.const 2
     global.set $~argc
-    local.get $7
     local.get $6
+    local.get $5
     local.get $2
     call_indirect (type $ffi)
     i32.const 0
     i32.lt_s
     if
-     local.get $3
+     local.get $4
      i32.const 5
      i32.shr_s
      i32.const 2
      i32.shl
-     local.get $8
+     local.get $7
      i32.add
-     local.tee $5
-     local.get $5
+     local.tee $8
+     local.get $8
      i32.load
      i32.const 1
-     local.get $3
+     local.get $4
      i32.const 31
      i32.and
      i32.shl
      i32.xor
      i32.store
-     local.get $3
-     i32.const 2
-     i32.shl
-     local.get $0
-     i32.add
-     local.get $7
-     f32.store offset=8
      local.get $4
      i32.const 2
      i32.shl
@@ -4118,28 +4123,35 @@
      i32.add
      local.get $6
      f32.store offset=8
+     local.get $3
+     i32.const 2
+     i32.shl
+     local.get $0
+     i32.add
+     local.get $5
+     f32.store offset=8
     end
-    local.get $3
+    local.get $4
     i32.const 1
     i32.sub
-    local.set $3
+    local.set $4
     br $repeat|0
    end
   end
   local.get $1
   i32.const 1
   i32.sub
-  local.set $3
+  local.set $4
   loop $repeat|2
-   local.get $3
+   local.get $4
    i32.const 2
    i32.ge_s
    if
     local.get $0
     f32.load offset=8
-    local.set $6
+    local.set $5
     local.get $0
-    local.get $3
+    local.get $4
     i32.const 2
     i32.shl
     local.get $0
@@ -4148,101 +4160,101 @@
     f32.load offset=8
     f32.store offset=8
     local.get $1
-    local.get $6
+    local.get $5
     f32.store offset=8
     i32.const 1
-    local.set $4
+    local.set $1
     loop $continue|3
-     local.get $4
+     local.get $1
      i32.const 5
      i32.shr_s
      i32.const 2
      i32.shl
-     local.get $8
+     local.get $7
      i32.add
      i32.load
-     local.get $4
+     local.get $1
      i32.const 31
      i32.and
      i32.shr_u
      i32.const 1
      i32.and
-     local.get $4
+     local.get $1
      i32.const 1
      i32.shl
      i32.add
-     local.tee $5
-     local.get $3
+     local.tee $3
+     local.get $4
      i32.lt_s
      if
-      local.get $5
-      local.set $4
+      local.get $3
+      local.set $1
       br $continue|3
      end
     end
     loop $continue|4
-     local.get $4
+     local.get $1
      i32.const 0
      i32.gt_s
      if
       local.get $0
       f32.load offset=8
-      local.set $6
-      local.get $4
+      local.set $5
+      local.get $1
       i32.const 2
       i32.shl
       local.get $0
       i32.add
       f32.load offset=8
-      local.set $7
+      local.set $6
       i32.const 2
       global.set $~argc
+      local.get $5
       local.get $6
-      local.get $7
       local.get $2
       call_indirect (type $ffi)
       i32.const 0
       i32.lt_s
       if
-       local.get $4
+       local.get $1
        i32.const 5
        i32.shr_s
        i32.const 2
        i32.shl
-       local.get $8
+       local.get $7
        i32.add
-       local.tee $1
-       local.get $1
+       local.tee $3
+       local.get $3
        i32.load
        i32.const 1
-       local.get $4
+       local.get $1
        i32.const 31
        i32.and
        i32.shl
        i32.xor
        i32.store
-       local.get $4
+       local.get $1
        i32.const 2
        i32.shl
        local.get $0
        i32.add
-       local.get $6
+       local.get $5
        f32.store offset=8
        local.get $0
-       local.get $7
+       local.get $6
        f32.store offset=8
       end
-      local.get $4
+      local.get $1
       i32.const 1
       i32.shr_s
-      local.set $4
+      local.set $1
       br $continue|4
      end
     end
-    local.get $3
+    local.get $4
     i32.const 1
     i32.sub
-    local.set $3
+    local.set $4
     br $repeat|2
    end
   end
@@ -4251,13 +4263,13 @@
   i32.add
   local.tee $1
   f32.load offset=8
-  local.set $6
+  local.set $5
   local.get $1
   local.get $0
   f32.load offset=8
   f32.store offset=8
   local.get $0
-  local.get $6
+  local.get $5
   f32.store offset=8
  )
  (func $~lib/array/Array<f32>#sort (; 73 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
@@ -4265,6 +4277,7 @@
   (local $3 i32)
   (local $4 f32)
   (local $5 f32)
+  (local $6 i32)
   local.get $1
   i32.eqz
   if
@@ -4320,23 +4333,26 @@
    local.get $0
    return
   end
+  local.get $2
+  local.set $6
   local.get $3
+  local.tee $2
   i32.const 256
   i32.lt_s
   if
+   local.get $6
    local.get $2
-   local.get $3
    local.get $1
    call $~lib/internal/sort/insertionSort<f32>
   else   
+   local.get $6
    local.get $2
-   local.get $3
    local.get $1
    call $~lib/internal/sort/weakHeapSort<f32>
   end
   local.get $0
  )
- (func $~lib/array/Array<f32>#sort|trampoline~anonymous|44 (; 74 ;) (type $ffi) (param $0 f32) (param $1 f32) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<f32>~anonymous|44 (; 74 ;) (type $ffi) (param $0 f32) (param $1 f32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -4573,9 +4589,9 @@
  (func $~lib/internal/sort/weakHeapSort<f64> (; 77 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
+  (local $5 f64)
   (local $6 f64)
-  (local $7 f64)
+  (local $7 i32)
   (local $8 i32)
   local.get $1
   i32.const 31
@@ -4584,36 +4600,36 @@
   i32.shr_s
   i32.const 2
   i32.shl
-  local.tee $5
+  local.tee $3
   call $~lib/allocator/arena/__memory_allocate
-  local.tee $8
+  local.tee $7
   i32.const 0
-  local.get $5
+  local.get $3
   call $~lib/internal/memory/memset
   local.get $1
   i32.const 1
   i32.sub
-  local.set $3
+  local.set $4
   loop $repeat|0
-   local.get $3
+   local.get $4
    i32.const 0
    i32.gt_s
    if
-    local.get $3
-    local.set $5
+    local.get $4
+    local.set $3
     loop $continue|1
-     local.get $5
+     local.get $3
      i32.const 1
      i32.and
-     local.get $5
+     local.get $3
      i32.const 6
      i32.shr_s
      i32.const 2
      i32.shl
-     local.get $8
+     local.get $7
      i32.add
      i32.load
-     local.get $5
+     local.get $3
      i32.const 1
      i32.shr_s
      i32.const 31
@@ -4623,63 +4639,56 @@
      i32.and
      i32.eq
      if
-      local.get $5
+      local.get $3
       i32.const 1
       i32.shr_s
-      local.set $5
+      local.set $3
       br $continue|1
      end
     end
-    local.get $5
+    local.get $3
     i32.const 1
     i32.shr_s
-    local.tee $4
-    i32.const 3
-    i32.shl
-    local.get $0
-    i32.add
-    f64.load offset=8
-    local.set $7
-    local.get $3
+    local.tee $3
     i32.const 3
     i32.shl
     local.get $0
     i32.add
     f64.load offset=8
     local.set $6
+    local.get $4
+    i32.const 3
+    i32.shl
+    local.get $0
+    i32.add
+    f64.load offset=8
+    local.set $5
     i32.const 2
     global.set $~argc
-    local.get $7
     local.get $6
+    local.get $5
     local.get $2
     call_indirect (type $FFi)
     i32.const 0
     i32.lt_s
     if
-     local.get $3
+     local.get $4
      i32.const 5
      i32.shr_s
      i32.const 2
      i32.shl
-     local.get $8
+     local.get $7
      i32.add
-     local.tee $5
-     local.get $5
+     local.tee $8
+     local.get $8
      i32.load
      i32.const 1
-     local.get $3
+     local.get $4
      i32.const 31
      i32.and
      i32.shl
      i32.xor
      i32.store
-     local.get $3
-     i32.const 3
-     i32.shl
-     local.get $0
-     i32.add
-     local.get $7
-     f64.store offset=8
      local.get $4
      i32.const 3
      i32.shl
@@ -4687,28 +4696,35 @@
      i32.add
      local.get $6
      f64.store offset=8
+     local.get $3
+     i32.const 3
+     i32.shl
+     local.get $0
+     i32.add
+     local.get $5
+     f64.store offset=8
     end
-    local.get $3
+    local.get $4
     i32.const 1
     i32.sub
-    local.set $3
+    local.set $4
     br $repeat|0
    end
   end
   local.get $1
   i32.const 1
   i32.sub
-  local.set $3
+  local.set $4
   loop $repeat|2
-   local.get $3
+   local.get $4
    i32.const 2
    i32.ge_s
    if
     local.get $0
     f64.load offset=8
-    local.set $6
+    local.set $5
     local.get $0
-    local.get $3
+    local.get $4
     i32.const 3
     i32.shl
     local.get $0
@@ -4717,101 +4733,101 @@
     f64.load offset=8
     f64.store offset=8
     local.get $1
-    local.get $6
+    local.get $5
     f64.store offset=8
     i32.const 1
-    local.set $4
+    local.set $1
     loop $continue|3
-     local.get $4
+     local.get $1
      i32.const 5
      i32.shr_s
      i32.const 2
      i32.shl
-     local.get $8
+     local.get $7
      i32.add
      i32.load
-     local.get $4
+     local.get $1
      i32.const 31
      i32.and
      i32.shr_u
      i32.const 1
      i32.and
-     local.get $4
+     local.get $1
      i32.const 1
      i32.shl
      i32.add
-     local.tee $5
-     local.get $3
+     local.tee $3
+     local.get $4
      i32.lt_s
      if
-      local.get $5
-      local.set $4
+      local.get $3
+      local.set $1
       br $continue|3
      end
     end
     loop $continue|4
-     local.get $4
+     local.get $1
      i32.const 0
      i32.gt_s
      if
       local.get $0
       f64.load offset=8
-      local.set $6
-      local.get $4
+      local.set $5
+      local.get $1
       i32.const 3
       i32.shl
       local.get $0
       i32.add
       f64.load offset=8
-      local.set $7
+      local.set $6
       i32.const 2
       global.set $~argc
+      local.get $5
       local.get $6
-      local.get $7
       local.get $2
       call_indirect (type $FFi)
       i32.const 0
       i32.lt_s
       if
-       local.get $4
+       local.get $1
        i32.const 5
        i32.shr_s
        i32.const 2
        i32.shl
-       local.get $8
+       local.get $7
        i32.add
-       local.tee $1
-       local.get $1
+       local.tee $3
+       local.get $3
        i32.load
        i32.const 1
-       local.get $4
+       local.get $1
        i32.const 31
        i32.and
        i32.shl
        i32.xor
        i32.store
-       local.get $4
+       local.get $1
        i32.const 3
        i32.shl
        local.get $0
        i32.add
-       local.get $6
+       local.get $5
        f64.store offset=8
        local.get $0
-       local.get $7
+       local.get $6
        f64.store offset=8
       end
-      local.get $4
+      local.get $1
       i32.const 1
       i32.shr_s
-      local.set $4
+      local.set $1
       br $continue|4
      end
     end
-    local.get $3
+    local.get $4
     i32.const 1
     i32.sub
-    local.set $3
+    local.set $4
     br $repeat|2
    end
   end
@@ -4820,13 +4836,13 @@
   i32.add
   local.tee $1
   f64.load offset=8
-  local.set $6
+  local.set $5
   local.get $1
   local.get $0
   f64.load offset=8
   f64.store offset=8
   local.get $0
-  local.get $6
+  local.get $5
   f64.store offset=8
  )
  (func $~lib/array/Array<f64>#sort (; 78 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
@@ -4834,6 +4850,7 @@
   (local $3 i32)
   (local $4 f64)
   (local $5 f64)
+  (local $6 i32)
   local.get $1
   i32.eqz
   if
@@ -4889,23 +4906,26 @@
    local.get $0
    return
   end
+  local.get $2
+  local.set $6
   local.get $3
+  local.tee $2
   i32.const 256
   i32.lt_s
   if
+   local.get $6
    local.get $2
-   local.get $3
    local.get $1
    call $~lib/internal/sort/insertionSort<f64>
   else   
+   local.get $6
    local.get $2
-   local.get $3
    local.get $1
    call $~lib/internal/sort/weakHeapSort<f64>
   end
   local.get $0
  )
- (func $~lib/array/Array<f64>#sort|trampoline~anonymous|45 (; 79 ;) (type $FFi) (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<f64>~anonymous|45 (; 79 ;) (type $FFi) (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   local.get $0
@@ -5077,7 +5097,7 @@
     local.get $0
     i32.add
     i32.load offset=8
-    local.set $6
+    local.set $5
     local.get $4
     i32.const 1
     i32.sub
@@ -5094,31 +5114,29 @@
        local.get $0
        i32.add
        i32.load offset=8
-       local.set $5
+       local.set $6
        i32.const 2
        global.set $~argc
-       local.get $6
        local.get $5
+       local.get $6
        local.get $2
        call_indirect (type $iii)
        i32.const 0
        i32.ge_s
        br_if $break|1
-       local.get $5
-       local.set $7
        local.get $3
-       local.tee $5
+       local.tee $7
        i32.const 1
        i32.sub
        local.set $3
-       local.get $5
+       local.get $7
        i32.const 1
        i32.add
        i32.const 2
        i32.shl
        local.get $0
        i32.add
-       local.get $7
+       local.get $6
        i32.store offset=8
        br $continue|1
       end
@@ -5131,7 +5149,7 @@
     i32.shl
     local.get $0
     i32.add
-    local.get $6
+    local.get $5
     i32.store offset=8
     local.get $4
     i32.const 1
@@ -5155,28 +5173,28 @@
   i32.shr_s
   i32.const 2
   i32.shl
-  local.tee $6
+  local.tee $3
   call $~lib/allocator/arena/__memory_allocate
   local.tee $7
   i32.const 0
-  local.get $6
+  local.get $3
   call $~lib/internal/memory/memset
   local.get $1
   i32.const 1
   i32.sub
-  local.set $3
+  local.set $4
   loop $repeat|0
-   local.get $3
+   local.get $4
    i32.const 0
    i32.gt_s
    if
-    local.get $3
-    local.set $4
+    local.get $4
+    local.set $3
     loop $continue|1
-     local.get $4
+     local.get $3
      i32.const 1
      i32.and
-     local.get $4
+     local.get $3
      i32.const 6
      i32.shr_s
      i32.const 2
@@ -5184,7 +5202,7 @@
      local.get $7
      i32.add
      i32.load
-     local.get $4
+     local.get $3
      i32.const 1
      i32.shr_s
      i32.const 31
@@ -5194,40 +5212,40 @@
      i32.and
      i32.eq
      if
-      local.get $4
+      local.get $3
       i32.const 1
       i32.shr_s
-      local.set $4
+      local.set $3
       br $continue|1
      end
     end
-    local.get $4
+    local.get $3
     i32.const 1
     i32.shr_s
-    local.tee $5
+    local.tee $6
     i32.const 2
     i32.shl
     local.get $0
     i32.add
     i32.load offset=8
-    local.set $4
-    local.get $3
+    local.set $5
+    local.get $4
     i32.const 2
     i32.shl
     local.get $0
     i32.add
     i32.load offset=8
-    local.set $6
+    local.set $3
     i32.const 2
     global.set $~argc
-    local.get $4
-    local.get $6
+    local.get $5
+    local.get $3
     local.get $2
     call_indirect (type $iii)
     i32.const 0
     i32.lt_s
     if
-     local.get $3
+     local.get $4
      i32.const 5
      i32.shr_s
      i32.const 2
@@ -5238,40 +5256,40 @@
      local.get $8
      i32.load
      i32.const 1
-     local.get $3
+     local.get $4
      i32.const 31
      i32.and
      i32.shl
      i32.xor
      i32.store
-     local.get $3
-     i32.const 2
-     i32.shl
-     local.get $0
-     i32.add
      local.get $4
-     i32.store offset=8
-     local.get $5
      i32.const 2
      i32.shl
      local.get $0
      i32.add
+     local.get $5
+     i32.store offset=8
      local.get $6
+     i32.const 2
+     i32.shl
+     local.get $0
+     i32.add
+     local.get $3
      i32.store offset=8
     end
-    local.get $3
+    local.get $4
     i32.const 1
     i32.sub
-    local.set $3
+    local.set $4
     br $repeat|0
    end
   end
   local.get $1
   i32.const 1
   i32.sub
-  local.set $3
+  local.set $4
   loop $repeat|2
-   local.get $3
+   local.get $4
    i32.const 2
    i32.ge_s
    if
@@ -5279,7 +5297,7 @@
     i32.load offset=8
     local.set $6
     local.get $0
-    local.get $3
+    local.get $4
     i32.const 2
     i32.shl
     local.get $0
@@ -5311,11 +5329,11 @@
      i32.const 1
      i32.shl
      i32.add
-     local.tee $4
-     local.get $3
+     local.tee $3
+     local.get $4
      i32.lt_s
      if
-      local.get $4
+      local.get $3
       local.set $5
       br $continue|3
      end
@@ -5334,11 +5352,11 @@
       local.get $0
       i32.add
       i32.load offset=8
-      local.set $4
+      local.set $3
       i32.const 2
       global.set $~argc
       local.get $6
-      local.get $4
+      local.get $3
       local.get $2
       call_indirect (type $iii)
       i32.const 0
@@ -5369,7 +5387,7 @@
        local.get $6
        i32.store offset=8
        local.get $0
-       local.get $4
+       local.get $3
        i32.store offset=8
       end
       local.get $5
@@ -5379,25 +5397,25 @@
       br $continue|4
      end
     end
-    local.get $3
+    local.get $4
     i32.const 1
     i32.sub
-    local.set $3
+    local.set $4
     br $repeat|2
    end
   end
   local.get $0
   i32.const 4
   i32.add
-  local.tee $2
+  local.tee $1
   i32.load offset=8
-  local.set $1
-  local.get $2
+  local.set $3
+  local.get $1
   local.get $0
   i32.load offset=8
   i32.store offset=8
   local.get $0
-  local.get $1
+  local.get $3
   i32.store offset=8
  )
  (func $~lib/array/Array<i32>#sort (; 83 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
@@ -5416,7 +5434,7 @@
   end
   local.get $0
   i32.load offset=4
-  local.tee $2
+  local.tee $3
   i32.const 1
   i32.le_s
   if
@@ -5425,62 +5443,66 @@
   end
   local.get $0
   i32.load
-  local.set $3
-  local.get $2
+  local.set $2
+  local.get $3
   i32.const 2
   i32.eq
   if
-   local.get $3
+   local.get $2
    i32.const 4
    i32.add
    i32.load offset=8
-   local.set $2
-   local.get $3
+   local.set $3
+   local.get $2
    i32.load offset=8
    local.set $4
    i32.const 2
    global.set $~argc
-   local.get $2
+   local.get $3
    local.get $4
    local.get $1
    call_indirect (type $iii)
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $2
     i32.const 4
     i32.add
     local.get $4
     i32.store offset=8
-    local.get $3
     local.get $2
+    local.get $3
     i32.store offset=8
    end
    local.get $0
    return
   end
   local.get $2
+  local.set $4
+  local.get $1
+  local.set $2
+  local.get $3
   i32.const 256
   i32.lt_s
   if
+   local.get $4
    local.get $3
    local.get $2
-   local.get $1
    call $~lib/internal/sort/insertionSort<i32>
   else   
+   local.get $4
    local.get $3
    local.get $2
-   local.get $1
    call $~lib/internal/sort/weakHeapSort<i32>
   end
   local.get $0
  )
- (func $~lib/array/Array<i32>#sort|trampoline~anonymous|46 (; 84 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<i32>~anonymous|46 (; 84 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $~lib/array/Array<u32>#sort|trampoline~anonymous|47 (; 85 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<u32>~anonymous|47 (; 85 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.gt_u
@@ -6464,7 +6486,7 @@
   i32.load
   i32.const 1
   i32.sub
-  local.tee $4
+  local.tee $1
   i32.const 0
   i32.lt_s
   if
@@ -6480,7 +6502,7 @@
   i32.const 0
   i32.ne
   local.set $7
-  local.get $4
+  local.get $1
   i32.eqz
   if
    i32.const 4184
@@ -6493,7 +6515,7 @@
   local.get $6
   i32.const 5
   i32.add
-  local.get $4
+  local.get $1
   i32.mul
   i32.const 5
   i32.add
@@ -6501,11 +6523,11 @@
   call $~lib/internal/string/allocateUnsafe
   local.set $2
   loop $repeat|0
+   local.get $3
    local.get $1
-   local.get $4
    i32.lt_s
    if
-    local.get $1
+    local.get $3
     local.get $5
     i32.add
     i32.load8_u offset=8
@@ -6515,7 +6537,7 @@
     i32.eqz
     i32.const 4
     i32.add
-    local.set $3
+    local.set $4
     local.get $2
     local.get $0
     i32.const 4184
@@ -6523,10 +6545,10 @@
     local.get $9
     select
     i32.const 0
-    local.get $3
+    local.get $4
     call $~lib/internal/string/copyUnsafe
     local.get $0
-    local.get $3
+    local.get $4
     i32.add
     local.set $0
     local.get $7
@@ -6542,14 +6564,14 @@
      i32.add
      local.set $0
     end
-    local.get $1
+    local.get $3
     i32.const 1
     i32.add
-    local.set $1
+    local.set $3
     br $repeat|0
    end
   end
-  local.get $4
+  local.get $1
   local.get $5
   i32.add
   i32.load8_u offset=8
@@ -6559,7 +6581,7 @@
   i32.eqz
   i32.const 4
   i32.add
-  local.set $3
+  local.set $4
   local.get $2
   local.get $0
   i32.const 4184
@@ -6567,13 +6589,13 @@
   local.get $1
   select
   i32.const 0
-  local.get $3
+  local.get $4
   call $~lib/internal/string/copyUnsafe
   local.get $2
-  local.set $1
+  local.set $3
   local.get $8
   local.get $0
-  local.get $3
+  local.get $4
   i32.add
   local.tee $0
   i32.gt_s
@@ -6581,7 +6603,7 @@
    local.get $2
    local.get $0
    call $~lib/string/String#substring
-   local.set $1
+   local.set $3
    local.get $2
    i32.eqz
    if
@@ -6593,7 +6615,7 @@
     unreachable
    end
   end
-  local.get $1
+  local.get $3
  )
  (func $~lib/internal/number/decimalCount32 (; 114 ;) (type $ii) (param $0 i32) (result i32)
   local.get $0
@@ -6853,7 +6875,7 @@
   i32.load offset=4
   i32.const 1
   i32.sub
-  local.tee $4
+  local.tee $5
   i32.const 0
   i32.lt_s
   if
@@ -6862,17 +6884,17 @@
   end
   local.get $0
   i32.load
-  local.set $5
+  local.set $0
   local.get $1
   i32.load
   local.tee $6
   i32.const 0
   i32.ne
   local.set $7
-  local.get $4
+  local.get $5
   i32.eqz
   if
-   local.get $5
+   local.get $0
    i32.load offset=8
    call $~lib/internal/number/itoa32
    return
@@ -6880,24 +6902,24 @@
   local.get $6
   i32.const 11
   i32.add
-  local.get $4
+  local.get $5
   i32.mul
   i32.const 11
   i32.add
   local.tee $8
   call $~lib/internal/string/allocateUnsafe
-  local.set $0
+  local.set $4
   loop $repeat|0
    local.get $3
-   local.get $4
+   local.get $5
    i32.lt_s
    if
-    local.get $0
+    local.get $4
     local.get $2
     local.get $3
     i32.const 2
     i32.shl
-    local.get $5
+    local.get $0
     i32.add
     i32.load offset=8
     call $~lib/internal/number/itoa_stream<i32>
@@ -6906,7 +6928,7 @@
     local.set $2
     local.get $7
     if
-     local.get $0
+     local.get $4
      local.get $2
      local.get $1
      i32.const 0
@@ -6924,15 +6946,14 @@
     br $repeat|0
    end
   end
-  local.get $0
-  local.set $3
   local.get $8
-  local.get $0
-  local.get $2
   local.get $4
+  local.tee $3
+  local.get $2
+  local.get $5
   i32.const 2
   i32.shl
-  local.get $5
+  local.get $0
   i32.add
   i32.load offset=8
   call $~lib/internal/number/itoa_stream<i32>
@@ -6941,11 +6962,11 @@
   local.tee $2
   i32.gt_s
   if
-   local.get $0
+   local.get $4
    local.get $2
    call $~lib/string/String#substring
    local.set $3
-   local.get $0
+   local.get $4
    i32.eqz
    if
     i32.const 0
@@ -7014,7 +7035,7 @@
   i32.load offset=4
   i32.const 1
   i32.sub
-  local.tee $4
+  local.tee $5
   i32.const 0
   i32.lt_s
   if
@@ -7023,17 +7044,17 @@
   end
   local.get $0
   i32.load
-  local.set $5
+  local.set $0
   local.get $1
   i32.load
   local.tee $6
   i32.const 0
   i32.ne
   local.set $7
-  local.get $4
+  local.get $5
   i32.eqz
   if
-   local.get $5
+   local.get $0
    i32.load offset=8
    call $~lib/internal/number/utoa32
    return
@@ -7041,24 +7062,24 @@
   local.get $6
   i32.const 10
   i32.add
-  local.get $4
+  local.get $5
   i32.mul
   i32.const 10
   i32.add
   local.tee $8
   call $~lib/internal/string/allocateUnsafe
-  local.set $0
+  local.set $4
   loop $repeat|0
    local.get $3
-   local.get $4
+   local.get $5
    i32.lt_s
    if
-    local.get $0
+    local.get $4
     local.get $2
     local.get $3
     i32.const 2
     i32.shl
-    local.get $5
+    local.get $0
     i32.add
     i32.load offset=8
     call $~lib/internal/number/itoa_stream<u32>
@@ -7067,7 +7088,7 @@
     local.set $2
     local.get $7
     if
-     local.get $0
+     local.get $4
      local.get $2
      local.get $1
      i32.const 0
@@ -7085,15 +7106,14 @@
     br $repeat|0
    end
   end
-  local.get $0
-  local.set $3
   local.get $8
-  local.get $0
-  local.get $2
   local.get $4
+  local.tee $3
+  local.get $2
+  local.get $5
   i32.const 2
   i32.shl
-  local.get $5
+  local.get $0
   i32.add
   i32.load offset=8
   call $~lib/internal/number/itoa_stream<u32>
@@ -7102,11 +7122,11 @@
   local.tee $2
   i32.gt_s
   if
-   local.get $0
+   local.get $4
    local.get $2
    call $~lib/string/String#substring
    local.set $3
-   local.get $0
+   local.get $4
    i32.eqz
    if
     i32.const 0
@@ -7123,32 +7143,32 @@
   (local $7 i32)
   (local $8 i64)
   (local $9 i32)
-  (local $10 i64)
+  (local $10 i32)
   (local $11 i32)
-  (local $12 i32)
+  (local $12 i64)
   (local $13 i64)
   (local $14 i64)
   local.get $3
   local.get $1
   i64.sub
-  local.set $8
+  local.set $12
   i64.const 1
   i32.const 0
   local.get $4
   i32.sub
   local.tee $11
   i64.extend_i32_s
-  local.tee $13
+  local.tee $1
   i64.shl
-  local.tee $10
+  local.tee $13
   i64.const 1
   i64.sub
   local.tee $14
   local.get $3
   i64.and
-  local.set $1
+  local.set $8
   local.get $3
-  local.get $13
+  local.get $1
   i64.shr_u
   i32.wrap_i64
   local.tee $7
@@ -7156,7 +7176,7 @@
   local.set $9
   i32.const 6616
   i32.load
-  local.set $12
+  local.set $10
   loop $continue|0
    local.get $9
    i32.const 0
@@ -7312,9 +7332,9 @@
     local.get $11
     i64.extend_i32_s
     i64.shl
-    local.get $1
+    local.get $8
     i64.add
-    local.tee $3
+    local.tee $1
     local.get $5
     i64.le_u
     if
@@ -7322,7 +7342,9 @@
      local.get $9
      i32.add
      global.set $~lib/internal/number/_K
-     local.get $12
+     local.get $5
+     local.set $3
+     local.get $10
      local.get $9
      i32.const 2
      i32.shl
@@ -7331,7 +7353,9 @@
      local.get $11
      i64.extend_i32_s
      i64.shl
-     local.set $1
+     local.set $8
+     local.get $12
+     local.set $5
      local.get $6
      i32.const 1
      i32.sub
@@ -7341,37 +7365,37 @@
      i32.add
      local.tee $2
      i32.load16_u offset=4
-     local.set $7
+     local.set $10
      loop $continue|2
-      local.get $3
-      local.get $8
+      local.get $1
+      local.get $5
       i64.lt_u
       local.tee $0
       if
-       local.get $5
        local.get $3
-       i64.sub
        local.get $1
+       i64.sub
+       local.get $8
        i64.ge_u
        local.set $0
       end
       local.get $0
       if
        local.get $1
-       local.get $3
-       i64.add
        local.get $8
+       i64.add
+       local.get $5
        i64.lt_u
        local.tee $0
        i32.eqz
        if
-        local.get $8
-        local.get $3
+        local.get $5
+        local.get $1
         i64.sub
         local.get $1
-        local.get $3
-        i64.add
         local.get $8
+        i64.add
+        local.get $5
         i64.sub
         i64.gt_u
         local.set $0
@@ -7379,19 +7403,19 @@
       end
       local.get $0
       if
-       local.get $7
+       local.get $10
        i32.const 1
        i32.sub
-       local.set $7
+       local.set $10
        local.get $1
-       local.get $3
+       local.get $8
        i64.add
-       local.set $3
+       local.set $1
        br $continue|2
       end
      end
      local.get $2
-     local.get $7
+     local.get $10
      i32.store16 offset=4
      local.get $6
      return
@@ -7404,14 +7428,14 @@
    i64.const 10
    i64.mul
    local.set $5
-   local.get $1
+   local.get $8
    i64.const 10
    i64.mul
-   local.tee $1
+   local.tee $8
    local.get $11
    i64.extend_i32_s
    i64.shr_u
-   local.tee $3
+   local.tee $1
    local.get $6
    i64.extend_i32_s
    i64.or
@@ -7428,7 +7452,7 @@
     i32.shl
     local.get $0
     i32.add
-    local.get $3
+    local.get $1
     i32.wrap_i64
     i32.const 65535
     i32.and
@@ -7440,10 +7464,10 @@
    i32.const 1
    i32.sub
    local.set $9
-   local.get $1
+   local.get $8
    local.get $14
    i64.and
-   local.tee $1
+   local.tee $8
    local.get $5
    i64.ge_u
    br_if $continue|3
@@ -7451,7 +7475,9 @@
    local.get $9
    i32.add
    global.set $~lib/internal/number/_K
-   local.get $12
+   local.get $13
+   local.set $1
+   local.get $10
    i32.const 0
    local.get $9
    i32.sub
@@ -7459,49 +7485,50 @@
    i32.shl
    i32.add
    i64.load32_u offset=8
-   local.get $8
+   local.get $12
    i64.mul
-   local.set $8
+   local.set $3
    local.get $6
+   local.tee $10
    i32.const 1
    i32.sub
    i32.const 1
    i32.shl
    local.get $0
    i32.add
-   local.tee $7
+   local.tee $4
    i32.load16_u offset=4
-   local.set $4
+   local.set $6
    loop $continue|4
-    local.get $1
     local.get $8
+    local.get $3
     i64.lt_u
     local.tee $2
     if
      local.get $5
-     local.get $1
+     local.get $8
      i64.sub
-     local.get $10
+     local.get $1
      i64.ge_u
      local.set $2
     end
     local.get $2
     if
      local.get $1
-     local.get $10
-     i64.add
      local.get $8
+     i64.add
+     local.get $3
      i64.lt_u
      local.tee $2
      i32.eqz
      if
+      local.get $3
       local.get $8
-      local.get $1
       i64.sub
       local.get $1
-      local.get $10
-      i64.add
       local.get $8
+      i64.add
+      local.get $3
       i64.sub
       i64.gt_u
       local.set $2
@@ -7509,21 +7536,21 @@
     end
     local.get $2
     if
-     local.get $4
+     local.get $6
      i32.const 1
      i32.sub
-     local.set $4
+     local.set $6
      local.get $1
-     local.get $10
+     local.get $8
      i64.add
-     local.set $1
+     local.set $8
      br $continue|4
     end
    end
-   local.get $7
    local.get $4
-   i32.store16 offset=4
    local.get $6
+   i32.store16 offset=4
+   local.get $10
   end
  )
  (func $~lib/internal/number/prettify (; 123 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -7549,74 +7576,73 @@
   local.get $1
   local.get $2
   i32.add
-  local.tee $5
-  i32.le_s
   local.tee $3
+  i32.le_s
+  local.tee $4
   if
-   local.get $5
+   local.get $3
    i32.const 21
    i32.le_s
-   local.set $3
+   local.set $4
   end
-  local.get $3
+  local.get $4
   if (result i32)
    local.get $1
-   local.set $3
+   local.set $4
    loop $repeat|0
     block $break|0
+     local.get $4
      local.get $3
-     local.get $5
      i32.ge_s
      br_if $break|0
-     local.get $3
+     local.get $4
      i32.const 1
      i32.shl
      local.get $0
      i32.add
      i32.const 48
      i32.store16 offset=4
-     local.get $3
+     local.get $4
      i32.const 1
      i32.add
-     local.set $3
+     local.set $4
      br $repeat|0
     end
    end
-   local.get $5
+   local.get $3
    i32.const 1
    i32.shl
    local.get $0
    i32.add
    i32.const 3145774
    i32.store offset=4
-   local.get $5
+   local.get $3
    i32.const 2
    i32.add
   else   
-   local.get $5
+   local.get $3
    i32.const 0
    i32.gt_s
-   local.tee $3
+   local.tee $4
    if
-    local.get $5
+    local.get $3
     i32.const 21
     i32.le_s
-    local.set $3
+    local.set $4
    end
-   local.get $3
+   local.get $4
    if (result i32)
-    local.get $5
+    local.get $3
     i32.const 1
     i32.shl
     local.get $0
     i32.add
-    local.tee $3
     i32.const 4
     i32.add
-    local.tee $0
+    local.tee $4
     i32.const 2
     i32.add
-    local.get $0
+    local.get $4
     i32.const 0
     local.get $2
     i32.sub
@@ -7624,6 +7650,10 @@
     i32.shl
     call $~lib/internal/memory/memmove
     local.get $3
+    i32.const 1
+    i32.shl
+    local.get $0
+    i32.add
     i32.const 46
     i32.store16 offset=4
     local.get $1
@@ -7631,25 +7661,25 @@
     i32.add
    else    
     i32.const -6
-    local.get $5
+    local.get $3
     i32.lt_s
-    local.tee $3
+    local.tee $4
     if
-     local.get $5
+     local.get $3
      i32.const 0
      i32.le_s
-     local.set $3
+     local.set $4
     end
-    local.get $3
+    local.get $4
     if (result i32)
      local.get $0
      i32.const 4
      i32.add
      local.tee $2
      i32.const 2
-     local.get $5
+     local.get $3
      i32.sub
-     local.tee $3
+     local.tee $4
      i32.const 1
      i32.shl
      i32.add
@@ -7662,29 +7692,29 @@
      i32.const 3014704
      i32.store offset=4
      i32.const 2
-     local.set $4
+     local.set $3
      loop $repeat|1
       block $break|1
-       local.get $4
        local.get $3
+       local.get $4
        i32.ge_s
        br_if $break|1
-       local.get $4
+       local.get $3
        i32.const 1
        i32.shl
        local.get $0
        i32.add
        i32.const 48
        i32.store16 offset=4
-       local.get $4
+       local.get $3
        i32.const 1
        i32.add
-       local.set $4
+       local.set $3
        br $repeat|1
       end
      end
      local.get $1
-     local.get $3
+     local.get $4
      i32.add
     else     
      local.get $1
@@ -7697,52 +7727,52 @@
       local.get $0
       i32.const 4
       i32.add
-      local.tee $3
+      local.tee $4
       block (result i32)
-       local.get $5
+       local.get $3
        i32.const 1
        i32.sub
-       local.tee $4
+       local.tee $3
        i32.const 0
        i32.lt_s
        local.tee $2
        if
         i32.const 0
-        local.get $4
+        local.get $3
         i32.sub
-        local.set $4
+        local.set $3
        end
-       local.get $4
+       local.get $3
       end
-      local.get $4
+      local.get $3
       call $~lib/internal/number/decimalCount32
       i32.const 1
       i32.add
-      local.tee $4
+      local.tee $5
       call $~lib/internal/number/utoa32_lut
-      local.get $3
+      local.get $4
       i32.const 45
       i32.const 43
       local.get $2
       select
       i32.store16 offset=4
-      local.get $4
+      local.get $5
       i32.const 2
       i32.add
      else      
       local.get $0
       i32.const 4
       i32.add
-      local.tee $3
+      local.tee $4
       i32.const 4
       i32.add
-      local.get $3
+      local.get $4
       i32.const 2
       i32.add
       local.get $1
       i32.const 1
       i32.shl
-      local.tee $4
+      local.tee $5
       i32.const 2
       i32.sub
       call $~lib/internal/memory/memmove
@@ -7750,7 +7780,7 @@
       i32.const 46
       i32.store16 offset=6
       local.get $0
-      local.get $4
+      local.get $5
       i32.add
       local.tee $0
       i32.const 101
@@ -7758,30 +7788,30 @@
       local.get $0
       i32.const 4
       i32.add
-      local.tee $3
+      local.tee $4
       block (result i32)
-       local.get $5
+       local.get $3
        i32.const 1
        i32.sub
-       local.tee $4
+       local.tee $3
        i32.const 0
        i32.lt_s
        local.tee $2
        if
         i32.const 0
-        local.get $4
+        local.get $3
         i32.sub
-        local.set $4
+        local.set $3
        end
-       local.get $4
+       local.get $3
       end
-      local.get $4
+      local.get $3
       call $~lib/internal/number/decimalCount32
       i32.const 1
       i32.add
       local.tee $0
       call $~lib/internal/number/utoa32_lut
-      local.get $3
+      local.get $4
       i32.const 45
       i32.const 43
       local.get $2
@@ -7803,19 +7833,18 @@
   (local $4 i32)
   (local $5 i64)
   (local $6 i32)
-  (local $7 i64)
-  (local $8 i32)
+  (local $7 i32)
+  (local $8 i64)
   (local $9 i64)
   (local $10 i64)
   (local $11 i64)
-  (local $12 i64)
-  (local $13 i32)
+  (local $12 i32)
+  (local $13 i64)
   (local $14 i32)
-  (local $15 i64)
   local.get $1
   f64.const 0
   f64.lt
-  local.tee $13
+  local.tee $12
   if (result f64)
    local.get $0
    i32.const 45
@@ -7826,32 +7855,32 @@
    local.get $1
   end
   i64.reinterpret_f64
-  local.tee $2
+  local.tee $13
   i64.const 9218868437227405312
   i64.and
   i64.const 52
   i64.shr_u
   i32.wrap_i64
-  local.set $8
-  local.get $2
+  local.set $7
+  local.get $13
   i64.const 4503599627370495
   i64.and
-  local.get $8
+  local.get $7
   i32.const 0
   i32.ne
-  local.tee $6
+  local.tee $4
   i64.extend_i32_u
   i64.const 52
   i64.shl
   i64.add
   local.set $2
-  local.get $8
+  local.get $7
   i32.const 1
-  local.get $6
+  local.get $4
   select
   i32.const 1075
   i32.sub
-  local.tee $8
+  local.tee $7
   i32.const 1
   i32.sub
   local.set $6
@@ -7880,7 +7909,7 @@
   i64.shl
   i64.const 1
   i64.sub
-  local.get $8
+  local.get $7
   local.get $14
   i32.sub
   local.get $6
@@ -7947,27 +7976,27 @@
   local.tee $2
   i64.const 4294967295
   i64.and
-  local.tee $7
+  local.tee $8
   global.get $~lib/internal/number/_frc_pow
   local.tee $5
   i64.const 4294967295
   i64.and
   local.tee $9
   i64.mul
-  local.set $10
+  local.set $3
   local.get $5
   i64.const 32
   i64.shr_u
-  local.tee $11
-  local.get $7
+  local.tee $10
+  local.get $8
   i64.mul
   local.get $2
   i64.const 32
   i64.shr_u
-  local.tee $12
+  local.tee $2
   local.get $9
   i64.mul
-  local.get $10
+  local.get $3
   i64.const 32
   i64.shr_u
   i64.add
@@ -7979,43 +8008,43 @@
   i64.add
   i64.const 32
   i64.shr_u
-  local.get $11
-  local.get $12
+  local.get $2
+  local.get $10
   i64.mul
   local.get $3
   i64.const 32
   i64.shr_u
   i64.add
   i64.add
-  local.set $2
+  local.set $13
   local.get $5
   i64.const 4294967295
   i64.and
-  local.tee $11
+  local.tee $2
   global.get $~lib/internal/number/_frc_plus
   local.tee $3
   i64.const 4294967295
   i64.and
   local.tee $10
   i64.mul
-  local.set $7
+  local.set $11
   local.get $10
   local.get $5
+  i64.const 32
+  i64.shr_u
+  local.tee $8
+  i64.mul
+  local.get $2
+  local.get $3
   i64.const 32
   i64.shr_u
   local.tee $9
   i64.mul
   local.get $11
-  local.get $3
-  i64.const 32
-  i64.shr_u
-  local.tee $12
-  i64.mul
-  local.get $7
   i64.const 32
   i64.shr_u
   i64.add
-  local.tee $3
+  local.tee $2
   i64.const 4294967295
   i64.and
   i64.add
@@ -8023,97 +8052,95 @@
   i64.add
   i64.const 32
   i64.shr_u
+  local.get $8
   local.get $9
-  local.get $12
   i64.mul
-  local.get $3
+  local.get $2
   i64.const 32
   i64.shr_u
   i64.add
   i64.add
-  local.set $15
+  local.set $11
   global.get $~lib/internal/number/_frc_minus
-  local.tee $3
+  local.tee $2
   i64.const 4294967295
   i64.and
-  local.tee $7
+  local.tee $8
   local.get $5
   i64.const 4294967295
   i64.and
   local.tee $9
   i64.mul
-  local.set $10
-  local.get $5
-  i64.const 32
-  i64.shr_u
-  local.tee $11
-  local.get $7
-  i64.mul
-  local.get $3
-  i64.const 32
-  i64.shr_u
-  local.tee $12
-  local.get $9
-  i64.mul
-  local.get $10
-  i64.const 32
-  i64.shr_u
-  i64.add
-  local.tee $3
-  i64.const 4294967295
-  i64.and
-  i64.add
-  local.set $5
-  local.get $15
+  local.set $3
+  local.get $11
   i64.const 1
   i64.sub
-  local.tee $7
-  local.get $11
-  local.get $12
+  local.tee $11
+  local.get $5
+  i64.const 32
+  i64.shr_u
+  local.tee $10
+  local.get $8
+  i64.mul
+  local.get $2
+  i64.const 32
+  i64.shr_u
+  local.tee $2
+  local.get $9
   i64.mul
   local.get $3
   i64.const 32
   i64.shr_u
   i64.add
-  local.get $5
+  local.tee $3
+  i64.const 4294967295
+  i64.and
+  i64.add
   i64.const 2147483647
   i64.add
   i64.const 32
   i64.shr_u
+  local.get $2
+  local.get $10
+  i64.mul
+  local.get $3
+  i64.const 32
+  i64.shr_u
+  i64.add
   i64.add
   i64.const 1
   i64.add
   i64.sub
   local.set $3
-  local.get $13
+  local.get $12
   i32.const 1
   i32.shl
   local.get $0
   i32.add
   local.get $0
-  local.get $2
-  local.get $8
+  local.get $13
+  global.get $~lib/internal/number/_exp_pow
+  local.tee $14
+  local.get $7
   local.get $4
   i32.sub
-  global.get $~lib/internal/number/_exp_pow
-  local.tee $4
   i32.add
   i32.const -64
   i32.sub
-  local.get $7
-  local.get $4
+  local.get $11
   global.get $~lib/internal/number/_exp
+  local.get $14
   i32.add
   i32.const -64
   i32.sub
   local.get $3
-  local.get $13
+  local.get $12
   call $~lib/internal/number/genDigits
-  local.get $13
+  local.get $12
   i32.sub
   global.get $~lib/internal/number/_K
   call $~lib/internal/number/prettify
-  local.get $13
+  local.get $12
   i32.add
  )
  (func $~lib/internal/number/dtoa (; 125 ;) (type $Fi) (param $0 f64) (result i32)
@@ -8380,7 +8407,7 @@
   end
   local.get $0
   i32.load
-  local.set $6
+  local.set $0
   local.get $1
   i32.load
   local.tee $7
@@ -8390,114 +8417,110 @@
   local.get $5
   i32.eqz
   if
-   local.get $6
+   local.get $0
    i32.load offset=8
    return
   end
-  i32.const 0
-  local.set $0
   local.get $5
   i32.const 1
   i32.add
-  local.set $2
+  local.set $3
   loop $repeat|0
    block $break|0
-    local.get $0
-    local.get $2
+    local.get $4
+    local.get $3
     i32.ge_s
     br_if $break|0
-    local.get $6
     local.get $0
+    local.get $4
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=8
     i32.load
-    local.get $3
+    local.get $2
     i32.add
-    local.set $3
-    local.get $0
+    local.set $2
+    local.get $4
     i32.const 1
     i32.add
-    local.set $0
+    local.set $4
     br $repeat|0
    end
   end
   i32.const 0
-  local.set $2
+  local.set $3
   local.get $5
   local.get $7
   i32.mul
-  local.get $3
+  local.get $2
   i32.add
   call $~lib/internal/string/allocateUnsafe
-  local.set $0
-  i32.const 0
-  local.set $3
+  local.set $4
   loop $repeat|1
    block $break|1
-    local.get $3
+    local.get $6
     local.get $5
     i32.ge_s
     br_if $break|1
+    local.get $0
     local.get $6
-    local.get $3
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=8
-    local.tee $4
+    local.tee $2
     if
-     local.get $0
+     local.get $4
+     local.get $3
      local.get $2
-     local.get $4
      i32.const 0
-     local.get $4
+     local.get $2
      i32.load
-     local.tee $4
+     local.tee $2
      call $~lib/internal/string/copyUnsafe
      local.get $2
-     local.get $4
+     local.get $3
      i32.add
-     local.set $2
+     local.set $3
     end
     local.get $8
     if
-     local.get $0
-     local.get $2
+     local.get $4
+     local.get $3
      local.get $1
      i32.const 0
      local.get $7
      call $~lib/internal/string/copyUnsafe
-     local.get $2
+     local.get $3
      local.get $7
      i32.add
-     local.set $2
+     local.set $3
     end
-    local.get $3
+    local.get $6
     i32.const 1
     i32.add
-    local.set $3
+    local.set $6
     br $repeat|1
    end
   end
-  local.get $6
+  local.get $0
   local.get $5
   i32.const 2
   i32.shl
   i32.add
   i32.load offset=8
-  local.tee $4
+  local.tee $2
   if
-   local.get $0
+   local.get $4
+   local.get $3
    local.get $2
-   local.get $4
    i32.const 0
-   local.get $4
+   local.get $2
    i32.load
    call $~lib/internal/string/copyUnsafe
   end
-  local.get $0
+  local.get $4
  )
  (func $~lib/array/Array<Ref>#join (; 129 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
@@ -8511,7 +8534,7 @@
   i32.load offset=4
   i32.const 1
   i32.sub
-  local.tee $3
+  local.tee $4
   i32.const 0
   i32.lt_s
   if
@@ -8520,40 +8543,38 @@
   end
   local.get $0
   i32.load
-  local.set $5
+  local.set $6
   i32.const 4216
   i32.load
-  local.tee $4
+  local.tee $5
   i32.const 0
   i32.ne
-  local.set $6
-  local.get $3
+  local.set $0
+  local.get $4
   i32.eqz
   if
    i32.const 6872
    return
   end
-  local.get $4
+  local.get $5
   i32.const 15
   i32.add
-  local.get $3
+  local.get $4
   i32.mul
   i32.const 15
   i32.add
   local.tee $7
   call $~lib/internal/string/allocateUnsafe
   local.set $2
-  i32.const 0
-  local.set $0
   loop $repeat|0
-   local.get $0
    local.get $3
+   local.get $4
    i32.lt_s
    if
-    local.get $0
+    local.get $3
     i32.const 2
     i32.shl
-    local.get $5
+    local.get $6
     i32.add
     i32.load offset=8
     if
@@ -8568,33 +8589,33 @@
      i32.add
      local.set $1
     end
-    local.get $6
+    local.get $0
     if
      local.get $2
      local.get $1
      i32.const 4216
      i32.const 0
-     local.get $4
+     local.get $5
      call $~lib/internal/string/copyUnsafe
      local.get $1
-     local.get $4
+     local.get $5
      i32.add
      local.set $1
     end
-    local.get $0
+    local.get $3
     i32.const 1
     i32.add
-    local.set $0
+    local.set $3
     br $repeat|0
    end
   end
   local.get $2
-  local.set $0
+  local.set $3
   block (result i32)
-   local.get $3
+   local.get $4
    i32.const 2
    i32.shl
-   local.get $5
+   local.get $6
    i32.add
    i32.load offset=8
    if
@@ -8617,7 +8638,7 @@
    local.get $2
    local.get $1
    call $~lib/string/String#substring
-   local.set $0
+   local.set $3
    local.get $2
    i32.eqz
    if
@@ -8629,7 +8650,7 @@
     unreachable
    end
   end
-  local.get $0
+  local.get $3
  )
  (func $~lib/internal/number/itoa_stream<i8> (; 130 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -9156,22 +9177,22 @@
   if
    local.get $2
    i32.wrap_i64
-   local.tee $3
+   local.tee $1
    call $~lib/internal/number/decimalCount32
-   local.set $1
+   local.set $3
    local.get $0
-   local.get $3
    local.get $1
+   local.get $3
    call $~lib/internal/number/utoa32_lut
   else   
    local.get $0
    local.get $2
    local.get $2
    call $~lib/internal/number/decimalCount64
-   local.tee $1
+   local.tee $3
    call $~lib/internal/number/utoa64_lut
   end
-  local.get $1
+  local.get $3
  )
  (func $~lib/array/Array<u64>#join (; 138 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
@@ -9385,14 +9406,14 @@
   if
    local.get $2
    i32.wrap_i64
-   local.tee $4
+   local.tee $1
    call $~lib/internal/number/decimalCount32
    local.get $3
    i32.add
-   local.set $1
+   local.set $4
    local.get $0
-   local.get $4
    local.get $1
+   local.get $4
    call $~lib/internal/number/utoa32_lut
   else   
    local.get $0
@@ -9401,7 +9422,7 @@
    call $~lib/internal/number/decimalCount64
    local.get $3
    i32.add
-   local.tee $1
+   local.tee $4
    call $~lib/internal/number/utoa64_lut
   end
   local.get $3
@@ -9410,7 +9431,7 @@
    i32.const 45
    i32.store16 offset=4
   end
-  local.get $1
+  local.get $4
  )
  (func $~lib/array/Array<i64>#join (; 141 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
@@ -9666,7 +9687,7 @@
   i32.load offset=4
   i32.const 1
   i32.sub
-  local.tee $4
+  local.tee $5
   i32.const 0
   i32.lt_s
   if
@@ -9675,17 +9696,17 @@
   end
   local.get $0
   i32.load
-  local.set $5
+  local.set $0
   local.get $1
   i32.load
   local.tee $6
   i32.const 0
   i32.ne
   local.set $7
-  local.get $4
+  local.get $5
   i32.eqz
   if
-   local.get $5
+   local.get $0
    i32.load8_u offset=8
    call $~lib/internal/number/utoa32
    return
@@ -9693,22 +9714,22 @@
   local.get $6
   i32.const 10
   i32.add
-  local.get $4
+  local.get $5
   i32.mul
   i32.const 10
   i32.add
   local.tee $8
   call $~lib/internal/string/allocateUnsafe
-  local.set $0
+  local.set $4
   loop $repeat|0
    local.get $3
-   local.get $4
+   local.get $5
    i32.lt_s
    if
-    local.get $0
+    local.get $4
     local.get $2
+    local.get $0
     local.get $3
-    local.get $5
     i32.add
     i32.load8_u offset=8
     call $~lib/internal/number/itoa_stream<u8>
@@ -9717,7 +9738,7 @@
     local.set $2
     local.get $7
     if
-     local.get $0
+     local.get $4
      local.get $2
      local.get $1
      i32.const 0
@@ -9735,12 +9756,11 @@
     br $repeat|0
    end
   end
-  local.get $0
-  local.set $3
   local.get $8
-  local.get $0
-  local.get $2
   local.get $4
+  local.tee $3
+  local.get $2
+  local.get $0
   local.get $5
   i32.add
   i32.load8_u offset=8
@@ -9750,11 +9770,11 @@
   local.tee $2
   i32.gt_s
   if
-   local.get $0
+   local.get $4
    local.get $2
    call $~lib/string/String#substring
    local.set $3
-   local.get $0
+   local.get $4
    i32.eqz
    if
     i32.const 0

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -334,7 +334,7 @@
  (data (i32.const 8408) "\04\00\00\00\00\00\00\00\d0 \00\00\00\00\00\00")
  (data (i32.const 8424) "\d8 \00\00\01\00\00\00")
  (table $0 57 funcref)
- (elem (i32.const 0) $null $start~anonymous|1 $start~anonymous|2 $start~anonymous|3 $start~anonymous|4 $start~anonymous|5 $start~anonymous|6 $start~anonymous|7 $start~anonymous|8 $start~anonymous|9 $start~anonymous|10 $start~anonymous|11 $start~anonymous|12 $start~anonymous|13 $start~anonymous|14 $start~anonymous|15 $start~anonymous|16 $start~anonymous|17 $start~anonymous|18 $start~anonymous|19 $start~anonymous|20 $start~anonymous|21 $start~anonymous|22 $start~anonymous|23 $start~anonymous|24 $start~anonymous|25 $start~anonymous|26 $start~anonymous|27 $start~anonymous|28 $start~anonymous|29 $start~anonymous|30 $start~anonymous|31 $start~anonymous|32 $start~anonymous|33 $start~anonymous|34 $start~anonymous|35 $start~anonymous|36 $start~anonymous|37 $start~anonymous|38 $start~anonymous|39 $start~anonymous|40 $start~anonymous|41 $start~anonymous|42 $start~anonymous|43 $~lib/array/Array<f32>#sort|trampoline~anonymous|44 $~lib/array/Array<f64>#sort|trampoline~anonymous|45 $~lib/array/Array<i32>#sort|trampoline~anonymous|46 $~lib/array/Array<u32>#sort|trampoline~anonymous|47 $std/array/assertSortedDefault<i32>~anonymous|48 $start~anonymous|49 $start~anonymous|50 $start~anonymous|51 $start~anonymous|52 $start~anonymous|53 $start~anonymous|54 $start~anonymous|55 $start~anonymous|56)
+ (elem (i32.const 0) $null $start~anonymous|1 $start~anonymous|2 $start~anonymous|3 $start~anonymous|4 $start~anonymous|5 $start~anonymous|6 $start~anonymous|7 $start~anonymous|8 $start~anonymous|9 $start~anonymous|10 $start~anonymous|11 $start~anonymous|12 $start~anonymous|13 $start~anonymous|14 $start~anonymous|15 $start~anonymous|16 $start~anonymous|17 $start~anonymous|18 $start~anonymous|19 $start~anonymous|20 $start~anonymous|21 $start~anonymous|22 $start~anonymous|23 $start~anonymous|24 $start~anonymous|25 $start~anonymous|26 $start~anonymous|27 $start~anonymous|28 $start~anonymous|29 $start~anonymous|30 $start~anonymous|31 $start~anonymous|32 $start~anonymous|33 $start~anonymous|34 $start~anonymous|35 $start~anonymous|36 $start~anonymous|37 $start~anonymous|38 $start~anonymous|39 $start~anonymous|40 $start~anonymous|41 $start~anonymous|42 $start~anonymous|43 $~lib/internal/sort/COMPARATOR<f32>~anonymous|44 $~lib/internal/sort/COMPARATOR<f64>~anonymous|45 $~lib/internal/sort/COMPARATOR<i32>~anonymous|46 $~lib/internal/sort/COMPARATOR<u32>~anonymous|47 $~lib/internal/sort/COMPARATOR<i32>~anonymous|48 $start~anonymous|49 $start~anonymous|50 $start~anonymous|51 $start~anonymous|52 $start~anonymous|53 $start~anonymous|54 $start~anonymous|55 $start~anonymous|56)
  (global $~lib/internal/allocator/AL_BITS i32 (i32.const 3))
  (global $~lib/internal/allocator/AL_SIZE i32 (i32.const 8))
  (global $~lib/internal/allocator/AL_MASK i32 (i32.const 7))
@@ -825,6 +825,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.const 268435454
   i32.gt_u
@@ -864,16 +865,20 @@
   local.get $0
   local.get $1
   i32.store offset=4
-  local.get $3
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  i32.const 0
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $2
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.0
+   local.get $3
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/memory/memset
+  end
   local.get $0
  )
  (func $~lib/array/Array.isArray<Array<i32> | null> (; 8 ;) (type $ii) (param $0 i32) (result i32)
@@ -921,6 +926,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.const 1073741816
   i32.gt_u
@@ -939,16 +945,20 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  local.get $3
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  i32.const 0
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $2
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.1
+   local.get $3
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/memory/memset
+  end
   block (result i32)
    local.get $0
    i32.eqz
@@ -1027,6 +1037,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   local.get $0
   i32.load
   local.set $4
@@ -1093,13 +1104,15 @@
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
    local.set $6
+   local.get $1
+   local.set $7
    local.get $3
    local.get $2
    i32.sub
-   local.set $7
+   local.set $8
    local.get $6
-   local.get $1
    local.get $7
+   local.get $8
    call $~lib/internal/memory/memset
   end
   local.get $0
@@ -1107,6 +1120,8 @@
  (func $~lib/array/Array<u8>#__get (; 18 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.load
   local.set $2
@@ -1117,14 +1132,18 @@
   i32.shr_u
   i32.lt_u
   if (result i32)
-   i32.const 0
-   local.set $3
    local.get $2
+   local.set $3
    local.get $1
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 0
    i32.shl
    i32.add
-   local.get $3
+   local.get $5
    i32.add
    i32.load8_u offset=8
   else   
@@ -1138,12 +1157,16 @@
   if
    block $~lib/array/Array<u8>#get:length|inlined.0 (result i32)
     local.get $0
+    local.set $3
+    local.get $3
     i32.load offset=4
    end
    local.set $2
    local.get $2
    block $~lib/array/Array<u8>#get:length|inlined.2 (result i32)
     local.get $1
+    local.set $3
+    local.get $3
     i32.load offset=4
    end
    i32.ne
@@ -1223,6 +1246,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   local.get $0
   i32.load
   local.set $4
@@ -1286,17 +1311,23 @@
     i32.lt_s
     i32.eqz
     br_if $break|0
-    block
-     i32.const 0
-     local.set $6
+    block $~lib/internal/arraybuffer/STORE<u32,u32>|inlined.0
      local.get $4
+     local.set $6
      local.get $2
+     local.set $7
+     local.get $1
+     local.set $8
+     i32.const 0
+     local.set $9
+     local.get $6
+     local.get $7
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $9
      i32.add
-     local.get $1
+     local.get $8
      i32.store offset=8
     end
     local.get $2
@@ -1313,6 +1344,8 @@
  (func $~lib/array/Array<u32>#__get (; 22 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.load
   local.set $2
@@ -1323,14 +1356,18 @@
   i32.shr_u
   i32.lt_u
   if (result i32)
-   i32.const 0
-   local.set $3
    local.get $2
+   local.set $3
    local.get $1
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 2
    i32.shl
    i32.add
-   local.get $3
+   local.get $5
    i32.add
    i32.load offset=8
   else   
@@ -1344,12 +1381,16 @@
   if
    block $~lib/array/Array<u32>#get:length|inlined.0 (result i32)
     local.get $0
+    local.set $3
+    local.get $3
     i32.load offset=4
    end
    local.set $2
    local.get $2
    block $~lib/array/Array<u32>#get:length|inlined.2 (result i32)
     local.get $1
+    local.set $3
+    local.get $3
     i32.load offset=4
    end
    i32.ne
@@ -2866,6 +2907,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.load
   local.set $2
@@ -2899,46 +2941,50 @@
     local.get $1
     call $~lib/internal/arraybuffer/allocateUnsafe
     local.set $3
-    local.get $3
-    global.get $~lib/internal/arraybuffer/HEADER_SIZE
-    i32.add
-    local.set $4
-    local.get $0
-    global.get $~lib/internal/arraybuffer/HEADER_SIZE
-    i32.add
-    local.set $5
-    local.get $4
-    local.get $5
-    local.get $2
-    call $~lib/internal/memory/memmove
+    block $~lib/memory/memory.copy|inlined.0
+     local.get $3
+     global.get $~lib/internal/arraybuffer/HEADER_SIZE
+     i32.add
+     local.set $4
+     local.get $0
+     global.get $~lib/internal/arraybuffer/HEADER_SIZE
+     i32.add
+     local.set $5
+     local.get $2
+     local.set $6
+     local.get $4
+     local.get $5
+     local.get $6
+     call $~lib/internal/memory/memmove
+    end
     block $~lib/memory/memory.free|inlined.0
-     block
-      local.get $0
-      call $~lib/allocator/arena/__memory_free
-      br $~lib/memory/memory.free|inlined.0
-      unreachable
-     end
-     unreachable
+     local.get $0
+     local.set $6
+     local.get $6
+     call $~lib/allocator/arena/__memory_free
+     br $~lib/memory/memory.free|inlined.0
     end
     local.get $3
     local.set $0
    end
-   local.get $0
-   global.get $~lib/internal/arraybuffer/HEADER_SIZE
-   i32.add
-   local.get $2
-   i32.add
-   local.set $3
-   i32.const 0
-   local.set $5
-   local.get $1
-   local.get $2
-   i32.sub
-   local.set $4
-   local.get $3
-   local.get $5
-   local.get $4
-   call $~lib/internal/memory/memset
+   block $~lib/memory/memory.fill|inlined.3
+    local.get $0
+    global.get $~lib/internal/arraybuffer/HEADER_SIZE
+    i32.add
+    local.get $2
+    i32.add
+    local.set $3
+    i32.const 0
+    local.set $6
+    local.get $1
+    local.get $2
+    i32.sub
+    local.set $5
+    local.get $3
+    local.get $6
+    local.get $5
+    call $~lib/internal/memory/memset
+   end
   else   
    local.get $1
    local.get $2
@@ -2969,6 +3015,9 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   local.get $0
   i32.load offset=4
   local.set $2
@@ -3012,22 +3061,32 @@
   local.get $0
   local.get $5
   i32.store offset=4
-  i32.const 0
-  local.set $6
-  local.get $3
-  local.get $2
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $6
-  i32.add
-  local.get $1
-  i32.store offset=8
+  block $~lib/internal/arraybuffer/STORE<i32,i32>|inlined.0
+   local.get $3
+   local.set $6
+   local.get $2
+   local.set $7
+   local.get $1
+   local.set $8
+   i32.const 0
+   local.set $9
+   local.get $6
+   local.get $7
+   i32.const 2
+   i32.shl
+   i32.add
+   local.get $9
+   i32.add
+   local.get $8
+   i32.store offset=8
+  end
   local.get $5
  )
  (func $~lib/array/Array<i32>#__get (; 31 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.load
   local.set $2
@@ -3038,14 +3097,18 @@
   i32.shr_u
   i32.lt_u
   if (result i32)
-   i32.const 0
-   local.set $3
    local.get $2
+   local.set $3
    local.get $1
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 2
    i32.shl
    i32.add
-   local.get $3
+   local.get $5
    i32.add
    i32.load offset=8
   else   
@@ -3183,6 +3246,8 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   local.get $0
   i32.load
   local.set $4
@@ -3317,30 +3382,40 @@
      local.get $11
      if
       block
-       block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.2 (result i32)
-        i32.const 0
-        local.set $6
+       block $~lib/internal/arraybuffer/STORE<i32,i32>|inlined.1
         local.get $4
-        local.get $9
+        local.set $6
+        local.get $8
+        local.set $7
+        block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.2 (result i32)
+         local.get $4
+         local.set $12
+         local.get $9
+         local.set $13
+         i32.const 0
+         local.set $14
+         local.get $12
+         local.get $13
+         i32.const 2
+         i32.shl
+         i32.add
+         local.get $14
+         i32.add
+         i32.load offset=8
+        end
+        local.set $14
+        i32.const 0
+        local.set $13
+        local.get $6
+        local.get $7
         i32.const 2
         i32.shl
         i32.add
-        local.get $6
+        local.get $13
         i32.add
-        i32.load offset=8
+        local.get $14
+        i32.store offset=8
        end
-       local.set $6
-       i32.const 0
-       local.set $7
-       local.get $4
-       local.get $8
-       i32.const 2
-       i32.shl
-       i32.add
-       local.get $7
-       i32.add
-       local.get $6
-       i32.store offset=8
        local.get $9
        i32.const 1
        i32.sub
@@ -3366,7 +3441,7 @@
    i32.const 2
    i32.shl
    i32.add
-   local.set $7
+   local.set $13
    local.get $4
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
@@ -3374,14 +3449,14 @@
    i32.const 2
    i32.shl
    i32.add
-   local.set $6
+   local.set $14
    local.get $11
    i32.const 2
    i32.shl
-   local.set $12
+   local.set $7
+   local.get $13
+   local.get $14
    local.get $7
-   local.get $6
-   local.get $12
    call $~lib/internal/memory/memmove
   end
   local.get $0
@@ -3413,12 +3488,16 @@
   if
    block $~lib/array/Array<i32>#get:length|inlined.15 (result i32)
     local.get $0
+    local.set $3
+    local.get $3
     i32.load offset=4
    end
    local.set $2
    local.get $2
    block $~lib/array/Array<i32>#get:length|inlined.17 (result i32)
     local.get $1
+    local.set $3
+    local.get $3
     i32.load offset=4
    end
    i32.ne
@@ -3473,6 +3552,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $0
   i32.load
   local.set $2
@@ -3518,39 +3598,47 @@
    local.get $2
    i32.store
   end
-  local.get $2
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  i32.const 4
-  i32.add
-  local.set $6
-  local.get $2
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $7
-  local.get $3
-  i32.const 1
-  i32.sub
-  i32.const 2
-  i32.shl
-  local.set $8
-  local.get $6
-  local.get $7
-  local.get $8
-  call $~lib/internal/memory/memmove
-  i32.const 0
-  local.set $8
-  i32.const 0
-  local.set $7
-  local.get $2
-  local.get $8
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $7
-  i32.add
-  local.get $1
-  i32.store offset=8
+  block $~lib/memory/memory.copy|inlined.4
+   local.get $2
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   i32.const 4
+   i32.add
+   local.set $6
+   local.get $2
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $7
+   local.get $3
+   i32.const 1
+   i32.sub
+   i32.const 2
+   i32.shl
+   local.set $8
+   local.get $6
+   local.get $7
+   local.get $8
+   call $~lib/internal/memory/memmove
+  end
+  block $~lib/internal/arraybuffer/STORE<i32,i32>|inlined.2
+   local.get $2
+   local.set $8
+   i32.const 0
+   local.set $7
+   local.get $1
+   local.set $6
+   i32.const 0
+   local.set $9
+   local.get $8
+   local.get $7
+   i32.const 2
+   i32.shl
+   i32.add
+   local.get $9
+   i32.add
+   local.get $6
+   i32.store offset=8
+  end
   local.get $0
   local.get $5
   i32.store offset=4
@@ -3564,6 +3652,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   local.get $0
   i32.load offset=4
   local.set $1
@@ -3582,59 +3671,69 @@
   i32.load
   local.set $2
   block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.3 (result i32)
-   i32.const 0
+   local.get $2
    local.set $3
    i32.const 0
    local.set $4
-   local.get $2
+   i32.const 0
+   local.set $5
    local.get $3
+   local.get $4
    i32.const 2
    i32.shl
    i32.add
-   local.get $4
+   local.get $5
    i32.add
    i32.load offset=8
   end
-  local.set $5
+  local.set $6
   local.get $1
   i32.const 1
   i32.sub
-  local.set $6
-  local.get $2
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  local.get $2
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  i32.const 4
-  i32.add
-  local.set $3
-  local.get $6
-  i32.const 2
-  i32.shl
   local.set $7
-  local.get $4
-  local.get $3
-  local.get $7
-  call $~lib/internal/memory/memmove
-  i32.const 0
-  local.set $7
-  i32.const 0
-  local.set $3
-  local.get $2
-  local.get $6
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $3
-  i32.add
-  local.get $7
-  i32.store offset=8
+  block $~lib/memory/memory.copy|inlined.5
+   local.get $2
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $5
+   local.get $2
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   i32.const 4
+   i32.add
+   local.set $4
+   local.get $7
+   i32.const 2
+   i32.shl
+   local.set $3
+   local.get $5
+   local.get $4
+   local.get $3
+   call $~lib/internal/memory/memmove
+  end
+  block $~lib/internal/arraybuffer/STORE<i32,i32>|inlined.3
+   local.get $2
+   local.set $3
+   local.get $7
+   local.set $4
+   i32.const 0
+   local.set $5
+   i32.const 0
+   local.set $8
+   local.get $3
+   local.get $4
+   i32.const 2
+   i32.shl
+   i32.add
+   local.get $8
+   i32.add
+   local.get $5
+   i32.store offset=8
+  end
   local.get $0
-  local.get $6
+  local.get $7
   i32.store offset=4
-  local.get $5
+  local.get $6
  )
  (func $~lib/array/Array<i32>#reverse (; 39 ;) (type $ii) (param $0 i32) (result i32)
   (local $1 i32)
@@ -3643,6 +3742,9 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   local.get $0
   i32.load
   local.set $1
@@ -3664,53 +3766,75 @@
     br_if $break|0
     block
      block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.4 (result i32)
-      i32.const 0
-      local.set $4
       local.get $1
+      local.set $4
       local.get $2
+      local.set $5
+      i32.const 0
+      local.set $6
+      local.get $4
+      local.get $5
       i32.const 2
       i32.shl
       i32.add
-      local.get $4
+      local.get $6
       i32.add
       i32.load offset=8
      end
-     local.set $4
-     block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.5 (result i32)
+     local.set $6
+     block $~lib/internal/arraybuffer/STORE<i32,i32>|inlined.4
+      local.get $1
+      local.set $5
+      local.get $2
+      local.set $4
+      block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.5 (result i32)
+       local.get $1
+       local.set $7
+       local.get $3
+       local.set $8
+       i32.const 0
+       local.set $9
+       local.get $7
+       local.get $8
+       i32.const 2
+       i32.shl
+       i32.add
+       local.get $9
+       i32.add
+       i32.load offset=8
+      end
+      local.set $9
+      i32.const 0
+      local.set $8
+      local.get $5
+      local.get $4
+      i32.const 2
+      i32.shl
+      i32.add
+      local.get $8
+      i32.add
+      local.get $9
+      i32.store offset=8
+     end
+     block $~lib/internal/arraybuffer/STORE<i32,i32>|inlined.5
+      local.get $1
+      local.set $8
+      local.get $3
+      local.set $9
+      local.get $6
+      local.set $4
       i32.const 0
       local.set $5
-      local.get $1
-      local.get $3
+      local.get $8
+      local.get $9
       i32.const 2
       i32.shl
       i32.add
       local.get $5
       i32.add
-      i32.load offset=8
+      local.get $4
+      i32.store offset=8
      end
-     local.set $5
-     i32.const 0
-     local.set $6
-     local.get $1
-     local.get $2
-     i32.const 2
-     i32.shl
-     i32.add
-     local.get $6
-     i32.add
-     local.get $5
-     i32.store offset=8
-     i32.const 0
-     local.set $6
-     local.get $1
-     local.get $3
-     i32.const 2
-     i32.shl
-     i32.add
-     local.get $6
-     i32.add
-     local.get $4
-     i32.store offset=8
     end
     block
      local.get $2
@@ -3734,6 +3858,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=4
   local.set $3
@@ -3779,10 +3904,14 @@
     if
      block
       block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.7 (result i32)
+       local.get $6
+       local.set $7
+       local.get $2
+       local.set $5
        i32.const 0
        local.set $4
-       local.get $6
-       local.get $2
+       local.get $7
+       local.get $5
        i32.const 2
        i32.shl
        i32.add
@@ -3815,6 +3944,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   local.get $0
   i32.load offset=4
   local.set $3
@@ -3876,42 +4006,48 @@
   i32.shl
   i32.add
   local.set $8
-  local.get $7
-  i32.load
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  local.get $2
-  i32.const 2
-  i32.shl
-  local.set $5
-  local.get $4
-  local.get $8
-  local.get $5
-  call $~lib/internal/memory/memmove
+  block $~lib/memory/memory.copy|inlined.6
+   local.get $7
+   i32.load
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   local.get $8
+   local.set $5
+   local.get $2
+   i32.const 2
+   i32.shl
+   local.set $9
+   local.get $4
+   local.get $5
+   local.get $9
+   call $~lib/internal/memory/memmove
+  end
   local.get $1
   local.get $2
   i32.add
-  local.set $9
+  local.set $10
   local.get $3
-  local.get $9
+  local.get $10
   i32.ne
   if
+   local.get $8
+   local.set $9
    local.get $6
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
-   local.get $9
+   local.get $10
    i32.const 2
    i32.shl
    i32.add
    local.set $5
    local.get $3
-   local.get $9
+   local.get $10
    i32.sub
    i32.const 2
    i32.shl
    local.set $4
-   local.get $8
+   local.get $9
    local.get $5
    local.get $4
    call $~lib/internal/memory/memmove
@@ -3946,6 +4082,9 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   local.get $0
   i32.load
   local.set $3
@@ -3986,17 +4125,25 @@
    i32.add
    i32.store offset=4
   end
-  i32.const 0
-  local.set $5
-  local.get $3
-  local.get $1
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $5
-  i32.add
-  local.get $2
-  i32.store offset=8
+  block $~lib/internal/arraybuffer/STORE<i32,i32>|inlined.6
+   local.get $3
+   local.set $5
+   local.get $1
+   local.set $6
+   local.get $2
+   local.set $7
+   i32.const 0
+   local.set $8
+   local.get $5
+   local.get $6
+   i32.const 2
+   i32.shl
+   i32.add
+   local.get $8
+   i32.add
+   local.get $7
+   i32.store offset=8
+  end
  )
  (func $start~anonymous|1 (; 44 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
@@ -4008,6 +4155,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   block $break|0
    block
     i32.const 0
@@ -4036,11 +4184,13 @@
      block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.9 (result i32)
       local.get $0
       i32.load
+      local.set $6
+      local.get $2
       local.set $5
       i32.const 0
       local.set $4
+      local.get $6
       local.get $5
-      local.get $2
       i32.const 2
       i32.shl
       i32.add
@@ -4112,6 +4262,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   block $break|0
    block
     i32.const 0
@@ -4140,11 +4291,13 @@
      block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.11 (result i32)
       local.get $0
       i32.load
+      local.set $6
+      local.get $2
       local.set $5
       i32.const 0
       local.set $4
+      local.get $6
       local.get $5
-      local.get $2
       i32.const 2
       i32.shl
       i32.add
@@ -4212,6 +4365,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   block $break|0
    block
     i32.const 0
@@ -4240,11 +4394,13 @@
      block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.13 (result i32)
       local.get $0
       i32.load
+      local.set $6
+      local.get $2
       local.set $5
       i32.const 0
       local.set $4
+      local.get $6
       local.get $5
-      local.get $2
       i32.const 2
       i32.shl
       i32.add
@@ -4312,6 +4468,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   block $break|0
    block
     i32.const 0
@@ -4341,14 +4498,16 @@
       local.get $0
       i32.load
       local.set $4
-      i32.const 0
-      local.set $5
-      local.get $4
       local.get $2
+      local.set $5
+      i32.const 0
+      local.set $6
+      local.get $4
+      local.get $5
       i32.const 2
       i32.shl
       i32.add
-      local.get $5
+      local.get $6
       i32.add
       i32.load offset=8
      end
@@ -4516,6 +4675,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.const 268435454
   i32.gt_u
@@ -4555,16 +4715,20 @@
   local.get $0
   local.get $1
   i32.store offset=4
-  local.get $3
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  i32.const 0
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $2
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.4
+   local.get $3
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/memory/memset
+  end
   local.get $0
  )
  (func $~lib/array/Array<i32>#map<f32> (; 71 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
@@ -4574,7 +4738,10 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 f32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 f32)
   local.get $0
   i32.load offset=4
   local.set $2
@@ -4602,22 +4769,28 @@
     i32.lt_s
     i32.eqz
     br_if $break|0
-    block
+    block $~lib/internal/arraybuffer/STORE<f32,f32>|inlined.0
+     local.get $4
+     local.set $6
+     local.get $5
+     local.set $7
      block (result f32)
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.15 (result i32)
        local.get $0
        i32.load
-       local.set $6
-       i32.const 0
-       local.set $7
-       local.get $6
+       local.set $8
        local.get $5
+       local.set $9
+       i32.const 0
+       local.set $10
+       local.get $8
+       local.get $9
        i32.const 2
        i32.shl
        i32.add
-       local.get $7
+       local.get $10
        i32.add
        i32.load offset=8
       end
@@ -4626,17 +4799,17 @@
       local.get $1
       call_indirect (type $iiif)
      end
-     local.set $8
+     local.set $11
      i32.const 0
-     local.set $7
-     local.get $4
-     local.get $5
+     local.set $10
+     local.get $6
+     local.get $7
      i32.const 2
      i32.shl
      i32.add
-     local.get $7
+     local.get $10
      i32.add
-     local.get $8
+     local.get $11
      f32.store offset=8
     end
     local.get $5
@@ -4653,6 +4826,8 @@
  (func $~lib/array/Array<f32>#__get (; 72 ;) (type $iif) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.load
   local.set $2
@@ -4663,14 +4838,18 @@
   i32.shr_u
   i32.lt_u
   if (result f32)
-   i32.const 0
-   local.set $3
    local.get $2
+   local.set $3
    local.get $1
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 2
    i32.shl
    i32.add
-   local.get $3
+   local.get $5
    i32.add
    f32.load offset=8
   else   
@@ -4695,6 +4874,9 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   local.get $0
   i32.load offset=4
   local.set $2
@@ -4722,22 +4904,28 @@
     i32.lt_s
     i32.eqz
     br_if $break|0
-    block
+    block $~lib/internal/arraybuffer/STORE<i32,i32>|inlined.7
+     local.get $4
+     local.set $6
+     local.get $5
+     local.set $7
      block (result i32)
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.16 (result i32)
        local.get $0
        i32.load
-       local.set $6
-       i32.const 0
-       local.set $7
-       local.get $6
+       local.set $8
        local.get $5
+       local.set $9
+       i32.const 0
+       local.set $10
+       local.get $8
+       local.get $9
        i32.const 2
        i32.shl
        i32.add
-       local.get $7
+       local.get $10
        i32.add
        i32.load offset=8
       end
@@ -4746,17 +4934,17 @@
       local.get $1
       call_indirect (type $iiii)
      end
-     local.set $7
+     local.set $10
      i32.const 0
-     local.set $6
-     local.get $4
-     local.get $5
+     local.set $9
+     local.get $6
+     local.get $7
      i32.const 2
      i32.shl
      i32.add
-     local.get $6
+     local.get $9
      i32.add
-     local.get $7
+     local.get $10
      i32.store offset=8
     end
     local.get $5
@@ -4798,6 +4986,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   i32.const 0
   i32.const 0
   call $~lib/array/Array<i32>#constructor
@@ -4829,22 +5018,24 @@
       local.get $0
       i32.load
       local.set $5
-      i32.const 0
-      local.set $6
-      local.get $5
       local.get $3
+      local.set $6
+      i32.const 0
+      local.set $7
+      local.get $5
+      local.get $6
       i32.const 2
       i32.shl
       i32.add
-      local.get $6
+      local.get $7
       i32.add
       i32.load offset=8
      end
-     local.set $6
+     local.set $7
      block (result i32)
       i32.const 3
       global.set $~argc
-      local.get $6
+      local.get $7
       local.get $3
       local.get $0
       local.get $1
@@ -4854,7 +5045,7 @@
      i32.ne
      if
       local.get $2
-      local.get $6
+      local.get $7
       call $~lib/array/Array<i32>#push
       drop
      end
@@ -4915,6 +5106,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   local.get $2
   local.set $3
   block $break|0
@@ -4947,14 +5139,16 @@
       local.get $0
       i32.load
       local.set $6
-      i32.const 0
-      local.set $7
-      local.get $6
       local.get $4
+      local.set $7
+      i32.const 0
+      local.set $8
+      local.get $6
+      local.get $7
       i32.const 2
       i32.shl
       i32.add
-      local.get $7
+      local.get $8
       i32.add
       i32.load offset=8
      end
@@ -4998,6 +5192,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   local.get $2
   local.set $3
   block $break|0
@@ -5030,14 +5225,16 @@
       local.get $0
       i32.load
       local.set $6
-      i32.const 0
-      local.set $7
-      local.get $6
       local.get $4
+      local.set $7
+      i32.const 0
+      local.set $8
+      local.get $6
+      local.get $7
       i32.const 2
       i32.shl
       i32.add
-      local.get $7
+      local.get $8
       i32.add
       i32.load offset=8
      end
@@ -5102,6 +5299,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $2
   local.set $3
   block $break|0
@@ -5124,14 +5322,16 @@
       local.get $0
       i32.load
       local.set $5
-      i32.const 0
-      local.set $6
-      local.get $5
       local.get $4
+      local.set $6
+      i32.const 0
+      local.set $7
+      local.get $5
+      local.get $6
       i32.const 2
       i32.shl
       i32.add
-      local.get $6
+      local.get $7
       i32.add
       i32.load offset=8
      end
@@ -5174,6 +5374,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $2
   local.set $3
   block $break|0
@@ -5196,14 +5397,16 @@
       local.get $0
       i32.load
       local.set $5
-      i32.const 0
-      local.set $6
-      local.get $5
       local.get $4
+      local.set $6
+      i32.const 0
+      local.set $7
+      local.get $5
+      local.get $6
       i32.const 2
       i32.shl
       i32.add
-      local.get $6
+      local.get $7
       i32.add
       i32.load offset=8
      end
@@ -5353,10 +5556,13 @@
  )
  (func $~lib/internal/sort/insertionSort<f32> (; 103 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
-  (local $5 f32)
+  (local $5 i32)
   (local $6 i32)
-  (local $7 f32)
-  (local $8 i32)
+  (local $7 i32)
+  (local $8 f32)
+  (local $9 i32)
+  (local $10 f32)
+  (local $11 f32)
   block $break|0
    i32.const 0
    local.set $4
@@ -5369,67 +5575,85 @@
     block
      block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.3 (result f32)
       local.get $0
+      local.set $5
       local.get $4
+      local.set $6
+      local.get $1
+      local.set $7
+      local.get $5
+      local.get $6
       i32.const 2
       i32.shl
       i32.add
-      local.get $1
+      local.get $7
       i32.add
       f32.load offset=8
      end
-     local.set $5
+     local.set $8
      local.get $4
      i32.const 1
      i32.sub
-     local.set $6
+     local.set $7
      block $break|1
       loop $continue|1
-       local.get $6
+       local.get $7
        i32.const 0
        i32.ge_s
        if
         block
          block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.4 (result f32)
           local.get $0
+          local.set $6
+          local.get $7
+          local.set $5
+          local.get $1
+          local.set $9
           local.get $6
+          local.get $5
           i32.const 2
           i32.shl
           i32.add
-          local.get $1
+          local.get $9
           i32.add
           f32.load offset=8
          end
-         local.set $7
+         local.set $10
          block (result i32)
           i32.const 2
           global.set $~argc
-          local.get $5
-          local.get $7
+          local.get $8
+          local.get $10
           local.get $3
           call_indirect (type $ffi)
          end
          i32.const 0
          i32.lt_s
          if
+          local.get $0
+          local.set $9
           block (result i32)
-           local.get $6
-           local.tee $8
+           local.get $7
+           local.tee $5
            i32.const 1
            i32.sub
-           local.set $6
-           local.get $8
+           local.set $7
+           local.get $5
           end
           i32.const 1
           i32.add
-          local.set $8
-          local.get $0
-          local.get $8
+          local.set $5
+          local.get $10
+          local.set $11
+          local.get $1
+          local.set $6
+          local.get $9
+          local.get $5
           i32.const 2
           i32.shl
           i32.add
-          local.get $1
+          local.get $6
           i32.add
-          local.get $7
+          local.get $11
           f32.store offset=8
          else          
           br $break|1
@@ -5439,19 +5663,27 @@
        end
       end
      end
-     local.get $6
-     i32.const 1
-     i32.add
-     local.set $8
-     local.get $0
-     local.get $8
-     i32.const 2
-     i32.shl
-     i32.add
-     local.get $1
-     i32.add
-     local.get $5
-     f32.store offset=8
+     block $~lib/internal/arraybuffer/STORE<f32,f32>|inlined.4
+      local.get $0
+      local.set $6
+      local.get $7
+      i32.const 1
+      i32.add
+      local.set $5
+      local.get $8
+      local.set $10
+      local.get $1
+      local.set $9
+      local.get $6
+      local.get $5
+      i32.const 2
+      i32.shl
+      i32.add
+      local.get $9
+      i32.add
+      local.get $10
+      f32.store offset=8
+     end
     end
     local.get $4
     i32.const 1
@@ -5469,10 +5701,13 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 f32)
-  (local $10 f32)
+  (local $9 i32)
+  (local $10 i32)
   (local $11 i32)
   (local $12 f32)
+  (local $13 f32)
+  (local $14 f32)
+  (local $15 f32)
   local.get $2
   i32.const 31
   i32.add
@@ -5483,36 +5718,44 @@
   local.set $4
   block $~lib/memory/memory.allocate|inlined.1 (result i32)
    local.get $4
+   local.set $5
+   local.get $5
    call $~lib/allocator/arena/__memory_allocate
    br $~lib/memory/memory.allocate|inlined.1
   end
-  local.set $5
-  i32.const 0
   local.set $6
-  local.get $5
-  local.get $6
-  local.get $4
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.5
+   local.get $6
+   local.set $5
+   i32.const 0
+   local.set $7
+   local.get $4
+   local.set $8
+   local.get $5
+   local.get $7
+   local.get $8
+   call $~lib/internal/memory/memset
+  end
   block $break|0
    local.get $2
    i32.const 1
    i32.sub
-   local.set $6
+   local.set $8
    loop $repeat|0
-    local.get $6
+    local.get $8
     i32.const 0
     i32.gt_s
     i32.eqz
     br_if $break|0
     block
-     local.get $6
+     local.get $8
      local.set $7
      block $break|1
       loop $continue|1
        local.get $7
        i32.const 1
        i32.and
-       local.get $5
+       local.get $6
        local.get $7
        i32.const 6
        i32.shr_s
@@ -5541,49 +5784,61 @@
      local.get $7
      i32.const 1
      i32.shr_s
-     local.set $8
+     local.set $5
      block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.5 (result f32)
       local.get $0
-      local.get $8
+      local.set $9
+      local.get $5
+      local.set $10
+      local.get $1
+      local.set $11
+      local.get $9
+      local.get $10
       i32.const 2
       i32.shl
       i32.add
-      local.get $1
+      local.get $11
       i32.add
       f32.load offset=8
      end
-     local.set $9
+     local.set $12
      block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.6 (result f32)
       local.get $0
-      local.get $6
+      local.set $11
+      local.get $8
+      local.set $10
+      local.get $1
+      local.set $9
+      local.get $11
+      local.get $10
       i32.const 2
       i32.shl
       i32.add
-      local.get $1
+      local.get $9
       i32.add
       f32.load offset=8
      end
-     local.set $10
+     local.set $13
      block (result i32)
       i32.const 2
       global.set $~argc
-      local.get $9
-      local.get $10
+      local.get $12
+      local.get $13
       local.get $3
       call_indirect (type $ffi)
      end
      i32.const 0
      i32.lt_s
      if
-      local.get $5
       local.get $6
+      local.get $8
       i32.const 5
       i32.shr_s
       i32.const 2
       i32.shl
       i32.add
-      local.get $5
       local.get $6
+      local.get $8
       i32.const 5
       i32.shr_s
       i32.const 2
@@ -5591,36 +5846,56 @@
       i32.add
       i32.load
       i32.const 1
-      local.get $6
+      local.get $8
       i32.const 31
       i32.and
       i32.shl
       i32.xor
       i32.store
-      local.get $0
-      local.get $6
-      i32.const 2
-      i32.shl
-      i32.add
-      local.get $1
-      i32.add
-      local.get $9
-      f32.store offset=8
-      local.get $0
-      local.get $8
-      i32.const 2
-      i32.shl
-      i32.add
-      local.get $1
-      i32.add
-      local.get $10
-      f32.store offset=8
+      block $~lib/internal/arraybuffer/STORE<f32,f32>|inlined.5
+       local.get $0
+       local.set $9
+       local.get $8
+       local.set $10
+       local.get $12
+       local.set $14
+       local.get $1
+       local.set $11
+       local.get $9
+       local.get $10
+       i32.const 2
+       i32.shl
+       i32.add
+       local.get $11
+       i32.add
+       local.get $14
+       f32.store offset=8
+      end
+      block $~lib/internal/arraybuffer/STORE<f32,f32>|inlined.6
+       local.get $0
+       local.set $11
+       local.get $5
+       local.set $10
+       local.get $13
+       local.set $14
+       local.get $1
+       local.set $9
+       local.get $11
+       local.get $10
+       i32.const 2
+       i32.shl
+       i32.add
+       local.get $9
+       i32.add
+       local.get $14
+       f32.store offset=8
+      end
      end
     end
-    local.get $6
+    local.get $8
     i32.const 1
     i32.sub
-    local.set $6
+    local.set $8
     br $repeat|0
     unreachable
    end
@@ -5630,74 +5905,100 @@
    local.get $2
    i32.const 1
    i32.sub
-   local.set $6
+   local.set $8
    loop $repeat|2
-    local.get $6
+    local.get $8
     i32.const 2
     i32.ge_s
     i32.eqz
     br_if $break|2
     block
      block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.7 (result f32)
+      local.get $0
+      local.set $5
       i32.const 0
-      local.set $8
+      local.set $7
+      local.get $1
+      local.set $9
+      local.get $5
+      local.get $7
+      i32.const 2
+      i32.shl
+      i32.add
+      local.get $9
+      i32.add
+      f32.load offset=8
+     end
+     local.set $13
+     block $~lib/internal/arraybuffer/STORE<f32,f32>|inlined.7
       local.get $0
+      local.set $9
+      i32.const 0
+      local.set $7
+      block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.8 (result f32)
+       local.get $0
+       local.set $5
+       local.get $8
+       local.set $10
+       local.get $1
+       local.set $11
+       local.get $5
+       local.get $10
+       i32.const 2
+       i32.shl
+       i32.add
+       local.get $11
+       i32.add
+       f32.load offset=8
+      end
+      local.set $12
+      local.get $1
+      local.set $11
+      local.get $9
+      local.get $7
+      i32.const 2
+      i32.shl
+      i32.add
+      local.get $11
+      i32.add
+      local.get $12
+      f32.store offset=8
+     end
+     block $~lib/internal/arraybuffer/STORE<f32,f32>|inlined.8
+      local.get $0
+      local.set $11
       local.get $8
+      local.set $7
+      local.get $13
+      local.set $12
+      local.get $1
+      local.set $9
+      local.get $11
+      local.get $7
       i32.const 2
       i32.shl
       i32.add
-      local.get $1
+      local.get $9
       i32.add
-      f32.load offset=8
+      local.get $12
+      f32.store offset=8
      end
-     local.set $10
-     i32.const 0
-     local.set $8
-     block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.8 (result f32)
-      local.get $0
-      local.get $6
-      i32.const 2
-      i32.shl
-      i32.add
-      local.get $1
-      i32.add
-      f32.load offset=8
-     end
-     local.set $9
-     local.get $0
-     local.get $8
-     i32.const 2
-     i32.shl
-     i32.add
-     local.get $1
-     i32.add
-     local.get $9
-     f32.store offset=8
-     local.get $0
-     local.get $6
-     i32.const 2
-     i32.shl
-     i32.add
-     local.get $1
-     i32.add
-     local.get $10
-     f32.store offset=8
      i32.const 1
-     local.set $8
+     local.set $9
      block $break|3
       loop $continue|3
-       local.get $8
+       local.get $9
        i32.const 1
        i32.shl
-       local.get $5
-       local.get $8
+       local.get $6
+       local.get $9
        i32.const 5
        i32.shr_s
        i32.const 2
        i32.shl
        i32.add
        i32.load
-       local.get $8
+       local.get $9
        i32.const 31
        i32.and
        i32.shr_u
@@ -5705,66 +6006,76 @@
        i32.and
        i32.add
        local.tee $7
-       local.get $6
+       local.get $8
        i32.lt_s
        if
         local.get $7
-        local.set $8
+        local.set $9
         br $continue|3
        end
       end
      end
      block $break|4
       loop $continue|4
-       local.get $8
+       local.get $9
        i32.const 0
        i32.gt_s
        if
         block
          block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.9 (result f32)
-          i32.const 0
-          local.set $11
           local.get $0
+          local.set $11
+          i32.const 0
+          local.set $10
+          local.get $1
+          local.set $5
           local.get $11
+          local.get $10
           i32.const 2
           i32.shl
           i32.add
-          local.get $1
+          local.get $5
           i32.add
           f32.load offset=8
          end
-         local.set $10
+         local.set $13
          block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.10 (result f32)
           local.get $0
-          local.get $8
+          local.set $5
+          local.get $9
+          local.set $10
+          local.get $1
+          local.set $11
+          local.get $5
+          local.get $10
           i32.const 2
           i32.shl
           i32.add
-          local.get $1
+          local.get $11
           i32.add
           f32.load offset=8
          end
-         local.set $9
+         local.set $12
          block (result i32)
           i32.const 2
           global.set $~argc
-          local.get $10
-          local.get $9
+          local.get $13
+          local.get $12
           local.get $3
           call_indirect (type $ffi)
          end
          i32.const 0
          i32.lt_s
          if
-          local.get $5
-          local.get $8
+          local.get $6
+          local.get $9
           i32.const 5
           i32.shr_s
           i32.const 2
           i32.shl
           i32.add
-          local.get $5
-          local.get $8
+          local.get $6
+          local.get $9
           i32.const 5
           i32.shr_s
           i32.const 2
@@ -5772,117 +6083,158 @@
           i32.add
           i32.load
           i32.const 1
-          local.get $8
+          local.get $9
           i32.const 31
           i32.and
           i32.shl
           i32.xor
           i32.store
-          local.get $0
-          local.get $8
-          i32.const 2
-          i32.shl
-          i32.add
-          local.get $1
-          i32.add
-          local.get $10
-          f32.store offset=8
-          i32.const 0
-          local.set $11
-          local.get $0
-          local.get $11
-          i32.const 2
-          i32.shl
-          i32.add
-          local.get $1
-          i32.add
-          local.get $9
-          f32.store offset=8
+          block $~lib/internal/arraybuffer/STORE<f32,f32>|inlined.9
+           local.get $0
+           local.set $11
+           local.get $9
+           local.set $10
+           local.get $13
+           local.set $14
+           local.get $1
+           local.set $5
+           local.get $11
+           local.get $10
+           i32.const 2
+           i32.shl
+           i32.add
+           local.get $5
+           i32.add
+           local.get $14
+           f32.store offset=8
+          end
+          block $~lib/internal/arraybuffer/STORE<f32,f32>|inlined.10
+           local.get $0
+           local.set $5
+           i32.const 0
+           local.set $10
+           local.get $12
+           local.set $14
+           local.get $1
+           local.set $11
+           local.get $5
+           local.get $10
+           i32.const 2
+           i32.shl
+           i32.add
+           local.get $11
+           i32.add
+           local.get $14
+           f32.store offset=8
+          end
          end
-         local.get $8
+         local.get $9
          i32.const 1
          i32.shr_s
-         local.set $8
+         local.set $9
         end
         br $continue|4
        end
       end
      end
     end
-    local.get $6
+    local.get $8
     i32.const 1
     i32.sub
-    local.set $6
+    local.set $8
     br $repeat|2
     unreachable
    end
    unreachable
   end
   block $~lib/memory/memory.free|inlined.1
-   block
-    local.get $5
-    call $~lib/allocator/arena/__memory_free
-    br $~lib/memory/memory.free|inlined.1
-    unreachable
-   end
-   unreachable
+   local.get $6
+   local.set $8
+   local.get $8
+   call $~lib/allocator/arena/__memory_free
+   br $~lib/memory/memory.free|inlined.1
   end
   block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.11 (result f32)
+   local.get $0
+   local.set $8
    i32.const 1
-   local.set $6
-   local.get $0
-   local.get $6
-   i32.const 2
-   i32.shl
-   i32.add
-   local.get $1
-   i32.add
-   f32.load offset=8
-  end
-  local.set $12
-  i32.const 1
-  local.set $6
-  block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.12 (result f32)
-   i32.const 0
    local.set $7
-   local.get $0
+   local.get $1
+   local.set $9
+   local.get $8
    local.get $7
    i32.const 2
    i32.shl
    i32.add
-   local.get $1
+   local.get $9
    i32.add
    f32.load offset=8
   end
-  local.set $10
-  local.get $0
-  local.get $6
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $1
-  i32.add
-  local.get $10
-  f32.store offset=8
-  i32.const 0
-  local.set $6
-  local.get $0
-  local.get $6
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $1
-  i32.add
-  local.get $12
-  f32.store offset=8
+  local.set $15
+  block $~lib/internal/arraybuffer/STORE<f32,f32>|inlined.11
+   local.get $0
+   local.set $9
+   i32.const 1
+   local.set $7
+   block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.12 (result f32)
+    local.get $0
+    local.set $8
+    i32.const 0
+    local.set $11
+    local.get $1
+    local.set $10
+    local.get $8
+    local.get $11
+    i32.const 2
+    i32.shl
+    i32.add
+    local.get $10
+    i32.add
+    f32.load offset=8
+   end
+   local.set $13
+   local.get $1
+   local.set $10
+   local.get $9
+   local.get $7
+   i32.const 2
+   i32.shl
+   i32.add
+   local.get $10
+   i32.add
+   local.get $13
+   f32.store offset=8
+  end
+  block $~lib/internal/arraybuffer/STORE<f32,f32>|inlined.12
+   local.get $0
+   local.set $10
+   i32.const 0
+   local.set $7
+   local.get $15
+   local.set $13
+   local.get $1
+   local.set $9
+   local.get $10
+   local.get $7
+   i32.const 2
+   i32.shl
+   i32.add
+   local.get $9
+   i32.add
+   local.get $13
+   f32.store offset=8
+  end
  )
  (func $~lib/array/Array<f32>#sort (; 105 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 f32)
+  (local $6 i32)
   (local $7 f32)
+  (local $8 f32)
+  (local $9 f32)
+  (local $10 i32)
   local.get $1
   i32.eqz
   if
@@ -5911,97 +6263,121 @@
   i32.eq
   if
    block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.1 (result f32)
+    local.get $3
+    local.set $4
     i32.const 1
-    local.set $4
-    i32.const 0
     local.set $5
-    local.get $3
+    i32.const 0
+    local.set $6
     local.get $4
-    i32.const 2
-    i32.shl
-    i32.add
-    local.get $5
-    i32.add
-    f32.load offset=8
-   end
-   local.set $6
-   block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.2 (result f32)
-    i32.const 0
-    local.set $5
-    i32.const 0
-    local.set $4
-    local.get $3
     local.get $5
     i32.const 2
     i32.shl
     i32.add
-    local.get $4
+    local.get $6
     i32.add
     f32.load offset=8
    end
    local.set $7
+   block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.2 (result f32)
+    local.get $3
+    local.set $6
+    i32.const 0
+    local.set $5
+    i32.const 0
+    local.set $4
+    local.get $6
+    local.get $5
+    i32.const 2
+    i32.shl
+    i32.add
+    local.get $4
+    i32.add
+    f32.load offset=8
+   end
+   local.set $8
    block (result i32)
     i32.const 2
     global.set $~argc
-    local.get $6
     local.get $7
+    local.get $8
     local.get $1
     call_indirect (type $ffi)
    end
    i32.const 0
    i32.lt_s
    if
-    i32.const 1
-    local.set $4
-    i32.const 0
-    local.set $5
-    local.get $3
-    local.get $4
-    i32.const 2
-    i32.shl
-    i32.add
-    local.get $5
-    i32.add
-    local.get $7
-    f32.store offset=8
-    i32.const 0
-    local.set $5
-    i32.const 0
-    local.set $4
-    local.get $3
-    local.get $5
-    i32.const 2
-    i32.shl
-    i32.add
-    local.get $4
-    i32.add
-    local.get $6
-    f32.store offset=8
+    block $~lib/internal/arraybuffer/STORE<f32,f32>|inlined.1
+     local.get $3
+     local.set $4
+     i32.const 1
+     local.set $5
+     local.get $8
+     local.set $9
+     i32.const 0
+     local.set $6
+     local.get $4
+     local.get $5
+     i32.const 2
+     i32.shl
+     i32.add
+     local.get $6
+     i32.add
+     local.get $9
+     f32.store offset=8
+    end
+    block $~lib/internal/arraybuffer/STORE<f32,f32>|inlined.2
+     local.get $3
+     local.set $6
+     i32.const 0
+     local.set $5
+     local.get $7
+     local.set $9
+     i32.const 0
+     local.set $4
+     local.get $6
+     local.get $5
+     i32.const 2
+     i32.shl
+     i32.add
+     local.get $4
+     i32.add
+     local.get $9
+     f32.store offset=8
+    end
    end
    local.get $0
    return
   end
-  i32.const 0
-  local.set $4
-  local.get $2
-  i32.const 256
-  i32.lt_s
-  if
+  block $~lib/internal/sort/SORT<f32>|inlined.0
    local.get $3
-   local.get $4
+   local.set $4
+   i32.const 0
+   local.set $5
    local.get $2
+   local.set $6
    local.get $1
-   call $~lib/internal/sort/insertionSort<f32>
-  else   
-   local.get $3
-   local.get $4
-   local.get $2
-   local.get $1
-   call $~lib/internal/sort/weakHeapSort<f32>
+   local.set $10
+   local.get $6
+   i32.const 256
+   i32.lt_s
+   if
+    local.get $4
+    local.get $5
+    local.get $6
+    local.get $10
+    call $~lib/internal/sort/insertionSort<f32>
+   else    
+    local.get $4
+    local.get $5
+    local.get $6
+    local.get $10
+    call $~lib/internal/sort/weakHeapSort<f32>
+   end
   end
   local.get $0
  )
- (func $~lib/array/Array<f32>#sort|trampoline~anonymous|44 (; 106 ;) (type $ffi) (param $0 f32) (param $1 f32) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<f32>~anonymous|44 (; 106 ;) (type $ffi) (param $0 f32) (param $1 f32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -6065,12 +6441,16 @@
   if
    block $~lib/array/Array<f32>#get:length|inlined.1 (result i32)
     local.get $0
+    local.set $3
+    local.get $3
     i32.load offset=4
    end
    local.set $2
    local.get $2
    block $~lib/array/Array<f32>#get:length|inlined.3 (result i32)
     local.get $1
+    local.set $3
+    local.get $3
     i32.load offset=4
    end
    i32.ne
@@ -6135,10 +6515,13 @@
  )
  (func $~lib/internal/sort/insertionSort<f64> (; 110 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
-  (local $5 f64)
+  (local $5 i32)
   (local $6 i32)
-  (local $7 f64)
-  (local $8 i32)
+  (local $7 i32)
+  (local $8 f64)
+  (local $9 i32)
+  (local $10 f64)
+  (local $11 f64)
   block $break|0
    i32.const 0
    local.set $4
@@ -6151,67 +6534,85 @@
     block
      block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.2 (result f64)
       local.get $0
+      local.set $5
       local.get $4
+      local.set $6
+      local.get $1
+      local.set $7
+      local.get $5
+      local.get $6
       i32.const 3
       i32.shl
       i32.add
-      local.get $1
+      local.get $7
       i32.add
       f64.load offset=8
      end
-     local.set $5
+     local.set $8
      local.get $4
      i32.const 1
      i32.sub
-     local.set $6
+     local.set $7
      block $break|1
       loop $continue|1
-       local.get $6
+       local.get $7
        i32.const 0
        i32.ge_s
        if
         block
          block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.3 (result f64)
           local.get $0
+          local.set $6
+          local.get $7
+          local.set $5
+          local.get $1
+          local.set $9
           local.get $6
+          local.get $5
           i32.const 3
           i32.shl
           i32.add
-          local.get $1
+          local.get $9
           i32.add
           f64.load offset=8
          end
-         local.set $7
+         local.set $10
          block (result i32)
           i32.const 2
           global.set $~argc
-          local.get $5
-          local.get $7
+          local.get $8
+          local.get $10
           local.get $3
           call_indirect (type $FFi)
          end
          i32.const 0
          i32.lt_s
          if
+          local.get $0
+          local.set $9
           block (result i32)
-           local.get $6
-           local.tee $8
+           local.get $7
+           local.tee $5
            i32.const 1
            i32.sub
-           local.set $6
-           local.get $8
+           local.set $7
+           local.get $5
           end
           i32.const 1
           i32.add
-          local.set $8
-          local.get $0
-          local.get $8
+          local.set $5
+          local.get $10
+          local.set $11
+          local.get $1
+          local.set $6
+          local.get $9
+          local.get $5
           i32.const 3
           i32.shl
           i32.add
-          local.get $1
+          local.get $6
           i32.add
-          local.get $7
+          local.get $11
           f64.store offset=8
          else          
           br $break|1
@@ -6221,19 +6622,27 @@
        end
       end
      end
-     local.get $6
-     i32.const 1
-     i32.add
-     local.set $8
-     local.get $0
-     local.get $8
-     i32.const 3
-     i32.shl
-     i32.add
-     local.get $1
-     i32.add
-     local.get $5
-     f64.store offset=8
+     block $~lib/internal/arraybuffer/STORE<f64,f64>|inlined.3
+      local.get $0
+      local.set $6
+      local.get $7
+      i32.const 1
+      i32.add
+      local.set $5
+      local.get $8
+      local.set $10
+      local.get $1
+      local.set $9
+      local.get $6
+      local.get $5
+      i32.const 3
+      i32.shl
+      i32.add
+      local.get $9
+      i32.add
+      local.get $10
+      f64.store offset=8
+     end
     end
     local.get $4
     i32.const 1
@@ -6251,10 +6660,13 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 f64)
-  (local $10 f64)
+  (local $9 i32)
+  (local $10 i32)
   (local $11 i32)
   (local $12 f64)
+  (local $13 f64)
+  (local $14 f64)
+  (local $15 f64)
   local.get $2
   i32.const 31
   i32.add
@@ -6265,36 +6677,44 @@
   local.set $4
   block $~lib/memory/memory.allocate|inlined.2 (result i32)
    local.get $4
+   local.set $5
+   local.get $5
    call $~lib/allocator/arena/__memory_allocate
    br $~lib/memory/memory.allocate|inlined.2
   end
-  local.set $5
-  i32.const 0
   local.set $6
-  local.get $5
-  local.get $6
-  local.get $4
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.6
+   local.get $6
+   local.set $5
+   i32.const 0
+   local.set $7
+   local.get $4
+   local.set $8
+   local.get $5
+   local.get $7
+   local.get $8
+   call $~lib/internal/memory/memset
+  end
   block $break|0
    local.get $2
    i32.const 1
    i32.sub
-   local.set $6
+   local.set $8
    loop $repeat|0
-    local.get $6
+    local.get $8
     i32.const 0
     i32.gt_s
     i32.eqz
     br_if $break|0
     block
-     local.get $6
+     local.get $8
      local.set $7
      block $break|1
       loop $continue|1
        local.get $7
        i32.const 1
        i32.and
-       local.get $5
+       local.get $6
        local.get $7
        i32.const 6
        i32.shr_s
@@ -6323,49 +6743,61 @@
      local.get $7
      i32.const 1
      i32.shr_s
-     local.set $8
+     local.set $5
      block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.4 (result f64)
       local.get $0
-      local.get $8
+      local.set $9
+      local.get $5
+      local.set $10
+      local.get $1
+      local.set $11
+      local.get $9
+      local.get $10
       i32.const 3
       i32.shl
       i32.add
-      local.get $1
+      local.get $11
       i32.add
       f64.load offset=8
      end
-     local.set $9
+     local.set $12
      block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.5 (result f64)
       local.get $0
-      local.get $6
+      local.set $11
+      local.get $8
+      local.set $10
+      local.get $1
+      local.set $9
+      local.get $11
+      local.get $10
       i32.const 3
       i32.shl
       i32.add
-      local.get $1
+      local.get $9
       i32.add
       f64.load offset=8
      end
-     local.set $10
+     local.set $13
      block (result i32)
       i32.const 2
       global.set $~argc
-      local.get $9
-      local.get $10
+      local.get $12
+      local.get $13
       local.get $3
       call_indirect (type $FFi)
      end
      i32.const 0
      i32.lt_s
      if
-      local.get $5
       local.get $6
+      local.get $8
       i32.const 5
       i32.shr_s
       i32.const 2
       i32.shl
       i32.add
-      local.get $5
       local.get $6
+      local.get $8
       i32.const 5
       i32.shr_s
       i32.const 2
@@ -6373,36 +6805,56 @@
       i32.add
       i32.load
       i32.const 1
-      local.get $6
+      local.get $8
       i32.const 31
       i32.and
       i32.shl
       i32.xor
       i32.store
-      local.get $0
-      local.get $6
-      i32.const 3
-      i32.shl
-      i32.add
-      local.get $1
-      i32.add
-      local.get $9
-      f64.store offset=8
-      local.get $0
-      local.get $8
-      i32.const 3
-      i32.shl
-      i32.add
-      local.get $1
-      i32.add
-      local.get $10
-      f64.store offset=8
+      block $~lib/internal/arraybuffer/STORE<f64,f64>|inlined.4
+       local.get $0
+       local.set $9
+       local.get $8
+       local.set $10
+       local.get $12
+       local.set $14
+       local.get $1
+       local.set $11
+       local.get $9
+       local.get $10
+       i32.const 3
+       i32.shl
+       i32.add
+       local.get $11
+       i32.add
+       local.get $14
+       f64.store offset=8
+      end
+      block $~lib/internal/arraybuffer/STORE<f64,f64>|inlined.5
+       local.get $0
+       local.set $11
+       local.get $5
+       local.set $10
+       local.get $13
+       local.set $14
+       local.get $1
+       local.set $9
+       local.get $11
+       local.get $10
+       i32.const 3
+       i32.shl
+       i32.add
+       local.get $9
+       i32.add
+       local.get $14
+       f64.store offset=8
+      end
      end
     end
-    local.get $6
+    local.get $8
     i32.const 1
     i32.sub
-    local.set $6
+    local.set $8
     br $repeat|0
     unreachable
    end
@@ -6412,74 +6864,100 @@
    local.get $2
    i32.const 1
    i32.sub
-   local.set $6
+   local.set $8
    loop $repeat|2
-    local.get $6
+    local.get $8
     i32.const 2
     i32.ge_s
     i32.eqz
     br_if $break|2
     block
      block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.6 (result f64)
+      local.get $0
+      local.set $5
       i32.const 0
-      local.set $8
+      local.set $7
+      local.get $1
+      local.set $9
+      local.get $5
+      local.get $7
+      i32.const 3
+      i32.shl
+      i32.add
+      local.get $9
+      i32.add
+      f64.load offset=8
+     end
+     local.set $13
+     block $~lib/internal/arraybuffer/STORE<f64,f64>|inlined.6
       local.get $0
+      local.set $9
+      i32.const 0
+      local.set $7
+      block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.7 (result f64)
+       local.get $0
+       local.set $5
+       local.get $8
+       local.set $10
+       local.get $1
+       local.set $11
+       local.get $5
+       local.get $10
+       i32.const 3
+       i32.shl
+       i32.add
+       local.get $11
+       i32.add
+       f64.load offset=8
+      end
+      local.set $12
+      local.get $1
+      local.set $11
+      local.get $9
+      local.get $7
+      i32.const 3
+      i32.shl
+      i32.add
+      local.get $11
+      i32.add
+      local.get $12
+      f64.store offset=8
+     end
+     block $~lib/internal/arraybuffer/STORE<f64,f64>|inlined.7
+      local.get $0
+      local.set $11
       local.get $8
+      local.set $7
+      local.get $13
+      local.set $12
+      local.get $1
+      local.set $9
+      local.get $11
+      local.get $7
       i32.const 3
       i32.shl
       i32.add
-      local.get $1
+      local.get $9
       i32.add
-      f64.load offset=8
+      local.get $12
+      f64.store offset=8
      end
-     local.set $10
-     i32.const 0
-     local.set $8
-     block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.7 (result f64)
-      local.get $0
-      local.get $6
-      i32.const 3
-      i32.shl
-      i32.add
-      local.get $1
-      i32.add
-      f64.load offset=8
-     end
-     local.set $9
-     local.get $0
-     local.get $8
-     i32.const 3
-     i32.shl
-     i32.add
-     local.get $1
-     i32.add
-     local.get $9
-     f64.store offset=8
-     local.get $0
-     local.get $6
-     i32.const 3
-     i32.shl
-     i32.add
-     local.get $1
-     i32.add
-     local.get $10
-     f64.store offset=8
      i32.const 1
-     local.set $8
+     local.set $9
      block $break|3
       loop $continue|3
-       local.get $8
+       local.get $9
        i32.const 1
        i32.shl
-       local.get $5
-       local.get $8
+       local.get $6
+       local.get $9
        i32.const 5
        i32.shr_s
        i32.const 2
        i32.shl
        i32.add
        i32.load
-       local.get $8
+       local.get $9
        i32.const 31
        i32.and
        i32.shr_u
@@ -6487,66 +6965,76 @@
        i32.and
        i32.add
        local.tee $7
-       local.get $6
+       local.get $8
        i32.lt_s
        if
         local.get $7
-        local.set $8
+        local.set $9
         br $continue|3
        end
       end
      end
      block $break|4
       loop $continue|4
-       local.get $8
+       local.get $9
        i32.const 0
        i32.gt_s
        if
         block
          block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.8 (result f64)
-          i32.const 0
-          local.set $11
           local.get $0
+          local.set $11
+          i32.const 0
+          local.set $10
+          local.get $1
+          local.set $5
           local.get $11
+          local.get $10
           i32.const 3
           i32.shl
           i32.add
-          local.get $1
+          local.get $5
           i32.add
           f64.load offset=8
          end
-         local.set $10
+         local.set $13
          block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.9 (result f64)
           local.get $0
-          local.get $8
+          local.set $5
+          local.get $9
+          local.set $10
+          local.get $1
+          local.set $11
+          local.get $5
+          local.get $10
           i32.const 3
           i32.shl
           i32.add
-          local.get $1
+          local.get $11
           i32.add
           f64.load offset=8
          end
-         local.set $9
+         local.set $12
          block (result i32)
           i32.const 2
           global.set $~argc
-          local.get $10
-          local.get $9
+          local.get $13
+          local.get $12
           local.get $3
           call_indirect (type $FFi)
          end
          i32.const 0
          i32.lt_s
          if
-          local.get $5
-          local.get $8
+          local.get $6
+          local.get $9
           i32.const 5
           i32.shr_s
           i32.const 2
           i32.shl
           i32.add
-          local.get $5
-          local.get $8
+          local.get $6
+          local.get $9
           i32.const 5
           i32.shr_s
           i32.const 2
@@ -6554,117 +7042,158 @@
           i32.add
           i32.load
           i32.const 1
-          local.get $8
+          local.get $9
           i32.const 31
           i32.and
           i32.shl
           i32.xor
           i32.store
-          local.get $0
-          local.get $8
-          i32.const 3
-          i32.shl
-          i32.add
-          local.get $1
-          i32.add
-          local.get $10
-          f64.store offset=8
-          i32.const 0
-          local.set $11
-          local.get $0
-          local.get $11
-          i32.const 3
-          i32.shl
-          i32.add
-          local.get $1
-          i32.add
-          local.get $9
-          f64.store offset=8
+          block $~lib/internal/arraybuffer/STORE<f64,f64>|inlined.8
+           local.get $0
+           local.set $11
+           local.get $9
+           local.set $10
+           local.get $13
+           local.set $14
+           local.get $1
+           local.set $5
+           local.get $11
+           local.get $10
+           i32.const 3
+           i32.shl
+           i32.add
+           local.get $5
+           i32.add
+           local.get $14
+           f64.store offset=8
+          end
+          block $~lib/internal/arraybuffer/STORE<f64,f64>|inlined.9
+           local.get $0
+           local.set $5
+           i32.const 0
+           local.set $10
+           local.get $12
+           local.set $14
+           local.get $1
+           local.set $11
+           local.get $5
+           local.get $10
+           i32.const 3
+           i32.shl
+           i32.add
+           local.get $11
+           i32.add
+           local.get $14
+           f64.store offset=8
+          end
          end
-         local.get $8
+         local.get $9
          i32.const 1
          i32.shr_s
-         local.set $8
+         local.set $9
         end
         br $continue|4
        end
       end
      end
     end
-    local.get $6
+    local.get $8
     i32.const 1
     i32.sub
-    local.set $6
+    local.set $8
     br $repeat|2
     unreachable
    end
    unreachable
   end
   block $~lib/memory/memory.free|inlined.2
-   block
-    local.get $5
-    call $~lib/allocator/arena/__memory_free
-    br $~lib/memory/memory.free|inlined.2
-    unreachable
-   end
-   unreachable
+   local.get $6
+   local.set $8
+   local.get $8
+   call $~lib/allocator/arena/__memory_free
+   br $~lib/memory/memory.free|inlined.2
   end
   block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.10 (result f64)
+   local.get $0
+   local.set $8
    i32.const 1
-   local.set $6
-   local.get $0
-   local.get $6
-   i32.const 3
-   i32.shl
-   i32.add
-   local.get $1
-   i32.add
-   f64.load offset=8
-  end
-  local.set $12
-  i32.const 1
-  local.set $6
-  block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.11 (result f64)
-   i32.const 0
    local.set $7
-   local.get $0
+   local.get $1
+   local.set $9
+   local.get $8
    local.get $7
    i32.const 3
    i32.shl
    i32.add
-   local.get $1
+   local.get $9
    i32.add
    f64.load offset=8
   end
-  local.set $10
-  local.get $0
-  local.get $6
-  i32.const 3
-  i32.shl
-  i32.add
-  local.get $1
-  i32.add
-  local.get $10
-  f64.store offset=8
-  i32.const 0
-  local.set $6
-  local.get $0
-  local.get $6
-  i32.const 3
-  i32.shl
-  i32.add
-  local.get $1
-  i32.add
-  local.get $12
-  f64.store offset=8
+  local.set $15
+  block $~lib/internal/arraybuffer/STORE<f64,f64>|inlined.10
+   local.get $0
+   local.set $9
+   i32.const 1
+   local.set $7
+   block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.11 (result f64)
+    local.get $0
+    local.set $8
+    i32.const 0
+    local.set $11
+    local.get $1
+    local.set $10
+    local.get $8
+    local.get $11
+    i32.const 3
+    i32.shl
+    i32.add
+    local.get $10
+    i32.add
+    f64.load offset=8
+   end
+   local.set $13
+   local.get $1
+   local.set $10
+   local.get $9
+   local.get $7
+   i32.const 3
+   i32.shl
+   i32.add
+   local.get $10
+   i32.add
+   local.get $13
+   f64.store offset=8
+  end
+  block $~lib/internal/arraybuffer/STORE<f64,f64>|inlined.11
+   local.get $0
+   local.set $10
+   i32.const 0
+   local.set $7
+   local.get $15
+   local.set $13
+   local.get $1
+   local.set $9
+   local.get $10
+   local.get $7
+   i32.const 3
+   i32.shl
+   i32.add
+   local.get $9
+   i32.add
+   local.get $13
+   f64.store offset=8
+  end
  )
  (func $~lib/array/Array<f64>#sort (; 112 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 f64)
+  (local $6 i32)
   (local $7 f64)
+  (local $8 f64)
+  (local $9 f64)
+  (local $10 i32)
   local.get $1
   i32.eqz
   if
@@ -6693,97 +7222,121 @@
   i32.eq
   if
    block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.0 (result f64)
+    local.get $3
+    local.set $4
     i32.const 1
-    local.set $4
-    i32.const 0
     local.set $5
-    local.get $3
+    i32.const 0
+    local.set $6
     local.get $4
-    i32.const 3
-    i32.shl
-    i32.add
-    local.get $5
-    i32.add
-    f64.load offset=8
-   end
-   local.set $6
-   block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.1 (result f64)
-    i32.const 0
-    local.set $5
-    i32.const 0
-    local.set $4
-    local.get $3
     local.get $5
     i32.const 3
     i32.shl
     i32.add
-    local.get $4
+    local.get $6
     i32.add
     f64.load offset=8
    end
    local.set $7
+   block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.1 (result f64)
+    local.get $3
+    local.set $6
+    i32.const 0
+    local.set $5
+    i32.const 0
+    local.set $4
+    local.get $6
+    local.get $5
+    i32.const 3
+    i32.shl
+    i32.add
+    local.get $4
+    i32.add
+    f64.load offset=8
+   end
+   local.set $8
    block (result i32)
     i32.const 2
     global.set $~argc
-    local.get $6
     local.get $7
+    local.get $8
     local.get $1
     call_indirect (type $FFi)
    end
    i32.const 0
    i32.lt_s
    if
-    i32.const 1
-    local.set $4
-    i32.const 0
-    local.set $5
-    local.get $3
-    local.get $4
-    i32.const 3
-    i32.shl
-    i32.add
-    local.get $5
-    i32.add
-    local.get $7
-    f64.store offset=8
-    i32.const 0
-    local.set $5
-    i32.const 0
-    local.set $4
-    local.get $3
-    local.get $5
-    i32.const 3
-    i32.shl
-    i32.add
-    local.get $4
-    i32.add
-    local.get $6
-    f64.store offset=8
+    block $~lib/internal/arraybuffer/STORE<f64,f64>|inlined.0
+     local.get $3
+     local.set $4
+     i32.const 1
+     local.set $5
+     local.get $8
+     local.set $9
+     i32.const 0
+     local.set $6
+     local.get $4
+     local.get $5
+     i32.const 3
+     i32.shl
+     i32.add
+     local.get $6
+     i32.add
+     local.get $9
+     f64.store offset=8
+    end
+    block $~lib/internal/arraybuffer/STORE<f64,f64>|inlined.1
+     local.get $3
+     local.set $6
+     i32.const 0
+     local.set $5
+     local.get $7
+     local.set $9
+     i32.const 0
+     local.set $4
+     local.get $6
+     local.get $5
+     i32.const 3
+     i32.shl
+     i32.add
+     local.get $4
+     i32.add
+     local.get $9
+     f64.store offset=8
+    end
    end
    local.get $0
    return
   end
-  i32.const 0
-  local.set $4
-  local.get $2
-  i32.const 256
-  i32.lt_s
-  if
+  block $~lib/internal/sort/SORT<f64>|inlined.0
    local.get $3
-   local.get $4
+   local.set $4
+   i32.const 0
+   local.set $5
    local.get $2
+   local.set $6
    local.get $1
-   call $~lib/internal/sort/insertionSort<f64>
-  else   
-   local.get $3
-   local.get $4
-   local.get $2
-   local.get $1
-   call $~lib/internal/sort/weakHeapSort<f64>
+   local.set $10
+   local.get $6
+   i32.const 256
+   i32.lt_s
+   if
+    local.get $4
+    local.get $5
+    local.get $6
+    local.get $10
+    call $~lib/internal/sort/insertionSort<f64>
+   else    
+    local.get $4
+    local.get $5
+    local.get $6
+    local.get $10
+    call $~lib/internal/sort/weakHeapSort<f64>
+   end
   end
   local.get $0
  )
- (func $~lib/array/Array<f64>#sort|trampoline~anonymous|45 (; 113 ;) (type $FFi) (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<f64>~anonymous|45 (; 113 ;) (type $FFi) (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   local.get $0
@@ -6838,6 +7391,8 @@
  (func $~lib/array/Array<f64>#__get (; 115 ;) (type $iiF) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.load
   local.set $2
@@ -6848,14 +7403,18 @@
   i32.shr_u
   i32.lt_u
   if (result f64)
-   i32.const 0
-   local.set $3
    local.get $2
+   local.set $3
    local.get $1
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 3
    i32.shl
    i32.add
-   local.get $3
+   local.get $5
    i32.add
    f64.load offset=8
   else   
@@ -6874,12 +7433,16 @@
   if
    block $~lib/array/Array<f64>#get:length|inlined.0 (result i32)
     local.get $0
+    local.set $3
+    local.get $3
     i32.load offset=4
    end
    local.set $2
    local.get $2
    block $~lib/array/Array<f64>#get:length|inlined.2 (result i32)
     local.get $1
+    local.set $3
+    local.get $3
     i32.load offset=4
    end
    i32.ne
@@ -6948,6 +7511,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   block $break|0
    i32.const 0
    local.set $4
@@ -6960,15 +7526,21 @@
     block
      block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.24 (result i32)
       local.get $0
+      local.set $5
       local.get $4
+      local.set $6
+      local.get $1
+      local.set $7
+      local.get $5
+      local.get $6
       i32.const 2
       i32.shl
       i32.add
-      local.get $1
+      local.get $7
       i32.add
       i32.load offset=8
      end
-     local.set $5
+     local.set $7
      local.get $4
      i32.const 1
      i32.sub
@@ -6982,45 +7554,57 @@
         block
          block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.25 (result i32)
           local.get $0
+          local.set $5
           local.get $6
+          local.set $8
+          local.get $1
+          local.set $9
+          local.get $5
+          local.get $8
           i32.const 2
           i32.shl
           i32.add
-          local.get $1
+          local.get $9
           i32.add
           i32.load offset=8
          end
-         local.set $7
+         local.set $9
          block (result i32)
           i32.const 2
           global.set $~argc
-          local.get $5
           local.get $7
+          local.get $9
           local.get $3
           call_indirect (type $iii)
          end
          i32.const 0
          i32.lt_s
          if
+          local.get $0
+          local.set $8
           block (result i32)
            local.get $6
-           local.tee $8
+           local.tee $5
            i32.const 1
            i32.sub
            local.set $6
-           local.get $8
+           local.get $5
           end
           i32.const 1
           i32.add
-          local.set $8
-          local.get $0
+          local.set $5
+          local.get $9
+          local.set $10
+          local.get $1
+          local.set $11
           local.get $8
+          local.get $5
           i32.const 2
           i32.shl
           i32.add
-          local.get $1
+          local.get $11
           i32.add
-          local.get $7
+          local.get $10
           i32.store offset=8
          else          
           br $break|1
@@ -7030,19 +7614,27 @@
        end
       end
      end
-     local.get $6
-     i32.const 1
-     i32.add
-     local.set $7
-     local.get $0
-     local.get $7
-     i32.const 2
-     i32.shl
-     i32.add
-     local.get $1
-     i32.add
-     local.get $5
-     i32.store offset=8
+     block $~lib/internal/arraybuffer/STORE<i32,i32>|inlined.11
+      local.get $0
+      local.set $9
+      local.get $6
+      i32.const 1
+      i32.add
+      local.set $11
+      local.get $7
+      local.set $10
+      local.get $1
+      local.set $5
+      local.get $9
+      local.get $11
+      i32.const 2
+      i32.shl
+      i32.add
+      local.get $5
+      i32.add
+      local.get $10
+      i32.store offset=8
+     end
     end
     local.get $4
     i32.const 1
@@ -7064,6 +7656,9 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $2
   i32.const 31
   i32.add
@@ -7074,36 +7669,44 @@
   local.set $4
   block $~lib/memory/memory.allocate|inlined.3 (result i32)
    local.get $4
+   local.set $5
+   local.get $5
    call $~lib/allocator/arena/__memory_allocate
    br $~lib/memory/memory.allocate|inlined.3
   end
-  local.set $5
-  i32.const 0
   local.set $6
-  local.get $5
-  local.get $6
-  local.get $4
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.7
+   local.get $6
+   local.set $5
+   i32.const 0
+   local.set $7
+   local.get $4
+   local.set $8
+   local.get $5
+   local.get $7
+   local.get $8
+   call $~lib/internal/memory/memset
+  end
   block $break|0
    local.get $2
    i32.const 1
    i32.sub
-   local.set $6
+   local.set $8
    loop $repeat|0
-    local.get $6
+    local.get $8
     i32.const 0
     i32.gt_s
     i32.eqz
     br_if $break|0
     block
-     local.get $6
+     local.get $8
      local.set $7
      block $break|1
       loop $continue|1
        local.get $7
        i32.const 1
        i32.and
-       local.get $5
+       local.get $6
        local.get $7
        i32.const 6
        i32.shr_s
@@ -7132,49 +7735,61 @@
      local.get $7
      i32.const 1
      i32.shr_s
-     local.set $8
+     local.set $5
      block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.26 (result i32)
       local.get $0
-      local.get $8
+      local.set $9
+      local.get $5
+      local.set $10
+      local.get $1
+      local.set $11
+      local.get $9
+      local.get $10
       i32.const 2
       i32.shl
       i32.add
-      local.get $1
+      local.get $11
       i32.add
       i32.load offset=8
      end
-     local.set $9
+     local.set $11
      block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.27 (result i32)
       local.get $0
-      local.get $6
+      local.set $10
+      local.get $8
+      local.set $9
+      local.get $1
+      local.set $12
+      local.get $10
+      local.get $9
       i32.const 2
       i32.shl
       i32.add
-      local.get $1
+      local.get $12
       i32.add
       i32.load offset=8
      end
-     local.set $10
+     local.set $12
      block (result i32)
       i32.const 2
       global.set $~argc
-      local.get $9
-      local.get $10
+      local.get $11
+      local.get $12
       local.get $3
       call_indirect (type $iii)
      end
      i32.const 0
      i32.lt_s
      if
-      local.get $5
       local.get $6
+      local.get $8
       i32.const 5
       i32.shr_s
       i32.const 2
       i32.shl
       i32.add
-      local.get $5
       local.get $6
+      local.get $8
       i32.const 5
       i32.shr_s
       i32.const 2
@@ -7182,36 +7797,56 @@
       i32.add
       i32.load
       i32.const 1
-      local.get $6
+      local.get $8
       i32.const 31
       i32.and
       i32.shl
       i32.xor
       i32.store
-      local.get $0
-      local.get $6
-      i32.const 2
-      i32.shl
-      i32.add
-      local.get $1
-      i32.add
-      local.get $9
-      i32.store offset=8
-      local.get $0
-      local.get $8
-      i32.const 2
-      i32.shl
-      i32.add
-      local.get $1
-      i32.add
-      local.get $10
-      i32.store offset=8
+      block $~lib/internal/arraybuffer/STORE<i32,i32>|inlined.12
+       local.get $0
+       local.set $9
+       local.get $8
+       local.set $10
+       local.get $11
+       local.set $13
+       local.get $1
+       local.set $14
+       local.get $9
+       local.get $10
+       i32.const 2
+       i32.shl
+       i32.add
+       local.get $14
+       i32.add
+       local.get $13
+       i32.store offset=8
+      end
+      block $~lib/internal/arraybuffer/STORE<i32,i32>|inlined.13
+       local.get $0
+       local.set $14
+       local.get $5
+       local.set $13
+       local.get $12
+       local.set $10
+       local.get $1
+       local.set $9
+       local.get $14
+       local.get $13
+       i32.const 2
+       i32.shl
+       i32.add
+       local.get $9
+       i32.add
+       local.get $10
+       i32.store offset=8
+      end
      end
     end
-    local.get $6
+    local.get $8
     i32.const 1
     i32.sub
-    local.set $6
+    local.set $8
     br $repeat|0
     unreachable
    end
@@ -7221,141 +7856,177 @@
    local.get $2
    i32.const 1
    i32.sub
-   local.set $6
+   local.set $8
    loop $repeat|2
-    local.get $6
+    local.get $8
     i32.const 2
     i32.ge_s
     i32.eqz
     br_if $break|2
     block
      block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.28 (result i32)
-      i32.const 0
-      local.set $10
       local.get $0
+      local.set $12
+      i32.const 0
+      local.set $11
+      local.get $1
+      local.set $5
+      local.get $12
+      local.get $11
+      i32.const 2
+      i32.shl
+      i32.add
+      local.get $5
+      i32.add
+      i32.load offset=8
+     end
+     local.set $5
+     block $~lib/internal/arraybuffer/STORE<i32,i32>|inlined.14
+      local.get $0
+      local.set $11
+      i32.const 0
+      local.set $12
+      block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.29 (result i32)
+       local.get $0
+       local.set $7
+       local.get $8
+       local.set $9
+       local.get $1
+       local.set $10
+       local.get $7
+       local.get $9
+       i32.const 2
+       i32.shl
+       i32.add
+       local.get $10
+       i32.add
+       i32.load offset=8
+      end
+      local.set $10
+      local.get $1
+      local.set $9
+      local.get $11
+      local.get $12
+      i32.const 2
+      i32.shl
+      i32.add
+      local.get $9
+      i32.add
+      local.get $10
+      i32.store offset=8
+     end
+     block $~lib/internal/arraybuffer/STORE<i32,i32>|inlined.15
+      local.get $0
+      local.set $9
+      local.get $8
+      local.set $10
+      local.get $5
+      local.set $12
+      local.get $1
+      local.set $11
+      local.get $9
       local.get $10
       i32.const 2
       i32.shl
       i32.add
-      local.get $1
+      local.get $11
       i32.add
-      i32.load offset=8
+      local.get $12
+      i32.store offset=8
      end
-     local.set $10
-     i32.const 0
-     local.set $9
-     block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.29 (result i32)
-      local.get $0
-      local.get $6
-      i32.const 2
-      i32.shl
-      i32.add
-      local.get $1
-      i32.add
-      i32.load offset=8
-     end
-     local.set $8
-     local.get $0
-     local.get $9
-     i32.const 2
-     i32.shl
-     i32.add
-     local.get $1
-     i32.add
-     local.get $8
-     i32.store offset=8
-     local.get $0
-     local.get $6
-     i32.const 2
-     i32.shl
-     i32.add
-     local.get $1
-     i32.add
-     local.get $10
-     i32.store offset=8
      i32.const 1
-     local.set $8
+     local.set $11
      block $break|3
       loop $continue|3
-       local.get $8
+       local.get $11
        i32.const 1
        i32.shl
-       local.get $5
-       local.get $8
+       local.get $6
+       local.get $11
        i32.const 5
        i32.shr_s
        i32.const 2
        i32.shl
        i32.add
        i32.load
-       local.get $8
+       local.get $11
        i32.const 31
        i32.and
        i32.shr_u
        i32.const 1
        i32.and
        i32.add
-       local.tee $9
-       local.get $6
+       local.tee $12
+       local.get $8
        i32.lt_s
        if
-        local.get $9
-        local.set $8
+        local.get $12
+        local.set $11
         br $continue|3
        end
       end
      end
      block $break|4
       loop $continue|4
-       local.get $8
+       local.get $11
        i32.const 0
        i32.gt_s
        if
         block
          block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.30 (result i32)
-          i32.const 0
-          local.set $7
           local.get $0
-          local.get $7
+          local.set $10
+          i32.const 0
+          local.set $9
+          local.get $1
+          local.set $7
+          local.get $10
+          local.get $9
           i32.const 2
           i32.shl
           i32.add
+          local.get $7
+          i32.add
+          i32.load offset=8
+         end
+         local.set $5
+         block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.31 (result i32)
+          local.get $0
+          local.set $7
+          local.get $11
+          local.set $9
           local.get $1
+          local.set $10
+          local.get $7
+          local.get $9
+          i32.const 2
+          i32.shl
+          i32.add
+          local.get $10
           i32.add
           i32.load offset=8
          end
          local.set $10
-         block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.31 (result i32)
-          local.get $0
-          local.get $8
-          i32.const 2
-          i32.shl
-          i32.add
-          local.get $1
-          i32.add
-          i32.load offset=8
-         end
-         local.set $7
          block (result i32)
           i32.const 2
           global.set $~argc
+          local.get $5
           local.get $10
-          local.get $7
           local.get $3
           call_indirect (type $iii)
          end
          i32.const 0
          i32.lt_s
          if
-          local.get $5
-          local.get $8
+          local.get $6
+          local.get $11
           i32.const 5
           i32.shr_s
           i32.const 2
           i32.shl
           i32.add
-          local.get $5
-          local.get $8
+          local.get $6
+          local.get $11
           i32.const 5
           i32.shr_s
           i32.const 2
@@ -7363,109 +8034,147 @@
           i32.add
           i32.load
           i32.const 1
-          local.get $8
+          local.get $11
           i32.const 31
           i32.and
           i32.shl
           i32.xor
           i32.store
-          local.get $0
-          local.get $8
-          i32.const 2
-          i32.shl
-          i32.add
-          local.get $1
-          i32.add
-          local.get $10
-          i32.store offset=8
-          i32.const 0
-          local.set $11
-          local.get $0
-          local.get $11
-          i32.const 2
-          i32.shl
-          i32.add
-          local.get $1
-          i32.add
-          local.get $7
-          i32.store offset=8
+          block $~lib/internal/arraybuffer/STORE<i32,i32>|inlined.16
+           local.get $0
+           local.set $9
+           local.get $11
+           local.set $7
+           local.get $5
+           local.set $13
+           local.get $1
+           local.set $14
+           local.get $9
+           local.get $7
+           i32.const 2
+           i32.shl
+           i32.add
+           local.get $14
+           i32.add
+           local.get $13
+           i32.store offset=8
+          end
+          block $~lib/internal/arraybuffer/STORE<i32,i32>|inlined.17
+           local.get $0
+           local.set $14
+           i32.const 0
+           local.set $13
+           local.get $10
+           local.set $7
+           local.get $1
+           local.set $9
+           local.get $14
+           local.get $13
+           i32.const 2
+           i32.shl
+           i32.add
+           local.get $9
+           i32.add
+           local.get $7
+           i32.store offset=8
+          end
          end
-         local.get $8
+         local.get $11
          i32.const 1
          i32.shr_s
-         local.set $8
+         local.set $11
         end
         br $continue|4
        end
       end
      end
     end
-    local.get $6
+    local.get $8
     i32.const 1
     i32.sub
-    local.set $6
+    local.set $8
     br $repeat|2
     unreachable
    end
    unreachable
   end
   block $~lib/memory/memory.free|inlined.3
-   block
-    local.get $5
-    call $~lib/allocator/arena/__memory_free
-    br $~lib/memory/memory.free|inlined.3
-    unreachable
-   end
-   unreachable
+   local.get $6
+   local.set $8
+   local.get $8
+   call $~lib/allocator/arena/__memory_free
+   br $~lib/memory/memory.free|inlined.3
   end
   block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.32 (result i32)
+   local.get $0
+   local.set $8
    i32.const 1
-   local.set $6
-   local.get $0
-   local.get $6
+   local.set $12
+   local.get $1
+   local.set $11
+   local.get $8
+   local.get $12
    i32.const 2
    i32.shl
    i32.add
-   local.get $1
+   local.get $11
    i32.add
    i32.load offset=8
   end
-  local.set $12
-  i32.const 1
-  local.set $6
-  block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.33 (result i32)
+  local.set $15
+  block $~lib/internal/arraybuffer/STORE<i32,i32>|inlined.18
+   local.get $0
+   local.set $11
+   i32.const 1
+   local.set $12
+   block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.33 (result i32)
+    local.get $0
+    local.set $8
+    i32.const 0
+    local.set $5
+    local.get $1
+    local.set $10
+    local.get $8
+    local.get $5
+    i32.const 2
+    i32.shl
+    i32.add
+    local.get $10
+    i32.add
+    i32.load offset=8
+   end
+   local.set $10
+   local.get $1
+   local.set $5
+   local.get $11
+   local.get $12
+   i32.const 2
+   i32.shl
+   i32.add
+   local.get $5
+   i32.add
+   local.get $10
+   i32.store offset=8
+  end
+  block $~lib/internal/arraybuffer/STORE<i32,i32>|inlined.19
+   local.get $0
+   local.set $5
    i32.const 0
-   local.set $9
-   local.get $0
-   local.get $9
+   local.set $10
+   local.get $15
+   local.set $12
+   local.get $1
+   local.set $11
+   local.get $5
+   local.get $10
    i32.const 2
    i32.shl
    i32.add
-   local.get $1
+   local.get $11
    i32.add
-   i32.load offset=8
+   local.get $12
+   i32.store offset=8
   end
-  local.set $9
-  local.get $0
-  local.get $6
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $1
-  i32.add
-  local.get $9
-  i32.store offset=8
-  i32.const 0
-  local.set $9
-  local.get $0
-  local.get $9
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $1
-  i32.add
-  local.get $12
-  i32.store offset=8
  )
  (func $~lib/array/Array<i32>#sort (; 120 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -7474,6 +8183,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   local.get $1
   i32.eqz
   if
@@ -7502,27 +8213,14 @@
   i32.eq
   if
    block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.22 (result i32)
-    i32.const 1
-    local.set $4
-    i32.const 0
-    local.set $5
     local.get $3
-    local.get $4
-    i32.const 2
-    i32.shl
-    i32.add
-    local.get $5
-    i32.add
-    i32.load offset=8
-   end
-   local.set $5
-   block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.23 (result i32)
-    i32.const 0
     local.set $4
+    i32.const 1
+    local.set $5
     i32.const 0
     local.set $6
-    local.get $3
     local.get $4
+    local.get $5
     i32.const 2
     i32.shl
     i32.add
@@ -7531,68 +8229,105 @@
     i32.load offset=8
    end
    local.set $6
+   block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.23 (result i32)
+    local.get $3
+    local.set $5
+    i32.const 0
+    local.set $4
+    i32.const 0
+    local.set $7
+    local.get $5
+    local.get $4
+    i32.const 2
+    i32.shl
+    i32.add
+    local.get $7
+    i32.add
+    i32.load offset=8
+   end
+   local.set $7
    block (result i32)
     i32.const 2
     global.set $~argc
-    local.get $5
     local.get $6
+    local.get $7
     local.get $1
     call_indirect (type $iii)
    end
    i32.const 0
    i32.lt_s
    if
-    i32.const 1
-    local.set $4
-    i32.const 0
-    local.set $7
-    local.get $3
-    local.get $4
-    i32.const 2
-    i32.shl
-    i32.add
-    local.get $7
-    i32.add
-    local.get $6
-    i32.store offset=8
-    i32.const 0
-    local.set $7
-    i32.const 0
-    local.set $4
-    local.get $3
-    local.get $7
-    i32.const 2
-    i32.shl
-    i32.add
-    local.get $4
-    i32.add
-    local.get $5
-    i32.store offset=8
+    block $~lib/internal/arraybuffer/STORE<i32,i32>|inlined.8
+     local.get $3
+     local.set $4
+     i32.const 1
+     local.set $5
+     local.get $7
+     local.set $8
+     i32.const 0
+     local.set $9
+     local.get $4
+     local.get $5
+     i32.const 2
+     i32.shl
+     i32.add
+     local.get $9
+     i32.add
+     local.get $8
+     i32.store offset=8
+    end
+    block $~lib/internal/arraybuffer/STORE<i32,i32>|inlined.9
+     local.get $3
+     local.set $9
+     i32.const 0
+     local.set $8
+     local.get $6
+     local.set $5
+     i32.const 0
+     local.set $4
+     local.get $9
+     local.get $8
+     i32.const 2
+     i32.shl
+     i32.add
+     local.get $4
+     i32.add
+     local.get $5
+     i32.store offset=8
+    end
    end
    local.get $0
    return
   end
-  i32.const 0
-  local.set $6
-  local.get $2
-  i32.const 256
-  i32.lt_s
-  if
+  block $~lib/internal/sort/SORT<i32>|inlined.0
    local.get $3
-   local.get $6
+   local.set $7
+   i32.const 0
+   local.set $6
    local.get $2
+   local.set $4
    local.get $1
-   call $~lib/internal/sort/insertionSort<i32>
-  else   
-   local.get $3
-   local.get $6
-   local.get $2
-   local.get $1
-   call $~lib/internal/sort/weakHeapSort<i32>
+   local.set $5
+   local.get $4
+   i32.const 256
+   i32.lt_s
+   if
+    local.get $7
+    local.get $6
+    local.get $4
+    local.get $5
+    call $~lib/internal/sort/insertionSort<i32>
+   else    
+    local.get $7
+    local.get $6
+    local.get $4
+    local.get $5
+    call $~lib/internal/sort/weakHeapSort<i32>
+   end
   end
   local.get $0
  )
- (func $~lib/array/Array<i32>#sort|trampoline~anonymous|46 (; 121 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<i32>~anonymous|46 (; 121 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
@@ -7622,6 +8357,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   block $break|0
    i32.const 0
    local.set $4
@@ -7634,15 +8372,21 @@
     block
      block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.3 (result i32)
       local.get $0
+      local.set $5
       local.get $4
+      local.set $6
+      local.get $1
+      local.set $7
+      local.get $5
+      local.get $6
       i32.const 2
       i32.shl
       i32.add
-      local.get $1
+      local.get $7
       i32.add
       i32.load offset=8
      end
-     local.set $5
+     local.set $7
      local.get $4
      i32.const 1
      i32.sub
@@ -7656,45 +8400,57 @@
         block
          block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.4 (result i32)
           local.get $0
+          local.set $5
           local.get $6
+          local.set $8
+          local.get $1
+          local.set $9
+          local.get $5
+          local.get $8
           i32.const 2
           i32.shl
           i32.add
-          local.get $1
+          local.get $9
           i32.add
           i32.load offset=8
          end
-         local.set $7
+         local.set $9
          block (result i32)
           i32.const 2
           global.set $~argc
-          local.get $5
           local.get $7
+          local.get $9
           local.get $3
           call_indirect (type $iii)
          end
          i32.const 0
          i32.lt_s
          if
+          local.get $0
+          local.set $8
           block (result i32)
            local.get $6
-           local.tee $8
+           local.tee $5
            i32.const 1
            i32.sub
            local.set $6
-           local.get $8
+           local.get $5
           end
           i32.const 1
           i32.add
-          local.set $8
-          local.get $0
+          local.set $5
+          local.get $9
+          local.set $10
+          local.get $1
+          local.set $11
           local.get $8
+          local.get $5
           i32.const 2
           i32.shl
           i32.add
-          local.get $1
+          local.get $11
           i32.add
-          local.get $7
+          local.get $10
           i32.store offset=8
          else          
           br $break|1
@@ -7704,19 +8460,27 @@
        end
       end
      end
-     local.get $6
-     i32.const 1
-     i32.add
-     local.set $7
-     local.get $0
-     local.get $7
-     i32.const 2
-     i32.shl
-     i32.add
-     local.get $1
-     i32.add
-     local.get $5
-     i32.store offset=8
+     block $~lib/internal/arraybuffer/STORE<u32,u32>|inlined.4
+      local.get $0
+      local.set $9
+      local.get $6
+      i32.const 1
+      i32.add
+      local.set $11
+      local.get $7
+      local.set $10
+      local.get $1
+      local.set $5
+      local.get $9
+      local.get $11
+      i32.const 2
+      i32.shl
+      i32.add
+      local.get $5
+      i32.add
+      local.get $10
+      i32.store offset=8
+     end
     end
     local.get $4
     i32.const 1
@@ -7738,6 +8502,9 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $2
   i32.const 31
   i32.add
@@ -7748,36 +8515,44 @@
   local.set $4
   block $~lib/memory/memory.allocate|inlined.4 (result i32)
    local.get $4
+   local.set $5
+   local.get $5
    call $~lib/allocator/arena/__memory_allocate
    br $~lib/memory/memory.allocate|inlined.4
   end
-  local.set $5
-  i32.const 0
   local.set $6
-  local.get $5
-  local.get $6
-  local.get $4
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.8
+   local.get $6
+   local.set $5
+   i32.const 0
+   local.set $7
+   local.get $4
+   local.set $8
+   local.get $5
+   local.get $7
+   local.get $8
+   call $~lib/internal/memory/memset
+  end
   block $break|0
    local.get $2
    i32.const 1
    i32.sub
-   local.set $6
+   local.set $8
    loop $repeat|0
-    local.get $6
+    local.get $8
     i32.const 0
     i32.gt_s
     i32.eqz
     br_if $break|0
     block
-     local.get $6
+     local.get $8
      local.set $7
      block $break|1
       loop $continue|1
        local.get $7
        i32.const 1
        i32.and
-       local.get $5
+       local.get $6
        local.get $7
        i32.const 6
        i32.shr_s
@@ -7806,49 +8581,61 @@
      local.get $7
      i32.const 1
      i32.shr_s
-     local.set $8
+     local.set $5
      block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.5 (result i32)
       local.get $0
-      local.get $8
+      local.set $9
+      local.get $5
+      local.set $10
+      local.get $1
+      local.set $11
+      local.get $9
+      local.get $10
       i32.const 2
       i32.shl
       i32.add
-      local.get $1
+      local.get $11
       i32.add
       i32.load offset=8
      end
-     local.set $9
+     local.set $11
      block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.6 (result i32)
       local.get $0
-      local.get $6
+      local.set $10
+      local.get $8
+      local.set $9
+      local.get $1
+      local.set $12
+      local.get $10
+      local.get $9
       i32.const 2
       i32.shl
       i32.add
-      local.get $1
+      local.get $12
       i32.add
       i32.load offset=8
      end
-     local.set $10
+     local.set $12
      block (result i32)
       i32.const 2
       global.set $~argc
-      local.get $9
-      local.get $10
+      local.get $11
+      local.get $12
       local.get $3
       call_indirect (type $iii)
      end
      i32.const 0
      i32.lt_s
      if
-      local.get $5
       local.get $6
+      local.get $8
       i32.const 5
       i32.shr_s
       i32.const 2
       i32.shl
       i32.add
-      local.get $5
       local.get $6
+      local.get $8
       i32.const 5
       i32.shr_s
       i32.const 2
@@ -7856,36 +8643,56 @@
       i32.add
       i32.load
       i32.const 1
-      local.get $6
+      local.get $8
       i32.const 31
       i32.and
       i32.shl
       i32.xor
       i32.store
-      local.get $0
-      local.get $6
-      i32.const 2
-      i32.shl
-      i32.add
-      local.get $1
-      i32.add
-      local.get $9
-      i32.store offset=8
-      local.get $0
-      local.get $8
-      i32.const 2
-      i32.shl
-      i32.add
-      local.get $1
-      i32.add
-      local.get $10
-      i32.store offset=8
+      block $~lib/internal/arraybuffer/STORE<u32,u32>|inlined.5
+       local.get $0
+       local.set $9
+       local.get $8
+       local.set $10
+       local.get $11
+       local.set $13
+       local.get $1
+       local.set $14
+       local.get $9
+       local.get $10
+       i32.const 2
+       i32.shl
+       i32.add
+       local.get $14
+       i32.add
+       local.get $13
+       i32.store offset=8
+      end
+      block $~lib/internal/arraybuffer/STORE<u32,u32>|inlined.6
+       local.get $0
+       local.set $14
+       local.get $5
+       local.set $13
+       local.get $12
+       local.set $10
+       local.get $1
+       local.set $9
+       local.get $14
+       local.get $13
+       i32.const 2
+       i32.shl
+       i32.add
+       local.get $9
+       i32.add
+       local.get $10
+       i32.store offset=8
+      end
      end
     end
-    local.get $6
+    local.get $8
     i32.const 1
     i32.sub
-    local.set $6
+    local.set $8
     br $repeat|0
     unreachable
    end
@@ -7895,141 +8702,177 @@
    local.get $2
    i32.const 1
    i32.sub
-   local.set $6
+   local.set $8
    loop $repeat|2
-    local.get $6
+    local.get $8
     i32.const 2
     i32.ge_s
     i32.eqz
     br_if $break|2
     block
      block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.7 (result i32)
-      i32.const 0
-      local.set $10
       local.get $0
+      local.set $12
+      i32.const 0
+      local.set $11
+      local.get $1
+      local.set $5
+      local.get $12
+      local.get $11
+      i32.const 2
+      i32.shl
+      i32.add
+      local.get $5
+      i32.add
+      i32.load offset=8
+     end
+     local.set $5
+     block $~lib/internal/arraybuffer/STORE<u32,u32>|inlined.7
+      local.get $0
+      local.set $11
+      i32.const 0
+      local.set $12
+      block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.8 (result i32)
+       local.get $0
+       local.set $7
+       local.get $8
+       local.set $9
+       local.get $1
+       local.set $10
+       local.get $7
+       local.get $9
+       i32.const 2
+       i32.shl
+       i32.add
+       local.get $10
+       i32.add
+       i32.load offset=8
+      end
+      local.set $10
+      local.get $1
+      local.set $9
+      local.get $11
+      local.get $12
+      i32.const 2
+      i32.shl
+      i32.add
+      local.get $9
+      i32.add
+      local.get $10
+      i32.store offset=8
+     end
+     block $~lib/internal/arraybuffer/STORE<u32,u32>|inlined.8
+      local.get $0
+      local.set $9
+      local.get $8
+      local.set $10
+      local.get $5
+      local.set $12
+      local.get $1
+      local.set $11
+      local.get $9
       local.get $10
       i32.const 2
       i32.shl
       i32.add
-      local.get $1
+      local.get $11
       i32.add
-      i32.load offset=8
+      local.get $12
+      i32.store offset=8
      end
-     local.set $10
-     i32.const 0
-     local.set $9
-     block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.8 (result i32)
-      local.get $0
-      local.get $6
-      i32.const 2
-      i32.shl
-      i32.add
-      local.get $1
-      i32.add
-      i32.load offset=8
-     end
-     local.set $8
-     local.get $0
-     local.get $9
-     i32.const 2
-     i32.shl
-     i32.add
-     local.get $1
-     i32.add
-     local.get $8
-     i32.store offset=8
-     local.get $0
-     local.get $6
-     i32.const 2
-     i32.shl
-     i32.add
-     local.get $1
-     i32.add
-     local.get $10
-     i32.store offset=8
      i32.const 1
-     local.set $8
+     local.set $11
      block $break|3
       loop $continue|3
-       local.get $8
+       local.get $11
        i32.const 1
        i32.shl
-       local.get $5
-       local.get $8
+       local.get $6
+       local.get $11
        i32.const 5
        i32.shr_s
        i32.const 2
        i32.shl
        i32.add
        i32.load
-       local.get $8
+       local.get $11
        i32.const 31
        i32.and
        i32.shr_u
        i32.const 1
        i32.and
        i32.add
-       local.tee $9
-       local.get $6
+       local.tee $12
+       local.get $8
        i32.lt_s
        if
-        local.get $9
-        local.set $8
+        local.get $12
+        local.set $11
         br $continue|3
        end
       end
      end
      block $break|4
       loop $continue|4
-       local.get $8
+       local.get $11
        i32.const 0
        i32.gt_s
        if
         block
          block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.9 (result i32)
-          i32.const 0
-          local.set $7
           local.get $0
-          local.get $7
+          local.set $10
+          i32.const 0
+          local.set $9
+          local.get $1
+          local.set $7
+          local.get $10
+          local.get $9
           i32.const 2
           i32.shl
           i32.add
+          local.get $7
+          i32.add
+          i32.load offset=8
+         end
+         local.set $5
+         block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.10 (result i32)
+          local.get $0
+          local.set $7
+          local.get $11
+          local.set $9
           local.get $1
+          local.set $10
+          local.get $7
+          local.get $9
+          i32.const 2
+          i32.shl
+          i32.add
+          local.get $10
           i32.add
           i32.load offset=8
          end
          local.set $10
-         block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.10 (result i32)
-          local.get $0
-          local.get $8
-          i32.const 2
-          i32.shl
-          i32.add
-          local.get $1
-          i32.add
-          i32.load offset=8
-         end
-         local.set $7
          block (result i32)
           i32.const 2
           global.set $~argc
+          local.get $5
           local.get $10
-          local.get $7
           local.get $3
           call_indirect (type $iii)
          end
          i32.const 0
          i32.lt_s
          if
-          local.get $5
-          local.get $8
+          local.get $6
+          local.get $11
           i32.const 5
           i32.shr_s
           i32.const 2
           i32.shl
           i32.add
-          local.get $5
-          local.get $8
+          local.get $6
+          local.get $11
           i32.const 5
           i32.shr_s
           i32.const 2
@@ -8037,109 +8880,147 @@
           i32.add
           i32.load
           i32.const 1
-          local.get $8
+          local.get $11
           i32.const 31
           i32.and
           i32.shl
           i32.xor
           i32.store
-          local.get $0
-          local.get $8
-          i32.const 2
-          i32.shl
-          i32.add
-          local.get $1
-          i32.add
-          local.get $10
-          i32.store offset=8
-          i32.const 0
-          local.set $11
-          local.get $0
-          local.get $11
-          i32.const 2
-          i32.shl
-          i32.add
-          local.get $1
-          i32.add
-          local.get $7
-          i32.store offset=8
+          block $~lib/internal/arraybuffer/STORE<u32,u32>|inlined.9
+           local.get $0
+           local.set $9
+           local.get $11
+           local.set $7
+           local.get $5
+           local.set $13
+           local.get $1
+           local.set $14
+           local.get $9
+           local.get $7
+           i32.const 2
+           i32.shl
+           i32.add
+           local.get $14
+           i32.add
+           local.get $13
+           i32.store offset=8
+          end
+          block $~lib/internal/arraybuffer/STORE<u32,u32>|inlined.10
+           local.get $0
+           local.set $14
+           i32.const 0
+           local.set $13
+           local.get $10
+           local.set $7
+           local.get $1
+           local.set $9
+           local.get $14
+           local.get $13
+           i32.const 2
+           i32.shl
+           i32.add
+           local.get $9
+           i32.add
+           local.get $7
+           i32.store offset=8
+          end
          end
-         local.get $8
+         local.get $11
          i32.const 1
          i32.shr_s
-         local.set $8
+         local.set $11
         end
         br $continue|4
        end
       end
      end
     end
-    local.get $6
+    local.get $8
     i32.const 1
     i32.sub
-    local.set $6
+    local.set $8
     br $repeat|2
     unreachable
    end
    unreachable
   end
   block $~lib/memory/memory.free|inlined.4
-   block
-    local.get $5
-    call $~lib/allocator/arena/__memory_free
-    br $~lib/memory/memory.free|inlined.4
-    unreachable
-   end
-   unreachable
+   local.get $6
+   local.set $8
+   local.get $8
+   call $~lib/allocator/arena/__memory_free
+   br $~lib/memory/memory.free|inlined.4
   end
   block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.11 (result i32)
+   local.get $0
+   local.set $8
    i32.const 1
-   local.set $6
-   local.get $0
-   local.get $6
+   local.set $12
+   local.get $1
+   local.set $11
+   local.get $8
+   local.get $12
    i32.const 2
    i32.shl
    i32.add
-   local.get $1
+   local.get $11
    i32.add
    i32.load offset=8
   end
-  local.set $12
-  i32.const 1
-  local.set $6
-  block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.12 (result i32)
+  local.set $15
+  block $~lib/internal/arraybuffer/STORE<u32,u32>|inlined.11
+   local.get $0
+   local.set $11
+   i32.const 1
+   local.set $12
+   block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.12 (result i32)
+    local.get $0
+    local.set $8
+    i32.const 0
+    local.set $5
+    local.get $1
+    local.set $10
+    local.get $8
+    local.get $5
+    i32.const 2
+    i32.shl
+    i32.add
+    local.get $10
+    i32.add
+    i32.load offset=8
+   end
+   local.set $10
+   local.get $1
+   local.set $5
+   local.get $11
+   local.get $12
+   i32.const 2
+   i32.shl
+   i32.add
+   local.get $5
+   i32.add
+   local.get $10
+   i32.store offset=8
+  end
+  block $~lib/internal/arraybuffer/STORE<u32,u32>|inlined.12
+   local.get $0
+   local.set $5
    i32.const 0
-   local.set $9
-   local.get $0
-   local.get $9
+   local.set $10
+   local.get $15
+   local.set $12
+   local.get $1
+   local.set $11
+   local.get $5
+   local.get $10
    i32.const 2
    i32.shl
    i32.add
-   local.get $1
+   local.get $11
    i32.add
-   i32.load offset=8
+   local.get $12
+   i32.store offset=8
   end
-  local.set $9
-  local.get $0
-  local.get $6
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $1
-  i32.add
-  local.get $9
-  i32.store offset=8
-  i32.const 0
-  local.set $9
-  local.get $0
-  local.get $9
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $1
-  i32.add
-  local.get $12
-  i32.store offset=8
  )
  (func $~lib/array/Array<u32>#sort (; 125 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -8148,6 +9029,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   local.get $1
   i32.eqz
   if
@@ -8176,27 +9059,14 @@
   i32.eq
   if
    block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.1 (result i32)
-    i32.const 1
-    local.set $4
-    i32.const 0
-    local.set $5
     local.get $3
-    local.get $4
-    i32.const 2
-    i32.shl
-    i32.add
-    local.get $5
-    i32.add
-    i32.load offset=8
-   end
-   local.set $5
-   block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.2 (result i32)
-    i32.const 0
     local.set $4
+    i32.const 1
+    local.set $5
     i32.const 0
     local.set $6
-    local.get $3
     local.get $4
+    local.get $5
     i32.const 2
     i32.shl
     i32.add
@@ -8205,68 +9075,105 @@
     i32.load offset=8
    end
    local.set $6
+   block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.2 (result i32)
+    local.get $3
+    local.set $5
+    i32.const 0
+    local.set $4
+    i32.const 0
+    local.set $7
+    local.get $5
+    local.get $4
+    i32.const 2
+    i32.shl
+    i32.add
+    local.get $7
+    i32.add
+    i32.load offset=8
+   end
+   local.set $7
    block (result i32)
     i32.const 2
     global.set $~argc
-    local.get $5
     local.get $6
+    local.get $7
     local.get $1
     call_indirect (type $iii)
    end
    i32.const 0
    i32.lt_s
    if
-    i32.const 1
-    local.set $4
-    i32.const 0
-    local.set $7
-    local.get $3
-    local.get $4
-    i32.const 2
-    i32.shl
-    i32.add
-    local.get $7
-    i32.add
-    local.get $6
-    i32.store offset=8
-    i32.const 0
-    local.set $7
-    i32.const 0
-    local.set $4
-    local.get $3
-    local.get $7
-    i32.const 2
-    i32.shl
-    i32.add
-    local.get $4
-    i32.add
-    local.get $5
-    i32.store offset=8
+    block $~lib/internal/arraybuffer/STORE<u32,u32>|inlined.1
+     local.get $3
+     local.set $4
+     i32.const 1
+     local.set $5
+     local.get $7
+     local.set $8
+     i32.const 0
+     local.set $9
+     local.get $4
+     local.get $5
+     i32.const 2
+     i32.shl
+     i32.add
+     local.get $9
+     i32.add
+     local.get $8
+     i32.store offset=8
+    end
+    block $~lib/internal/arraybuffer/STORE<u32,u32>|inlined.2
+     local.get $3
+     local.set $9
+     i32.const 0
+     local.set $8
+     local.get $6
+     local.set $5
+     i32.const 0
+     local.set $4
+     local.get $9
+     local.get $8
+     i32.const 2
+     i32.shl
+     i32.add
+     local.get $4
+     i32.add
+     local.get $5
+     i32.store offset=8
+    end
    end
    local.get $0
    return
   end
-  i32.const 0
-  local.set $6
-  local.get $2
-  i32.const 256
-  i32.lt_s
-  if
+  block $~lib/internal/sort/SORT<u32>|inlined.0
    local.get $3
-   local.get $6
+   local.set $7
+   i32.const 0
+   local.set $6
    local.get $2
+   local.set $4
    local.get $1
-   call $~lib/internal/sort/insertionSort<u32>
-  else   
-   local.get $3
-   local.get $6
-   local.get $2
-   local.get $1
-   call $~lib/internal/sort/weakHeapSort<u32>
+   local.set $5
+   local.get $4
+   i32.const 256
+   i32.lt_s
+   if
+    local.get $7
+    local.get $6
+    local.get $4
+    local.get $5
+    call $~lib/internal/sort/insertionSort<u32>
+   else    
+    local.get $7
+    local.get $6
+    local.get $4
+    local.get $5
+    call $~lib/internal/sort/weakHeapSort<u32>
+   end
   end
   local.get $0
  )
- (func $~lib/array/Array<u32>#sort|trampoline~anonymous|47 (; 126 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<u32>~anonymous|47 (; 126 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.gt_u
@@ -8297,6 +9204,7 @@
  (func $std/array/createReverseOrderedArray (; 128 ;) (type $ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
   i32.const 0
   local.get $0
   call $~lib/array/Array<i32>#constructor
@@ -8308,6 +9216,8 @@
     local.get $2
     block $~lib/array/Array<i32>#get:length|inlined.43 (result i32)
      local.get $1
+     local.set $3
+     local.get $3
      i32.load offset=4
     end
     i32.lt_s
@@ -8317,6 +9227,8 @@
     local.get $2
     block $~lib/array/Array<i32>#get:length|inlined.44 (result i32)
      local.get $1
+     local.set $3
+     local.get $3
      i32.load offset=4
     end
     i32.const 1
@@ -8395,6 +9307,7 @@
  (func $std/array/createRandomOrderedArray (; 130 ;) (type $ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
   i32.const 0
   local.get $0
   call $~lib/array/Array<i32>#constructor
@@ -8406,6 +9319,8 @@
     local.get $2
     block $~lib/array/Array<i32>#get:length|inlined.46 (result i32)
      local.get $1
+     local.set $3
+     local.get $3
      i32.load offset=4
     end
     i32.lt_s
@@ -8416,6 +9331,8 @@
     call $~lib/math/NativeMath.random
     block $~lib/array/Array<i32>#get:length|inlined.47 (result i32)
      local.get $1
+     local.set $3
+     local.get $3
      i32.load offset=4
     end
     f64.convert_i32_s
@@ -8433,7 +9350,7 @@
   end
   local.get $1
  )
- (func $std/array/assertSortedDefault<i32>~anonymous|48 (; 131 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<i32>~anonymous|48 (; 131 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
@@ -8447,6 +9364,8 @@
     local.set $2
     block $~lib/array/Array<i32>#get:length|inlined.48 (result i32)
      local.get $0
+     local.set $3
+     local.get $3
      i32.load offset=4
     end
     local.set $3
@@ -8537,6 +9456,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.const 268435454
   i32.gt_u
@@ -8576,22 +9496,29 @@
   local.get $0
   local.get $1
   i32.store offset=4
-  local.get $3
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  i32.const 0
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $2
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.9
+   local.get $3
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/memory/memset
+  end
   local.get $0
  )
  (func $~lib/array/Array<Array<i32>>#__set (; 140 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   local.get $0
   i32.load
   local.set $3
@@ -8632,21 +9559,31 @@
    i32.add
    i32.store offset=4
   end
-  i32.const 0
-  local.set $5
-  local.get $3
-  local.get $1
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $5
-  i32.add
-  local.get $2
-  i32.store offset=8
+  block $~lib/internal/arraybuffer/STORE<Array<i32>,Array<i32>>|inlined.0
+   local.get $3
+   local.set $5
+   local.get $1
+   local.set $6
+   local.get $2
+   local.set $7
+   i32.const 0
+   local.set $8
+   local.get $5
+   local.get $6
+   i32.const 2
+   i32.shl
+   i32.add
+   local.get $8
+   i32.add
+   local.get $7
+   i32.store offset=8
+  end
  )
  (func $~lib/array/Array<Array<i32>>#__get (; 141 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.load
   local.set $2
@@ -8657,14 +9594,18 @@
   i32.shr_u
   i32.lt_u
   if (result i32)
-   i32.const 0
-   local.set $3
    local.get $2
+   local.set $3
    local.get $1
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 2
    i32.shl
    i32.add
-   local.get $3
+   local.get $5
    i32.add
    i32.load offset=8
   else   
@@ -8674,6 +9615,7 @@
  (func $std/array/createReverseOrderedNestedArray (; 142 ;) (type $ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
   i32.const 0
   local.get $0
   call $~lib/array/Array<Array<i32>>#constructor
@@ -8685,6 +9627,8 @@
     local.get $2
     block $~lib/array/Array<Array<i32>>#get:length|inlined.1 (result i32)
      local.get $1
+     local.set $3
+     local.get $3
      i32.load offset=4
     end
     i32.lt_s
@@ -8703,6 +9647,8 @@
      i32.const 0
      block $~lib/array/Array<Array<i32>>#get:length|inlined.2 (result i32)
       local.get $1
+      local.set $3
+      local.get $3
       i32.load offset=4
      end
      i32.const 1
@@ -8737,6 +9683,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   block $break|0
    i32.const 0
    local.set $4
@@ -8749,15 +9698,21 @@
     block
      block $~lib/internal/arraybuffer/LOAD<Array<i32>,Array<i32>>|inlined.3 (result i32)
       local.get $0
+      local.set $5
       local.get $4
+      local.set $6
+      local.get $1
+      local.set $7
+      local.get $5
+      local.get $6
       i32.const 2
       i32.shl
       i32.add
-      local.get $1
+      local.get $7
       i32.add
       i32.load offset=8
      end
-     local.set $5
+     local.set $7
      local.get $4
      i32.const 1
      i32.sub
@@ -8771,45 +9726,57 @@
         block
          block $~lib/internal/arraybuffer/LOAD<Array<i32>,Array<i32>>|inlined.4 (result i32)
           local.get $0
+          local.set $5
           local.get $6
+          local.set $8
+          local.get $1
+          local.set $9
+          local.get $5
+          local.get $8
           i32.const 2
           i32.shl
           i32.add
-          local.get $1
+          local.get $9
           i32.add
           i32.load offset=8
          end
-         local.set $7
+         local.set $9
          block (result i32)
           i32.const 2
           global.set $~argc
-          local.get $5
           local.get $7
+          local.get $9
           local.get $3
           call_indirect (type $iii)
          end
          i32.const 0
          i32.lt_s
          if
+          local.get $0
+          local.set $8
           block (result i32)
            local.get $6
-           local.tee $8
+           local.tee $5
            i32.const 1
            i32.sub
            local.set $6
-           local.get $8
+           local.get $5
           end
           i32.const 1
           i32.add
-          local.set $8
-          local.get $0
+          local.set $5
+          local.get $9
+          local.set $10
+          local.get $1
+          local.set $11
           local.get $8
+          local.get $5
           i32.const 2
           i32.shl
           i32.add
-          local.get $1
+          local.get $11
           i32.add
-          local.get $7
+          local.get $10
           i32.store offset=8
          else          
           br $break|1
@@ -8819,19 +9786,27 @@
        end
       end
      end
-     local.get $6
-     i32.const 1
-     i32.add
-     local.set $7
-     local.get $0
-     local.get $7
-     i32.const 2
-     i32.shl
-     i32.add
-     local.get $1
-     i32.add
-     local.get $5
-     i32.store offset=8
+     block $~lib/internal/arraybuffer/STORE<Array<i32>,Array<i32>>|inlined.4
+      local.get $0
+      local.set $9
+      local.get $6
+      i32.const 1
+      i32.add
+      local.set $11
+      local.get $7
+      local.set $10
+      local.get $1
+      local.set $5
+      local.get $9
+      local.get $11
+      i32.const 2
+      i32.shl
+      i32.add
+      local.get $5
+      i32.add
+      local.get $10
+      i32.store offset=8
+     end
     end
     local.get $4
     i32.const 1
@@ -8850,6 +9825,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   local.get $1
   i32.eqz
   if
@@ -8878,27 +9855,14 @@
   i32.eq
   if
    block $~lib/internal/arraybuffer/LOAD<Array<i32>,Array<i32>>|inlined.1 (result i32)
-    i32.const 1
-    local.set $4
-    i32.const 0
-    local.set $5
     local.get $3
-    local.get $4
-    i32.const 2
-    i32.shl
-    i32.add
-    local.get $5
-    i32.add
-    i32.load offset=8
-   end
-   local.set $5
-   block $~lib/internal/arraybuffer/LOAD<Array<i32>,Array<i32>>|inlined.2 (result i32)
-    i32.const 0
     local.set $4
+    i32.const 1
+    local.set $5
     i32.const 0
     local.set $6
-    local.get $3
     local.get $4
+    local.get $5
     i32.const 2
     i32.shl
     i32.add
@@ -8907,54 +9871,91 @@
     i32.load offset=8
    end
    local.set $6
+   block $~lib/internal/arraybuffer/LOAD<Array<i32>,Array<i32>>|inlined.2 (result i32)
+    local.get $3
+    local.set $5
+    i32.const 0
+    local.set $4
+    i32.const 0
+    local.set $7
+    local.get $5
+    local.get $4
+    i32.const 2
+    i32.shl
+    i32.add
+    local.get $7
+    i32.add
+    i32.load offset=8
+   end
+   local.set $7
    block (result i32)
     i32.const 2
     global.set $~argc
-    local.get $5
     local.get $6
+    local.get $7
     local.get $1
     call_indirect (type $iii)
    end
    i32.const 0
    i32.lt_s
    if
-    i32.const 1
-    local.set $4
-    i32.const 0
-    local.set $7
-    local.get $3
-    local.get $4
-    i32.const 2
-    i32.shl
-    i32.add
-    local.get $7
-    i32.add
-    local.get $6
-    i32.store offset=8
-    i32.const 0
-    local.set $7
-    i32.const 0
-    local.set $4
-    local.get $3
-    local.get $7
-    i32.const 2
-    i32.shl
-    i32.add
-    local.get $4
-    i32.add
-    local.get $5
-    i32.store offset=8
+    block $~lib/internal/arraybuffer/STORE<Array<i32>,Array<i32>>|inlined.1
+     local.get $3
+     local.set $4
+     i32.const 1
+     local.set $5
+     local.get $7
+     local.set $8
+     i32.const 0
+     local.set $9
+     local.get $4
+     local.get $5
+     i32.const 2
+     i32.shl
+     i32.add
+     local.get $9
+     i32.add
+     local.get $8
+     i32.store offset=8
+    end
+    block $~lib/internal/arraybuffer/STORE<Array<i32>,Array<i32>>|inlined.2
+     local.get $3
+     local.set $9
+     i32.const 0
+     local.set $8
+     local.get $6
+     local.set $5
+     i32.const 0
+     local.set $4
+     local.get $9
+     local.get $8
+     i32.const 2
+     i32.shl
+     i32.add
+     local.get $4
+     i32.add
+     local.get $5
+     i32.store offset=8
+    end
    end
    local.get $0
    return
   end
-  i32.const 0
-  local.set $6
-  local.get $3
-  local.get $6
-  local.get $2
-  local.get $1
-  call $~lib/internal/sort/insertionSort<Array<i32>>
+  block $~lib/internal/sort/SORT<Array<i32>>|inlined.0
+   local.get $3
+   local.set $7
+   i32.const 0
+   local.set $6
+   local.get $2
+   local.set $4
+   local.get $1
+   local.set $5
+   local.get $7
+   local.get $6
+   local.get $4
+   local.get $5
+   call $~lib/internal/sort/insertionSort<Array<i32>>
+  end
   local.get $0
  )
  (func $std/array/isSorted<Array<i32>> (; 146 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
@@ -8966,6 +9967,8 @@
     local.set $2
     block $~lib/array/Array<Array<i32>>#get:length|inlined.3 (result i32)
      local.get $0
+     local.set $3
+     local.get $3
      i32.load offset=4
     end
     local.set $3
@@ -9028,6 +10031,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.const 268435454
   i32.gt_u
@@ -9067,16 +10071,20 @@
   local.get $0
   local.get $1
   i32.store offset=4
-  local.get $3
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  i32.const 0
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $2
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.10
+   local.get $3
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/memory/memset
+  end
   local.get $0
  )
  (func $std/array/Proxy<i32>#constructor (; 149 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
@@ -9096,6 +10104,9 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   local.get $0
   i32.load
   local.set $3
@@ -9136,21 +10147,30 @@
    i32.add
    i32.store offset=4
   end
-  i32.const 0
-  local.set $5
-  local.get $3
-  local.get $1
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $5
-  i32.add
-  local.get $2
-  i32.store offset=8
+  block $~lib/internal/arraybuffer/STORE<Proxy<i32>,Proxy<i32>>|inlined.0
+   local.get $3
+   local.set $5
+   local.get $1
+   local.set $6
+   local.get $2
+   local.set $7
+   i32.const 0
+   local.set $8
+   local.get $5
+   local.get $6
+   i32.const 2
+   i32.shl
+   i32.add
+   local.get $8
+   i32.add
+   local.get $7
+   i32.store offset=8
+  end
  )
  (func $std/array/createReverseOrderedElementsArray (; 151 ;) (type $ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
   i32.const 0
   local.get $0
   call $~lib/array/Array<Proxy<i32>>#constructor
@@ -9162,6 +10182,8 @@
     local.get $2
     block $~lib/array/Array<Proxy<i32>>#get:length|inlined.1 (result i32)
      local.get $1
+     local.set $3
+     local.get $3
      i32.load offset=4
     end
     i32.lt_s
@@ -9172,6 +10194,8 @@
     i32.const 0
     block $~lib/array/Array<Proxy<i32>>#get:length|inlined.2 (result i32)
      local.get $1
+     local.set $3
+     local.get $3
      i32.load offset=4
     end
     i32.const 1
@@ -9204,6 +10228,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   block $break|0
    i32.const 0
    local.set $4
@@ -9216,15 +10243,21 @@
     block
      block $~lib/internal/arraybuffer/LOAD<Proxy<i32>,Proxy<i32>>|inlined.2 (result i32)
       local.get $0
+      local.set $5
       local.get $4
+      local.set $6
+      local.get $1
+      local.set $7
+      local.get $5
+      local.get $6
       i32.const 2
       i32.shl
       i32.add
-      local.get $1
+      local.get $7
       i32.add
       i32.load offset=8
      end
-     local.set $5
+     local.set $7
      local.get $4
      i32.const 1
      i32.sub
@@ -9238,45 +10271,57 @@
         block
          block $~lib/internal/arraybuffer/LOAD<Proxy<i32>,Proxy<i32>>|inlined.3 (result i32)
           local.get $0
+          local.set $5
           local.get $6
+          local.set $8
+          local.get $1
+          local.set $9
+          local.get $5
+          local.get $8
           i32.const 2
           i32.shl
           i32.add
-          local.get $1
+          local.get $9
           i32.add
           i32.load offset=8
          end
-         local.set $7
+         local.set $9
          block (result i32)
           i32.const 2
           global.set $~argc
-          local.get $5
           local.get $7
+          local.get $9
           local.get $3
           call_indirect (type $iii)
          end
          i32.const 0
          i32.lt_s
          if
+          local.get $0
+          local.set $8
           block (result i32)
            local.get $6
-           local.tee $8
+           local.tee $5
            i32.const 1
            i32.sub
            local.set $6
-           local.get $8
+           local.get $5
           end
           i32.const 1
           i32.add
-          local.set $8
-          local.get $0
+          local.set $5
+          local.get $9
+          local.set $10
+          local.get $1
+          local.set $11
           local.get $8
+          local.get $5
           i32.const 2
           i32.shl
           i32.add
-          local.get $1
+          local.get $11
           i32.add
-          local.get $7
+          local.get $10
           i32.store offset=8
          else          
           br $break|1
@@ -9286,19 +10331,27 @@
        end
       end
      end
-     local.get $6
-     i32.const 1
-     i32.add
-     local.set $7
-     local.get $0
-     local.get $7
-     i32.const 2
-     i32.shl
-     i32.add
-     local.get $1
-     i32.add
-     local.get $5
-     i32.store offset=8
+     block $~lib/internal/arraybuffer/STORE<Proxy<i32>,Proxy<i32>>|inlined.4
+      local.get $0
+      local.set $9
+      local.get $6
+      i32.const 1
+      i32.add
+      local.set $11
+      local.get $7
+      local.set $10
+      local.get $1
+      local.set $5
+      local.get $9
+      local.get $11
+      i32.const 2
+      i32.shl
+      i32.add
+      local.get $5
+      i32.add
+      local.get $10
+      i32.store offset=8
+     end
     end
     local.get $4
     i32.const 1
@@ -9317,6 +10370,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   local.get $1
   i32.eqz
   if
@@ -9345,27 +10400,14 @@
   i32.eq
   if
    block $~lib/internal/arraybuffer/LOAD<Proxy<i32>,Proxy<i32>>|inlined.0 (result i32)
-    i32.const 1
-    local.set $4
-    i32.const 0
-    local.set $5
     local.get $3
-    local.get $4
-    i32.const 2
-    i32.shl
-    i32.add
-    local.get $5
-    i32.add
-    i32.load offset=8
-   end
-   local.set $5
-   block $~lib/internal/arraybuffer/LOAD<Proxy<i32>,Proxy<i32>>|inlined.1 (result i32)
-    i32.const 0
     local.set $4
+    i32.const 1
+    local.set $5
     i32.const 0
     local.set $6
-    local.get $3
     local.get $4
+    local.get $5
     i32.const 2
     i32.shl
     i32.add
@@ -9374,59 +10416,98 @@
     i32.load offset=8
    end
    local.set $6
+   block $~lib/internal/arraybuffer/LOAD<Proxy<i32>,Proxy<i32>>|inlined.1 (result i32)
+    local.get $3
+    local.set $5
+    i32.const 0
+    local.set $4
+    i32.const 0
+    local.set $7
+    local.get $5
+    local.get $4
+    i32.const 2
+    i32.shl
+    i32.add
+    local.get $7
+    i32.add
+    i32.load offset=8
+   end
+   local.set $7
    block (result i32)
     i32.const 2
     global.set $~argc
-    local.get $5
     local.get $6
+    local.get $7
     local.get $1
     call_indirect (type $iii)
    end
    i32.const 0
    i32.lt_s
    if
-    i32.const 1
-    local.set $4
-    i32.const 0
-    local.set $7
-    local.get $3
-    local.get $4
-    i32.const 2
-    i32.shl
-    i32.add
-    local.get $7
-    i32.add
-    local.get $6
-    i32.store offset=8
-    i32.const 0
-    local.set $7
-    i32.const 0
-    local.set $4
-    local.get $3
-    local.get $7
-    i32.const 2
-    i32.shl
-    i32.add
-    local.get $4
-    i32.add
-    local.get $5
-    i32.store offset=8
+    block $~lib/internal/arraybuffer/STORE<Proxy<i32>,Proxy<i32>>|inlined.1
+     local.get $3
+     local.set $4
+     i32.const 1
+     local.set $5
+     local.get $7
+     local.set $8
+     i32.const 0
+     local.set $9
+     local.get $4
+     local.get $5
+     i32.const 2
+     i32.shl
+     i32.add
+     local.get $9
+     i32.add
+     local.get $8
+     i32.store offset=8
+    end
+    block $~lib/internal/arraybuffer/STORE<Proxy<i32>,Proxy<i32>>|inlined.2
+     local.get $3
+     local.set $9
+     i32.const 0
+     local.set $8
+     local.get $6
+     local.set $5
+     i32.const 0
+     local.set $4
+     local.get $9
+     local.get $8
+     i32.const 2
+     i32.shl
+     i32.add
+     local.get $4
+     i32.add
+     local.get $5
+     i32.store offset=8
+    end
    end
    local.get $0
    return
   end
-  i32.const 0
-  local.set $6
-  local.get $3
-  local.get $6
-  local.get $2
-  local.get $1
-  call $~lib/internal/sort/insertionSort<Proxy<i32>>
+  block $~lib/internal/sort/SORT<Proxy<i32>>|inlined.0
+   local.get $3
+   local.set $7
+   i32.const 0
+   local.set $6
+   local.get $2
+   local.set $4
+   local.get $1
+   local.set $5
+   local.get $7
+   local.get $6
+   local.get $4
+   local.get $5
+   call $~lib/internal/sort/insertionSort<Proxy<i32>>
+  end
   local.get $0
  )
  (func $~lib/array/Array<Proxy<i32>>#__get (; 155 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.load
   local.set $2
@@ -9437,14 +10518,18 @@
   i32.shr_u
   i32.lt_u
   if (result i32)
-   i32.const 0
-   local.set $3
    local.get $2
+   local.set $3
    local.get $1
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 2
    i32.shl
    i32.add
-   local.get $3
+   local.get $5
    i32.add
    i32.load offset=8
   else   
@@ -9460,6 +10545,8 @@
     local.set $2
     block $~lib/array/Array<Proxy<i32>>#get:length|inlined.3 (result i32)
      local.get $0
+     local.set $3
+     local.get $3
      i32.load offset=4
     end
     local.set $3
@@ -9715,6 +10802,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   block $break|0
    i32.const 0
    local.set $4
@@ -9727,15 +10817,21 @@
     block
      block $~lib/internal/arraybuffer/LOAD<String,String>|inlined.2 (result i32)
       local.get $0
+      local.set $5
       local.get $4
+      local.set $6
+      local.get $1
+      local.set $7
+      local.get $5
+      local.get $6
       i32.const 2
       i32.shl
       i32.add
-      local.get $1
+      local.get $7
       i32.add
       i32.load offset=8
      end
-     local.set $5
+     local.set $7
      local.get $4
      i32.const 1
      i32.sub
@@ -9749,45 +10845,57 @@
         block
          block $~lib/internal/arraybuffer/LOAD<String,String>|inlined.3 (result i32)
           local.get $0
+          local.set $5
           local.get $6
+          local.set $8
+          local.get $1
+          local.set $9
+          local.get $5
+          local.get $8
           i32.const 2
           i32.shl
           i32.add
-          local.get $1
+          local.get $9
           i32.add
           i32.load offset=8
          end
-         local.set $7
+         local.set $9
          block (result i32)
           i32.const 2
           global.set $~argc
-          local.get $5
           local.get $7
+          local.get $9
           local.get $3
           call_indirect (type $iii)
          end
          i32.const 0
          i32.lt_s
          if
+          local.get $0
+          local.set $8
           block (result i32)
            local.get $6
-           local.tee $8
+           local.tee $5
            i32.const 1
            i32.sub
            local.set $6
-           local.get $8
+           local.get $5
           end
           i32.const 1
           i32.add
-          local.set $8
-          local.get $0
+          local.set $5
+          local.get $9
+          local.set $10
+          local.get $1
+          local.set $11
           local.get $8
+          local.get $5
           i32.const 2
           i32.shl
           i32.add
-          local.get $1
+          local.get $11
           i32.add
-          local.get $7
+          local.get $10
           i32.store offset=8
          else          
           br $break|1
@@ -9797,19 +10905,27 @@
        end
       end
      end
-     local.get $6
-     i32.const 1
-     i32.add
-     local.set $7
-     local.get $0
-     local.get $7
-     i32.const 2
-     i32.shl
-     i32.add
-     local.get $1
-     i32.add
-     local.get $5
-     i32.store offset=8
+     block $~lib/internal/arraybuffer/STORE<String,String>|inlined.3
+      local.get $0
+      local.set $9
+      local.get $6
+      i32.const 1
+      i32.add
+      local.set $11
+      local.get $7
+      local.set $10
+      local.get $1
+      local.set $5
+      local.get $9
+      local.get $11
+      i32.const 2
+      i32.shl
+      i32.add
+      local.get $5
+      i32.add
+      local.get $10
+      i32.store offset=8
+     end
     end
     local.get $4
     i32.const 1
@@ -9828,6 +10944,8 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   local.get $1
   i32.eqz
   if
@@ -9856,27 +10974,14 @@
   i32.eq
   if
    block $~lib/internal/arraybuffer/LOAD<String,String>|inlined.0 (result i32)
-    i32.const 1
-    local.set $4
-    i32.const 0
-    local.set $5
     local.get $3
-    local.get $4
-    i32.const 2
-    i32.shl
-    i32.add
-    local.get $5
-    i32.add
-    i32.load offset=8
-   end
-   local.set $5
-   block $~lib/internal/arraybuffer/LOAD<String,String>|inlined.1 (result i32)
-    i32.const 0
     local.set $4
+    i32.const 1
+    local.set $5
     i32.const 0
     local.set $6
-    local.get $3
     local.get $4
+    local.get $5
     i32.const 2
     i32.shl
     i32.add
@@ -9885,59 +10990,98 @@
     i32.load offset=8
    end
    local.set $6
+   block $~lib/internal/arraybuffer/LOAD<String,String>|inlined.1 (result i32)
+    local.get $3
+    local.set $5
+    i32.const 0
+    local.set $4
+    i32.const 0
+    local.set $7
+    local.get $5
+    local.get $4
+    i32.const 2
+    i32.shl
+    i32.add
+    local.get $7
+    i32.add
+    i32.load offset=8
+   end
+   local.set $7
    block (result i32)
     i32.const 2
     global.set $~argc
-    local.get $5
     local.get $6
+    local.get $7
     local.get $1
     call_indirect (type $iii)
    end
    i32.const 0
    i32.lt_s
    if
-    i32.const 1
-    local.set $4
-    i32.const 0
-    local.set $7
-    local.get $3
-    local.get $4
-    i32.const 2
-    i32.shl
-    i32.add
-    local.get $7
-    i32.add
-    local.get $6
-    i32.store offset=8
-    i32.const 0
-    local.set $7
-    i32.const 0
-    local.set $4
-    local.get $3
-    local.get $7
-    i32.const 2
-    i32.shl
-    i32.add
-    local.get $4
-    i32.add
-    local.get $5
-    i32.store offset=8
+    block $~lib/internal/arraybuffer/STORE<String,String>|inlined.0
+     local.get $3
+     local.set $4
+     i32.const 1
+     local.set $5
+     local.get $7
+     local.set $8
+     i32.const 0
+     local.set $9
+     local.get $4
+     local.get $5
+     i32.const 2
+     i32.shl
+     i32.add
+     local.get $9
+     i32.add
+     local.get $8
+     i32.store offset=8
+    end
+    block $~lib/internal/arraybuffer/STORE<String,String>|inlined.1
+     local.get $3
+     local.set $9
+     i32.const 0
+     local.set $8
+     local.get $6
+     local.set $5
+     i32.const 0
+     local.set $4
+     local.get $9
+     local.get $8
+     i32.const 2
+     i32.shl
+     i32.add
+     local.get $4
+     i32.add
+     local.get $5
+     i32.store offset=8
+    end
    end
    local.get $0
    return
   end
-  i32.const 0
-  local.set $6
-  local.get $3
-  local.get $6
-  local.get $2
-  local.get $1
-  call $~lib/internal/sort/insertionSort<String>
+  block $~lib/internal/sort/SORT<String>|inlined.0
+   local.get $3
+   local.set $7
+   i32.const 0
+   local.set $6
+   local.get $2
+   local.set $4
+   local.get $1
+   local.set $5
+   local.get $7
+   local.get $6
+   local.get $4
+   local.get $5
+   call $~lib/internal/sort/insertionSort<String>
+  end
   local.get $0
  )
  (func $~lib/array/Array<String>#__get (; 164 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.load
   local.set $2
@@ -9948,14 +11092,18 @@
   i32.shr_u
   i32.lt_u
   if (result i32)
-   i32.const 0
-   local.set $3
    local.get $2
+   local.set $3
    local.get $1
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 2
    i32.shl
    i32.add
-   local.get $3
+   local.get $5
    i32.add
    i32.load offset=8
   else   
@@ -9971,6 +11119,8 @@
     local.set $2
     block $~lib/array/Array<String>#get:length|inlined.0 (result i32)
      local.get $0
+     local.set $3
+     local.get $3
      i32.load offset=4
     end
     local.set $3
@@ -10085,12 +11235,16 @@
   if
    block $~lib/array/Array<String>#get:length|inlined.1 (result i32)
     local.get $0
+    local.set $3
+    local.get $3
     i32.load offset=4
    end
    local.set $2
    local.get $2
    block $~lib/array/Array<String>#get:length|inlined.3 (result i32)
     local.get $1
+    local.set $3
+    local.get $3
     i32.load offset=4
    end
    i32.ne
@@ -10142,6 +11296,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.const 268435454
   i32.gt_u
@@ -10181,16 +11336,20 @@
   local.get $0
   local.get $1
   i32.store offset=4
-  local.get $3
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  i32.const 0
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $2
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.11
+   local.get $3
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/memory/memset
+  end
   local.get $0
  )
  (func $~lib/internal/string/allocateUnsafe (; 171 ;) (type $ii) (param $0 i32) (result i32)
@@ -10412,6 +11571,9 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   local.get $0
   i32.load
   local.set $3
@@ -10452,21 +11614,30 @@
    i32.add
    i32.store offset=4
   end
-  i32.const 0
-  local.set $5
-  local.get $3
-  local.get $1
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $5
-  i32.add
-  local.get $2
-  i32.store offset=8
+  block $~lib/internal/arraybuffer/STORE<String,String>|inlined.4
+   local.get $3
+   local.set $5
+   local.get $1
+   local.set $6
+   local.get $2
+   local.set $7
+   i32.const 0
+   local.set $8
+   local.get $5
+   local.get $6
+   i32.const 2
+   i32.shl
+   i32.add
+   local.get $8
+   i32.add
+   local.get $7
+   i32.store offset=8
+  end
  )
  (func $std/array/createRandomStringArray (; 178 ;) (type $ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
   i32.const 0
   local.get $0
   call $~lib/array/Array<String>#constructor
@@ -10478,6 +11649,8 @@
     local.get $2
     block $~lib/array/Array<String>#get:length|inlined.5 (result i32)
      local.get $1
+     local.set $3
+     local.get $3
      i32.load offset=4
     end
     i32.lt_s
@@ -10634,6 +11807,8 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
   local.get $0
   i32.load offset=4
   i32.const 1
@@ -10664,16 +11839,18 @@
    i32.const 4184
    i32.const 4200
    block $~lib/internal/arraybuffer/LOAD<bool,bool>|inlined.0 (result i32)
-    i32.const 0
+    local.get $5
     local.set $8
     i32.const 0
     local.set $9
-    local.get $5
+    i32.const 0
+    local.set $10
     local.get $8
+    local.get $9
     i32.const 0
     i32.shl
     i32.add
-    local.get $9
+    local.get $10
     i32.add
     i32.load8_u offset=8
    end
@@ -10683,18 +11860,18 @@
    return
   end
   i32.const 5
-  local.set $9
-  local.get $9
+  local.set $10
+  local.get $10
   local.get $6
   i32.add
   local.get $2
   i32.mul
-  local.get $9
+  local.get $10
   i32.add
-  local.set $8
-  local.get $8
+  local.set $9
+  local.get $9
   call $~lib/internal/string/allocateUnsafe
-  local.set $10
+  local.set $8
   i32.const 0
   local.set $11
   block $break|0
@@ -10708,14 +11885,18 @@
     br_if $break|0
     block
      block $~lib/internal/arraybuffer/LOAD<bool,bool>|inlined.1 (result i32)
-      i32.const 0
-      local.set $13
       local.get $5
+      local.set $13
       local.get $12
+      local.set $14
+      i32.const 0
+      local.set $15
+      local.get $13
+      local.get $14
       i32.const 0
       i32.shl
       i32.add
-      local.get $13
+      local.get $15
       i32.add
       i32.load8_u offset=8
      end
@@ -10726,8 +11907,8 @@
      i32.ne
      i32.eqz
      i32.add
-     local.set $9
-     local.get $10
+     local.set $10
+     local.get $8
      local.get $11
      i32.const 4184
      i32.const 4200
@@ -10736,15 +11917,15 @@
      i32.ne
      select
      i32.const 0
-     local.get $9
+     local.get $10
      call $~lib/internal/string/copyUnsafe
      local.get $11
-     local.get $9
+     local.get $10
      i32.add
      local.set $11
      local.get $7
      if
-      local.get $10
+      local.get $8
       local.get $11
       local.get $1
       i32.const 0
@@ -10766,14 +11947,18 @@
    unreachable
   end
   block $~lib/internal/arraybuffer/LOAD<bool,bool>|inlined.2 (result i32)
-   i32.const 0
-   local.set $12
    local.get $5
+   local.set $12
    local.get $2
+   local.set $15
+   i32.const 0
+   local.set $14
+   local.get $12
+   local.get $15
    i32.const 0
    i32.shl
    i32.add
-   local.get $12
+   local.get $14
    i32.add
    i32.load8_u offset=8
   end
@@ -10784,8 +11969,8 @@
   i32.ne
   i32.eqz
   i32.add
-  local.set $9
-  local.get $10
+  local.set $10
+  local.get $8
   local.get $11
   i32.const 4184
   i32.const 4200
@@ -10794,44 +11979,46 @@
   i32.ne
   select
   i32.const 0
-  local.get $9
+  local.get $10
   call $~lib/internal/string/copyUnsafe
   local.get $11
-  local.get $9
+  local.get $10
   i32.add
   local.set $11
-  local.get $10
-  local.set $12
   local.get $8
+  local.set $14
+  local.get $9
   local.get $11
   i32.gt_s
   if
-   local.get $10
+   local.get $8
    i32.const 0
    local.get $11
    call $~lib/string/String#substring
-   local.set $12
-   local.get $10
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 4088
-    i32.const 28
-    i32.const 4
-    call $~lib/env/abort
-    unreachable
-   end
-   block $~lib/memory/memory.free|inlined.5
-    block
-     local.get $10
-     call $~lib/allocator/arena/__memory_free
-     br $~lib/memory/memory.free|inlined.5
+   local.set $14
+   block $~lib/internal/string/freeUnsafe|inlined.0
+    local.get $8
+    local.set $15
+    local.get $15
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 4088
+     i32.const 28
+     i32.const 4
+     call $~lib/env/abort
      unreachable
     end
-    unreachable
+    block $~lib/memory/memory.free|inlined.5
+     local.get $15
+     local.set $12
+     local.get $12
+     call $~lib/allocator/arena/__memory_free
+     br $~lib/memory/memory.free|inlined.5
+    end
    end
   end
-  local.get $12
+  local.get $14
   return
  )
  (func $~lib/internal/number/decimalCount32 (; 182 ;) (type $ii) (param $0 i32) (result i32)
@@ -10910,8 +12097,10 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 i64)
-  (local $10 i64)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i64)
+  (local $12 i64)
   block $~lib/internal/number/DIGITS|inlined.0 (result i32)
    i32.const 4832
   end
@@ -10943,23 +12132,31 @@
       i32.rem_u
       local.set $7
       block $~lib/internal/arraybuffer/LOAD<u32,u64>|inlined.0 (result i64)
-       i32.const 0
-       local.set $8
        local.get $3
+       local.set $8
        local.get $6
+       local.set $9
+       i32.const 0
+       local.set $10
+       local.get $8
+       local.get $9
        i32.const 2
        i32.shl
        i32.add
-       local.get $8
+       local.get $10
        i32.add
        i64.load32_u offset=8
       end
-      local.set $9
+      local.set $11
       block $~lib/internal/arraybuffer/LOAD<u32,u64>|inlined.1 (result i64)
+       local.get $3
+       local.set $10
+       local.get $7
+       local.set $9
        i32.const 0
        local.set $8
-       local.get $3
-       local.get $7
+       local.get $10
+       local.get $9
        i32.const 2
        i32.shl
        i32.add
@@ -10967,7 +12164,7 @@
        i32.add
        i64.load32_u offset=8
       end
-      local.set $10
+      local.set $12
       local.get $2
       i32.const 4
       i32.sub
@@ -10977,8 +12174,8 @@
       i32.const 1
       i32.shl
       i32.add
-      local.get $9
-      local.get $10
+      local.get $11
+      local.get $12
       i64.const 32
       i64.shl
       i64.or
@@ -11007,24 +12204,28 @@
    i32.sub
    local.set $2
    block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.13 (result i32)
-    i32.const 0
-    local.set $5
     local.get $3
+    local.set $5
     local.get $6
+    local.set $4
+    i32.const 0
+    local.set $8
+    local.get $5
+    local.get $4
     i32.const 2
     i32.shl
     i32.add
-    local.get $5
+    local.get $8
     i32.add
     i32.load offset=8
    end
-   local.set $5
+   local.set $8
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $5
+   local.get $8
    i32.store offset=4
   end
   local.get $1
@@ -11036,24 +12237,28 @@
    i32.sub
    local.set $2
    block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.14 (result i32)
-    i32.const 0
-    local.set $5
     local.get $3
+    local.set $8
     local.get $1
+    local.set $6
+    i32.const 0
+    local.set $7
+    local.get $8
+    local.get $6
     i32.const 2
     i32.shl
     i32.add
-    local.get $5
+    local.get $7
     i32.add
     i32.load offset=8
    end
-   local.set $5
+   local.set $7
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $5
+   local.get $7
    i32.store offset=4
   else   
    local.get $2
@@ -11063,13 +12268,13 @@
    global.get $~lib/internal/string/CharCode._0
    local.get $1
    i32.add
-   local.set $5
+   local.set $7
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $5
+   local.get $7
    i32.store16 offset=4
   end
  )
@@ -11077,6 +12282,9 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.eqz
   if
@@ -11102,10 +12310,18 @@
   local.get $2
   call $~lib/internal/string/allocateUnsafe
   local.set $3
-  local.get $3
-  local.get $0
-  local.get $2
-  call $~lib/internal/number/utoa32_lut
+  block $~lib/internal/number/utoa32_core|inlined.0
+   local.get $3
+   local.set $4
+   local.get $0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/number/utoa32_lut
+  end
   local.get $1
   if
    local.get $3
@@ -11122,6 +12338,9 @@
  (func $~lib/internal/number/itoa_stream<i32> (; 186 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -11155,10 +12374,18 @@
   local.get $4
   i32.add
   local.set $3
-  local.get $0
-  local.get $2
-  local.get $3
-  call $~lib/internal/number/utoa32_lut
+  block $~lib/internal/number/utoa32_core|inlined.1
+   local.get $0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $3
+   local.set $7
+   local.get $5
+   local.get $6
+   local.get $7
+   call $~lib/internal/number/utoa32_lut
+  end
   local.get $4
   if
    local.get $0
@@ -11179,6 +12406,8 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   local.get $0
   i32.load offset=4
   i32.const 1
@@ -11207,16 +12436,18 @@
   i32.eqz
   if
    block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.34 (result i32)
-    i32.const 0
+    local.get $5
     local.set $8
     i32.const 0
     local.set $9
-    local.get $5
+    i32.const 0
+    local.set $10
     local.get $8
+    local.get $9
     i32.const 2
     i32.shl
     i32.add
-    local.get $9
+    local.get $10
     i32.add
     i32.load offset=8
    end
@@ -11230,12 +12461,12 @@
   i32.mul
   i32.const 11
   i32.add
-  local.set $9
-  local.get $9
-  call $~lib/internal/string/allocateUnsafe
-  local.set $8
-  i32.const 0
   local.set $10
+  local.get $10
+  call $~lib/internal/string/allocateUnsafe
+  local.set $9
+  i32.const 0
+  local.set $8
   block $break|0
    i32.const 0
    local.set $11
@@ -11247,37 +12478,41 @@
     br_if $break|0
     block
      block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.35 (result i32)
-      i32.const 0
-      local.set $12
       local.get $5
+      local.set $12
       local.get $11
+      local.set $13
+      i32.const 0
+      local.set $14
+      local.get $12
+      local.get $13
       i32.const 2
       i32.shl
       i32.add
-      local.get $12
+      local.get $14
       i32.add
       i32.load offset=8
      end
      local.set $4
-     local.get $10
      local.get $8
-     local.get $10
+     local.get $9
+     local.get $8
      local.get $4
      call $~lib/internal/number/itoa_stream<i32>
      i32.add
-     local.set $10
+     local.set $8
      local.get $7
      if
+      local.get $9
       local.get $8
-      local.get $10
       local.get $1
       i32.const 0
       local.get $6
       call $~lib/internal/string/copyUnsafe
-      local.get $10
+      local.get $8
       local.get $6
       i32.add
-      local.set $10
+      local.set $8
      end
     end
     local.get $11
@@ -11290,62 +12525,71 @@
    unreachable
   end
   block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.36 (result i32)
-   i32.const 0
-   local.set $11
    local.get $5
+   local.set $11
    local.get $2
+   local.set $14
+   i32.const 0
+   local.set $13
+   local.get $11
+   local.get $14
    i32.const 2
    i32.shl
    i32.add
-   local.get $11
+   local.get $13
    i32.add
    i32.load offset=8
   end
   local.set $4
-  local.get $10
   local.get $8
-  local.get $10
+  local.get $9
+  local.get $8
   local.get $4
   call $~lib/internal/number/itoa_stream<i32>
   i32.add
-  local.set $10
-  local.get $8
-  local.set $11
+  local.set $8
   local.get $9
+  local.set $13
   local.get $10
+  local.get $8
   i32.gt_s
   if
-   local.get $8
+   local.get $9
    i32.const 0
-   local.get $10
-   call $~lib/string/String#substring
-   local.set $11
    local.get $8
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 4088
-    i32.const 28
-    i32.const 4
-    call $~lib/env/abort
-    unreachable
-   end
-   block $~lib/memory/memory.free|inlined.6
-    block
-     local.get $8
-     call $~lib/allocator/arena/__memory_free
-     br $~lib/memory/memory.free|inlined.6
+   call $~lib/string/String#substring
+   local.set $13
+   block $~lib/internal/string/freeUnsafe|inlined.1
+    local.get $9
+    local.set $14
+    local.get $14
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 4088
+     i32.const 28
+     i32.const 4
+     call $~lib/env/abort
      unreachable
     end
-    unreachable
+    block $~lib/memory/memory.free|inlined.6
+     local.get $14
+     local.set $11
+     local.get $11
+     call $~lib/allocator/arena/__memory_free
+     br $~lib/memory/memory.free|inlined.6
+    end
    end
   end
-  local.get $11
+  local.get $13
   return
  )
  (func $~lib/internal/number/utoa32 (; 188 ;) (type $ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.eqz
   if
@@ -11358,10 +12602,18 @@
   local.get $1
   call $~lib/internal/string/allocateUnsafe
   local.set $2
-  local.get $2
-  local.get $0
-  local.get $1
-  call $~lib/internal/number/utoa32_lut
+  block $~lib/internal/number/utoa32_core|inlined.2
+   local.get $2
+   local.set $3
+   local.get $0
+   local.set $4
+   local.get $1
+   local.set $5
+   local.get $3
+   local.get $4
+   local.get $5
+   call $~lib/internal/number/utoa32_lut
+  end
   local.get $2
  )
  (func $~lib/internal/number/itoa<u32> (; 189 ;) (type $ii) (param $0 i32) (result i32)
@@ -11371,6 +12623,9 @@
  )
  (func $~lib/internal/number/itoa_stream<u32> (; 190 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -11391,10 +12646,18 @@
   local.get $2
   call $~lib/internal/number/decimalCount32
   local.set $3
-  local.get $0
-  local.get $2
-  local.get $3
-  call $~lib/internal/number/utoa32_lut
+  block $~lib/internal/number/utoa32_core|inlined.3
+   local.get $0
+   local.set $4
+   local.get $2
+   local.set $5
+   local.get $3
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/number/utoa32_lut
+  end
   local.get $3
  )
  (func $~lib/array/Array<u32>#join (; 191 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
@@ -11409,6 +12672,8 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   local.get $0
   i32.load offset=4
   i32.const 1
@@ -11437,16 +12702,18 @@
   i32.eqz
   if
    block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.15 (result i32)
-    i32.const 0
+    local.get $5
     local.set $8
     i32.const 0
     local.set $9
-    local.get $5
+    i32.const 0
+    local.set $10
     local.get $8
+    local.get $9
     i32.const 2
     i32.shl
     i32.add
-    local.get $9
+    local.get $10
     i32.add
     i32.load offset=8
    end
@@ -11460,12 +12727,12 @@
   i32.mul
   i32.const 10
   i32.add
-  local.set $9
-  local.get $9
-  call $~lib/internal/string/allocateUnsafe
-  local.set $8
-  i32.const 0
   local.set $10
+  local.get $10
+  call $~lib/internal/string/allocateUnsafe
+  local.set $9
+  i32.const 0
+  local.set $8
   block $break|0
    i32.const 0
    local.set $11
@@ -11477,37 +12744,41 @@
     br_if $break|0
     block
      block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.16 (result i32)
-      i32.const 0
-      local.set $12
       local.get $5
+      local.set $12
       local.get $11
+      local.set $13
+      i32.const 0
+      local.set $14
+      local.get $12
+      local.get $13
       i32.const 2
       i32.shl
       i32.add
-      local.get $12
+      local.get $14
       i32.add
       i32.load offset=8
      end
      local.set $4
-     local.get $10
      local.get $8
-     local.get $10
+     local.get $9
+     local.get $8
      local.get $4
      call $~lib/internal/number/itoa_stream<u32>
      i32.add
-     local.set $10
+     local.set $8
      local.get $7
      if
+      local.get $9
       local.get $8
-      local.get $10
       local.get $1
       i32.const 0
       local.get $6
       call $~lib/internal/string/copyUnsafe
-      local.get $10
+      local.get $8
       local.get $6
       i32.add
-      local.set $10
+      local.set $8
      end
     end
     local.get $11
@@ -11520,57 +12791,63 @@
    unreachable
   end
   block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.17 (result i32)
-   i32.const 0
-   local.set $11
    local.get $5
+   local.set $11
    local.get $2
+   local.set $14
+   i32.const 0
+   local.set $13
+   local.get $11
+   local.get $14
    i32.const 2
    i32.shl
    i32.add
-   local.get $11
+   local.get $13
    i32.add
    i32.load offset=8
   end
   local.set $4
-  local.get $10
   local.get $8
-  local.get $10
+  local.get $9
+  local.get $8
   local.get $4
   call $~lib/internal/number/itoa_stream<u32>
   i32.add
-  local.set $10
-  local.get $8
-  local.set $11
+  local.set $8
   local.get $9
+  local.set $13
   local.get $10
+  local.get $8
   i32.gt_s
   if
-   local.get $8
+   local.get $9
    i32.const 0
-   local.get $10
-   call $~lib/string/String#substring
-   local.set $11
    local.get $8
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 4088
-    i32.const 28
-    i32.const 4
-    call $~lib/env/abort
-    unreachable
-   end
-   block $~lib/memory/memory.free|inlined.7
-    block
-     local.get $8
-     call $~lib/allocator/arena/__memory_free
-     br $~lib/memory/memory.free|inlined.7
+   call $~lib/string/String#substring
+   local.set $13
+   block $~lib/internal/string/freeUnsafe|inlined.2
+    local.get $9
+    local.set $14
+    local.get $14
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 4088
+     i32.const 28
+     i32.const 4
+     call $~lib/env/abort
      unreachable
     end
-    unreachable
+    block $~lib/memory/memory.free|inlined.7
+     local.get $14
+     local.set $11
+     local.get $11
+     call $~lib/allocator/arena/__memory_free
+     br $~lib/memory/memory.free|inlined.7
+    end
    end
   end
-  local.get $11
+  local.get $13
   return
  )
  (func $~lib/builtins/isFinite<f64> (; 192 ;) (type $Fi) (param $0 f64) (result i32)
@@ -11594,9 +12871,14 @@
   (local $17 i32)
   (local $18 i32)
   (local $19 i64)
-  (local $20 i64)
-  (local $21 i32)
-  (local $22 i32)
+  (local $20 i32)
+  (local $21 i64)
+  (local $22 i64)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i64)
+  (local $27 i64)
   i32.const 0
   local.get $4
   i32.sub
@@ -11886,90 +13168,110 @@
        local.get $14
        i32.add
        global.set $~lib/internal/number/_K
-       block $~lib/internal/arraybuffer/LOAD<u32,u64>|inlined.2 (result i64)
-        i32.const 0
+       block $~lib/internal/number/grisuRound|inlined.0
+        local.get $0
         local.set $18
-        local.get $16
-        local.get $14
-        i32.const 2
+        local.get $15
+        local.set $20
+        local.get $5
+        local.set $21
+        local.get $19
+        local.set $22
+        block $~lib/internal/arraybuffer/LOAD<u32,u64>|inlined.2 (result i64)
+         local.get $16
+         local.set $23
+         local.get $14
+         local.set $24
+         i32.const 0
+         local.set $25
+         local.get $23
+         local.get $24
+         i32.const 2
+         i32.shl
+         i32.add
+         local.get $25
+         i32.add
+         i64.load32_u offset=8
+        end
+        local.get $7
+        i64.extend_i32_s
+        i64.shl
+        local.set $26
+        local.get $10
+        local.set $27
+        local.get $18
+        local.get $20
+        i32.const 1
+        i32.sub
+        i32.const 1
         i32.shl
         i32.add
-        local.get $18
-        i32.add
-        i64.load32_u offset=8
-       end
-       local.get $7
-       i64.extend_i32_s
-       i64.shl
-       local.set $20
-       local.get $0
-       local.get $15
-       i32.const 1
-       i32.sub
-       i32.const 1
-       i32.shl
-       i32.add
-       local.set $18
-       local.get $18
-       i32.load16_u offset=4
-       local.set $21
-       block $break|2
-        loop $continue|2
-         local.get $19
-         local.get $10
-         i64.lt_u
-         local.tee $22
-         if (result i32)
-          local.get $5
-          local.get $19
-          i64.sub
-          local.get $20
-          i64.ge_u
-         else          
+        local.set $25
+        local.get $25
+        i32.load16_u offset=4
+        local.set $24
+        block $break|2
+         loop $continue|2
           local.get $22
-         end
-         local.tee $22
-         if (result i32)
-          local.get $19
-          local.get $20
-          i64.add
-          local.get $10
+          local.get $27
           i64.lt_u
-          local.tee $22
+          local.tee $23
+          if (result i32)
+           local.get $21
+           local.get $22
+           i64.sub
+           local.get $26
+           i64.ge_u
+          else           
+           local.get $23
+          end
+          local.tee $23
+          i32.const 0
+          i32.ne
           if (result i32)
            local.get $22
+           local.get $26
+           i64.add
+           local.get $27
+           i64.lt_u
+           local.tee $23
+           if (result i32)
+            local.get $23
+           else            
+            local.get $27
+            local.get $22
+            i64.sub
+            local.get $22
+            local.get $26
+            i64.add
+            local.get $27
+            i64.sub
+            i64.gt_u
+           end
           else           
-           local.get $10
-           local.get $19
-           i64.sub
-           local.get $19
-           local.get $20
-           i64.add
-           local.get $10
-           i64.sub
-           i64.gt_u
+           local.get $23
           end
-         else          
-          local.get $22
-         end
-         if
-          block
-           local.get $21
-           i32.const 1
-           i32.sub
-           local.set $21
-           local.get $19
-           local.get $20
-           i64.add
-           local.set $19
+          i32.const 0
+          i32.ne
+          if
+           block
+            local.get $24
+            i32.const 1
+            i32.sub
+            local.set $24
+            local.get $22
+            local.get $26
+            i64.add
+            local.set $22
+           end
+           br $continue|2
           end
-          br $continue|2
          end
         end
+        local.get $25
+        local.get $24
+        i32.store16 offset=4
        end
-       local.get $18
-       local.get $21
-       i32.store16 offset=4
        local.get $15
        return
       end
@@ -12041,91 +13343,111 @@
        global.set $~lib/internal/number/_K
        local.get $10
        block $~lib/internal/arraybuffer/LOAD<u32,u64>|inlined.3 (result i64)
+        local.get $16
+        local.set $17
         i32.const 0
         local.get $14
         i32.sub
-        local.set $17
+        local.set $24
         i32.const 0
-        local.set $21
-        local.get $16
+        local.set $25
         local.get $17
+        local.get $24
         i32.const 2
         i32.shl
         i32.add
-        local.get $21
+        local.get $25
         i32.add
         i64.load32_u offset=8
        end
        i64.mul
        local.set $10
-       local.get $0
-       local.get $15
-       i32.const 1
-       i32.sub
-       i32.const 1
-       i32.shl
-       i32.add
-       local.set $21
-       local.get $21
-       i32.load16_u offset=4
-       local.set $17
-       block $break|4
-        loop $continue|4
-         local.get $13
-         local.get $10
-         i64.lt_u
-         local.tee $18
-         if (result i32)
-          local.get $5
-          local.get $13
-          i64.sub
-          local.get $8
-          i64.ge_u
-         else          
-          local.get $18
-         end
-         local.tee $18
-         if (result i32)
-          local.get $13
-          local.get $8
-          i64.add
-          local.get $10
+       block $~lib/internal/number/grisuRound|inlined.1
+        local.get $0
+        local.set $25
+        local.get $15
+        local.set $24
+        local.get $5
+        local.set $27
+        local.get $13
+        local.set $26
+        local.get $8
+        local.set $22
+        local.get $10
+        local.set $21
+        local.get $25
+        local.get $24
+        i32.const 1
+        i32.sub
+        i32.const 1
+        i32.shl
+        i32.add
+        local.set $17
+        local.get $17
+        i32.load16_u offset=4
+        local.set $20
+        block $break|4
+         loop $continue|4
+          local.get $26
+          local.get $21
           i64.lt_u
           local.tee $18
           if (result i32)
-           local.get $18
+           local.get $27
+           local.get $26
+           i64.sub
+           local.get $22
+           i64.ge_u
           else           
-           local.get $10
-           local.get $13
-           i64.sub
-           local.get $13
-           local.get $8
-           i64.add
-           local.get $10
-           i64.sub
-           i64.gt_u
+           local.get $18
           end
-         else          
-          local.get $18
-         end
-         if
-          block
-           local.get $17
-           i32.const 1
-           i32.sub
-           local.set $17
-           local.get $13
-           local.get $8
+          local.tee $18
+          i32.const 0
+          i32.ne
+          if (result i32)
+           local.get $26
+           local.get $22
            i64.add
-           local.set $13
+           local.get $21
+           i64.lt_u
+           local.tee $18
+           if (result i32)
+            local.get $18
+           else            
+            local.get $21
+            local.get $26
+            i64.sub
+            local.get $26
+            local.get $22
+            i64.add
+            local.get $21
+            i64.sub
+            i64.gt_u
+           end
+          else           
+           local.get $18
           end
-          br $continue|4
+          i32.const 0
+          i32.ne
+          if
+           block
+            local.get $20
+            i32.const 1
+            i32.sub
+            local.set $20
+            local.get $26
+            local.get $22
+            i64.add
+            local.set $26
+           end
+           br $continue|4
+          end
          end
         end
+        local.get $17
+        local.get $20
+        i32.store16 offset=4
        end
-       local.get $21
-       local.get $17
-       i32.store16 offset=4
        local.get $15
        return
       end
@@ -12143,6 +13465,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   local.get $2
   i32.eqz
   if
@@ -12237,26 +13562,28 @@
     i32.shl
     i32.add
     local.set $4
-    local.get $4
-    global.get $~lib/internal/string/HEADER_SIZE
-    i32.add
-    i32.const 2
-    i32.add
-    local.set $5
-    local.get $4
-    global.get $~lib/internal/string/HEADER_SIZE
-    i32.add
-    local.set $6
-    i32.const 0
-    local.get $2
-    i32.sub
-    i32.const 1
-    i32.shl
-    local.set $7
-    local.get $5
-    local.get $6
-    local.get $7
-    call $~lib/internal/memory/memmove
+    block $~lib/memory/memory.copy|inlined.9
+     local.get $4
+     global.get $~lib/internal/string/HEADER_SIZE
+     i32.add
+     i32.const 2
+     i32.add
+     local.set $5
+     local.get $4
+     global.get $~lib/internal/string/HEADER_SIZE
+     i32.add
+     local.set $6
+     i32.const 0
+     local.get $2
+     i32.sub
+     i32.const 1
+     i32.shl
+     local.set $7
+     local.get $5
+     local.get $6
+     local.get $7
+     call $~lib/internal/memory/memmove
+    end
     local.get $0
     local.get $3
     i32.const 1
@@ -12285,26 +13612,28 @@
      local.get $3
      i32.sub
      local.set $4
-     local.get $0
-     global.get $~lib/internal/string/HEADER_SIZE
-     i32.add
-     local.get $4
-     i32.const 1
-     i32.shl
-     i32.add
-     local.set $7
-     local.get $0
-     global.get $~lib/internal/string/HEADER_SIZE
-     i32.add
-     local.set $6
-     local.get $1
-     i32.const 1
-     i32.shl
-     local.set $5
-     local.get $7
-     local.get $6
-     local.get $5
-     call $~lib/internal/memory/memmove
+     block $~lib/memory/memory.copy|inlined.10
+      local.get $0
+      global.get $~lib/internal/string/HEADER_SIZE
+      i32.add
+      local.get $4
+      i32.const 1
+      i32.shl
+      i32.add
+      local.set $7
+      local.get $0
+      global.get $~lib/internal/string/HEADER_SIZE
+      i32.add
+      local.set $6
+      local.get $1
+      i32.const 1
+      i32.shl
+      local.set $5
+      local.get $7
+      local.get $6
+      local.get $5
+      call $~lib/internal/memory/memmove
+     end
      local.get $0
      global.get $~lib/internal/string/CharCode._0
      global.get $~lib/internal/string/CharCode.DOT
@@ -12374,10 +13703,18 @@
        i32.const 1
        i32.add
        local.set $7
-       local.get $4
-       local.get $5
-       local.get $7
-       call $~lib/internal/number/utoa32_lut
+       block $~lib/internal/number/utoa32_core|inlined.4
+        local.get $4
+        local.set $8
+        local.get $5
+        local.set $9
+        local.get $7
+        local.set $10
+        local.get $8
+        local.get $9
+        local.get $10
+        call $~lib/internal/number/utoa32_lut
+       end
        local.get $4
        global.get $~lib/internal/string/CharCode.MINUS
        global.get $~lib/internal/string/CharCode.PLUS
@@ -12396,26 +13733,28 @@
       i32.const 1
       i32.shl
       local.set $7
-      local.get $0
-      global.get $~lib/internal/string/HEADER_SIZE
-      i32.add
-      i32.const 4
-      i32.add
-      local.set $6
-      local.get $0
-      global.get $~lib/internal/string/HEADER_SIZE
-      i32.add
-      i32.const 2
-      i32.add
-      local.set $5
-      local.get $7
-      i32.const 2
-      i32.sub
-      local.set $4
-      local.get $6
-      local.get $5
-      local.get $4
-      call $~lib/internal/memory/memmove
+      block $~lib/memory/memory.copy|inlined.11
+       local.get $0
+       global.get $~lib/internal/string/HEADER_SIZE
+       i32.add
+       i32.const 4
+       i32.add
+       local.set $6
+       local.get $0
+       global.get $~lib/internal/string/HEADER_SIZE
+       i32.add
+       i32.const 2
+       i32.add
+       local.set $5
+       local.get $7
+       i32.const 2
+       i32.sub
+       local.set $4
+       local.get $6
+       local.get $5
+       local.get $4
+       call $~lib/internal/memory/memmove
+      end
       local.get $0
       global.get $~lib/internal/string/CharCode.DOT
       i32.store16 offset=6
@@ -12451,18 +13790,26 @@
        call $~lib/internal/number/decimalCount32
        i32.const 1
        i32.add
-       local.set $8
-       local.get $4
-       local.get $5
-       local.get $8
-       call $~lib/internal/number/utoa32_lut
+       local.set $10
+       block $~lib/internal/number/utoa32_core|inlined.5
+        local.get $4
+        local.set $9
+        local.get $5
+        local.set $8
+        local.get $10
+        local.set $11
+        local.get $9
+        local.get $8
+        local.get $11
+        call $~lib/internal/number/utoa32_lut
+       end
        local.get $4
        global.get $~lib/internal/string/CharCode.MINUS
        global.get $~lib/internal/string/CharCode.PLUS
        local.get $6
        select
        i32.store16 offset=4
-       local.get $8
+       local.get $10
       end
       i32.add
       local.set $1
@@ -12482,29 +13829,35 @@
  )
  (func $~lib/internal/number/dtoa_core (; 195 ;) (type $iFi) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
-  (local $3 i64)
+  (local $3 f64)
   (local $4 i32)
-  (local $5 i64)
+  (local $5 i32)
   (local $6 i64)
-  (local $7 i64)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 f64)
-  (local $12 i32)
+  (local $7 i32)
+  (local $8 i64)
+  (local $9 i64)
+  (local $10 i64)
+  (local $11 i32)
+  (local $12 i64)
   (local $13 i32)
   (local $14 i32)
-  (local $15 i64)
-  (local $16 i64)
-  (local $17 i64)
-  (local $18 i64)
-  (local $19 i64)
-  (local $20 i64)
+  (local $15 i32)
+  (local $16 f64)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   (local $21 i64)
   (local $22 i64)
   (local $23 i64)
   (local $24 i64)
-  (local $25 i32)
+  (local $25 i64)
+  (local $26 i64)
+  (local $27 i64)
+  (local $28 i64)
+  (local $29 i64)
+  (local $30 i64)
+  (local $31 i32)
   local.get $1
   f64.const 0
   f64.lt
@@ -12520,31 +13873,37 @@
   end
   block $~lib/internal/number/grisu2|inlined.0 (result i32)
    local.get $1
-   i64.reinterpret_f64
    local.set $3
+   local.get $0
+   local.set $4
+   local.get $2
+   local.set $5
    local.get $3
+   i64.reinterpret_f64
+   local.set $6
+   local.get $6
    i64.const 9218868437227405312
    i64.and
    i64.const 52
    i64.shr_u
    i32.wrap_i64
-   local.set $4
-   local.get $3
+   local.set $7
+   local.get $6
    i64.const 4503599627370495
    i64.and
-   local.set $5
-   local.get $4
+   local.set $8
+   local.get $7
    i32.const 0
    i32.ne
    i64.extend_i32_u
    i64.const 52
    i64.shl
-   local.get $5
+   local.get $8
    i64.add
-   local.set $6
-   local.get $4
+   local.set $9
+   local.get $7
    i32.const 1
-   local.get $4
+   local.get $7
    i32.const 0
    i32.ne
    select
@@ -12552,86 +13911,90 @@
    i32.const 52
    i32.add
    i32.sub
-   local.set $4
-   block
-    local.get $6
+   local.set $7
+   block $~lib/internal/number/normalizedBoundaries|inlined.0
+    local.get $9
+    local.set $10
+    local.get $7
+    local.set $11
+    local.get $10
     i64.const 1
     i64.shl
     i64.const 1
     i64.add
-    local.set $7
-    local.get $4
+    local.set $12
+    local.get $11
     i32.const 1
     i32.sub
-    local.set $8
-    local.get $7
+    local.set $13
+    local.get $12
     i64.clz
     i32.wrap_i64
-    local.set $9
-    local.get $7
-    local.get $9
+    local.set $14
+    local.get $12
+    local.get $14
     i64.extend_i32_s
     i64.shl
-    local.set $7
-    local.get $8
-    local.get $9
+    local.set $12
+    local.get $13
+    local.get $14
     i32.sub
-    local.set $8
+    local.set $13
     i32.const 1
-    local.get $6
+    local.get $10
     i64.const 4503599627370496
     i64.eq
     i32.add
-    local.set $10
-    local.get $7
+    local.set $15
+    local.get $12
     global.set $~lib/internal/number/_frc_plus
-    local.get $6
     local.get $10
+    local.get $15
     i64.extend_i32_s
     i64.shl
     i64.const 1
     i64.sub
-    local.get $4
-    local.get $10
+    local.get $11
+    local.get $15
     i32.sub
-    local.get $8
+    local.get $13
     i32.sub
     i64.extend_i32_s
     i64.shl
     global.set $~lib/internal/number/_frc_minus
-    local.get $8
+    local.get $13
     global.set $~lib/internal/number/_exp
    end
-   block
+   block $~lib/internal/number/getCachedPower|inlined.0
     global.get $~lib/internal/number/_exp
-    local.set $10
+    local.set $15
     i32.const -61
-    local.get $10
+    local.get $15
     i32.sub
     f64.convert_i32_s
     f64.const 0.30102999566398114
     f64.mul
     f64.const 347
     f64.add
-    local.set $11
-    local.get $11
+    local.set $16
+    local.get $16
     i32.trunc_f64_s
-    local.set $9
-    local.get $9
-    local.get $9
+    local.set $14
+    local.get $14
+    local.get $14
     f64.convert_i32_s
-    local.get $11
+    local.get $16
     f64.ne
     i32.add
-    local.set $9
-    local.get $9
+    local.set $14
+    local.get $14
     i32.const 3
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $8
+    local.set $13
     i32.const 348
-    local.get $8
+    local.get $13
     i32.const 3
     i32.shl
     i32.sub
@@ -12640,282 +14003,304 @@
      i32.const 6280
     end
     i32.load
-    local.set $12
+    local.set $11
     block $~lib/internal/number/EXP_POWERS|inlined.0 (result i32)
      i32.const 6544
     end
     i32.load
-    local.set $13
+    local.set $17
     block $~lib/internal/arraybuffer/LOAD<u64,u64>|inlined.0 (result i64)
+     local.get $11
+     local.set $18
+     local.get $13
+     local.set $19
      i32.const 0
-     local.set $14
-     local.get $12
-     local.get $8
+     local.set $20
+     local.get $18
+     local.get $19
      i32.const 3
      i32.shl
      i32.add
-     local.get $14
+     local.get $20
      i32.add
      i64.load offset=8
     end
     global.set $~lib/internal/number/_frc_pow
     block $~lib/internal/arraybuffer/LOAD<i16,i32>|inlined.0 (result i32)
-     i32.const 0
-     local.set $14
+     local.get $17
+     local.set $20
      local.get $13
-     local.get $8
+     local.set $19
+     i32.const 0
+     local.set $18
+     local.get $20
+     local.get $19
      i32.const 1
      i32.shl
      i32.add
-     local.get $14
+     local.get $18
      i32.add
      i32.load16_s offset=8
     end
     global.set $~lib/internal/number/_exp_pow
    end
-   local.get $6
+   local.get $9
    i64.clz
    i32.wrap_i64
-   local.set $13
-   local.get $6
-   local.get $13
+   local.set $17
+   local.get $9
+   local.get $17
    i64.extend_i32_s
    i64.shl
-   local.set $6
-   local.get $4
-   local.get $13
+   local.set $9
+   local.get $7
+   local.get $17
    i32.sub
-   local.set $4
-   global.get $~lib/internal/number/_frc_pow
    local.set $7
-   global.get $~lib/internal/number/_exp_pow
+   global.get $~lib/internal/number/_frc_pow
    local.set $12
+   global.get $~lib/internal/number/_exp_pow
+   local.set $11
    block $~lib/internal/number/umul64f|inlined.0 (result i64)
-    local.get $6
-    i64.const 4294967295
-    i64.and
-    local.set $15
-    local.get $7
-    i64.const 4294967295
-    i64.and
-    local.set $16
-    local.get $6
-    i64.const 32
-    i64.shr_u
-    local.set $17
-    local.get $7
-    i64.const 32
-    i64.shr_u
-    local.set $18
-    local.get $15
-    local.get $16
-    i64.mul
-    local.set $19
-    local.get $17
-    local.get $16
-    i64.mul
-    local.get $19
-    i64.const 32
-    i64.shr_u
-    i64.add
-    local.set $20
-    local.get $15
-    local.get $18
-    i64.mul
-    local.get $20
-    i64.const 4294967295
-    i64.and
-    i64.add
+    local.get $9
+    local.set $10
+    local.get $12
     local.set $21
+    local.get $10
+    i64.const 4294967295
+    i64.and
+    local.set $22
     local.get $21
+    i64.const 4294967295
+    i64.and
+    local.set $23
+    local.get $10
+    i64.const 32
+    i64.shr_u
+    local.set $24
+    local.get $21
+    i64.const 32
+    i64.shr_u
+    local.set $25
+    local.get $22
+    local.get $23
+    i64.mul
+    local.set $26
+    local.get $24
+    local.get $23
+    i64.mul
+    local.get $26
+    i64.const 32
+    i64.shr_u
+    i64.add
+    local.set $27
+    local.get $22
+    local.get $25
+    i64.mul
+    local.get $27
+    i64.const 4294967295
+    i64.and
+    i64.add
+    local.set $28
+    local.get $28
     i64.const 2147483647
     i64.add
-    local.set $21
-    local.get $20
+    local.set $28
+    local.get $27
     i64.const 32
     i64.shr_u
-    local.set $20
-    local.get $21
+    local.set $27
+    local.get $28
     i64.const 32
     i64.shr_u
-    local.set $21
-    local.get $17
-    local.get $18
+    local.set $28
+    local.get $24
+    local.get $25
     i64.mul
-    local.get $20
+    local.get $27
     i64.add
-    local.get $21
+    local.get $28
     i64.add
    end
-   local.set $21
+   local.set $28
    block $~lib/internal/number/umul64e|inlined.0 (result i32)
-    local.get $4
-    local.get $12
+    local.get $7
+    local.set $13
+    local.get $11
+    local.set $14
+    local.get $13
+    local.get $14
     i32.add
     i32.const 64
     i32.add
    end
-   local.set $8
+   local.set $14
    block $~lib/internal/number/umul64f|inlined.1 (result i64)
     global.get $~lib/internal/number/_frc_plus
-    local.set $20
-    local.get $20
+    local.set $27
+    local.get $12
+    local.set $26
+    local.get $27
     i64.const 4294967295
     i64.and
-    local.set $19
-    local.get $7
+    local.set $25
+    local.get $26
     i64.const 4294967295
     i64.and
-    local.set $18
-    local.get $20
+    local.set $24
+    local.get $27
     i64.const 32
     i64.shr_u
-    local.set $17
-    local.get $7
-    i64.const 32
-    i64.shr_u
-    local.set $16
-    local.get $19
-    local.get $18
-    i64.mul
-    local.set $15
-    local.get $17
-    local.get $18
-    i64.mul
-    local.get $15
-    i64.const 32
-    i64.shr_u
-    i64.add
-    local.set $22
-    local.get $19
-    local.get $16
-    i64.mul
-    local.get $22
-    i64.const 4294967295
-    i64.and
-    i64.add
     local.set $23
+    local.get $26
+    i64.const 32
+    i64.shr_u
+    local.set $22
+    local.get $25
+    local.get $24
+    i64.mul
+    local.set $21
     local.get $23
+    local.get $24
+    i64.mul
+    local.get $21
+    i64.const 32
+    i64.shr_u
+    i64.add
+    local.set $10
+    local.get $25
+    local.get $22
+    i64.mul
+    local.get $10
+    i64.const 4294967295
+    i64.and
+    i64.add
+    local.set $29
+    local.get $29
     i64.const 2147483647
     i64.add
-    local.set $23
-    local.get $22
+    local.set $29
+    local.get $10
     i64.const 32
     i64.shr_u
-    local.set $22
+    local.set $10
+    local.get $29
+    i64.const 32
+    i64.shr_u
+    local.set $29
     local.get $23
-    i64.const 32
-    i64.shr_u
-    local.set $23
-    local.get $17
-    local.get $16
+    local.get $22
     i64.mul
-    local.get $22
+    local.get $10
     i64.add
-    local.get $23
+    local.get $29
     i64.add
    end
    i64.const 1
    i64.sub
-   local.set $23
+   local.set $29
    block $~lib/internal/number/umul64e|inlined.1 (result i32)
     global.get $~lib/internal/number/_exp
-    local.set $9
-    local.get $9
-    local.get $12
+    local.set $13
+    local.get $11
+    local.set $15
+    local.get $13
+    local.get $15
     i32.add
     i32.const 64
     i32.add
    end
-   local.set $9
+   local.set $15
    block $~lib/internal/number/umul64f|inlined.2 (result i64)
     global.get $~lib/internal/number/_frc_minus
+    local.set $10
+    local.get $12
+    local.set $21
+    local.get $10
+    i64.const 4294967295
+    i64.and
     local.set $22
-    local.get $22
+    local.get $21
     i64.const 4294967295
     i64.and
-    local.set $15
-    local.get $7
-    i64.const 4294967295
-    i64.and
-    local.set $16
-    local.get $22
+    local.set $23
+    local.get $10
     i64.const 32
     i64.shr_u
-    local.set $17
-    local.get $7
-    i64.const 32
-    i64.shr_u
-    local.set $18
-    local.get $15
-    local.get $16
-    i64.mul
-    local.set $19
-    local.get $17
-    local.get $16
-    i64.mul
-    local.get $19
-    i64.const 32
-    i64.shr_u
-    i64.add
-    local.set $20
-    local.get $15
-    local.get $18
-    i64.mul
-    local.get $20
-    i64.const 4294967295
-    i64.and
-    i64.add
     local.set $24
+    local.get $21
+    i64.const 32
+    i64.shr_u
+    local.set $25
+    local.get $22
+    local.get $23
+    i64.mul
+    local.set $26
     local.get $24
+    local.get $23
+    i64.mul
+    local.get $26
+    i64.const 32
+    i64.shr_u
+    i64.add
+    local.set $27
+    local.get $22
+    local.get $25
+    i64.mul
+    local.get $27
+    i64.const 4294967295
+    i64.and
+    i64.add
+    local.set $30
+    local.get $30
     i64.const 2147483647
     i64.add
-    local.set $24
-    local.get $20
+    local.set $30
+    local.get $27
     i64.const 32
     i64.shr_u
-    local.set $20
+    local.set $27
+    local.get $30
+    i64.const 32
+    i64.shr_u
+    local.set $30
     local.get $24
-    i64.const 32
-    i64.shr_u
-    local.set $24
-    local.get $17
-    local.get $18
+    local.get $25
     i64.mul
-    local.get $20
+    local.get $27
     i64.add
-    local.get $24
+    local.get $30
     i64.add
    end
    i64.const 1
    i64.add
-   local.set $24
-   local.get $23
-   local.get $24
+   local.set $30
+   local.get $29
+   local.get $30
    i64.sub
-   local.set $20
-   local.get $0
-   local.get $21
-   local.get $8
-   local.get $23
-   local.get $9
-   local.get $20
-   local.get $2
+   local.set $27
+   local.get $4
+   local.get $28
+   local.get $14
+   local.get $29
+   local.get $15
+   local.get $27
+   local.get $5
    call $~lib/internal/number/genDigits
   end
-  local.set $25
+  local.set $31
   local.get $0
   local.get $2
   i32.const 1
   i32.shl
   i32.add
-  local.get $25
+  local.get $31
   local.get $2
   i32.sub
   global.get $~lib/internal/number/_K
   call $~lib/internal/number/prettify
-  local.set $25
-  local.get $25
+  local.set $31
+  local.get $31
   local.get $2
   i32.add
  )
@@ -12923,6 +14308,8 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   f64.const 0
   f64.eq
@@ -12960,24 +14347,26 @@
   local.get $2
   call $~lib/string/String#substring
   local.set $3
-  local.get $1
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 4088
-   i32.const 28
-   i32.const 4
-   call $~lib/env/abort
-   unreachable
-  end
-  block $~lib/memory/memory.free|inlined.8
-   block
-    local.get $1
-    call $~lib/allocator/arena/__memory_free
-    br $~lib/memory/memory.free|inlined.8
+  block $~lib/internal/string/freeUnsafe|inlined.3
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 4088
+    i32.const 28
+    i32.const 4
+    call $~lib/env/abort
     unreachable
    end
-   unreachable
+   block $~lib/memory/memory.free|inlined.8
+    local.get $4
+    local.set $5
+    local.get $5
+    call $~lib/allocator/arena/__memory_free
+    br $~lib/memory/memory.free|inlined.8
+   end
   end
   local.get $3
  )
@@ -13042,22 +14431,24 @@
     local.get $3
     select
     local.set $5
-    local.get $0
-    global.get $~lib/internal/string/HEADER_SIZE
-    i32.add
-    local.set $6
-    local.get $5
-    global.get $~lib/internal/string/HEADER_SIZE
-    i32.add
-    local.set $7
-    local.get $4
-    i32.const 1
-    i32.shl
-    local.set $8
-    local.get $6
-    local.get $7
-    local.get $8
-    call $~lib/internal/memory/memmove
+    block $~lib/memory/memory.copy|inlined.12
+     local.get $0
+     global.get $~lib/internal/string/HEADER_SIZE
+     i32.add
+     local.set $6
+     local.get $5
+     global.get $~lib/internal/string/HEADER_SIZE
+     i32.add
+     local.set $7
+     local.get $4
+     i32.const 1
+     i32.shl
+     local.set $8
+     local.get $6
+     local.get $7
+     local.get $8
+     call $~lib/internal/memory/memmove
+    end
     local.get $4
     return
    end
@@ -13080,6 +14471,8 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   local.get $0
   i32.load offset=4
   i32.const 1
@@ -13108,16 +14501,18 @@
   i32.eqz
   if
    block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.13 (result f64)
-    i32.const 0
+    local.get $5
     local.set $8
     i32.const 0
     local.set $9
-    local.get $5
+    i32.const 0
+    local.set $10
     local.get $8
+    local.get $9
     i32.const 3
     i32.shl
     i32.add
-    local.get $9
+    local.get $10
     i32.add
     f64.load offset=8
    end
@@ -13131,12 +14526,12 @@
   i32.mul
   i32.const 28
   i32.add
-  local.set $9
-  local.get $9
-  call $~lib/internal/string/allocateUnsafe
-  local.set $8
-  i32.const 0
   local.set $10
+  local.get $10
+  call $~lib/internal/string/allocateUnsafe
+  local.set $9
+  i32.const 0
+  local.set $8
   block $break|0
    i32.const 0
    local.set $11
@@ -13148,37 +14543,41 @@
     br_if $break|0
     block
      block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.14 (result f64)
-      i32.const 0
-      local.set $12
       local.get $5
+      local.set $12
       local.get $11
+      local.set $13
+      i32.const 0
+      local.set $14
+      local.get $12
+      local.get $13
       i32.const 3
       i32.shl
       i32.add
-      local.get $12
+      local.get $14
       i32.add
       f64.load offset=8
      end
      local.set $4
-     local.get $10
      local.get $8
-     local.get $10
+     local.get $9
+     local.get $8
      local.get $4
      call $~lib/internal/number/dtoa_stream
      i32.add
-     local.set $10
+     local.set $8
      local.get $7
      if
+      local.get $9
       local.get $8
-      local.get $10
       local.get $1
       i32.const 0
       local.get $6
       call $~lib/internal/string/copyUnsafe
-      local.get $10
+      local.get $8
       local.get $6
       i32.add
-      local.set $10
+      local.set $8
      end
     end
     local.get $11
@@ -13191,57 +14590,63 @@
    unreachable
   end
   block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.15 (result f64)
-   i32.const 0
-   local.set $11
    local.get $5
+   local.set $11
    local.get $2
+   local.set $14
+   i32.const 0
+   local.set $13
+   local.get $11
+   local.get $14
    i32.const 3
    i32.shl
    i32.add
-   local.get $11
+   local.get $13
    i32.add
    f64.load offset=8
   end
   local.set $4
-  local.get $10
   local.get $8
-  local.get $10
+  local.get $9
+  local.get $8
   local.get $4
   call $~lib/internal/number/dtoa_stream
   i32.add
-  local.set $10
-  local.get $8
-  local.set $11
+  local.set $8
   local.get $9
+  local.set $13
   local.get $10
+  local.get $8
   i32.gt_s
   if
-   local.get $8
+   local.get $9
    i32.const 0
-   local.get $10
-   call $~lib/string/String#substring
-   local.set $11
    local.get $8
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 4088
-    i32.const 28
-    i32.const 4
-    call $~lib/env/abort
-    unreachable
-   end
-   block $~lib/memory/memory.free|inlined.9
-    block
-     local.get $8
-     call $~lib/allocator/arena/__memory_free
-     br $~lib/memory/memory.free|inlined.9
+   call $~lib/string/String#substring
+   local.set $13
+   block $~lib/internal/string/freeUnsafe|inlined.4
+    local.get $9
+    local.set $14
+    local.get $14
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 4088
+     i32.const 28
+     i32.const 4
+     call $~lib/env/abort
      unreachable
     end
-    unreachable
+    block $~lib/memory/memory.free|inlined.9
+     local.get $14
+     local.set $11
+     local.get $11
+     call $~lib/allocator/arena/__memory_free
+     br $~lib/memory/memory.free|inlined.9
+    end
    end
   end
-  local.get $11
+  local.get $13
   return
  )
  (func $~lib/array/Array<String>#join (; 199 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
@@ -13256,6 +14661,8 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   local.get $0
   i32.load offset=4
   i32.const 1
@@ -13284,91 +14691,101 @@
   i32.eqz
   if
    block $~lib/internal/arraybuffer/LOAD<String,String>|inlined.5 (result i32)
-    i32.const 0
+    local.get $5
     local.set $8
     i32.const 0
     local.set $9
-    local.get $5
+    i32.const 0
+    local.set $10
     local.get $8
+    local.get $9
     i32.const 2
     i32.shl
     i32.add
-    local.get $9
+    local.get $10
     i32.add
     i32.load offset=8
    end
    return
   end
   i32.const 0
-  local.set $9
+  local.set $10
   block $break|0
    block
     i32.const 0
-    local.set $8
+    local.set $9
     local.get $2
     i32.const 1
     i32.add
-    local.set $10
+    local.set $8
    end
    loop $repeat|0
+    local.get $9
     local.get $8
-    local.get $10
     i32.lt_s
     i32.eqz
     br_if $break|0
-    local.get $9
+    local.get $10
     block $~lib/internal/arraybuffer/LOAD<String,String>|inlined.6 (result i32)
-     i32.const 0
-     local.set $11
      local.get $5
-     local.get $8
+     local.set $11
+     local.get $9
+     local.set $12
+     i32.const 0
+     local.set $13
+     local.get $11
+     local.get $12
      i32.const 2
      i32.shl
      i32.add
-     local.get $11
+     local.get $13
      i32.add
      i32.load offset=8
     end
     i32.load
     i32.add
-    local.set $9
-    local.get $8
+    local.set $10
+    local.get $9
     i32.const 1
     i32.add
-    local.set $8
+    local.set $9
     br $repeat|0
     unreachable
    end
    unreachable
   end
   i32.const 0
-  local.set $10
-  local.get $9
+  local.set $8
+  local.get $10
   local.get $6
   local.get $2
   i32.mul
   i32.add
   call $~lib/internal/string/allocateUnsafe
-  local.set $8
+  local.set $9
   block $break|1
    i32.const 0
-   local.set $11
+   local.set $13
    loop $repeat|1
-    local.get $11
+    local.get $13
     local.get $2
     i32.lt_s
     i32.eqz
     br_if $break|1
     block
      block $~lib/internal/arraybuffer/LOAD<String,String>|inlined.7 (result i32)
-      i32.const 0
-      local.set $12
       local.get $5
+      local.set $12
+      local.get $13
+      local.set $11
+      i32.const 0
+      local.set $14
+      local.get $12
       local.get $11
       i32.const 2
       i32.shl
       i32.add
-      local.get $12
+      local.get $14
       i32.add
       i32.load offset=8
      end
@@ -13377,46 +14794,50 @@
      if
       local.get $4
       i32.load
-      local.set $12
+      local.set $14
+      local.get $9
       local.get $8
-      local.get $10
       local.get $4
       i32.const 0
-      local.get $12
+      local.get $14
       call $~lib/internal/string/copyUnsafe
-      local.get $10
-      local.get $12
+      local.get $8
+      local.get $14
       i32.add
-      local.set $10
+      local.set $8
      end
      local.get $7
      if
+      local.get $9
       local.get $8
-      local.get $10
       local.get $1
       i32.const 0
       local.get $6
       call $~lib/internal/string/copyUnsafe
-      local.get $10
+      local.get $8
       local.get $6
       i32.add
-      local.set $10
+      local.set $8
      end
     end
-    local.get $11
+    local.get $13
     i32.const 1
     i32.add
-    local.set $11
+    local.set $13
     br $repeat|1
     unreachable
    end
    unreachable
   end
   block $~lib/internal/arraybuffer/LOAD<String,String>|inlined.8 (result i32)
+   local.get $5
+   local.set $13
+   local.get $2
+   local.set $14
    i32.const 0
    local.set $11
-   local.get $5
-   local.get $2
+   local.get $13
+   local.get $14
    i32.const 2
    i32.shl
    i32.add
@@ -13430,14 +14851,14 @@
    local.get $4
    i32.load
    local.set $11
+   local.get $9
    local.get $8
-   local.get $10
    local.get $4
    i32.const 0
    local.get $11
    call $~lib/internal/string/copyUnsafe
   end
-  local.get $8
+  local.get $9
   return
  )
  (func $std/array/Ref#constructor (; 200 ;) (type $ii) (param $0 i32) (result i32)
@@ -13455,6 +14876,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.const 268435454
   i32.gt_u
@@ -13494,34 +14916,44 @@
   local.get $0
   local.get $1
   i32.store offset=4
-  local.get $3
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  i32.const 0
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $2
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.12
+   local.get $3
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/memory/memset
+  end
   local.get $0
  )
  (func $~lib/array/Array<Ref>#__unchecked_set (; 202 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.load
   local.set $3
-  i32.const 0
-  local.set $4
-  local.get $3
   local.get $1
+  local.set $4
+  local.get $2
+  local.set $5
+  i32.const 0
+  local.set $6
+  local.get $3
+  local.get $4
   i32.const 2
   i32.shl
   i32.add
-  local.get $4
+  local.get $6
   i32.add
-  local.get $2
+  local.get $5
   i32.store offset=8
  )
  (func $~lib/array/Array<Ref>#join (; 203 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
@@ -13536,6 +14968,8 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   local.get $0
   i32.load offset=4
   i32.const 1
@@ -13590,14 +15024,18 @@
     br_if $break|0
     block
      block $~lib/internal/arraybuffer/LOAD<Ref,Ref>|inlined.0 (result i32)
-      i32.const 0
-      local.set $12
       local.get $5
+      local.set $12
       local.get $11
+      local.set $13
+      i32.const 0
+      local.set $14
+      local.get $12
+      local.get $13
       i32.const 2
       i32.shl
       i32.add
-      local.get $12
+      local.get $14
       i32.add
       i32.load offset=8
      end
@@ -13639,10 +15077,14 @@
    unreachable
   end
   block $~lib/internal/arraybuffer/LOAD<Ref,Ref>|inlined.2 (result i32)
+   local.get $5
+   local.set $13
+   local.get $2
+   local.set $14
    i32.const 0
    local.set $11
-   local.get $5
-   local.get $2
+   local.get $13
+   local.get $14
    i32.const 2
    i32.shl
    i32.add
@@ -13673,24 +15115,26 @@
    local.get $10
    call $~lib/string/String#substring
    local.set $11
-   local.get $9
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 4088
-    i32.const 28
-    i32.const 4
-    call $~lib/env/abort
-    unreachable
-   end
-   block $~lib/memory/memory.free|inlined.10
-    block
-     local.get $9
-     call $~lib/allocator/arena/__memory_free
-     br $~lib/memory/memory.free|inlined.10
+   block $~lib/internal/string/freeUnsafe|inlined.5
+    local.get $9
+    local.set $14
+    local.get $14
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 4088
+     i32.const 28
+     i32.const 4
+     call $~lib/env/abort
      unreachable
     end
-    unreachable
+    block $~lib/memory/memory.free|inlined.10
+     local.get $14
+     local.set $13
+     local.get $13
+     call $~lib/allocator/arena/__memory_free
+     br $~lib/memory/memory.free|inlined.10
+    end
    end
   end
   local.get $11
@@ -13709,6 +15153,8 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -13754,16 +15200,22 @@
   local.get $4
   i32.add
   local.set $3
-  local.get $2
-  i32.const 24
-  i32.shl
-  i32.const 24
-  i32.shr_s
-  local.set $5
-  local.get $0
-  local.get $5
-  local.get $3
-  call $~lib/internal/number/utoa32_lut
+  block $~lib/internal/number/utoa32_core|inlined.6
+   local.get $0
+   local.set $5
+   local.get $2
+   i32.const 24
+   i32.shl
+   i32.const 24
+   i32.shr_s
+   local.set $6
+   local.get $3
+   local.set $7
+   local.get $5
+   local.get $6
+   local.get $7
+   call $~lib/internal/number/utoa32_lut
+  end
   local.get $4
   if
    local.get $0
@@ -13784,6 +15236,8 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   local.get $0
   i32.load offset=4
   i32.const 1
@@ -13812,16 +15266,18 @@
   i32.eqz
   if
    block $~lib/internal/arraybuffer/LOAD<i8,i8>|inlined.0 (result i32)
-    i32.const 0
+    local.get $5
     local.set $8
     i32.const 0
     local.set $9
-    local.get $5
+    i32.const 0
+    local.set $10
     local.get $8
+    local.get $9
     i32.const 0
     i32.shl
     i32.add
-    local.get $9
+    local.get $10
     i32.add
     i32.load8_s offset=8
    end
@@ -13835,12 +15291,12 @@
   i32.mul
   i32.const 11
   i32.add
-  local.set $9
-  local.get $9
-  call $~lib/internal/string/allocateUnsafe
-  local.set $8
-  i32.const 0
   local.set $10
+  local.get $10
+  call $~lib/internal/string/allocateUnsafe
+  local.set $9
+  i32.const 0
+  local.set $8
   block $break|0
    i32.const 0
    local.set $11
@@ -13852,37 +15308,41 @@
     br_if $break|0
     block
      block $~lib/internal/arraybuffer/LOAD<i8,i8>|inlined.1 (result i32)
-      i32.const 0
-      local.set $12
       local.get $5
+      local.set $12
       local.get $11
+      local.set $13
+      i32.const 0
+      local.set $14
+      local.get $12
+      local.get $13
       i32.const 0
       i32.shl
       i32.add
-      local.get $12
+      local.get $14
       i32.add
       i32.load8_s offset=8
      end
      local.set $4
-     local.get $10
      local.get $8
-     local.get $10
+     local.get $9
+     local.get $8
      local.get $4
      call $~lib/internal/number/itoa_stream<i8>
      i32.add
-     local.set $10
+     local.set $8
      local.get $7
      if
+      local.get $9
       local.get $8
-      local.get $10
       local.get $1
       i32.const 0
       local.get $6
       call $~lib/internal/string/copyUnsafe
-      local.get $10
+      local.get $8
       local.get $6
       i32.add
-      local.set $10
+      local.set $8
      end
     end
     local.get $11
@@ -13895,57 +15355,63 @@
    unreachable
   end
   block $~lib/internal/arraybuffer/LOAD<i8,i8>|inlined.2 (result i32)
-   i32.const 0
-   local.set $11
    local.get $5
+   local.set $11
    local.get $2
+   local.set $14
+   i32.const 0
+   local.set $13
+   local.get $11
+   local.get $14
    i32.const 0
    i32.shl
    i32.add
-   local.get $11
+   local.get $13
    i32.add
    i32.load8_s offset=8
   end
   local.set $4
-  local.get $10
   local.get $8
-  local.get $10
+  local.get $9
+  local.get $8
   local.get $4
   call $~lib/internal/number/itoa_stream<i8>
   i32.add
-  local.set $10
-  local.get $8
-  local.set $11
+  local.set $8
   local.get $9
+  local.set $13
   local.get $10
+  local.get $8
   i32.gt_s
   if
-   local.get $8
+   local.get $9
    i32.const 0
-   local.get $10
-   call $~lib/string/String#substring
-   local.set $11
    local.get $8
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 4088
-    i32.const 28
-    i32.const 4
-    call $~lib/env/abort
-    unreachable
-   end
-   block $~lib/memory/memory.free|inlined.11
-    block
-     local.get $8
-     call $~lib/allocator/arena/__memory_free
-     br $~lib/memory/memory.free|inlined.11
+   call $~lib/string/String#substring
+   local.set $13
+   block $~lib/internal/string/freeUnsafe|inlined.6
+    local.get $9
+    local.set $14
+    local.get $14
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 4088
+     i32.const 28
+     i32.const 4
+     call $~lib/env/abort
      unreachable
     end
-    unreachable
+    block $~lib/memory/memory.free|inlined.11
+     local.get $14
+     local.set $11
+     local.get $11
+     call $~lib/allocator/arena/__memory_free
+     br $~lib/memory/memory.free|inlined.11
+    end
    end
   end
-  local.get $11
+  local.get $13
   return
  )
  (func $~lib/internal/number/itoa<u16> (; 207 ;) (type $ii) (param $0 i32) (result i32)
@@ -13958,6 +15424,8 @@
  (func $~lib/internal/number/itoa_stream<u16> (; 208 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -13982,14 +15450,20 @@
   i32.and
   call $~lib/internal/number/decimalCount32
   local.set $3
-  local.get $2
-  i32.const 65535
-  i32.and
-  local.set $4
-  local.get $0
-  local.get $4
-  local.get $3
-  call $~lib/internal/number/utoa32_lut
+  block $~lib/internal/number/utoa32_core|inlined.7
+   local.get $0
+   local.set $4
+   local.get $2
+   i32.const 65535
+   i32.and
+   local.set $5
+   local.get $3
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/number/utoa32_lut
+  end
   local.get $3
  )
  (func $~lib/array/Array<u16>#join (; 209 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
@@ -14004,6 +15478,8 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   local.get $0
   i32.load offset=4
   i32.const 1
@@ -14032,16 +15508,18 @@
   i32.eqz
   if
    block $~lib/internal/arraybuffer/LOAD<u16,u16>|inlined.0 (result i32)
-    i32.const 0
+    local.get $5
     local.set $8
     i32.const 0
     local.set $9
-    local.get $5
+    i32.const 0
+    local.set $10
     local.get $8
+    local.get $9
     i32.const 1
     i32.shl
     i32.add
-    local.get $9
+    local.get $10
     i32.add
     i32.load16_u offset=8
    end
@@ -14055,12 +15533,12 @@
   i32.mul
   i32.const 10
   i32.add
-  local.set $9
-  local.get $9
-  call $~lib/internal/string/allocateUnsafe
-  local.set $8
-  i32.const 0
   local.set $10
+  local.get $10
+  call $~lib/internal/string/allocateUnsafe
+  local.set $9
+  i32.const 0
+  local.set $8
   block $break|0
    i32.const 0
    local.set $11
@@ -14072,37 +15550,41 @@
     br_if $break|0
     block
      block $~lib/internal/arraybuffer/LOAD<u16,u16>|inlined.1 (result i32)
-      i32.const 0
-      local.set $12
       local.get $5
+      local.set $12
       local.get $11
+      local.set $13
+      i32.const 0
+      local.set $14
+      local.get $12
+      local.get $13
       i32.const 1
       i32.shl
       i32.add
-      local.get $12
+      local.get $14
       i32.add
       i32.load16_u offset=8
      end
      local.set $4
-     local.get $10
      local.get $8
-     local.get $10
+     local.get $9
+     local.get $8
      local.get $4
      call $~lib/internal/number/itoa_stream<u16>
      i32.add
-     local.set $10
+     local.set $8
      local.get $7
      if
+      local.get $9
       local.get $8
-      local.get $10
       local.get $1
       i32.const 0
       local.get $6
       call $~lib/internal/string/copyUnsafe
-      local.get $10
+      local.get $8
       local.get $6
       i32.add
-      local.set $10
+      local.set $8
      end
     end
     local.get $11
@@ -14115,57 +15597,63 @@
    unreachable
   end
   block $~lib/internal/arraybuffer/LOAD<u16,u16>|inlined.2 (result i32)
-   i32.const 0
-   local.set $11
    local.get $5
+   local.set $11
    local.get $2
+   local.set $14
+   i32.const 0
+   local.set $13
+   local.get $11
+   local.get $14
    i32.const 1
    i32.shl
    i32.add
-   local.get $11
+   local.get $13
    i32.add
    i32.load16_u offset=8
   end
   local.set $4
-  local.get $10
   local.get $8
-  local.get $10
+  local.get $9
+  local.get $8
   local.get $4
   call $~lib/internal/number/itoa_stream<u16>
   i32.add
-  local.set $10
-  local.get $8
-  local.set $11
+  local.set $8
   local.get $9
+  local.set $13
   local.get $10
+  local.get $8
   i32.gt_s
   if
-   local.get $8
+   local.get $9
    i32.const 0
-   local.get $10
-   call $~lib/string/String#substring
-   local.set $11
    local.get $8
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 4088
-    i32.const 28
-    i32.const 4
-    call $~lib/env/abort
-    unreachable
-   end
-   block $~lib/memory/memory.free|inlined.12
-    block
-     local.get $8
-     call $~lib/allocator/arena/__memory_free
-     br $~lib/memory/memory.free|inlined.12
+   call $~lib/string/String#substring
+   local.set $13
+   block $~lib/internal/string/freeUnsafe|inlined.7
+    local.get $9
+    local.set $14
+    local.get $14
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 4088
+     i32.const 28
+     i32.const 4
+     call $~lib/env/abort
      unreachable
     end
-    unreachable
+    block $~lib/memory/memory.free|inlined.12
+     local.get $14
+     local.set $11
+     local.get $11
+     call $~lib/allocator/arena/__memory_free
+     br $~lib/memory/memory.free|inlined.12
+    end
    end
   end
-  local.get $11
+  local.get $13
   return
  )
  (func $~lib/internal/number/decimalCount64 (; 210 ;) (type $Ii) (param $0 i64) (result i32)
@@ -14248,8 +15736,10 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
-  (local $13 i64)
-  (local $14 i64)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i64)
+  (local $16 i64)
   block $~lib/internal/number/DIGITS|inlined.1 (result i32)
    i32.const 7712
   end
@@ -14300,23 +15790,31 @@
       i32.rem_u
       local.set $11
       block $~lib/internal/arraybuffer/LOAD<u32,u64>|inlined.4 (result i64)
-       i32.const 0
-       local.set $12
        local.get $3
+       local.set $12
        local.get $10
+       local.set $13
+       i32.const 0
+       local.set $14
+       local.get $12
+       local.get $13
        i32.const 2
        i32.shl
        i32.add
-       local.get $12
+       local.get $14
        i32.add
        i64.load32_u offset=8
       end
-      local.set $13
+      local.set $15
       block $~lib/internal/arraybuffer/LOAD<u32,u64>|inlined.5 (result i64)
+       local.get $3
+       local.set $14
+       local.get $11
+       local.set $13
        i32.const 0
        local.set $12
-       local.get $3
-       local.get $11
+       local.get $14
+       local.get $13
        i32.const 2
        i32.shl
        i32.add
@@ -14324,7 +15822,7 @@
        i32.add
        i64.load32_u offset=8
       end
-      local.set $14
+      local.set $16
       local.get $2
       i32.const 4
       i32.sub
@@ -14334,30 +15832,38 @@
       i32.const 1
       i32.shl
       i32.add
-      local.get $13
-      local.get $14
+      local.get $15
+      local.get $16
       i64.const 32
       i64.shl
       i64.or
       i64.store offset=4
       block $~lib/internal/arraybuffer/LOAD<u32,u64>|inlined.6 (result i64)
-       i32.const 0
-       local.set $12
        local.get $3
+       local.set $12
        local.get $8
+       local.set $13
+       i32.const 0
+       local.set $14
+       local.get $12
+       local.get $13
        i32.const 2
        i32.shl
        i32.add
-       local.get $12
+       local.get $14
        i32.add
        i64.load32_u offset=8
       end
-      local.set $13
+      local.set $15
       block $~lib/internal/arraybuffer/LOAD<u32,u64>|inlined.7 (result i64)
+       local.get $3
+       local.set $14
+       local.get $9
+       local.set $13
        i32.const 0
        local.set $12
-       local.get $3
-       local.get $9
+       local.get $14
+       local.get $13
        i32.const 2
        i32.shl
        i32.add
@@ -14365,7 +15871,7 @@
        i32.add
        i64.load32_u offset=8
       end
-      local.set $14
+      local.set $16
       local.get $2
       i32.const 4
       i32.sub
@@ -14375,8 +15881,8 @@
       i32.const 1
       i32.shl
       i32.add
-      local.get $13
-      local.get $14
+      local.get $15
+      local.get $16
       i64.const 32
       i64.shl
       i64.or
@@ -14396,6 +15902,10 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i64)
   local.get $0
   i64.eqz
   if
@@ -14416,10 +15926,18 @@
    local.get $3
    call $~lib/internal/string/allocateUnsafe
    local.set $1
-   local.get $1
-   local.get $2
-   local.get $3
-   call $~lib/internal/number/utoa32_lut
+   block $~lib/internal/number/utoa32_core|inlined.8
+    local.get $1
+    local.set $4
+    local.get $2
+    local.set $5
+    local.get $3
+    local.set $6
+    local.get $4
+    local.get $5
+    local.get $6
+    call $~lib/internal/number/utoa32_lut
+   end
   else   
    local.get $0
    call $~lib/internal/number/decimalCount64
@@ -14427,10 +15945,18 @@
    local.get $3
    call $~lib/internal/string/allocateUnsafe
    local.set $1
-   local.get $1
-   local.get $0
-   local.get $3
-   call $~lib/internal/number/utoa64_lut
+   block $~lib/internal/number/utoa64_core|inlined.0
+    local.get $1
+    local.set $2
+    local.get $0
+    local.set $7
+    local.get $3
+    local.set $6
+    local.get $2
+    local.get $7
+    local.get $6
+    call $~lib/internal/number/utoa64_lut
+   end
   end
   local.get $1
  )
@@ -14442,6 +15968,10 @@
  (func $~lib/internal/number/itoa_stream<u64> (; 214 ;) (type $iiIi) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i64)
   local.get $0
   local.get $1
   i32.const 1
@@ -14470,18 +16000,34 @@
    local.get $4
    call $~lib/internal/number/decimalCount32
    local.set $3
-   local.get $0
-   local.get $4
-   local.get $3
-   call $~lib/internal/number/utoa32_lut
+   block $~lib/internal/number/utoa32_core|inlined.9
+    local.get $0
+    local.set $5
+    local.get $4
+    local.set $6
+    local.get $3
+    local.set $7
+    local.get $5
+    local.get $6
+    local.get $7
+    call $~lib/internal/number/utoa32_lut
+   end
   else   
    local.get $2
    call $~lib/internal/number/decimalCount64
    local.set $3
-   local.get $0
-   local.get $2
-   local.get $3
-   call $~lib/internal/number/utoa64_lut
+   block $~lib/internal/number/utoa64_core|inlined.1
+    local.get $0
+    local.set $4
+    local.get $2
+    local.set $8
+    local.get $3
+    local.set $7
+    local.get $4
+    local.get $8
+    local.get $7
+    call $~lib/internal/number/utoa64_lut
+   end
   end
   local.get $3
  )
@@ -14497,6 +16043,8 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   local.get $0
   i32.load offset=4
   i32.const 1
@@ -14525,16 +16073,18 @@
   i32.eqz
   if
    block $~lib/internal/arraybuffer/LOAD<u64,u64>|inlined.1 (result i64)
-    i32.const 0
+    local.get $5
     local.set $8
     i32.const 0
     local.set $9
-    local.get $5
+    i32.const 0
+    local.set $10
     local.get $8
+    local.get $9
     i32.const 3
     i32.shl
     i32.add
-    local.get $9
+    local.get $10
     i32.add
     i64.load offset=8
    end
@@ -14548,12 +16098,12 @@
   i32.mul
   i32.const 20
   i32.add
-  local.set $9
-  local.get $9
-  call $~lib/internal/string/allocateUnsafe
-  local.set $8
-  i32.const 0
   local.set $10
+  local.get $10
+  call $~lib/internal/string/allocateUnsafe
+  local.set $9
+  i32.const 0
+  local.set $8
   block $break|0
    i32.const 0
    local.set $11
@@ -14565,37 +16115,41 @@
     br_if $break|0
     block
      block $~lib/internal/arraybuffer/LOAD<u64,u64>|inlined.2 (result i64)
-      i32.const 0
-      local.set $12
       local.get $5
+      local.set $12
       local.get $11
+      local.set $13
+      i32.const 0
+      local.set $14
+      local.get $12
+      local.get $13
       i32.const 3
       i32.shl
       i32.add
-      local.get $12
+      local.get $14
       i32.add
       i64.load offset=8
      end
      local.set $4
-     local.get $10
      local.get $8
-     local.get $10
+     local.get $9
+     local.get $8
      local.get $4
      call $~lib/internal/number/itoa_stream<u64>
      i32.add
-     local.set $10
+     local.set $8
      local.get $7
      if
+      local.get $9
       local.get $8
-      local.get $10
       local.get $1
       i32.const 0
       local.get $6
       call $~lib/internal/string/copyUnsafe
-      local.get $10
+      local.get $8
       local.get $6
       i32.add
-      local.set $10
+      local.set $8
      end
     end
     local.get $11
@@ -14608,57 +16162,63 @@
    unreachable
   end
   block $~lib/internal/arraybuffer/LOAD<u64,u64>|inlined.3 (result i64)
-   i32.const 0
-   local.set $11
    local.get $5
+   local.set $11
    local.get $2
+   local.set $14
+   i32.const 0
+   local.set $13
+   local.get $11
+   local.get $14
    i32.const 3
    i32.shl
    i32.add
-   local.get $11
+   local.get $13
    i32.add
    i64.load offset=8
   end
   local.set $4
-  local.get $10
   local.get $8
-  local.get $10
+  local.get $9
+  local.get $8
   local.get $4
   call $~lib/internal/number/itoa_stream<u64>
   i32.add
-  local.set $10
-  local.get $8
-  local.set $11
+  local.set $8
   local.get $9
+  local.set $13
   local.get $10
+  local.get $8
   i32.gt_s
   if
-   local.get $8
+   local.get $9
    i32.const 0
-   local.get $10
-   call $~lib/string/String#substring
-   local.set $11
    local.get $8
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 4088
-    i32.const 28
-    i32.const 4
-    call $~lib/env/abort
-    unreachable
-   end
-   block $~lib/memory/memory.free|inlined.13
-    block
-     local.get $8
-     call $~lib/allocator/arena/__memory_free
-     br $~lib/memory/memory.free|inlined.13
+   call $~lib/string/String#substring
+   local.set $13
+   block $~lib/internal/string/freeUnsafe|inlined.8
+    local.get $9
+    local.set $14
+    local.get $14
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 4088
+     i32.const 28
+     i32.const 4
+     call $~lib/env/abort
      unreachable
     end
-    unreachable
+    block $~lib/memory/memory.free|inlined.13
+     local.get $14
+     local.set $11
+     local.get $11
+     call $~lib/allocator/arena/__memory_free
+     br $~lib/memory/memory.free|inlined.13
+    end
    end
   end
-  local.get $11
+  local.get $13
   return
  )
  (func $~lib/internal/number/itoa64 (; 216 ;) (type $Ii) (param $0 i64) (result i32)
@@ -14666,6 +16226,10 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i64)
   local.get $0
   i64.eqz
   if
@@ -14699,10 +16263,18 @@
    local.get $4
    call $~lib/internal/string/allocateUnsafe
    local.set $2
-   local.get $2
-   local.get $3
-   local.get $4
-   call $~lib/internal/number/utoa32_lut
+   block $~lib/internal/number/utoa32_core|inlined.10
+    local.get $2
+    local.set $5
+    local.get $3
+    local.set $6
+    local.get $4
+    local.set $7
+    local.get $5
+    local.get $6
+    local.get $7
+    call $~lib/internal/number/utoa32_lut
+   end
   else   
    local.get $0
    call $~lib/internal/number/decimalCount64
@@ -14712,10 +16284,18 @@
    local.get $4
    call $~lib/internal/string/allocateUnsafe
    local.set $2
-   local.get $2
-   local.get $0
-   local.get $4
-   call $~lib/internal/number/utoa64_lut
+   block $~lib/internal/number/utoa64_core|inlined.2
+    local.get $2
+    local.set $3
+    local.get $0
+    local.set $8
+    local.get $4
+    local.set $7
+    local.get $3
+    local.get $8
+    local.get $7
+    call $~lib/internal/number/utoa64_lut
+   end
   end
   local.get $1
   if
@@ -14734,6 +16314,10 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i64)
   local.get $0
   local.get $1
   i32.const 1
@@ -14775,20 +16359,36 @@
    local.get $4
    i32.add
    local.set $3
-   local.get $0
-   local.get $5
-   local.get $3
-   call $~lib/internal/number/utoa32_lut
+   block $~lib/internal/number/utoa32_core|inlined.11
+    local.get $0
+    local.set $6
+    local.get $5
+    local.set $7
+    local.get $3
+    local.set $8
+    local.get $6
+    local.get $7
+    local.get $8
+    call $~lib/internal/number/utoa32_lut
+   end
   else   
    local.get $2
    call $~lib/internal/number/decimalCount64
    local.get $4
    i32.add
    local.set $3
-   local.get $0
-   local.get $2
-   local.get $3
-   call $~lib/internal/number/utoa64_lut
+   block $~lib/internal/number/utoa64_core|inlined.3
+    local.get $0
+    local.set $5
+    local.get $2
+    local.set $9
+    local.get $3
+    local.set $8
+    local.get $5
+    local.get $9
+    local.get $8
+    call $~lib/internal/number/utoa64_lut
+   end
   end
   local.get $4
   if
@@ -14810,6 +16410,8 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   local.get $0
   i32.load offset=4
   i32.const 1
@@ -14838,16 +16440,18 @@
   i32.eqz
   if
    block $~lib/internal/arraybuffer/LOAD<i64,i64>|inlined.0 (result i64)
-    i32.const 0
+    local.get $5
     local.set $8
     i32.const 0
     local.set $9
-    local.get $5
+    i32.const 0
+    local.set $10
     local.get $8
+    local.get $9
     i32.const 3
     i32.shl
     i32.add
-    local.get $9
+    local.get $10
     i32.add
     i64.load offset=8
    end
@@ -14861,12 +16465,12 @@
   i32.mul
   i32.const 21
   i32.add
-  local.set $9
-  local.get $9
-  call $~lib/internal/string/allocateUnsafe
-  local.set $8
-  i32.const 0
   local.set $10
+  local.get $10
+  call $~lib/internal/string/allocateUnsafe
+  local.set $9
+  i32.const 0
+  local.set $8
   block $break|0
    i32.const 0
    local.set $11
@@ -14878,37 +16482,41 @@
     br_if $break|0
     block
      block $~lib/internal/arraybuffer/LOAD<i64,i64>|inlined.1 (result i64)
-      i32.const 0
-      local.set $12
       local.get $5
+      local.set $12
       local.get $11
+      local.set $13
+      i32.const 0
+      local.set $14
+      local.get $12
+      local.get $13
       i32.const 3
       i32.shl
       i32.add
-      local.get $12
+      local.get $14
       i32.add
       i64.load offset=8
      end
      local.set $4
-     local.get $10
      local.get $8
-     local.get $10
+     local.get $9
+     local.get $8
      local.get $4
      call $~lib/internal/number/itoa_stream<i64>
      i32.add
-     local.set $10
+     local.set $8
      local.get $7
      if
+      local.get $9
       local.get $8
-      local.get $10
       local.get $1
       i32.const 0
       local.get $6
       call $~lib/internal/string/copyUnsafe
-      local.get $10
+      local.get $8
       local.get $6
       i32.add
-      local.set $10
+      local.set $8
      end
     end
     local.get $11
@@ -14921,57 +16529,63 @@
    unreachable
   end
   block $~lib/internal/arraybuffer/LOAD<i64,i64>|inlined.2 (result i64)
-   i32.const 0
-   local.set $11
    local.get $5
+   local.set $11
    local.get $2
+   local.set $14
+   i32.const 0
+   local.set $13
+   local.get $11
+   local.get $14
    i32.const 3
    i32.shl
    i32.add
-   local.get $11
+   local.get $13
    i32.add
    i64.load offset=8
   end
   local.set $4
-  local.get $10
   local.get $8
-  local.get $10
+  local.get $9
+  local.get $8
   local.get $4
   call $~lib/internal/number/itoa_stream<i64>
   i32.add
-  local.set $10
-  local.get $8
-  local.set $11
+  local.set $8
   local.get $9
+  local.set $13
   local.get $10
+  local.get $8
   i32.gt_s
   if
-   local.get $8
+   local.get $9
    i32.const 0
-   local.get $10
-   call $~lib/string/String#substring
-   local.set $11
    local.get $8
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 4088
-    i32.const 28
-    i32.const 4
-    call $~lib/env/abort
-    unreachable
-   end
-   block $~lib/memory/memory.free|inlined.14
-    block
-     local.get $8
-     call $~lib/allocator/arena/__memory_free
-     br $~lib/memory/memory.free|inlined.14
+   call $~lib/string/String#substring
+   local.set $13
+   block $~lib/internal/string/freeUnsafe|inlined.9
+    local.get $9
+    local.set $14
+    local.get $14
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 4088
+     i32.const 28
+     i32.const 4
+     call $~lib/env/abort
      unreachable
     end
-    unreachable
+    block $~lib/memory/memory.free|inlined.14
+     local.get $14
+     local.set $11
+     local.get $11
+     call $~lib/allocator/arena/__memory_free
+     br $~lib/memory/memory.free|inlined.14
+    end
    end
   end
-  local.get $11
+  local.get $13
   return
  )
  (func $~lib/array/Array<Array<i32>>#join (; 220 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
@@ -14983,6 +16597,8 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   local.get $0
   i32.load offset=4
   i32.const 1
@@ -15011,16 +16627,18 @@
   i32.eqz
   if
    block $~lib/internal/arraybuffer/LOAD<Array<i32>,Array<i32>>|inlined.5 (result i32)
-    i32.const 0
+    local.get $5
     local.set $8
     i32.const 0
     local.set $9
-    local.get $5
+    i32.const 0
+    local.set $10
     local.get $8
+    local.get $9
     i32.const 2
     i32.shl
     i32.add
-    local.get $9
+    local.get $10
     i32.add
     i32.load offset=8
    end
@@ -15037,23 +16655,27 @@
   end
   block $break|0
    i32.const 0
-   local.set $9
+   local.set $10
    loop $repeat|0
-    local.get $9
+    local.get $10
     local.get $2
     i32.lt_s
     i32.eqz
     br_if $break|0
     block
      block $~lib/internal/arraybuffer/LOAD<Array<i32>,Array<i32>>|inlined.6 (result i32)
-      i32.const 0
-      local.set $8
       local.get $5
+      local.set $9
+      local.get $10
+      local.set $8
+      i32.const 0
+      local.set $11
       local.get $9
+      local.get $8
       i32.const 2
       i32.shl
       i32.add
-      local.get $8
+      local.get $11
       i32.add
       i32.load offset=8
      end
@@ -15075,24 +16697,28 @@
       local.set $3
      end
     end
-    local.get $9
+    local.get $10
     i32.const 1
     i32.add
-    local.set $9
+    local.set $10
     br $repeat|0
     unreachable
    end
    unreachable
   end
   block $~lib/internal/arraybuffer/LOAD<Array<i32>,Array<i32>>|inlined.7 (result i32)
-   i32.const 0
-   local.set $9
    local.get $5
+   local.set $10
    local.get $2
+   local.set $11
+   i32.const 0
+   local.set $8
+   local.get $10
+   local.get $11
    i32.const 2
    i32.shl
    i32.add
-   local.get $9
+   local.get $8
    i32.add
    i32.load offset=8
   end
@@ -15119,6 +16745,8 @@
  (func $~lib/internal/number/itoa_stream<u8> (; 222 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -15143,14 +16771,20 @@
   i32.and
   call $~lib/internal/number/decimalCount32
   local.set $3
-  local.get $2
-  i32.const 255
-  i32.and
-  local.set $4
-  local.get $0
-  local.get $4
-  local.get $3
-  call $~lib/internal/number/utoa32_lut
+  block $~lib/internal/number/utoa32_core|inlined.12
+   local.get $0
+   local.set $4
+   local.get $2
+   i32.const 255
+   i32.and
+   local.set $5
+   local.get $3
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/number/utoa32_lut
+  end
   local.get $3
  )
  (func $~lib/array/Array<u8>#join (; 223 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
@@ -15165,6 +16799,8 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   local.get $0
   i32.load offset=4
   i32.const 1
@@ -15193,16 +16829,18 @@
   i32.eqz
   if
    block $~lib/internal/arraybuffer/LOAD<u8,u8>|inlined.1 (result i32)
-    i32.const 0
+    local.get $5
     local.set $8
     i32.const 0
     local.set $9
-    local.get $5
+    i32.const 0
+    local.set $10
     local.get $8
+    local.get $9
     i32.const 0
     i32.shl
     i32.add
-    local.get $9
+    local.get $10
     i32.add
     i32.load8_u offset=8
    end
@@ -15216,12 +16854,12 @@
   i32.mul
   i32.const 10
   i32.add
-  local.set $9
-  local.get $9
-  call $~lib/internal/string/allocateUnsafe
-  local.set $8
-  i32.const 0
   local.set $10
+  local.get $10
+  call $~lib/internal/string/allocateUnsafe
+  local.set $9
+  i32.const 0
+  local.set $8
   block $break|0
    i32.const 0
    local.set $11
@@ -15233,37 +16871,41 @@
     br_if $break|0
     block
      block $~lib/internal/arraybuffer/LOAD<u8,u8>|inlined.2 (result i32)
-      i32.const 0
-      local.set $12
       local.get $5
+      local.set $12
       local.get $11
+      local.set $13
+      i32.const 0
+      local.set $14
+      local.get $12
+      local.get $13
       i32.const 0
       i32.shl
       i32.add
-      local.get $12
+      local.get $14
       i32.add
       i32.load8_u offset=8
      end
      local.set $4
-     local.get $10
      local.get $8
-     local.get $10
+     local.get $9
+     local.get $8
      local.get $4
      call $~lib/internal/number/itoa_stream<u8>
      i32.add
-     local.set $10
+     local.set $8
      local.get $7
      if
+      local.get $9
       local.get $8
-      local.get $10
       local.get $1
       i32.const 0
       local.get $6
       call $~lib/internal/string/copyUnsafe
-      local.get $10
+      local.get $8
       local.get $6
       i32.add
-      local.set $10
+      local.set $8
      end
     end
     local.get $11
@@ -15276,57 +16918,63 @@
    unreachable
   end
   block $~lib/internal/arraybuffer/LOAD<u8,u8>|inlined.3 (result i32)
-   i32.const 0
-   local.set $11
    local.get $5
+   local.set $11
    local.get $2
+   local.set $14
+   i32.const 0
+   local.set $13
+   local.get $11
+   local.get $14
    i32.const 0
    i32.shl
    i32.add
-   local.get $11
+   local.get $13
    i32.add
    i32.load8_u offset=8
   end
   local.set $4
-  local.get $10
   local.get $8
-  local.get $10
+  local.get $9
+  local.get $8
   local.get $4
   call $~lib/internal/number/itoa_stream<u8>
   i32.add
-  local.set $10
-  local.get $8
-  local.set $11
+  local.set $8
   local.get $9
+  local.set $13
   local.get $10
+  local.get $8
   i32.gt_s
   if
-   local.get $8
+   local.get $9
    i32.const 0
-   local.get $10
-   call $~lib/string/String#substring
-   local.set $11
    local.get $8
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 4088
-    i32.const 28
-    i32.const 4
-    call $~lib/env/abort
-    unreachable
-   end
-   block $~lib/memory/memory.free|inlined.15
-    block
-     local.get $8
-     call $~lib/allocator/arena/__memory_free
-     br $~lib/memory/memory.free|inlined.15
+   call $~lib/string/String#substring
+   local.set $13
+   block $~lib/internal/string/freeUnsafe|inlined.10
+    local.get $9
+    local.set $14
+    local.get $14
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 4088
+     i32.const 28
+     i32.const 4
+     call $~lib/env/abort
      unreachable
     end
-    unreachable
+    block $~lib/memory/memory.free|inlined.15
+     local.get $14
+     local.set $11
+     local.get $11
+     call $~lib/allocator/arena/__memory_free
+     br $~lib/memory/memory.free|inlined.15
+    end
    end
   end
-  local.get $11
+  local.get $13
   return
  )
  (func $~lib/array/Array<Array<u8>>#join (; 224 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
@@ -15338,6 +16986,8 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   local.get $0
   i32.load offset=4
   i32.const 1
@@ -15366,16 +17016,18 @@
   i32.eqz
   if
    block $~lib/internal/arraybuffer/LOAD<Array<u8>,Array<u8>>|inlined.0 (result i32)
-    i32.const 0
+    local.get $5
     local.set $8
     i32.const 0
     local.set $9
-    local.get $5
+    i32.const 0
+    local.set $10
     local.get $8
+    local.get $9
     i32.const 2
     i32.shl
     i32.add
-    local.get $9
+    local.get $10
     i32.add
     i32.load offset=8
    end
@@ -15392,23 +17044,27 @@
   end
   block $break|0
    i32.const 0
-   local.set $9
+   local.set $10
    loop $repeat|0
-    local.get $9
+    local.get $10
     local.get $2
     i32.lt_s
     i32.eqz
     br_if $break|0
     block
      block $~lib/internal/arraybuffer/LOAD<Array<u8>,Array<u8>>|inlined.1 (result i32)
-      i32.const 0
-      local.set $8
       local.get $5
+      local.set $9
+      local.get $10
+      local.set $8
+      i32.const 0
+      local.set $11
       local.get $9
+      local.get $8
       i32.const 2
       i32.shl
       i32.add
-      local.get $8
+      local.get $11
       i32.add
       i32.load offset=8
      end
@@ -15430,24 +17086,28 @@
       local.set $3
      end
     end
-    local.get $9
+    local.get $10
     i32.const 1
     i32.add
-    local.set $9
+    local.set $10
     br $repeat|0
     unreachable
    end
    unreachable
   end
   block $~lib/internal/arraybuffer/LOAD<Array<u8>,Array<u8>>|inlined.2 (result i32)
-   i32.const 0
-   local.set $9
    local.get $5
+   local.set $10
    local.get $2
+   local.set $11
+   i32.const 0
+   local.set $8
+   local.get $10
+   local.get $11
    i32.const 2
    i32.shl
    i32.add
-   local.get $9
+   local.get $8
    i32.add
    i32.load offset=8
   end
@@ -15473,6 +17133,8 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   local.get $0
   i32.load offset=4
   i32.const 1
@@ -15501,16 +17163,18 @@
   i32.eqz
   if
    block $~lib/internal/arraybuffer/LOAD<Array<u32>,Array<u32>>|inlined.0 (result i32)
-    i32.const 0
+    local.get $5
     local.set $8
     i32.const 0
     local.set $9
-    local.get $5
+    i32.const 0
+    local.set $10
     local.get $8
+    local.get $9
     i32.const 2
     i32.shl
     i32.add
-    local.get $9
+    local.get $10
     i32.add
     i32.load offset=8
    end
@@ -15527,23 +17191,27 @@
   end
   block $break|0
    i32.const 0
-   local.set $9
+   local.set $10
    loop $repeat|0
-    local.get $9
+    local.get $10
     local.get $2
     i32.lt_s
     i32.eqz
     br_if $break|0
     block
      block $~lib/internal/arraybuffer/LOAD<Array<u32>,Array<u32>>|inlined.1 (result i32)
-      i32.const 0
-      local.set $8
       local.get $5
+      local.set $9
+      local.get $10
+      local.set $8
+      i32.const 0
+      local.set $11
       local.get $9
+      local.get $8
       i32.const 2
       i32.shl
       i32.add
-      local.get $8
+      local.get $11
       i32.add
       i32.load offset=8
      end
@@ -15565,24 +17233,28 @@
       local.set $3
      end
     end
-    local.get $9
+    local.get $10
     i32.const 1
     i32.add
-    local.set $9
+    local.set $10
     br $repeat|0
     unreachable
    end
    unreachable
   end
   block $~lib/internal/arraybuffer/LOAD<Array<u32>,Array<u32>>|inlined.2 (result i32)
-   i32.const 0
-   local.set $9
    local.get $5
+   local.set $10
    local.get $2
+   local.set $11
+   i32.const 0
+   local.set $8
+   local.get $10
+   local.get $11
    i32.const 2
    i32.shl
    i32.add
-   local.get $9
+   local.get $8
    i32.add
    i32.load offset=8
   end
@@ -15608,6 +17280,8 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   local.get $0
   i32.load offset=4
   i32.const 1
@@ -15636,16 +17310,18 @@
   i32.eqz
   if
    block $~lib/internal/arraybuffer/LOAD<Array<Array<u32>>,Array<Array<u32>>>|inlined.0 (result i32)
-    i32.const 0
+    local.get $5
     local.set $8
     i32.const 0
     local.set $9
-    local.get $5
+    i32.const 0
+    local.set $10
     local.get $8
+    local.get $9
     i32.const 2
     i32.shl
     i32.add
-    local.get $9
+    local.get $10
     i32.add
     i32.load offset=8
    end
@@ -15662,23 +17338,27 @@
   end
   block $break|0
    i32.const 0
-   local.set $9
+   local.set $10
    loop $repeat|0
-    local.get $9
+    local.get $10
     local.get $2
     i32.lt_s
     i32.eqz
     br_if $break|0
     block
      block $~lib/internal/arraybuffer/LOAD<Array<Array<u32>>,Array<Array<u32>>>|inlined.1 (result i32)
-      i32.const 0
-      local.set $8
       local.get $5
+      local.set $9
+      local.get $10
+      local.set $8
+      i32.const 0
+      local.set $11
       local.get $9
+      local.get $8
       i32.const 2
       i32.shl
       i32.add
-      local.get $8
+      local.get $11
       i32.add
       i32.load offset=8
      end
@@ -15700,24 +17380,28 @@
       local.set $3
      end
     end
-    local.get $9
+    local.get $10
     i32.const 1
     i32.add
-    local.set $9
+    local.set $10
     br $repeat|0
     unreachable
    end
    unreachable
   end
   block $~lib/internal/arraybuffer/LOAD<Array<Array<u32>>,Array<Array<u32>>>|inlined.2 (result i32)
-   i32.const 0
-   local.set $9
    local.get $5
+   local.set $10
    local.get $2
+   local.set $11
+   i32.const 0
+   local.set $8
+   local.get $10
+   local.get $11
    i32.const 2
    i32.shl
    i32.add
-   local.get $9
+   local.get $8
    i32.add
    i32.load offset=8
   end

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -1437,25 +1437,26 @@
   (local $4 i32)
   local.get $0
   i32.load
-  local.set $3
+  local.set $4
   local.get $1
   i32.const 0
   i32.lt_s
   if (result i32)
    local.get $1
-   local.get $3
-   i32.add
-   local.tee $4
-   i32.const 0
    local.get $4
+   i32.add
+   local.tee $3
+   i32.const 0
+   local.get $3
    i32.const 0
    i32.gt_s
    select
   else   
    local.get $1
+   local.tee $3
+   local.get $4
    local.get $3
-   local.get $1
-   local.get $3
+   local.get $4
    i32.lt_s
    select
   end
@@ -1465,33 +1466,34 @@
   i32.lt_s
   if (result i32)
    local.get $2
-   local.get $3
-   i32.add
-   local.tee $4
-   i32.const 0
    local.get $4
+   i32.add
+   local.tee $3
+   i32.const 0
+   local.get $3
    i32.const 0
    i32.gt_s
    select
   else   
    local.get $2
+   local.tee $3
+   local.get $4
    local.get $3
-   local.get $2
-   local.get $3
+   local.get $4
    i32.lt_s
    select
   end
   local.get $1
   i32.sub
-  local.tee $4
+  local.tee $3
   i32.const 0
-  local.get $4
+  local.get $3
   i32.const 0
   i32.gt_s
   select
-  local.tee $2
-  call $~lib/internal/arraybuffer/allocateUnsafe
   local.tee $3
+  call $~lib/internal/arraybuffer/allocateUnsafe
+  local.tee $2
   i32.const 8
   i32.add
   local.get $0
@@ -1499,9 +1501,9 @@
   i32.add
   local.get $1
   i32.add
-  local.get $2
-  call $~lib/internal/memory/memmove
   local.get $3
+  call $~lib/internal/memory/memmove
+  local.get $2
  )
  (func $~lib/arraybuffer/ArrayBuffer#slice|trampoline (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)

--- a/tests/compiler/std/arraybuffer.untouched.wat
+++ b/tests/compiler/std/arraybuffer.untouched.wat
@@ -412,6 +412,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   global.get $~lib/internal/arraybuffer/MAX_BLENGTH
   i32.gt_u
@@ -437,9 +438,11 @@
    local.set $4
    i32.const 0
    local.set $5
+   local.get $1
+   local.set $6
    local.get $4
    local.get $5
-   local.get $1
+   local.get $6
    call $~lib/internal/memory/memset
   end
   local.get $3
@@ -1878,6 +1881,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   local.get $0
   i32.load
   local.set $3
@@ -1947,20 +1951,24 @@
   local.get $6
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $7
-  local.get $7
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  local.get $0
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.get $1
-  i32.add
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $6
-  call $~lib/internal/memory/memmove
+  block $~lib/memory/memory.copy|inlined.0
+   local.get $7
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   local.get $0
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.get $1
+   i32.add
+   local.set $5
+   local.get $6
+   local.set $8
+   local.get $4
+   local.get $5
+   local.get $8
+   call $~lib/internal/memory/memmove
+  end
   local.get $7
  )
  (func $~lib/arraybuffer/ArrayBuffer#slice|trampoline (; 9 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -2047,6 +2055,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.const 1073741816
   i32.gt_u
@@ -2065,16 +2074,20 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  local.get $3
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  i32.const 0
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $2
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.1
+   local.get $3
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/memory/memset
+  end
   block (result i32)
    local.get $0
    i32.eqz
@@ -2123,6 +2136,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.const 268435454
   i32.gt_u
@@ -2141,16 +2155,20 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  local.get $3
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  i32.const 0
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $2
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.2
+   local.get $3
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/memory/memset
+  end
   block (result i32)
    local.get $0
    i32.eqz

--- a/tests/compiler/std/dataview.optimized.wat
+++ b/tests/compiler/std/dataview.optimized.wat
@@ -474,18 +474,19 @@
   (local $4 i32)
   local.get $0
   i32.load offset=8
-  local.set $3
+  local.set $4
   local.get $1
+  local.tee $3
   i32.const 1073741816
   i32.gt_u
-  local.tee $4
+  local.tee $1
   if (result i32)
-   local.get $4
-  else   
    local.get $1
+  else   
+   local.get $3
    i32.const 4
    i32.add
-   local.get $3
+   local.get $4
    i32.gt_s
   end
   if
@@ -503,7 +504,7 @@
    local.get $0
    i32.load offset=4
    i32.add
-   local.get $1
+   local.get $3
    i32.add
    f32.load offset=8
   else   
@@ -512,7 +513,7 @@
    local.get $0
    i32.load offset=4
    i32.add
-   local.get $1
+   local.get $3
    i32.add
    i32.load offset=8
    local.tee $0
@@ -595,19 +596,20 @@
   i32.load offset=8
   local.set $3
   local.get $1
+  local.tee $2
   i32.const 1073741816
   i32.gt_u
-  local.tee $2
+  local.tee $1
   i32.eqz
   if
-   local.get $1
+   local.get $2
    i32.const 1
    i32.add
    local.get $3
    i32.gt_s
-   local.set $2
+   local.set $1
   end
-  local.get $2
+  local.get $1
   if
    i32.const 0
    i32.const 136
@@ -621,7 +623,7 @@
   local.get $0
   i32.load offset=4
   i32.add
-  local.get $1
+  local.get $2
   i32.add
   i32.load8_s offset=8
  )
@@ -630,18 +632,19 @@
   (local $4 i32)
   local.get $0
   i32.load offset=8
-  local.set $3
+  local.set $4
   local.get $1
+  local.tee $3
   i32.const 1073741816
   i32.gt_u
-  local.tee $4
+  local.tee $1
   if (result i32)
-   local.get $4
-  else   
    local.get $1
+  else   
+   local.get $3
    i32.const 2
    i32.add
-   local.get $3
+   local.get $4
    i32.gt_s
   end
   if
@@ -657,7 +660,7 @@
   local.get $0
   i32.load offset=4
   i32.add
-  local.get $1
+  local.get $3
   i32.add
   i32.load16_s offset=8
   local.set $0
@@ -683,18 +686,19 @@
   (local $4 i32)
   local.get $0
   i32.load offset=8
-  local.set $3
+  local.set $4
   local.get $1
+  local.tee $3
   i32.const 1073741816
   i32.gt_u
-  local.tee $4
+  local.tee $1
   if (result i32)
-   local.get $4
-  else   
    local.get $1
+  else   
+   local.get $3
    i32.const 4
    i32.add
-   local.get $3
+   local.get $4
    i32.gt_s
   end
   if
@@ -710,7 +714,7 @@
   local.get $0
   i32.load offset=4
   i32.add
-  local.get $1
+  local.get $3
   i32.add
   i32.load offset=8
   local.set $0
@@ -767,19 +771,20 @@
   i32.load offset=8
   local.set $3
   local.get $1
+  local.tee $2
   i32.const 1073741816
   i32.gt_u
-  local.tee $2
+  local.tee $1
   i32.eqz
   if
-   local.get $1
+   local.get $2
    i32.const 1
    i32.add
    local.get $3
    i32.gt_s
-   local.set $2
+   local.set $1
   end
-  local.get $2
+  local.get $1
   if
    i32.const 0
    i32.const 136
@@ -793,7 +798,7 @@
   local.get $0
   i32.load offset=4
   i32.add
-  local.get $1
+  local.get $2
   i32.add
   i32.load8_u offset=8
  )
@@ -802,18 +807,19 @@
   (local $4 i32)
   local.get $0
   i32.load offset=8
-  local.set $3
+  local.set $4
   local.get $1
+  local.tee $3
   i32.const 1073741816
   i32.gt_u
-  local.tee $4
+  local.tee $1
   if (result i32)
-   local.get $4
-  else   
    local.get $1
+  else   
+   local.get $3
    i32.const 2
    i32.add
-   local.get $3
+   local.get $4
    i32.gt_s
   end
   if
@@ -829,7 +835,7 @@
   local.get $0
   i32.load offset=4
   i32.add
-  local.get $1
+  local.get $3
   i32.add
   i32.load16_u offset=8
   local.set $0

--- a/tests/compiler/std/dataview.untouched.wat
+++ b/tests/compiler/std/dataview.untouched.wat
@@ -420,6 +420,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.const 1073741816
   i32.gt_u
@@ -438,16 +439,20 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  local.get $3
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  i32.const 0
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $2
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.0
+   local.get $3
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/memory/memset
+  end
   block (result i32)
    local.get $0
    i32.eqz
@@ -494,6 +499,8 @@
  (func $~lib/internal/typedarray/TypedArray<u8>#__set (; 8 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -508,21 +515,27 @@
    call $~lib/env/abort
    unreachable
   end
-  local.get $0
-  i32.load
-  local.set $3
-  local.get $0
-  i32.load offset=4
-  local.set $4
-  local.get $3
-  local.get $1
-  i32.const 0
-  i32.shl
-  i32.add
-  local.get $4
-  i32.add
-  local.get $2
-  i32.store8 offset=8
+  block $~lib/internal/arraybuffer/STORE<u8,u32>|inlined.0
+   local.get $0
+   i32.load
+   local.set $3
+   local.get $1
+   local.set $4
+   local.get $2
+   local.set $5
+   local.get $0
+   i32.load offset=4
+   local.set $6
+   local.get $3
+   local.get $4
+   i32.const 0
+   i32.shl
+   i32.add
+   local.get $6
+   i32.add
+   local.get $5
+   i32.store8 offset=8
+  end
  )
  (func $~lib/dataview/DataView#constructor (; 9 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $3
@@ -607,31 +620,38 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  i32.const 4
-  local.set $3
-  local.get $0
-  i32.load offset=8
-  local.set $4
-  local.get $1
-  global.get $~lib/internal/arraybuffer/MAX_BLENGTH
-  i32.gt_u
-  local.tee $5
-  if (result i32)
-   local.get $5
-  else   
+  (local $6 i32)
+  block $~lib/dataview/checkOffset|inlined.0
    local.get $1
+   local.set $3
+   i32.const 4
+   local.set $4
+   local.get $0
+   i32.load offset=8
+   local.set $5
    local.get $3
-   i32.add
-   local.get $4
-   i32.gt_s
-  end
-  if
+   global.get $~lib/internal/arraybuffer/MAX_BLENGTH
+   i32.gt_u
+   local.tee $6
+   if (result i32)
+    local.get $6
+   else    
+    local.get $3
+    local.get $4
+    i32.add
+    local.get $5
+    i32.gt_s
+   end
    i32.const 0
-   i32.const 136
-   i32.const 188
-   i32.const 73
-   call $~lib/env/abort
-   unreachable
+   i32.ne
+   if
+    i32.const 0
+    i32.const 136
+    i32.const 188
+    i32.const 73
+    call $~lib/env/abort
+    unreachable
+   end
   end
   local.get $2
   i32.const 0
@@ -701,31 +721,38 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  i32.const 8
-  local.set $3
-  local.get $0
-  i32.load offset=8
-  local.set $4
-  local.get $1
-  global.get $~lib/internal/arraybuffer/MAX_BLENGTH
-  i32.gt_u
-  local.tee $5
-  if (result i32)
-   local.get $5
-  else   
+  (local $6 i32)
+  block $~lib/dataview/checkOffset|inlined.1
    local.get $1
+   local.set $3
+   i32.const 8
+   local.set $4
+   local.get $0
+   i32.load offset=8
+   local.set $5
    local.get $3
-   i32.add
-   local.get $4
-   i32.gt_s
-  end
-  if
+   global.get $~lib/internal/arraybuffer/MAX_BLENGTH
+   i32.gt_u
+   local.tee $6
+   if (result i32)
+    local.get $6
+   else    
+    local.get $3
+    local.get $4
+    i32.add
+    local.get $5
+    i32.gt_s
+   end
    i32.const 0
-   i32.const 136
-   i32.const 188
-   i32.const 73
-   call $~lib/env/abort
-   unreachable
+   i32.ne
+   if
+    i32.const 0
+    i32.const 136
+    i32.const 188
+    i32.const 73
+    call $~lib/env/abort
+    unreachable
+   end
   end
   local.get $2
   i32.const 0
@@ -756,31 +783,38 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  i32.const 1
-  local.set $2
-  local.get $0
-  i32.load offset=8
-  local.set $3
-  local.get $1
-  global.get $~lib/internal/arraybuffer/MAX_BLENGTH
-  i32.gt_u
-  local.tee $4
-  if (result i32)
-   local.get $4
-  else   
+  (local $5 i32)
+  block $~lib/dataview/checkOffset|inlined.2
    local.get $1
+   local.set $2
+   i32.const 1
+   local.set $3
+   local.get $0
+   i32.load offset=8
+   local.set $4
    local.get $2
-   i32.add
-   local.get $3
-   i32.gt_s
-  end
-  if
+   global.get $~lib/internal/arraybuffer/MAX_BLENGTH
+   i32.gt_u
+   local.tee $5
+   if (result i32)
+    local.get $5
+   else    
+    local.get $2
+    local.get $3
+    i32.add
+    local.get $4
+    i32.gt_s
+   end
    i32.const 0
-   i32.const 136
-   i32.const 188
-   i32.const 73
-   call $~lib/env/abort
-   unreachable
+   i32.ne
+   if
+    i32.const 0
+    i32.const 136
+    i32.const 188
+    i32.const 73
+    call $~lib/env/abort
+    unreachable
+   end
   end
   local.get $0
   i32.load
@@ -812,31 +846,38 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  i32.const 2
-  local.set $3
-  local.get $0
-  i32.load offset=8
-  local.set $4
-  local.get $1
-  global.get $~lib/internal/arraybuffer/MAX_BLENGTH
-  i32.gt_u
-  local.tee $5
-  if (result i32)
-   local.get $5
-  else   
+  (local $7 i32)
+  block $~lib/dataview/checkOffset|inlined.3
    local.get $1
+   local.set $3
+   i32.const 2
+   local.set $4
+   local.get $0
+   i32.load offset=8
+   local.set $5
    local.get $3
-   i32.add
-   local.get $4
-   i32.gt_s
-  end
-  if
+   global.get $~lib/internal/arraybuffer/MAX_BLENGTH
+   i32.gt_u
+   local.tee $6
+   if (result i32)
+    local.get $6
+   else    
+    local.get $3
+    local.get $4
+    i32.add
+    local.get $5
+    i32.gt_s
+   end
    i32.const 0
-   i32.const 136
-   i32.const 188
-   i32.const 73
-   call $~lib/env/abort
-   unreachable
+   i32.ne
+   if
+    i32.const 0
+    i32.const 136
+    i32.const 188
+    i32.const 73
+    call $~lib/env/abort
+    unreachable
+   end
   end
   local.get $0
   i32.load
@@ -846,14 +887,14 @@
   local.get $1
   i32.add
   i32.load16_s offset=8
-  local.set $6
+  local.set $7
   local.get $2
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $6
+   local.get $7
   else   
-   local.get $6
+   local.get $7
    call $~lib/polyfills/bswap<i16>
   end
  )
@@ -876,31 +917,38 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  i32.const 4
-  local.set $3
-  local.get $0
-  i32.load offset=8
-  local.set $4
-  local.get $1
-  global.get $~lib/internal/arraybuffer/MAX_BLENGTH
-  i32.gt_u
-  local.tee $5
-  if (result i32)
-   local.get $5
-  else   
+  (local $7 i32)
+  block $~lib/dataview/checkOffset|inlined.4
    local.get $1
+   local.set $3
+   i32.const 4
+   local.set $4
+   local.get $0
+   i32.load offset=8
+   local.set $5
    local.get $3
-   i32.add
-   local.get $4
-   i32.gt_s
-  end
-  if
+   global.get $~lib/internal/arraybuffer/MAX_BLENGTH
+   i32.gt_u
+   local.tee $6
+   if (result i32)
+    local.get $6
+   else    
+    local.get $3
+    local.get $4
+    i32.add
+    local.get $5
+    i32.gt_s
+   end
    i32.const 0
-   i32.const 136
-   i32.const 188
-   i32.const 73
-   call $~lib/env/abort
-   unreachable
+   i32.ne
+   if
+    i32.const 0
+    i32.const 136
+    i32.const 188
+    i32.const 73
+    call $~lib/env/abort
+    unreachable
+   end
   end
   local.get $0
   i32.load
@@ -910,14 +958,14 @@
   local.get $1
   i32.add
   i32.load offset=8
-  local.set $6
+  local.set $7
   local.get $2
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $6
+   local.get $7
   else   
-   local.get $6
+   local.get $7
    call $~lib/polyfills/bswap<i32>
   end
  )
@@ -964,32 +1012,39 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i64)
-  i32.const 8
-  local.set $3
-  local.get $0
-  i32.load offset=8
-  local.set $4
-  local.get $1
-  global.get $~lib/internal/arraybuffer/MAX_BLENGTH
-  i32.gt_u
-  local.tee $5
-  if (result i32)
-   local.get $5
-  else   
+  (local $6 i32)
+  (local $7 i64)
+  block $~lib/dataview/checkOffset|inlined.5
    local.get $1
+   local.set $3
+   i32.const 8
+   local.set $4
+   local.get $0
+   i32.load offset=8
+   local.set $5
    local.get $3
-   i32.add
-   local.get $4
-   i32.gt_s
-  end
-  if
+   global.get $~lib/internal/arraybuffer/MAX_BLENGTH
+   i32.gt_u
+   local.tee $6
+   if (result i32)
+    local.get $6
+   else    
+    local.get $3
+    local.get $4
+    i32.add
+    local.get $5
+    i32.gt_s
+   end
    i32.const 0
-   i32.const 136
-   i32.const 188
-   i32.const 73
-   call $~lib/env/abort
-   unreachable
+   i32.ne
+   if
+    i32.const 0
+    i32.const 136
+    i32.const 188
+    i32.const 73
+    call $~lib/env/abort
+    unreachable
+   end
   end
   local.get $0
   i32.load
@@ -999,14 +1054,14 @@
   local.get $1
   i32.add
   i64.load offset=8
-  local.set $6
+  local.set $7
   local.get $2
   i32.const 0
   i32.ne
   if (result i64)
-   local.get $6
+   local.get $7
   else   
-   local.get $6
+   local.get $7
    call $~lib/polyfills/bswap<i64>
   end
  )
@@ -1014,31 +1069,38 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  i32.const 1
-  local.set $2
-  local.get $0
-  i32.load offset=8
-  local.set $3
-  local.get $1
-  global.get $~lib/internal/arraybuffer/MAX_BLENGTH
-  i32.gt_u
-  local.tee $4
-  if (result i32)
-   local.get $4
-  else   
+  (local $5 i32)
+  block $~lib/dataview/checkOffset|inlined.6
    local.get $1
+   local.set $2
+   i32.const 1
+   local.set $3
+   local.get $0
+   i32.load offset=8
+   local.set $4
    local.get $2
-   i32.add
-   local.get $3
-   i32.gt_s
-  end
-  if
+   global.get $~lib/internal/arraybuffer/MAX_BLENGTH
+   i32.gt_u
+   local.tee $5
+   if (result i32)
+    local.get $5
+   else    
+    local.get $2
+    local.get $3
+    i32.add
+    local.get $4
+    i32.gt_s
+   end
    i32.const 0
-   i32.const 136
-   i32.const 188
-   i32.const 73
-   call $~lib/env/abort
-   unreachable
+   i32.ne
+   if
+    i32.const 0
+    i32.const 136
+    i32.const 188
+    i32.const 73
+    call $~lib/env/abort
+    unreachable
+   end
   end
   local.get $0
   i32.load
@@ -1068,31 +1130,38 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  i32.const 2
-  local.set $3
-  local.get $0
-  i32.load offset=8
-  local.set $4
-  local.get $1
-  global.get $~lib/internal/arraybuffer/MAX_BLENGTH
-  i32.gt_u
-  local.tee $5
-  if (result i32)
-   local.get $5
-  else   
+  (local $7 i32)
+  block $~lib/dataview/checkOffset|inlined.7
    local.get $1
+   local.set $3
+   i32.const 2
+   local.set $4
+   local.get $0
+   i32.load offset=8
+   local.set $5
    local.get $3
-   i32.add
-   local.get $4
-   i32.gt_s
-  end
-  if
+   global.get $~lib/internal/arraybuffer/MAX_BLENGTH
+   i32.gt_u
+   local.tee $6
+   if (result i32)
+    local.get $6
+   else    
+    local.get $3
+    local.get $4
+    i32.add
+    local.get $5
+    i32.gt_s
+   end
    i32.const 0
-   i32.const 136
-   i32.const 188
-   i32.const 73
-   call $~lib/env/abort
-   unreachable
+   i32.ne
+   if
+    i32.const 0
+    i32.const 136
+    i32.const 188
+    i32.const 73
+    call $~lib/env/abort
+    unreachable
+   end
   end
   local.get $0
   i32.load
@@ -1102,14 +1171,14 @@
   local.get $1
   i32.add
   i32.load16_u offset=8
-  local.set $6
+  local.set $7
   local.get $2
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $6
+   local.get $7
   else   
-   local.get $6
+   local.get $7
    call $~lib/polyfills/bswap<u16>
   end
  )
@@ -1118,31 +1187,38 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  i32.const 4
-  local.set $3
-  local.get $0
-  i32.load offset=8
-  local.set $4
-  local.get $1
-  global.get $~lib/internal/arraybuffer/MAX_BLENGTH
-  i32.gt_u
-  local.tee $5
-  if (result i32)
-   local.get $5
-  else   
+  (local $7 i32)
+  block $~lib/dataview/checkOffset|inlined.8
    local.get $1
+   local.set $3
+   i32.const 4
+   local.set $4
+   local.get $0
+   i32.load offset=8
+   local.set $5
    local.get $3
-   i32.add
-   local.get $4
-   i32.gt_s
-  end
-  if
+   global.get $~lib/internal/arraybuffer/MAX_BLENGTH
+   i32.gt_u
+   local.tee $6
+   if (result i32)
+    local.get $6
+   else    
+    local.get $3
+    local.get $4
+    i32.add
+    local.get $5
+    i32.gt_s
+   end
    i32.const 0
-   i32.const 136
-   i32.const 188
-   i32.const 73
-   call $~lib/env/abort
-   unreachable
+   i32.ne
+   if
+    i32.const 0
+    i32.const 136
+    i32.const 188
+    i32.const 73
+    call $~lib/env/abort
+    unreachable
+   end
   end
   local.get $0
   i32.load
@@ -1152,14 +1228,14 @@
   local.get $1
   i32.add
   i32.load offset=8
-  local.set $6
+  local.set $7
   local.get $2
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $6
+   local.get $7
   else   
-   local.get $6
+   local.get $7
    call $~lib/polyfills/bswap<u32>
   end
  )
@@ -1167,32 +1243,39 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i64)
-  i32.const 8
-  local.set $3
-  local.get $0
-  i32.load offset=8
-  local.set $4
-  local.get $1
-  global.get $~lib/internal/arraybuffer/MAX_BLENGTH
-  i32.gt_u
-  local.tee $5
-  if (result i32)
-   local.get $5
-  else   
+  (local $6 i32)
+  (local $7 i64)
+  block $~lib/dataview/checkOffset|inlined.9
    local.get $1
+   local.set $3
+   i32.const 8
+   local.set $4
+   local.get $0
+   i32.load offset=8
+   local.set $5
    local.get $3
-   i32.add
-   local.get $4
-   i32.gt_s
-  end
-  if
+   global.get $~lib/internal/arraybuffer/MAX_BLENGTH
+   i32.gt_u
+   local.tee $6
+   if (result i32)
+    local.get $6
+   else    
+    local.get $3
+    local.get $4
+    i32.add
+    local.get $5
+    i32.gt_s
+   end
    i32.const 0
-   i32.const 136
-   i32.const 188
-   i32.const 73
-   call $~lib/env/abort
-   unreachable
+   i32.ne
+   if
+    i32.const 0
+    i32.const 136
+    i32.const 188
+    i32.const 73
+    call $~lib/env/abort
+    unreachable
+   end
   end
   local.get $0
   i32.load
@@ -1202,14 +1285,14 @@
   local.get $1
   i32.add
   i64.load offset=8
-  local.set $6
+  local.set $7
   local.get $2
   i32.const 0
   i32.ne
   if (result i64)
-   local.get $6
+   local.get $7
   else   
-   local.get $6
+   local.get $7
    call $~lib/polyfills/bswap<u64>
   end
  )
@@ -1217,31 +1300,38 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  i32.const 4
-  local.set $4
-  local.get $0
-  i32.load offset=8
-  local.set $5
-  local.get $1
-  global.get $~lib/internal/arraybuffer/MAX_BLENGTH
-  i32.gt_u
-  local.tee $6
-  if (result i32)
-   local.get $6
-  else   
+  (local $7 i32)
+  block $~lib/dataview/checkOffset|inlined.10
    local.get $1
+   local.set $4
+   i32.const 4
+   local.set $5
+   local.get $0
+   i32.load offset=8
+   local.set $6
    local.get $4
-   i32.add
-   local.get $5
-   i32.gt_s
-  end
-  if
+   global.get $~lib/internal/arraybuffer/MAX_BLENGTH
+   i32.gt_u
+   local.tee $7
+   if (result i32)
+    local.get $7
+   else    
+    local.get $4
+    local.get $5
+    i32.add
+    local.get $6
+    i32.gt_s
+   end
    i32.const 0
-   i32.const 136
-   i32.const 188
-   i32.const 73
-   call $~lib/env/abort
-   unreachable
+   i32.ne
+   if
+    i32.const 0
+    i32.const 136
+    i32.const 188
+    i32.const 73
+    call $~lib/env/abort
+    unreachable
+   end
   end
   local.get $3
   i32.const 0
@@ -1274,31 +1364,38 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  i32.const 8
-  local.set $4
-  local.get $0
-  i32.load offset=8
-  local.set $5
-  local.get $1
-  global.get $~lib/internal/arraybuffer/MAX_BLENGTH
-  i32.gt_u
-  local.tee $6
-  if (result i32)
-   local.get $6
-  else   
+  (local $7 i32)
+  block $~lib/dataview/checkOffset|inlined.11
    local.get $1
+   local.set $4
+   i32.const 8
+   local.set $5
+   local.get $0
+   i32.load offset=8
+   local.set $6
    local.get $4
-   i32.add
-   local.get $5
-   i32.gt_s
-  end
-  if
+   global.get $~lib/internal/arraybuffer/MAX_BLENGTH
+   i32.gt_u
+   local.tee $7
+   if (result i32)
+    local.get $7
+   else    
+    local.get $4
+    local.get $5
+    i32.add
+    local.get $6
+    i32.gt_s
+   end
    i32.const 0
-   i32.const 136
-   i32.const 188
-   i32.const 73
-   call $~lib/env/abort
-   unreachable
+   i32.ne
+   if
+    i32.const 0
+    i32.const 136
+    i32.const 188
+    i32.const 73
+    call $~lib/env/abort
+    unreachable
+   end
   end
   local.get $3
   i32.const 0
@@ -1331,31 +1428,38 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  i32.const 1
-  local.set $3
-  local.get $0
-  i32.load offset=8
-  local.set $4
-  local.get $1
-  global.get $~lib/internal/arraybuffer/MAX_BLENGTH
-  i32.gt_u
-  local.tee $5
-  if (result i32)
-   local.get $5
-  else   
+  (local $6 i32)
+  block $~lib/dataview/checkOffset|inlined.12
    local.get $1
+   local.set $3
+   i32.const 1
+   local.set $4
+   local.get $0
+   i32.load offset=8
+   local.set $5
    local.get $3
-   i32.add
-   local.get $4
-   i32.gt_s
-  end
-  if
+   global.get $~lib/internal/arraybuffer/MAX_BLENGTH
+   i32.gt_u
+   local.tee $6
+   if (result i32)
+    local.get $6
+   else    
+    local.get $3
+    local.get $4
+    i32.add
+    local.get $5
+    i32.gt_s
+   end
    i32.const 0
-   i32.const 136
-   i32.const 188
-   i32.const 73
-   call $~lib/env/abort
-   unreachable
+   i32.ne
+   if
+    i32.const 0
+    i32.const 136
+    i32.const 188
+    i32.const 73
+    call $~lib/env/abort
+    unreachable
+   end
   end
   local.get $0
   i32.load
@@ -1371,31 +1475,38 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  i32.const 2
-  local.set $4
-  local.get $0
-  i32.load offset=8
-  local.set $5
-  local.get $1
-  global.get $~lib/internal/arraybuffer/MAX_BLENGTH
-  i32.gt_u
-  local.tee $6
-  if (result i32)
-   local.get $6
-  else   
+  (local $7 i32)
+  block $~lib/dataview/checkOffset|inlined.13
    local.get $1
+   local.set $4
+   i32.const 2
+   local.set $5
+   local.get $0
+   i32.load offset=8
+   local.set $6
    local.get $4
-   i32.add
-   local.get $5
-   i32.gt_s
-  end
-  if
+   global.get $~lib/internal/arraybuffer/MAX_BLENGTH
+   i32.gt_u
+   local.tee $7
+   if (result i32)
+    local.get $7
+   else    
+    local.get $4
+    local.get $5
+    i32.add
+    local.get $6
+    i32.gt_s
+   end
    i32.const 0
-   i32.const 136
-   i32.const 188
-   i32.const 73
-   call $~lib/env/abort
-   unreachable
+   i32.ne
+   if
+    i32.const 0
+    i32.const 136
+    i32.const 188
+    i32.const 73
+    call $~lib/env/abort
+    unreachable
+   end
   end
   local.get $0
   i32.load
@@ -1419,31 +1530,38 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  i32.const 4
-  local.set $4
-  local.get $0
-  i32.load offset=8
-  local.set $5
-  local.get $1
-  global.get $~lib/internal/arraybuffer/MAX_BLENGTH
-  i32.gt_u
-  local.tee $6
-  if (result i32)
-   local.get $6
-  else   
+  (local $7 i32)
+  block $~lib/dataview/checkOffset|inlined.14
    local.get $1
+   local.set $4
+   i32.const 4
+   local.set $5
+   local.get $0
+   i32.load offset=8
+   local.set $6
    local.get $4
-   i32.add
-   local.get $5
-   i32.gt_s
-  end
-  if
+   global.get $~lib/internal/arraybuffer/MAX_BLENGTH
+   i32.gt_u
+   local.tee $7
+   if (result i32)
+    local.get $7
+   else    
+    local.get $4
+    local.get $5
+    i32.add
+    local.get $6
+    i32.gt_s
+   end
    i32.const 0
-   i32.const 136
-   i32.const 188
-   i32.const 73
-   call $~lib/env/abort
-   unreachable
+   i32.ne
+   if
+    i32.const 0
+    i32.const 136
+    i32.const 188
+    i32.const 73
+    call $~lib/env/abort
+    unreachable
+   end
   end
   local.get $0
   i32.load
@@ -1467,31 +1585,38 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  i32.const 8
-  local.set $4
-  local.get $0
-  i32.load offset=8
-  local.set $5
-  local.get $1
-  global.get $~lib/internal/arraybuffer/MAX_BLENGTH
-  i32.gt_u
-  local.tee $6
-  if (result i32)
-   local.get $6
-  else   
+  (local $7 i32)
+  block $~lib/dataview/checkOffset|inlined.15
    local.get $1
+   local.set $4
+   i32.const 8
+   local.set $5
+   local.get $0
+   i32.load offset=8
+   local.set $6
    local.get $4
-   i32.add
-   local.get $5
-   i32.gt_s
-  end
-  if
+   global.get $~lib/internal/arraybuffer/MAX_BLENGTH
+   i32.gt_u
+   local.tee $7
+   if (result i32)
+    local.get $7
+   else    
+    local.get $4
+    local.get $5
+    i32.add
+    local.get $6
+    i32.gt_s
+   end
    i32.const 0
-   i32.const 136
-   i32.const 188
-   i32.const 73
-   call $~lib/env/abort
-   unreachable
+   i32.ne
+   if
+    i32.const 0
+    i32.const 136
+    i32.const 188
+    i32.const 73
+    call $~lib/env/abort
+    unreachable
+   end
   end
   local.get $0
   i32.load
@@ -1515,31 +1640,38 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  i32.const 1
-  local.set $3
-  local.get $0
-  i32.load offset=8
-  local.set $4
-  local.get $1
-  global.get $~lib/internal/arraybuffer/MAX_BLENGTH
-  i32.gt_u
-  local.tee $5
-  if (result i32)
-   local.get $5
-  else   
+  (local $6 i32)
+  block $~lib/dataview/checkOffset|inlined.16
    local.get $1
+   local.set $3
+   i32.const 1
+   local.set $4
+   local.get $0
+   i32.load offset=8
+   local.set $5
    local.get $3
-   i32.add
-   local.get $4
-   i32.gt_s
-  end
-  if
+   global.get $~lib/internal/arraybuffer/MAX_BLENGTH
+   i32.gt_u
+   local.tee $6
+   if (result i32)
+    local.get $6
+   else    
+    local.get $3
+    local.get $4
+    i32.add
+    local.get $5
+    i32.gt_s
+   end
    i32.const 0
-   i32.const 136
-   i32.const 188
-   i32.const 73
-   call $~lib/env/abort
-   unreachable
+   i32.ne
+   if
+    i32.const 0
+    i32.const 136
+    i32.const 188
+    i32.const 73
+    call $~lib/env/abort
+    unreachable
+   end
   end
   local.get $0
   i32.load
@@ -1555,31 +1687,38 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  i32.const 2
-  local.set $4
-  local.get $0
-  i32.load offset=8
-  local.set $5
-  local.get $1
-  global.get $~lib/internal/arraybuffer/MAX_BLENGTH
-  i32.gt_u
-  local.tee $6
-  if (result i32)
-   local.get $6
-  else   
+  (local $7 i32)
+  block $~lib/dataview/checkOffset|inlined.17
    local.get $1
+   local.set $4
+   i32.const 2
+   local.set $5
+   local.get $0
+   i32.load offset=8
+   local.set $6
    local.get $4
-   i32.add
-   local.get $5
-   i32.gt_s
-  end
-  if
+   global.get $~lib/internal/arraybuffer/MAX_BLENGTH
+   i32.gt_u
+   local.tee $7
+   if (result i32)
+    local.get $7
+   else    
+    local.get $4
+    local.get $5
+    i32.add
+    local.get $6
+    i32.gt_s
+   end
    i32.const 0
-   i32.const 136
-   i32.const 188
-   i32.const 73
-   call $~lib/env/abort
-   unreachable
+   i32.ne
+   if
+    i32.const 0
+    i32.const 136
+    i32.const 188
+    i32.const 73
+    call $~lib/env/abort
+    unreachable
+   end
   end
   local.get $0
   i32.load
@@ -1603,31 +1742,38 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  i32.const 4
-  local.set $4
-  local.get $0
-  i32.load offset=8
-  local.set $5
-  local.get $1
-  global.get $~lib/internal/arraybuffer/MAX_BLENGTH
-  i32.gt_u
-  local.tee $6
-  if (result i32)
-   local.get $6
-  else   
+  (local $7 i32)
+  block $~lib/dataview/checkOffset|inlined.18
    local.get $1
+   local.set $4
+   i32.const 4
+   local.set $5
+   local.get $0
+   i32.load offset=8
+   local.set $6
    local.get $4
-   i32.add
-   local.get $5
-   i32.gt_s
-  end
-  if
+   global.get $~lib/internal/arraybuffer/MAX_BLENGTH
+   i32.gt_u
+   local.tee $7
+   if (result i32)
+    local.get $7
+   else    
+    local.get $4
+    local.get $5
+    i32.add
+    local.get $6
+    i32.gt_s
+   end
    i32.const 0
-   i32.const 136
-   i32.const 188
-   i32.const 73
-   call $~lib/env/abort
-   unreachable
+   i32.ne
+   if
+    i32.const 0
+    i32.const 136
+    i32.const 188
+    i32.const 73
+    call $~lib/env/abort
+    unreachable
+   end
   end
   local.get $0
   i32.load
@@ -1651,31 +1797,38 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  i32.const 8
-  local.set $4
-  local.get $0
-  i32.load offset=8
-  local.set $5
-  local.get $1
-  global.get $~lib/internal/arraybuffer/MAX_BLENGTH
-  i32.gt_u
-  local.tee $6
-  if (result i32)
-   local.get $6
-  else   
+  (local $7 i32)
+  block $~lib/dataview/checkOffset|inlined.19
    local.get $1
+   local.set $4
+   i32.const 8
+   local.set $5
+   local.get $0
+   i32.load offset=8
+   local.set $6
    local.get $4
-   i32.add
-   local.get $5
-   i32.gt_s
-  end
-  if
+   global.get $~lib/internal/arraybuffer/MAX_BLENGTH
+   i32.gt_u
+   local.tee $7
+   if (result i32)
+    local.get $7
+   else    
+    local.get $4
+    local.get $5
+    i32.add
+    local.get $6
+    i32.gt_s
+   end
    i32.const 0
-   i32.const 136
-   i32.const 188
-   i32.const 73
-   call $~lib/env/abort
-   unreachable
+   i32.ne
+   if
+    i32.const 0
+    i32.const 136
+    i32.const 188
+    i32.const 73
+    call $~lib/env/abort
+    unreachable
+   end
   end
   local.get $0
   i32.load

--- a/tests/compiler/std/gc-array.untouched.wat
+++ b/tests/compiler/std/gc-array.untouched.wat
@@ -139,6 +139,8 @@
   if
    block $~lib/collector/itcm/refToObj|inlined.0 (result i32)
     local.get $0
+    local.set $1
+    local.get $1
     global.get $~lib/collector/itcm/HEADER_SIZE
     i32.sub
    end
@@ -382,6 +384,8 @@
       global.set $~argc
       block $~lib/collector/itcm/objToRef|inlined.0 (result i32)
        local.get $0
+       local.set $1
+       local.get $1
        global.get $~lib/collector/itcm/HEADER_SIZE
        i32.add
       end
@@ -434,13 +438,11 @@
      i32.ge_u
      if
       block $~lib/memory/memory.free|inlined.0
-       block
-        local.get $0
-        call $~lib/allocator/arena/__memory_free
-        br $~lib/memory/memory.free|inlined.0
-        unreachable
-       end
-       unreachable
+       local.get $0
+       local.set $1
+       local.get $1
+       call $~lib/allocator/arena/__memory_free
+       br $~lib/memory/memory.free|inlined.0
       end
      end
     else     
@@ -524,6 +526,8 @@
   call $~lib/collector/itcm/ManagedObjectList#push
   block $~lib/collector/itcm/objToRef|inlined.1 (result i32)
    local.get $3
+   local.set $2
+   local.get $2
    global.get $~lib/collector/itcm/HEADER_SIZE
    i32.add
   end
@@ -2272,6 +2276,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.load
   local.set $2
@@ -2305,37 +2310,43 @@
     local.get $1
     call $~lib/internal/arraybuffer/allocateUnsafe
     local.set $3
-    local.get $3
-    global.get $~lib/internal/arraybuffer/HEADER_SIZE
-    i32.add
-    local.set $4
-    local.get $0
-    global.get $~lib/internal/arraybuffer/HEADER_SIZE
-    i32.add
-    local.set $5
-    local.get $4
-    local.get $5
-    local.get $2
-    call $~lib/internal/memory/memmove
+    block $~lib/memory/memory.copy|inlined.0
+     local.get $3
+     global.get $~lib/internal/arraybuffer/HEADER_SIZE
+     i32.add
+     local.set $4
+     local.get $0
+     global.get $~lib/internal/arraybuffer/HEADER_SIZE
+     i32.add
+     local.set $5
+     local.get $2
+     local.set $6
+     local.get $4
+     local.get $5
+     local.get $6
+     call $~lib/internal/memory/memmove
+    end
     local.get $3
     local.set $0
    end
-   local.get $0
-   global.get $~lib/internal/arraybuffer/HEADER_SIZE
-   i32.add
-   local.get $2
-   i32.add
-   local.set $3
-   i32.const 0
-   local.set $5
-   local.get $1
-   local.get $2
-   i32.sub
-   local.set $4
-   local.get $3
-   local.get $5
-   local.get $4
-   call $~lib/internal/memory/memset
+   block $~lib/memory/memory.fill|inlined.0
+    local.get $0
+    global.get $~lib/internal/arraybuffer/HEADER_SIZE
+    i32.add
+    local.get $2
+    i32.add
+    local.set $3
+    i32.const 0
+    local.set $6
+    local.get $1
+    local.get $2
+    i32.sub
+    local.set $5
+    local.get $3
+    local.get $6
+    local.get $5
+    call $~lib/internal/memory/memset
+   end
   else   
    local.get $1
    local.get $2
@@ -2365,19 +2376,23 @@
   (local $3 i32)
   block $~lib/collector/itcm/refToObj|inlined.1 (result i32)
    local.get $0
+   local.set $2
+   local.get $2
    global.get $~lib/collector/itcm/HEADER_SIZE
    i32.sub
   end
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   call $~lib/collector/itcm/ManagedObject#get:color
   global.get $~lib/collector/itcm/white
   i32.eqz
   i32.eq
-  local.tee $3
+  local.tee $2
   if (result i32)
    block $~lib/collector/itcm/refToObj|inlined.3 (result i32)
     local.get $1
+    local.set $2
+    local.get $2
     global.get $~lib/collector/itcm/HEADER_SIZE
     i32.sub
    end
@@ -2385,10 +2400,10 @@
    global.get $~lib/collector/itcm/white
    i32.eq
   else   
-   local.get $3
+   local.get $2
   end
   if
-   local.get $2
+   local.get $3
    call $~lib/collector/itcm/ManagedObject#makeGray
   end
  )
@@ -2396,6 +2411,9 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   local.get $0
   i32.load
   local.set $3
@@ -2436,17 +2454,25 @@
    i32.add
    i32.store offset=4
   end
-  i32.const 0
-  local.set $5
-  local.get $3
-  local.get $1
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $5
-  i32.add
-  local.get $2
-  i32.store offset=8
+  block $~lib/internal/arraybuffer/STORE<Foo,Foo>|inlined.0
+   local.get $3
+   local.set $5
+   local.get $1
+   local.set $6
+   local.get $2
+   local.set $7
+   i32.const 0
+   local.set $8
+   local.get $5
+   local.get $6
+   i32.const 2
+   i32.shl
+   i32.add
+   local.get $8
+   i32.add
+   local.get $7
+   i32.store offset=8
+  end
   local.get $0
   local.get $2
   call $~lib/collector/itcm/__gc_link

--- a/tests/compiler/std/gc-basics.untouched.wat
+++ b/tests/compiler/std/gc-basics.untouched.wat
@@ -215,6 +215,8 @@
   if
    block $~lib/collector/itcm/refToObj|inlined.0 (result i32)
     local.get $0
+    local.set $1
+    local.get $1
     global.get $~lib/collector/itcm/HEADER_SIZE
     i32.sub
    end
@@ -333,6 +335,8 @@
       global.set $~argc
       block $~lib/collector/itcm/objToRef|inlined.0 (result i32)
        local.get $0
+       local.set $1
+       local.get $1
        global.get $~lib/collector/itcm/HEADER_SIZE
        i32.add
       end
@@ -385,13 +389,11 @@
      i32.ge_u
      if
       block $~lib/memory/memory.free|inlined.0
-       block
-        local.get $0
-        call $~lib/allocator/arena/__memory_free
-        br $~lib/memory/memory.free|inlined.0
-        unreachable
-       end
-       unreachable
+       local.get $0
+       local.set $1
+       local.get $1
+       call $~lib/allocator/arena/__memory_free
+       br $~lib/memory/memory.free|inlined.0
       end
      end
     else     
@@ -439,6 +441,8 @@
   call $~lib/collector/itcm/ManagedObjectList#push
   block $~lib/collector/itcm/objToRef|inlined.1 (result i32)
    local.get $3
+   local.set $2
+   local.get $2
    global.get $~lib/collector/itcm/HEADER_SIZE
    i32.add
   end
@@ -551,6 +555,8 @@
     local.get $3
    end
    local.tee $3
+   i32.const 0
+   i32.ne
    if (result i32)
     local.get $1
     local.get $2
@@ -558,6 +564,8 @@
    else    
     local.get $3
    end
+   i32.const 0
+   i32.ne
    i32.eqz
    if
     i32.const 0

--- a/tests/compiler/std/gc-object.untouched.wat
+++ b/tests/compiler/std/gc-object.untouched.wat
@@ -207,6 +207,8 @@
   if
    block $~lib/collector/itcm/refToObj|inlined.0 (result i32)
     local.get $0
+    local.set $1
+    local.get $1
     global.get $~lib/collector/itcm/HEADER_SIZE
     i32.sub
    end
@@ -325,6 +327,8 @@
       global.set $~argc
       block $~lib/collector/itcm/objToRef|inlined.0 (result i32)
        local.get $0
+       local.set $1
+       local.get $1
        global.get $~lib/collector/itcm/HEADER_SIZE
        i32.add
       end
@@ -377,13 +381,11 @@
      i32.ge_u
      if
       block $~lib/memory/memory.free|inlined.0
-       block
-        local.get $0
-        call $~lib/allocator/arena/__memory_free
-        br $~lib/memory/memory.free|inlined.0
-        unreachable
-       end
-       unreachable
+       local.get $0
+       local.set $1
+       local.get $1
+       call $~lib/allocator/arena/__memory_free
+       br $~lib/memory/memory.free|inlined.0
       end
      end
     else     
@@ -431,6 +433,8 @@
   call $~lib/collector/itcm/ManagedObjectList#push
   block $~lib/collector/itcm/objToRef|inlined.1 (result i32)
    local.get $3
+   local.set $2
+   local.get $2
    global.get $~lib/collector/itcm/HEADER_SIZE
    i32.add
   end

--- a/tests/compiler/std/libm.untouched.wat
+++ b/tests/compiler/std/libm.untouched.wat
@@ -72,7 +72,10 @@
  (export "tanh" (func $std/libm/tanh))
  (export "trunc" (func $std/libm/trunc))
  (func $std/libm/abs (; 0 ;) (type $FF) (param $0 f64) (result f64)
+  (local $1 f64)
   local.get $0
+  local.set $1
+  local.get $1
   f64.abs
  )
  (func $~lib/math/R (; 1 ;) (type $FF) (param $0 f64) (result f64)
@@ -871,6 +874,8 @@
    else    
     local.get $3
    end
+   i32.const 0
+   i32.ne
    if
     local.get $0
     return
@@ -1915,11 +1920,17 @@
   call $~lib/math/NativeMath.cbrt
  )
  (func $std/libm/ceil (; 21 ;) (type $FF) (param $0 f64) (result f64)
+  (local $1 f64)
   local.get $0
+  local.set $1
+  local.get $1
   f64.ceil
  )
  (func $std/libm/clz32 (; 22 ;) (type $FF) (param $0 f64) (result f64)
+  (local $1 f64)
   local.get $0
+  local.set $1
+  local.get $1
   i32.trunc_f64_s
   i32.clz
   f64.convert_i32_s
@@ -2507,6 +2518,7 @@
   (local $2 i32)
   (local $3 f64)
   (local $4 f64)
+  (local $5 f64)
   local.get $0
   i64.reinterpret_f64
   local.set $1
@@ -2570,6 +2582,8 @@
    return
   end
   block $~lib/math/expo2|inlined.0 (result f64)
+   local.get $0
+   local.set $4
    i32.const 1023
    i32.const 2043
    i32.const 2
@@ -2581,14 +2595,14 @@
    i64.const 32
    i64.shl
    f64.reinterpret_i64
-   local.set $4
-   local.get $0
+   local.set $5
+   local.get $4
    f64.const 1416.0996898839683
    f64.sub
    call $~lib/math/NativeMath.exp
-   local.get $4
+   local.get $5
    f64.mul
-   local.get $4
+   local.get $5
    f64.mul
   end
   local.set $3
@@ -2607,11 +2621,17 @@
   call $~lib/math/NativeMath.expm1
  )
  (func $std/libm/floor (; 32 ;) (type $FF) (param $0 f64) (result f64)
+  (local $1 f64)
   local.get $0
+  local.set $1
+  local.get $1
   f64.floor
  )
  (func $std/libm/fround (; 33 ;) (type $Ff) (param $0 f64) (result f32)
+  (local $1 f64)
   local.get $0
+  local.set $1
+  local.get $1
   f32.demote_f64
  )
  (func $~lib/math/NativeMath.hypot (; 34 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
@@ -3401,13 +3421,25 @@
   call $~lib/math/NativeMath.log2
  )
  (func $std/libm/max (; 45 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+  (local $2 f64)
+  (local $3 f64)
   local.get $0
+  local.set $2
   local.get $1
+  local.set $3
+  local.get $2
+  local.get $3
   f64.max
  )
  (func $std/libm/min (; 46 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+  (local $2 f64)
+  (local $3 f64)
   local.get $0
+  local.set $2
   local.get $1
+  local.set $3
+  local.get $2
+  local.get $3
   f64.min
  )
  (func $~lib/math/NativeMath.pow (; 47 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
@@ -3705,6 +3737,8 @@
     i32.eq
    end
    local.tee $14
+   i32.const 0
+   i32.ne
    if (result i32)
     local.get $14
    else    
@@ -3712,6 +3746,8 @@
     i32.const 1072693248
     i32.eq
    end
+   i32.const 0
+   i32.ne
    if
     local.get $15
     local.set $16
@@ -4504,28 +4540,34 @@
   call $~lib/math/NativeMath.pow
  )
  (func $std/libm/round (; 49 ;) (type $FF) (param $0 f64) (result f64)
+  (local $1 f64)
   local.get $0
+  local.set $1
+  local.get $1
   f64.const 0.5
   f64.add
   f64.floor
-  local.get $0
+  local.get $1
   f64.copysign
  )
  (func $std/libm/sign (; 50 ;) (type $FF) (param $0 f64) (result f64)
+  (local $1 f64)
   block $~lib/math/NativeMath.sign|inlined.0 (result f64)
    local.get $0
+   local.set $1
+   local.get $1
    f64.const 0
    f64.gt
    if (result f64)
     f64.const 1
    else    
-    local.get $0
+    local.get $1
     f64.const 0
     f64.lt
     if (result f64)
      f64.const -1
     else     
-     local.get $0
+     local.get $1
     end
    end
    br $~lib/math/NativeMath.sign|inlined.0
@@ -4546,6 +4588,7 @@
   (local $4 f64)
   (local $5 f64)
   (local $6 f64)
+  (local $7 f64)
   local.get $0
   i64.reinterpret_f64
   i64.const 9223372036854775807
@@ -4615,6 +4658,8 @@
   local.get $5
   f64.mul
   block $~lib/math/expo2|inlined.1 (result f64)
+   local.get $2
+   local.set $6
    i32.const 1023
    i32.const 2043
    i32.const 2
@@ -4626,14 +4671,14 @@
    i64.const 32
    i64.shl
    f64.reinterpret_i64
-   local.set $6
-   local.get $2
+   local.set $7
+   local.get $6
    f64.const 1416.0996898839683
    f64.sub
    call $~lib/math/NativeMath.exp
-   local.get $6
+   local.get $7
    f64.mul
-   local.get $6
+   local.get $7
    f64.mul
   end
   f64.mul
@@ -4645,7 +4690,10 @@
   call $~lib/math/NativeMath.sinh
  )
  (func $std/libm/sqrt (; 55 ;) (type $FF) (param $0 f64) (result f64)
+  (local $1 f64)
   local.get $0
+  local.set $1
+  local.get $1
   f64.sqrt
  )
  (func $~lib/math/NativeMath.tan (; 56 ;) (type $FF) (param $0 f64) (result f64)
@@ -4753,7 +4801,10 @@
   call $~lib/math/NativeMath.tanh
  )
  (func $std/libm/trunc (; 60 ;) (type $FF) (param $0 f64) (result f64)
+  (local $1 f64)
   local.get $0
+  local.set $1
+  local.get $1
   f64.trunc
  )
  (func $null (; 61 ;) (type $v)

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -426,6 +426,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   global.get $~lib/internal/arraybuffer/MAX_BLENGTH
   i32.gt_u
@@ -451,9 +452,11 @@
    local.set $4
    i32.const 0
    local.set $5
+   local.get $1
+   local.set $6
    local.get $4
    local.get $5
-   local.get $1
+   local.get $6
    call $~lib/internal/memory/memset
   end
   local.get $3
@@ -562,6 +565,8 @@
       else       
        local.get $4
       end
+      i32.const 0
+      i32.ne
       if
        local.get $3
        return
@@ -581,10 +586,13 @@
   i32.const 0
  )
  (func $~lib/map/Map<i8,i32>#has (; 11 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<i8>|inlined.0 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i32.const 24
    i32.shl
    i32.const 24
@@ -743,6 +751,8 @@
   (local $6 i32)
   block $~lib/internal/hash/HASH<i8>|inlined.1 (result i32)
    local.get $1
+   local.set $3
+   local.get $3
    i32.const 24
    i32.shl
    i32.const 24
@@ -750,15 +760,15 @@
    call $~lib/internal/hash/hash8
    br $~lib/internal/hash/HASH<i8>|inlined.1
   end
-  local.set $3
+  local.set $4
   local.get $0
   local.get $1
-  local.get $3
-  call $~lib/map/Map<i8,i32>#find
-  local.set $4
   local.get $4
+  call $~lib/map/Map<i8,i32>#find
+  local.set $5
+  local.get $5
   if
-   local.get $4
+   local.get $5
    local.get $2
    i32.store offset=4
   else   
@@ -793,8 +803,8 @@
    end
    local.get $0
    i32.load offset=8
-   local.set $5
-   local.get $5
+   local.set $3
+   local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
    block (result i32)
@@ -812,11 +822,11 @@
    end
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    local.get $1
    i32.store8
-   local.get $4
+   local.get $5
    local.get $2
    i32.store offset=4
    local.get $0
@@ -827,7 +837,7 @@
    i32.store offset=20
    local.get $0
    i32.load
-   local.get $3
+   local.get $4
    local.get $0
    i32.load offset=4
    i32.and
@@ -835,21 +845,24 @@
    i32.mul
    i32.add
    local.set $6
-   local.get $4
+   local.get $5
    local.get $6
    i32.load offset=8
    i32.store offset=8
    local.get $6
-   local.get $4
+   local.get $5
    i32.store offset=8
   end
  )
  (func $~lib/map/Map<i8,i32>#get (; 14 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
+  (local $3 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<i8>|inlined.3 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i32.const 24
    i32.shl
    i32.const 24
@@ -858,10 +871,10 @@
    br $~lib/internal/hash/HASH<i8>|inlined.3
   end
   call $~lib/map/Map<i8,i32>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   if (result i32)
-   local.get $2
+   local.get $3
    i32.load offset=4
   else   
    unreachable
@@ -880,6 +893,8 @@
   local.get $1
   block $~lib/internal/hash/HASH<i8>|inlined.4 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i32.const 24
    i32.shl
    i32.const 24
@@ -888,15 +903,15 @@
    br $~lib/internal/hash/HASH<i8>|inlined.4
   end
   call $~lib/map/Map<i8,i32>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   i32.eqz
   if
    i32.const 0
    return
   end
-  local.get $2
-  local.get $2
+  local.get $3
+  local.get $3
   i32.load offset=8
   global.get $~lib/map/EMPTY
   i32.or
@@ -911,21 +926,21 @@
   i32.load offset=4
   i32.const 1
   i32.shr_u
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   i32.const 1
   i32.add
   global.get $~lib/map/INITIAL_CAPACITY
-  local.tee $4
+  local.tee $2
   local.get $0
   i32.load offset=20
   local.tee $5
-  local.get $4
+  local.get $2
   local.get $5
   i32.gt_u
   select
   i32.ge_u
-  local.tee $4
+  local.tee $2
   if (result i32)
    local.get $0
    i32.load offset=20
@@ -937,11 +952,11 @@
    i32.trunc_f64_s
    i32.lt_s
   else   
-   local.get $4
+   local.get $2
   end
   if
    local.get $0
-   local.get $3
+   local.get $4
    call $~lib/map/Map<i8,i32>#rehash
   end
   i32.const 1
@@ -1425,6 +1440,8 @@
       else       
        local.get $4
       end
+      i32.const 0
+      i32.ne
       if
        local.get $3
        return
@@ -1444,10 +1461,13 @@
   i32.const 0
  )
  (func $~lib/map/Map<u8,i32>#has (; 21 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<u8>|inlined.0 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i32.const 255
    i32.and
    call $~lib/internal/hash/hash8
@@ -1604,20 +1624,22 @@
   (local $6 i32)
   block $~lib/internal/hash/HASH<u8>|inlined.1 (result i32)
    local.get $1
+   local.set $3
+   local.get $3
    i32.const 255
    i32.and
    call $~lib/internal/hash/hash8
    br $~lib/internal/hash/HASH<u8>|inlined.1
   end
-  local.set $3
+  local.set $4
   local.get $0
   local.get $1
-  local.get $3
-  call $~lib/map/Map<u8,i32>#find
-  local.set $4
   local.get $4
+  call $~lib/map/Map<u8,i32>#find
+  local.set $5
+  local.get $5
   if
-   local.get $4
+   local.get $5
    local.get $2
    i32.store offset=4
   else   
@@ -1652,8 +1674,8 @@
    end
    local.get $0
    i32.load offset=8
-   local.set $5
-   local.get $5
+   local.set $3
+   local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
    block (result i32)
@@ -1671,11 +1693,11 @@
    end
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    local.get $1
    i32.store8
-   local.get $4
+   local.get $5
    local.get $2
    i32.store offset=4
    local.get $0
@@ -1686,7 +1708,7 @@
    i32.store offset=20
    local.get $0
    i32.load
-   local.get $3
+   local.get $4
    local.get $0
    i32.load offset=4
    i32.and
@@ -1694,31 +1716,34 @@
    i32.mul
    i32.add
    local.set $6
-   local.get $4
+   local.get $5
    local.get $6
    i32.load offset=8
    i32.store offset=8
    local.get $6
-   local.get $4
+   local.get $5
    i32.store offset=8
   end
  )
  (func $~lib/map/Map<u8,i32>#get (; 24 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
+  (local $3 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<u8>|inlined.3 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i32.const 255
    i32.and
    call $~lib/internal/hash/hash8
    br $~lib/internal/hash/HASH<u8>|inlined.3
   end
   call $~lib/map/Map<u8,i32>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   if (result i32)
-   local.get $2
+   local.get $3
    i32.load offset=4
   else   
    unreachable
@@ -1737,21 +1762,23 @@
   local.get $1
   block $~lib/internal/hash/HASH<u8>|inlined.4 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i32.const 255
    i32.and
    call $~lib/internal/hash/hash8
    br $~lib/internal/hash/HASH<u8>|inlined.4
   end
   call $~lib/map/Map<u8,i32>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   i32.eqz
   if
    i32.const 0
    return
   end
-  local.get $2
-  local.get $2
+  local.get $3
+  local.get $3
   i32.load offset=8
   global.get $~lib/map/EMPTY
   i32.or
@@ -1766,21 +1793,21 @@
   i32.load offset=4
   i32.const 1
   i32.shr_u
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   i32.const 1
   i32.add
   global.get $~lib/map/INITIAL_CAPACITY
-  local.tee $4
+  local.tee $2
   local.get $0
   i32.load offset=20
   local.tee $5
-  local.get $4
+  local.get $2
   local.get $5
   i32.gt_u
   select
   i32.ge_u
-  local.tee $4
+  local.tee $2
   if (result i32)
    local.get $0
    i32.load offset=20
@@ -1792,11 +1819,11 @@
    i32.trunc_f64_s
    i32.lt_s
   else   
-   local.get $4
+   local.get $2
   end
   if
    local.get $0
-   local.get $3
+   local.get $4
    call $~lib/map/Map<u8,i32>#rehash
   end
   i32.const 1
@@ -2290,6 +2317,8 @@
       else       
        local.get $4
       end
+      i32.const 0
+      i32.ne
       if
        local.get $3
        return
@@ -2309,10 +2338,13 @@
   i32.const 0
  )
  (func $~lib/map/Map<i16,i32>#has (; 32 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<i16>|inlined.0 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i32.const 16
    i32.shl
    i32.const 16
@@ -2471,6 +2503,8 @@
   (local $6 i32)
   block $~lib/internal/hash/HASH<i16>|inlined.1 (result i32)
    local.get $1
+   local.set $3
+   local.get $3
    i32.const 16
    i32.shl
    i32.const 16
@@ -2478,15 +2512,15 @@
    call $~lib/internal/hash/hash16
    br $~lib/internal/hash/HASH<i16>|inlined.1
   end
-  local.set $3
+  local.set $4
   local.get $0
   local.get $1
-  local.get $3
-  call $~lib/map/Map<i16,i32>#find
-  local.set $4
   local.get $4
+  call $~lib/map/Map<i16,i32>#find
+  local.set $5
+  local.get $5
   if
-   local.get $4
+   local.get $5
    local.get $2
    i32.store offset=4
   else   
@@ -2521,8 +2555,8 @@
    end
    local.get $0
    i32.load offset=8
-   local.set $5
-   local.get $5
+   local.set $3
+   local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
    block (result i32)
@@ -2540,11 +2574,11 @@
    end
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    local.get $1
    i32.store16
-   local.get $4
+   local.get $5
    local.get $2
    i32.store offset=4
    local.get $0
@@ -2555,7 +2589,7 @@
    i32.store offset=20
    local.get $0
    i32.load
-   local.get $3
+   local.get $4
    local.get $0
    i32.load offset=4
    i32.and
@@ -2563,21 +2597,24 @@
    i32.mul
    i32.add
    local.set $6
-   local.get $4
+   local.get $5
    local.get $6
    i32.load offset=8
    i32.store offset=8
    local.get $6
-   local.get $4
+   local.get $5
    i32.store offset=8
   end
  )
  (func $~lib/map/Map<i16,i32>#get (; 35 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
+  (local $3 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<i16>|inlined.3 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i32.const 16
    i32.shl
    i32.const 16
@@ -2586,10 +2623,10 @@
    br $~lib/internal/hash/HASH<i16>|inlined.3
   end
   call $~lib/map/Map<i16,i32>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   if (result i32)
-   local.get $2
+   local.get $3
    i32.load offset=4
   else   
    unreachable
@@ -2608,6 +2645,8 @@
   local.get $1
   block $~lib/internal/hash/HASH<i16>|inlined.4 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i32.const 16
    i32.shl
    i32.const 16
@@ -2616,15 +2655,15 @@
    br $~lib/internal/hash/HASH<i16>|inlined.4
   end
   call $~lib/map/Map<i16,i32>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   i32.eqz
   if
    i32.const 0
    return
   end
-  local.get $2
-  local.get $2
+  local.get $3
+  local.get $3
   i32.load offset=8
   global.get $~lib/map/EMPTY
   i32.or
@@ -2639,21 +2678,21 @@
   i32.load offset=4
   i32.const 1
   i32.shr_u
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   i32.const 1
   i32.add
   global.get $~lib/map/INITIAL_CAPACITY
-  local.tee $4
+  local.tee $2
   local.get $0
   i32.load offset=20
   local.tee $5
-  local.get $4
+  local.get $2
   local.get $5
   i32.gt_u
   select
   i32.ge_u
-  local.tee $4
+  local.tee $2
   if (result i32)
    local.get $0
    i32.load offset=20
@@ -2665,11 +2704,11 @@
    i32.trunc_f64_s
    i32.lt_s
   else   
-   local.get $4
+   local.get $2
   end
   if
    local.get $0
-   local.get $3
+   local.get $4
    call $~lib/map/Map<i16,i32>#rehash
   end
   i32.const 1
@@ -3153,6 +3192,8 @@
       else       
        local.get $4
       end
+      i32.const 0
+      i32.ne
       if
        local.get $3
        return
@@ -3172,10 +3213,13 @@
   i32.const 0
  )
  (func $~lib/map/Map<u16,i32>#has (; 42 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<u16>|inlined.0 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i32.const 65535
    i32.and
    call $~lib/internal/hash/hash16
@@ -3332,20 +3376,22 @@
   (local $6 i32)
   block $~lib/internal/hash/HASH<u16>|inlined.1 (result i32)
    local.get $1
+   local.set $3
+   local.get $3
    i32.const 65535
    i32.and
    call $~lib/internal/hash/hash16
    br $~lib/internal/hash/HASH<u16>|inlined.1
   end
-  local.set $3
+  local.set $4
   local.get $0
   local.get $1
-  local.get $3
-  call $~lib/map/Map<u16,i32>#find
-  local.set $4
   local.get $4
+  call $~lib/map/Map<u16,i32>#find
+  local.set $5
+  local.get $5
   if
-   local.get $4
+   local.get $5
    local.get $2
    i32.store offset=4
   else   
@@ -3380,8 +3426,8 @@
    end
    local.get $0
    i32.load offset=8
-   local.set $5
-   local.get $5
+   local.set $3
+   local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
    block (result i32)
@@ -3399,11 +3445,11 @@
    end
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    local.get $1
    i32.store16
-   local.get $4
+   local.get $5
    local.get $2
    i32.store offset=4
    local.get $0
@@ -3414,7 +3460,7 @@
    i32.store offset=20
    local.get $0
    i32.load
-   local.get $3
+   local.get $4
    local.get $0
    i32.load offset=4
    i32.and
@@ -3422,31 +3468,34 @@
    i32.mul
    i32.add
    local.set $6
-   local.get $4
+   local.get $5
    local.get $6
    i32.load offset=8
    i32.store offset=8
    local.get $6
-   local.get $4
+   local.get $5
    i32.store offset=8
   end
  )
  (func $~lib/map/Map<u16,i32>#get (; 45 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
+  (local $3 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<u16>|inlined.3 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i32.const 65535
    i32.and
    call $~lib/internal/hash/hash16
    br $~lib/internal/hash/HASH<u16>|inlined.3
   end
   call $~lib/map/Map<u16,i32>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   if (result i32)
-   local.get $2
+   local.get $3
    i32.load offset=4
   else   
    unreachable
@@ -3465,21 +3514,23 @@
   local.get $1
   block $~lib/internal/hash/HASH<u16>|inlined.4 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i32.const 65535
    i32.and
    call $~lib/internal/hash/hash16
    br $~lib/internal/hash/HASH<u16>|inlined.4
   end
   call $~lib/map/Map<u16,i32>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   i32.eqz
   if
    i32.const 0
    return
   end
-  local.get $2
-  local.get $2
+  local.get $3
+  local.get $3
   i32.load offset=8
   global.get $~lib/map/EMPTY
   i32.or
@@ -3494,21 +3545,21 @@
   i32.load offset=4
   i32.const 1
   i32.shr_u
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   i32.const 1
   i32.add
   global.get $~lib/map/INITIAL_CAPACITY
-  local.tee $4
+  local.tee $2
   local.get $0
   i32.load offset=20
   local.tee $5
-  local.get $4
+  local.get $2
   local.get $5
   i32.gt_u
   select
   i32.ge_u
-  local.tee $4
+  local.tee $2
   if (result i32)
    local.get $0
    i32.load offset=20
@@ -3520,11 +3571,11 @@
    i32.trunc_f64_s
    i32.lt_s
   else   
-   local.get $4
+   local.get $2
   end
   if
    local.get $0
-   local.get $3
+   local.get $4
    call $~lib/map/Map<u16,i32>#rehash
   end
   i32.const 1
@@ -4034,6 +4085,8 @@
       else       
        local.get $4
       end
+      i32.const 0
+      i32.ne
       if
        local.get $3
        return
@@ -4053,10 +4106,13 @@
   i32.const 0
  )
  (func $~lib/map/Map<i32,i32>#has (; 53 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<i32>|inlined.0 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    call $~lib/internal/hash/hash32
    br $~lib/internal/hash/HASH<i32>|inlined.0
   end
@@ -4211,18 +4267,20 @@
   (local $6 i32)
   block $~lib/internal/hash/HASH<i32>|inlined.1 (result i32)
    local.get $1
+   local.set $3
+   local.get $3
    call $~lib/internal/hash/hash32
    br $~lib/internal/hash/HASH<i32>|inlined.1
   end
-  local.set $3
+  local.set $4
   local.get $0
   local.get $1
-  local.get $3
-  call $~lib/map/Map<i32,i32>#find
-  local.set $4
   local.get $4
+  call $~lib/map/Map<i32,i32>#find
+  local.set $5
+  local.get $5
   if
-   local.get $4
+   local.get $5
    local.get $2
    i32.store offset=4
   else   
@@ -4257,8 +4315,8 @@
    end
    local.get $0
    i32.load offset=8
-   local.set $5
-   local.get $5
+   local.set $3
+   local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
    block (result i32)
@@ -4276,11 +4334,11 @@
    end
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    local.get $1
    i32.store
-   local.get $4
+   local.get $5
    local.get $2
    i32.store offset=4
    local.get $0
@@ -4291,7 +4349,7 @@
    i32.store offset=20
    local.get $0
    i32.load
-   local.get $3
+   local.get $4
    local.get $0
    i32.load offset=4
    i32.and
@@ -4299,29 +4357,32 @@
    i32.mul
    i32.add
    local.set $6
-   local.get $4
+   local.get $5
    local.get $6
    i32.load offset=8
    i32.store offset=8
    local.get $6
-   local.get $4
+   local.get $5
    i32.store offset=8
   end
  )
  (func $~lib/map/Map<i32,i32>#get (; 56 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
+  (local $3 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<i32>|inlined.3 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    call $~lib/internal/hash/hash32
    br $~lib/internal/hash/HASH<i32>|inlined.3
   end
   call $~lib/map/Map<i32,i32>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   if (result i32)
-   local.get $2
+   local.get $3
    i32.load offset=4
   else   
    unreachable
@@ -4340,19 +4401,21 @@
   local.get $1
   block $~lib/internal/hash/HASH<i32>|inlined.4 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    call $~lib/internal/hash/hash32
    br $~lib/internal/hash/HASH<i32>|inlined.4
   end
   call $~lib/map/Map<i32,i32>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   i32.eqz
   if
    i32.const 0
    return
   end
-  local.get $2
-  local.get $2
+  local.get $3
+  local.get $3
   i32.load offset=8
   global.get $~lib/map/EMPTY
   i32.or
@@ -4367,21 +4430,21 @@
   i32.load offset=4
   i32.const 1
   i32.shr_u
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   i32.const 1
   i32.add
   global.get $~lib/map/INITIAL_CAPACITY
-  local.tee $4
+  local.tee $2
   local.get $0
   i32.load offset=20
   local.tee $5
-  local.get $4
+  local.get $2
   local.get $5
   i32.gt_u
   select
   i32.ge_u
-  local.tee $4
+  local.tee $2
   if (result i32)
    local.get $0
    i32.load offset=20
@@ -4393,11 +4456,11 @@
    i32.trunc_f64_s
    i32.lt_s
   else   
-   local.get $4
+   local.get $2
   end
   if
    local.get $0
-   local.get $3
+   local.get $4
    call $~lib/map/Map<i32,i32>#rehash
   end
   i32.const 1
@@ -4851,6 +4914,8 @@
       else       
        local.get $4
       end
+      i32.const 0
+      i32.ne
       if
        local.get $3
        return
@@ -4870,10 +4935,13 @@
   i32.const 0
  )
  (func $~lib/map/Map<u32,i32>#has (; 63 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<u32>|inlined.0 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    call $~lib/internal/hash/hash32
    br $~lib/internal/hash/HASH<u32>|inlined.0
   end
@@ -5028,18 +5096,20 @@
   (local $6 i32)
   block $~lib/internal/hash/HASH<u32>|inlined.1 (result i32)
    local.get $1
+   local.set $3
+   local.get $3
    call $~lib/internal/hash/hash32
    br $~lib/internal/hash/HASH<u32>|inlined.1
   end
-  local.set $3
+  local.set $4
   local.get $0
   local.get $1
-  local.get $3
-  call $~lib/map/Map<u32,i32>#find
-  local.set $4
   local.get $4
+  call $~lib/map/Map<u32,i32>#find
+  local.set $5
+  local.get $5
   if
-   local.get $4
+   local.get $5
    local.get $2
    i32.store offset=4
   else   
@@ -5074,8 +5144,8 @@
    end
    local.get $0
    i32.load offset=8
-   local.set $5
-   local.get $5
+   local.set $3
+   local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
    block (result i32)
@@ -5093,11 +5163,11 @@
    end
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    local.get $1
    i32.store
-   local.get $4
+   local.get $5
    local.get $2
    i32.store offset=4
    local.get $0
@@ -5108,7 +5178,7 @@
    i32.store offset=20
    local.get $0
    i32.load
-   local.get $3
+   local.get $4
    local.get $0
    i32.load offset=4
    i32.and
@@ -5116,29 +5186,32 @@
    i32.mul
    i32.add
    local.set $6
-   local.get $4
+   local.get $5
    local.get $6
    i32.load offset=8
    i32.store offset=8
    local.get $6
-   local.get $4
+   local.get $5
    i32.store offset=8
   end
  )
  (func $~lib/map/Map<u32,i32>#get (; 66 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
+  (local $3 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<u32>|inlined.3 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    call $~lib/internal/hash/hash32
    br $~lib/internal/hash/HASH<u32>|inlined.3
   end
   call $~lib/map/Map<u32,i32>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   if (result i32)
-   local.get $2
+   local.get $3
    i32.load offset=4
   else   
    unreachable
@@ -5157,19 +5230,21 @@
   local.get $1
   block $~lib/internal/hash/HASH<u32>|inlined.4 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    call $~lib/internal/hash/hash32
    br $~lib/internal/hash/HASH<u32>|inlined.4
   end
   call $~lib/map/Map<u32,i32>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   i32.eqz
   if
    i32.const 0
    return
   end
-  local.get $2
-  local.get $2
+  local.get $3
+  local.get $3
   i32.load offset=8
   global.get $~lib/map/EMPTY
   i32.or
@@ -5184,21 +5259,21 @@
   i32.load offset=4
   i32.const 1
   i32.shr_u
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   i32.const 1
   i32.add
   global.get $~lib/map/INITIAL_CAPACITY
-  local.tee $4
+  local.tee $2
   local.get $0
   i32.load offset=20
   local.tee $5
-  local.get $4
+  local.get $2
   local.get $5
   i32.gt_u
   select
   i32.ge_u
-  local.tee $4
+  local.tee $2
   if (result i32)
    local.get $0
    i32.load offset=20
@@ -5210,11 +5285,11 @@
    i32.trunc_f64_s
    i32.lt_s
   else   
-   local.get $4
+   local.get $2
   end
   if
    local.get $0
-   local.get $3
+   local.get $4
    call $~lib/map/Map<u32,i32>#rehash
   end
   i32.const 1
@@ -5756,6 +5831,8 @@
       else       
        local.get $4
       end
+      i32.const 0
+      i32.ne
       if
        local.get $3
        return
@@ -5775,10 +5852,13 @@
   i32.const 0
  )
  (func $~lib/map/Map<i64,i32>#has (; 74 ;) (type $iIi) (param $0 i32) (param $1 i64) (result i32)
+  (local $2 i64)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<i64>|inlined.0 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    call $~lib/internal/hash/hash64
    br $~lib/internal/hash/HASH<i64>|inlined.0
   end
@@ -5928,24 +6008,27 @@
   i32.store offset=16
  )
  (func $~lib/map/Map<i64,i32>#set (; 76 ;) (type $iIiv) (param $0 i32) (param $1 i64) (param $2 i32)
-  (local $3 i32)
+  (local $3 i64)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   block $~lib/internal/hash/HASH<i64>|inlined.1 (result i32)
    local.get $1
+   local.set $3
+   local.get $3
    call $~lib/internal/hash/hash64
    br $~lib/internal/hash/HASH<i64>|inlined.1
   end
-  local.set $3
+  local.set $4
   local.get $0
   local.get $1
-  local.get $3
-  call $~lib/map/Map<i64,i32>#find
-  local.set $4
   local.get $4
+  call $~lib/map/Map<i64,i32>#find
+  local.set $5
+  local.get $5
   if
-   local.get $4
+   local.get $5
    local.get $2
    i32.store offset=8
   else   
@@ -5980,30 +6063,30 @@
    end
    local.get $0
    i32.load offset=8
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
    block (result i32)
     local.get $0
     local.get $0
     i32.load offset=16
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     i32.store offset=16
-    local.get $6
+    local.get $7
    end
    block $~lib/map/ENTRY_SIZE<i64,i32>|inlined.5 (result i32)
     i32.const 16
    end
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    local.get $1
    i64.store
-   local.get $4
+   local.get $5
    local.get $2
    i32.store offset=8
    local.get $0
@@ -6014,37 +6097,40 @@
    i32.store offset=20
    local.get $0
    i32.load
-   local.get $3
+   local.get $4
    local.get $0
    i32.load offset=4
    i32.and
    global.get $~lib/map/BUCKET_SIZE
    i32.mul
    i32.add
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $7
+   local.get $5
+   local.get $7
    i32.load offset=8
    i32.store offset=12
-   local.get $6
-   local.get $4
+   local.get $7
+   local.get $5
    i32.store offset=8
   end
  )
  (func $~lib/map/Map<i64,i32>#get (; 77 ;) (type $iIi) (param $0 i32) (param $1 i64) (result i32)
-  (local $2 i32)
+  (local $2 i64)
+  (local $3 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<i64>|inlined.3 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    call $~lib/internal/hash/hash64
    br $~lib/internal/hash/HASH<i64>|inlined.3
   end
   call $~lib/map/Map<i64,i32>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   if (result i32)
-   local.get $2
+   local.get $3
    i32.load offset=8
   else   
    unreachable
@@ -6055,27 +6141,30 @@
   i32.load offset=20
  )
  (func $~lib/map/Map<i64,i32>#delete (; 79 ;) (type $iIi) (param $0 i32) (param $1 i64) (result i32)
-  (local $2 i32)
+  (local $2 i64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<i64>|inlined.4 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    call $~lib/internal/hash/hash64
    br $~lib/internal/hash/HASH<i64>|inlined.4
   end
   call $~lib/map/Map<i64,i32>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   i32.eqz
   if
    i32.const 0
    return
   end
-  local.get $2
-  local.get $2
+  local.get $3
+  local.get $3
   i32.load offset=12
   global.get $~lib/map/EMPTY
   i32.or
@@ -6090,21 +6179,21 @@
   i32.load offset=4
   i32.const 1
   i32.shr_u
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   i32.const 1
   i32.add
   global.get $~lib/map/INITIAL_CAPACITY
-  local.tee $4
+  local.tee $5
   local.get $0
   i32.load offset=20
-  local.tee $5
-  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_u
   select
   i32.ge_u
-  local.tee $4
+  local.tee $5
   if (result i32)
    local.get $0
    i32.load offset=20
@@ -6116,11 +6205,11 @@
    i32.trunc_f64_s
    i32.lt_s
   else   
-   local.get $4
+   local.get $5
   end
   if
    local.get $0
-   local.get $3
+   local.get $4
    call $~lib/map/Map<i64,i32>#rehash
   end
   i32.const 1
@@ -6581,6 +6670,8 @@
       else       
        local.get $4
       end
+      i32.const 0
+      i32.ne
       if
        local.get $3
        return
@@ -6600,10 +6691,13 @@
   i32.const 0
  )
  (func $~lib/map/Map<u64,i32>#has (; 84 ;) (type $iIi) (param $0 i32) (param $1 i64) (result i32)
+  (local $2 i64)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<u64>|inlined.0 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    call $~lib/internal/hash/hash64
    br $~lib/internal/hash/HASH<u64>|inlined.0
   end
@@ -6753,24 +6847,27 @@
   i32.store offset=16
  )
  (func $~lib/map/Map<u64,i32>#set (; 86 ;) (type $iIiv) (param $0 i32) (param $1 i64) (param $2 i32)
-  (local $3 i32)
+  (local $3 i64)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   block $~lib/internal/hash/HASH<u64>|inlined.1 (result i32)
    local.get $1
+   local.set $3
+   local.get $3
    call $~lib/internal/hash/hash64
    br $~lib/internal/hash/HASH<u64>|inlined.1
   end
-  local.set $3
+  local.set $4
   local.get $0
   local.get $1
-  local.get $3
-  call $~lib/map/Map<u64,i32>#find
-  local.set $4
   local.get $4
+  call $~lib/map/Map<u64,i32>#find
+  local.set $5
+  local.get $5
   if
-   local.get $4
+   local.get $5
    local.get $2
    i32.store offset=8
   else   
@@ -6805,30 +6902,30 @@
    end
    local.get $0
    i32.load offset=8
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
    block (result i32)
     local.get $0
     local.get $0
     i32.load offset=16
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     i32.store offset=16
-    local.get $6
+    local.get $7
    end
    block $~lib/map/ENTRY_SIZE<u64,i32>|inlined.5 (result i32)
     i32.const 16
    end
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    local.get $1
    i64.store
-   local.get $4
+   local.get $5
    local.get $2
    i32.store offset=8
    local.get $0
@@ -6839,37 +6936,40 @@
    i32.store offset=20
    local.get $0
    i32.load
-   local.get $3
+   local.get $4
    local.get $0
    i32.load offset=4
    i32.and
    global.get $~lib/map/BUCKET_SIZE
    i32.mul
    i32.add
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $7
+   local.get $5
+   local.get $7
    i32.load offset=8
    i32.store offset=12
-   local.get $6
-   local.get $4
+   local.get $7
+   local.get $5
    i32.store offset=8
   end
  )
  (func $~lib/map/Map<u64,i32>#get (; 87 ;) (type $iIi) (param $0 i32) (param $1 i64) (result i32)
-  (local $2 i32)
+  (local $2 i64)
+  (local $3 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<u64>|inlined.3 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    call $~lib/internal/hash/hash64
    br $~lib/internal/hash/HASH<u64>|inlined.3
   end
   call $~lib/map/Map<u64,i32>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   if (result i32)
-   local.get $2
+   local.get $3
    i32.load offset=8
   else   
    unreachable
@@ -6880,27 +6980,30 @@
   i32.load offset=20
  )
  (func $~lib/map/Map<u64,i32>#delete (; 89 ;) (type $iIi) (param $0 i32) (param $1 i64) (result i32)
-  (local $2 i32)
+  (local $2 i64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<u64>|inlined.4 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    call $~lib/internal/hash/hash64
    br $~lib/internal/hash/HASH<u64>|inlined.4
   end
   call $~lib/map/Map<u64,i32>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   i32.eqz
   if
    i32.const 0
    return
   end
-  local.get $2
-  local.get $2
+  local.get $3
+  local.get $3
   i32.load offset=12
   global.get $~lib/map/EMPTY
   i32.or
@@ -6915,21 +7018,21 @@
   i32.load offset=4
   i32.const 1
   i32.shr_u
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   i32.const 1
   i32.add
   global.get $~lib/map/INITIAL_CAPACITY
-  local.tee $4
+  local.tee $5
   local.get $0
   i32.load offset=20
-  local.tee $5
-  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_u
   select
   i32.ge_u
-  local.tee $4
+  local.tee $5
   if (result i32)
    local.get $0
    i32.load offset=20
@@ -6941,11 +7044,11 @@
    i32.trunc_f64_s
    i32.lt_s
   else   
-   local.get $4
+   local.get $5
   end
   if
    local.get $0
-   local.get $3
+   local.get $4
    call $~lib/map/Map<u64,i32>#rehash
   end
   i32.const 1
@@ -7406,6 +7509,8 @@
       else       
        local.get $4
       end
+      i32.const 0
+      i32.ne
       if
        local.get $3
        return
@@ -7425,10 +7530,13 @@
   i32.const 0
  )
  (func $~lib/map/Map<f32,i32>#has (; 94 ;) (type $ifi) (param $0 i32) (param $1 f32) (result i32)
+  (local $2 f32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<f32>|inlined.0 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i32.reinterpret_f32
    call $~lib/internal/hash/hash32
    br $~lib/internal/hash/HASH<f32>|inlined.0
@@ -7580,25 +7688,28 @@
   i32.store offset=16
  )
  (func $~lib/map/Map<f32,i32>#set (; 96 ;) (type $ifiv) (param $0 i32) (param $1 f32) (param $2 i32)
-  (local $3 i32)
+  (local $3 f32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   block $~lib/internal/hash/HASH<f32>|inlined.1 (result i32)
    local.get $1
+   local.set $3
+   local.get $3
    i32.reinterpret_f32
    call $~lib/internal/hash/hash32
    br $~lib/internal/hash/HASH<f32>|inlined.1
   end
-  local.set $3
+  local.set $4
   local.get $0
   local.get $1
-  local.get $3
-  call $~lib/map/Map<f32,i32>#find
-  local.set $4
   local.get $4
+  call $~lib/map/Map<f32,i32>#find
+  local.set $5
+  local.get $5
   if
-   local.get $4
+   local.get $5
    local.get $2
    i32.store offset=4
   else   
@@ -7633,30 +7744,30 @@
    end
    local.get $0
    i32.load offset=8
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
    block (result i32)
     local.get $0
     local.get $0
     i32.load offset=16
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     i32.store offset=16
-    local.get $6
+    local.get $7
    end
    block $~lib/map/ENTRY_SIZE<f32,i32>|inlined.5 (result i32)
     i32.const 12
    end
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    local.get $1
    f32.store
-   local.get $4
+   local.get $5
    local.get $2
    i32.store offset=4
    local.get $0
@@ -7667,38 +7778,41 @@
    i32.store offset=20
    local.get $0
    i32.load
-   local.get $3
+   local.get $4
    local.get $0
    i32.load offset=4
    i32.and
    global.get $~lib/map/BUCKET_SIZE
    i32.mul
    i32.add
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $7
+   local.get $5
+   local.get $7
    i32.load offset=8
    i32.store offset=8
-   local.get $6
-   local.get $4
+   local.get $7
+   local.get $5
    i32.store offset=8
   end
  )
  (func $~lib/map/Map<f32,i32>#get (; 97 ;) (type $ifi) (param $0 i32) (param $1 f32) (result i32)
-  (local $2 i32)
+  (local $2 f32)
+  (local $3 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<f32>|inlined.3 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i32.reinterpret_f32
    call $~lib/internal/hash/hash32
    br $~lib/internal/hash/HASH<f32>|inlined.3
   end
   call $~lib/map/Map<f32,i32>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   if (result i32)
-   local.get $2
+   local.get $3
    i32.load offset=4
   else   
    unreachable
@@ -7709,28 +7823,31 @@
   i32.load offset=20
  )
  (func $~lib/map/Map<f32,i32>#delete (; 99 ;) (type $ifi) (param $0 i32) (param $1 f32) (result i32)
-  (local $2 i32)
+  (local $2 f32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<f32>|inlined.4 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i32.reinterpret_f32
    call $~lib/internal/hash/hash32
    br $~lib/internal/hash/HASH<f32>|inlined.4
   end
   call $~lib/map/Map<f32,i32>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   i32.eqz
   if
    i32.const 0
    return
   end
-  local.get $2
-  local.get $2
+  local.get $3
+  local.get $3
   i32.load offset=8
   global.get $~lib/map/EMPTY
   i32.or
@@ -7745,21 +7862,21 @@
   i32.load offset=4
   i32.const 1
   i32.shr_u
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   i32.const 1
   i32.add
   global.get $~lib/map/INITIAL_CAPACITY
-  local.tee $4
+  local.tee $5
   local.get $0
   i32.load offset=20
-  local.tee $5
-  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_u
   select
   i32.ge_u
-  local.tee $4
+  local.tee $5
   if (result i32)
    local.get $0
    i32.load offset=20
@@ -7771,11 +7888,11 @@
    i32.trunc_f64_s
    i32.lt_s
   else   
-   local.get $4
+   local.get $5
   end
   if
    local.get $0
-   local.get $3
+   local.get $4
    call $~lib/map/Map<f32,i32>#rehash
   end
   i32.const 1
@@ -8236,6 +8353,8 @@
       else       
        local.get $4
       end
+      i32.const 0
+      i32.ne
       if
        local.get $3
        return
@@ -8255,10 +8374,13 @@
   i32.const 0
  )
  (func $~lib/map/Map<f64,i32>#has (; 104 ;) (type $iFi) (param $0 i32) (param $1 f64) (result i32)
+  (local $2 f64)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<f64>|inlined.0 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i64.reinterpret_f64
    call $~lib/internal/hash/hash64
    br $~lib/internal/hash/HASH<f64>|inlined.0
@@ -8410,25 +8532,28 @@
   i32.store offset=16
  )
  (func $~lib/map/Map<f64,i32>#set (; 106 ;) (type $iFiv) (param $0 i32) (param $1 f64) (param $2 i32)
-  (local $3 i32)
+  (local $3 f64)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   block $~lib/internal/hash/HASH<f64>|inlined.1 (result i32)
    local.get $1
+   local.set $3
+   local.get $3
    i64.reinterpret_f64
    call $~lib/internal/hash/hash64
    br $~lib/internal/hash/HASH<f64>|inlined.1
   end
-  local.set $3
+  local.set $4
   local.get $0
   local.get $1
-  local.get $3
-  call $~lib/map/Map<f64,i32>#find
-  local.set $4
   local.get $4
+  call $~lib/map/Map<f64,i32>#find
+  local.set $5
+  local.get $5
   if
-   local.get $4
+   local.get $5
    local.get $2
    i32.store offset=8
   else   
@@ -8463,30 +8588,30 @@
    end
    local.get $0
    i32.load offset=8
-   local.set $5
-   local.get $5
+   local.set $6
+   local.get $6
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
    block (result i32)
     local.get $0
     local.get $0
     i32.load offset=16
-    local.tee $6
+    local.tee $7
     i32.const 1
     i32.add
     i32.store offset=16
-    local.get $6
+    local.get $7
    end
    block $~lib/map/ENTRY_SIZE<f64,i32>|inlined.5 (result i32)
     i32.const 16
    end
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    local.get $1
    f64.store
-   local.get $4
+   local.get $5
    local.get $2
    i32.store offset=8
    local.get $0
@@ -8497,38 +8622,41 @@
    i32.store offset=20
    local.get $0
    i32.load
-   local.get $3
+   local.get $4
    local.get $0
    i32.load offset=4
    i32.and
    global.get $~lib/map/BUCKET_SIZE
    i32.mul
    i32.add
-   local.set $6
-   local.get $4
-   local.get $6
+   local.set $7
+   local.get $5
+   local.get $7
    i32.load offset=8
    i32.store offset=12
-   local.get $6
-   local.get $4
+   local.get $7
+   local.get $5
    i32.store offset=8
   end
  )
  (func $~lib/map/Map<f64,i32>#get (; 107 ;) (type $iFi) (param $0 i32) (param $1 f64) (result i32)
-  (local $2 i32)
+  (local $2 f64)
+  (local $3 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<f64>|inlined.3 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i64.reinterpret_f64
    call $~lib/internal/hash/hash64
    br $~lib/internal/hash/HASH<f64>|inlined.3
   end
   call $~lib/map/Map<f64,i32>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   if (result i32)
-   local.get $2
+   local.get $3
    i32.load offset=8
   else   
    unreachable
@@ -8539,28 +8667,31 @@
   i32.load offset=20
  )
  (func $~lib/map/Map<f64,i32>#delete (; 109 ;) (type $iFi) (param $0 i32) (param $1 f64) (result i32)
-  (local $2 i32)
+  (local $2 f64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<f64>|inlined.4 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i64.reinterpret_f64
    call $~lib/internal/hash/hash64
    br $~lib/internal/hash/HASH<f64>|inlined.4
   end
   call $~lib/map/Map<f64,i32>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   i32.eqz
   if
    i32.const 0
    return
   end
-  local.get $2
-  local.get $2
+  local.get $3
+  local.get $3
   i32.load offset=12
   global.get $~lib/map/EMPTY
   i32.or
@@ -8575,21 +8706,21 @@
   i32.load offset=4
   i32.const 1
   i32.shr_u
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   i32.const 1
   i32.add
   global.get $~lib/map/INITIAL_CAPACITY
-  local.tee $4
+  local.tee $5
   local.get $0
   i32.load offset=20
-  local.tee $5
-  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_u
   select
   i32.ge_u
-  local.tee $4
+  local.tee $5
   if (result i32)
    local.get $0
    i32.load offset=20
@@ -8601,11 +8732,11 @@
    i32.trunc_f64_s
    i32.lt_s
   else   
-   local.get $4
+   local.get $5
   end
   if
    local.get $0
-   local.get $3
+   local.get $4
    call $~lib/map/Map<f64,i32>#rehash
   end
   i32.const 1

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -5795,8 +5795,8 @@
    local.get $0
    local.get $1
    f64.mul
-   local.tee $0
-   local.get $0
+   local.tee $1
+   local.get $1
    f64.div
    return
   end
@@ -6020,8 +6020,8 @@
    local.get $0
    local.get $1
    f32.mul
-   local.tee $0
-   local.get $0
+   local.tee $1
+   local.get $1
    f32.div
    return
   end
@@ -8175,11 +8175,14 @@
   call $std/math/check<f32>
  )
  (func $std/math/test_sign (; 127 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
-  (local $2 i32)
+  (local $2 f64)
+  (local $3 i32)
+  local.get $0
+  local.set $2
   f64.const 1
   f64.const -1
-  local.get $0
-  local.get $0
+  local.get $2
+  local.get $2
   f64.const 0
   f64.lt
   select
@@ -8190,16 +8193,16 @@
   local.get $1
   f64.const 0
   call $std/math/check<f64>
-  local.tee $2
+  local.tee $3
   if
    local.get $0
    call $~lib/bindings/Math/sign
    local.get $1
    f64.const 0
    call $std/math/check<f64>
-   local.set $2
+   local.set $3
   end
-  local.get $2
+  local.get $3
  )
  (func $std/math/test_signf (; 128 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
   f32.const 1

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -233,6 +233,7 @@
  )
  (func $std/math/ulperr (; 34 ;) (type $FFFF) (param $0 f64) (param $1 f64) (param $2 f64) (result f64)
   (local $3 i32)
+  (local $4 f64)
   local.get $0
   call $~lib/builtins/isNaN<f64>
   local.tee $3
@@ -252,12 +253,14 @@
   if
    block $~lib/math/NativeMath.signbit|inlined.2 (result i32)
     local.get $0
+    local.set $4
+    local.get $4
     i64.reinterpret_f64
     i64.const 63
     i64.shr_u
     i32.wrap_i64
-    local.get $0
-    local.get $0
+    local.get $4
+    local.get $4
     f64.eq
     i32.and
    end
@@ -265,12 +268,14 @@
    i32.ne
    block $~lib/math/NativeMath.signbit|inlined.3 (result i32)
     local.get $1
+    local.set $4
+    local.get $4
     i64.reinterpret_f64
     i64.const 63
     i64.shr_u
     i32.wrap_i64
-    local.get $1
-    local.get $1
+    local.get $4
+    local.get $4
     f64.eq
     i32.and
    end
@@ -469,6 +474,7 @@
  )
  (func $std/math/ulperrf (; 40 ;) (type $ffff) (param $0 f32) (param $1 f32) (param $2 f32) (result f32)
   (local $3 i32)
+  (local $4 f32)
   local.get $0
   call $~lib/builtins/isNaN<f32>
   local.tee $3
@@ -488,11 +494,13 @@
   if
    block $~lib/math/NativeMathf.signbit|inlined.2 (result i32)
     local.get $0
+    local.set $4
+    local.get $4
     i32.reinterpret_f32
     i32.const 31
     i32.shr_u
-    local.get $0
-    local.get $0
+    local.get $4
+    local.get $4
     f32.eq
     i32.and
    end
@@ -500,11 +508,13 @@
    i32.ne
    block $~lib/math/NativeMathf.signbit|inlined.3 (result i32)
     local.get $1
+    local.set $4
+    local.get $4
     i32.reinterpret_f32
     i32.const 31
     i32.shr_u
-    local.get $1
-    local.get $1
+    local.get $4
+    local.get $4
     f32.eq
     i32.and
    end
@@ -592,22 +602,25 @@
   call $std/math/check<f32>
  )
  (func $std/math/test_abs (; 44 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  (local $4 i32)
+  (local $4 f64)
+  (local $5 i32)
   block $~lib/math/NativeMath.abs|inlined.0 (result f64)
    local.get $0
+   local.set $4
+   local.get $4
    f64.abs
   end
   local.get $1
   local.get $2
   local.get $3
   call $std/math/check<f64>
-  local.tee $4
+  local.tee $5
   if (result i32)
    global.get $std/math/js
    i32.eqz
-   local.tee $4
+   local.tee $5
    if (result i32)
-    local.get $4
+    local.get $5
    else    
     local.get $0
     call $~lib/bindings/Math/abs
@@ -617,12 +630,15 @@
     call $std/math/check<f64>
    end
   else   
-   local.get $4
+   local.get $5
   end
  )
  (func $std/math/test_absf (; 45 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+  (local $4 f32)
   block $~lib/math/NativeMathf.abs|inlined.0 (result f32)
    local.get $0
+   local.set $4
+   local.get $4
    f32.abs
   end
   local.get $1
@@ -2099,6 +2115,8 @@
    else    
     local.get $3
    end
+   i32.const 0
+   i32.ne
    if
     local.get $0
     return
@@ -2271,6 +2289,8 @@
    else    
     local.get $3
    end
+   i32.const 0
+   i32.ne
    if
     local.get $0
     return
@@ -4244,22 +4264,25 @@
   call $std/math/check<f32>
  )
  (func $std/math/test_ceil (; 84 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  (local $4 i32)
+  (local $4 f64)
+  (local $5 i32)
   block $~lib/math/NativeMath.ceil|inlined.0 (result f64)
    local.get $0
+   local.set $4
+   local.get $4
    f64.ceil
   end
   local.get $1
   local.get $2
   local.get $3
   call $std/math/check<f64>
-  local.tee $4
+  local.tee $5
   if (result i32)
    global.get $std/math/js
    i32.eqz
-   local.tee $4
+   local.tee $5
    if (result i32)
-    local.get $4
+    local.get $5
    else    
     local.get $0
     call $~lib/bindings/Math/ceil
@@ -4269,12 +4292,15 @@
     call $std/math/check<f64>
    end
   else   
-   local.get $4
+   local.get $5
   end
  )
  (func $std/math/test_ceilf (; 85 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+  (local $4 f32)
   block $~lib/math/NativeMathf.ceil|inlined.0 (result f32)
    local.get $0
+   local.set $4
+   local.get $4
    f32.ceil
   end
   local.get $1
@@ -4766,6 +4792,7 @@
   (local $2 i32)
   (local $3 f64)
   (local $4 f64)
+  (local $5 f64)
   local.get $0
   i64.reinterpret_f64
   local.set $1
@@ -4829,6 +4856,8 @@
    return
   end
   block $~lib/math/expo2|inlined.0 (result f64)
+   local.get $0
+   local.set $4
    i32.const 1023
    i32.const 2043
    i32.const 2
@@ -4840,14 +4869,14 @@
    i64.const 32
    i64.shl
    f64.reinterpret_i64
-   local.set $4
-   local.get $0
+   local.set $5
+   local.get $4
    f64.const 1416.0996898839683
    f64.sub
    call $~lib/math/NativeMath.exp
-   local.get $4
+   local.get $5
    f64.mul
-   local.get $4
+   local.get $5
    f64.mul
   end
   local.set $3
@@ -5322,6 +5351,7 @@
  (func $~lib/math/NativeMathf.cosh (; 92 ;) (type $ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
+  (local $3 f32)
   local.get $0
   i32.reinterpret_f32
   local.set $1
@@ -5380,6 +5410,8 @@
    return
   end
   block $~lib/math/expo2f|inlined.0 (result f32)
+   local.get $0
+   local.set $2
    i32.const 127
    i32.const 235
    i32.const 1
@@ -5388,14 +5420,14 @@
    i32.const 23
    i32.shl
    f32.reinterpret_i32
-   local.set $2
-   local.get $0
+   local.set $3
+   local.get $2
    f32.const 162.88958740234375
    f32.sub
    call $~lib/math/NativeMathf.exp
-   local.get $2
+   local.get $3
    f32.mul
-   local.get $2
+   local.get $3
    f32.mul
   end
  )
@@ -5478,22 +5510,25 @@
   call $std/math/check<f32>
  )
  (func $std/math/test_floor (; 98 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  (local $4 i32)
+  (local $4 f64)
+  (local $5 i32)
   block $~lib/math/NativeMath.floor|inlined.0 (result f64)
    local.get $0
+   local.set $4
+   local.get $4
    f64.floor
   end
   local.get $1
   local.get $2
   local.get $3
   call $std/math/check<f64>
-  local.tee $4
+  local.tee $5
   if (result i32)
    global.get $std/math/js
    i32.eqz
-   local.tee $4
+   local.tee $5
    if (result i32)
-    local.get $4
+    local.get $5
    else    
     local.get $0
     call $~lib/bindings/Math/floor
@@ -5503,12 +5538,15 @@
     call $std/math/check<f64>
    end
   else   
-   local.get $4
+   local.get $5
   end
  )
  (func $std/math/test_floorf (; 99 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+  (local $4 f32)
   block $~lib/math/NativeMathf.floor|inlined.0 (result f32)
    local.get $0
+   local.set $4
+   local.get $4
    f32.floor
   end
   local.get $1
@@ -6947,23 +6985,29 @@
   call $std/math/check<f32>
  )
  (func $std/math/test_max (; 116 ;) (type $FFFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
-  (local $5 i32)
+  (local $5 f64)
+  (local $6 f64)
+  (local $7 i32)
   block $~lib/math/NativeMath.max|inlined.0 (result f64)
    local.get $0
+   local.set $5
    local.get $1
+   local.set $6
+   local.get $5
+   local.get $6
    f64.max
   end
   local.get $2
   local.get $3
   local.get $4
   call $std/math/check<f64>
-  local.tee $5
+  local.tee $7
   if (result i32)
    global.get $std/math/js
    i32.eqz
-   local.tee $5
+   local.tee $7
    if (result i32)
-    local.get $5
+    local.get $7
    else    
     local.get $0
     local.get $1
@@ -6974,13 +7018,19 @@
     call $std/math/check<f64>
    end
   else   
-   local.get $5
+   local.get $7
   end
  )
  (func $std/math/test_maxf (; 117 ;) (type $ffffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+  (local $5 f32)
+  (local $6 f32)
   block $~lib/math/NativeMathf.max|inlined.0 (result f32)
    local.get $0
+   local.set $5
    local.get $1
+   local.set $6
+   local.get $5
+   local.get $6
    f32.max
   end
   local.get $2
@@ -6989,23 +7039,29 @@
   call $std/math/check<f32>
  )
  (func $std/math/test_min (; 118 ;) (type $FFFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
-  (local $5 i32)
+  (local $5 f64)
+  (local $6 f64)
+  (local $7 i32)
   block $~lib/math/NativeMath.min|inlined.0 (result f64)
    local.get $0
+   local.set $5
    local.get $1
+   local.set $6
+   local.get $5
+   local.get $6
    f64.min
   end
   local.get $2
   local.get $3
   local.get $4
   call $std/math/check<f64>
-  local.tee $5
+  local.tee $7
   if (result i32)
    global.get $std/math/js
    i32.eqz
-   local.tee $5
+   local.tee $7
    if (result i32)
-    local.get $5
+    local.get $7
    else    
     local.get $0
     local.get $1
@@ -7016,13 +7072,19 @@
     call $std/math/check<f64>
    end
   else   
-   local.get $5
+   local.get $7
   end
  )
  (func $std/math/test_minf (; 119 ;) (type $ffffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+  (local $5 f32)
+  (local $6 f32)
   block $~lib/math/NativeMathf.min|inlined.0 (result f32)
    local.get $0
+   local.set $5
    local.get $1
+   local.set $6
+   local.get $5
+   local.get $6
    f32.min
   end
   local.get $2
@@ -7083,7 +7145,9 @@
    local.get $8
   else   
    local.get $1
-   local.get $1
+   local.set $9
+   local.get $9
+   local.get $9
    f64.ne
   end
   i32.const 0
@@ -7368,7 +7432,9 @@
    local.get $8
   else   
    local.get $1
-   local.get $1
+   local.set $9
+   local.get $9
+   local.get $9
    f32.ne
   end
   i32.const 0
@@ -7873,6 +7939,8 @@
     i32.eq
    end
    local.tee $14
+   i32.const 0
+   i32.ne
    if (result i32)
     local.get $14
    else    
@@ -7880,6 +7948,8 @@
     i32.const 1072693248
     i32.eq
    end
+   i32.const 0
+   i32.ne
    if
     local.get $15
     local.set $16
@@ -9848,12 +9918,15 @@
   f32.sub
  )
  (func $std/math/test_round (; 133 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+  (local $4 f64)
   block $~lib/math/NativeMath.round|inlined.0 (result f64)
    local.get $0
+   local.set $4
+   local.get $4
    f64.const 0.5
    f64.add
    f64.floor
-   local.get $0
+   local.get $4
    f64.copysign
   end
   local.get $1
@@ -9862,12 +9935,15 @@
   call $std/math/check<f64>
  )
  (func $std/math/test_roundf (; 134 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+  (local $4 f32)
   block $~lib/math/NativeMathf.round|inlined.0 (result f32)
    local.get $0
+   local.set $4
+   local.get $4
    f32.const 0.5
    f32.add
    f32.floor
-   local.get $0
+   local.get $4
    f32.copysign
   end
   local.get $1
@@ -9876,21 +9952,24 @@
   call $std/math/check<f32>
  )
  (func $std/math/test_sign (; 135 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  (local $4 i32)
+  (local $4 f64)
+  (local $5 i32)
   block $~lib/math/NativeMath.sign|inlined.0 (result f64)
    local.get $0
+   local.set $4
+   local.get $4
    f64.const 0
    f64.gt
    if (result f64)
     f64.const 1
    else    
-    local.get $0
+    local.get $4
     f64.const 0
     f64.lt
     if (result f64)
      f64.const -1
     else     
-     local.get $0
+     local.get $4
     end
    end
    br $~lib/math/NativeMath.sign|inlined.0
@@ -9899,13 +9978,13 @@
   local.get $2
   local.get $3
   call $std/math/check<f64>
-  local.tee $4
+  local.tee $5
   if (result i32)
    global.get $std/math/js
    i32.eqz
-   local.tee $4
+   local.tee $5
    if (result i32)
-    local.get $4
+    local.get $5
    else    
     local.get $0
     call $~lib/bindings/Math/sign
@@ -9915,24 +9994,27 @@
     call $std/math/check<f64>
    end
   else   
-   local.get $4
+   local.get $5
   end
  )
  (func $std/math/test_signf (; 136 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+  (local $4 f32)
   block $~lib/math/NativeMathf.sign|inlined.0 (result f32)
    local.get $0
+   local.set $4
+   local.get $4
    f32.const 0
    f32.gt
    if (result f32)
     f32.const 1
    else    
-    local.get $0
+    local.get $4
     f32.const 0
     f32.lt
     if (result f32)
      f32.const -1
     else     
-     local.get $0
+     local.get $4
     end
    end
    br $~lib/math/NativeMathf.sign|inlined.0
@@ -10610,6 +10692,7 @@
   (local $4 f64)
   (local $5 f64)
   (local $6 f64)
+  (local $7 f64)
   local.get $0
   i64.reinterpret_f64
   i64.const 9223372036854775807
@@ -10679,6 +10762,8 @@
   local.get $5
   f64.mul
   block $~lib/math/expo2|inlined.1 (result f64)
+   local.get $2
+   local.set $6
    i32.const 1023
    i32.const 2043
    i32.const 2
@@ -10690,14 +10775,14 @@
    i64.const 32
    i64.shl
    f64.reinterpret_i64
-   local.set $6
-   local.get $2
+   local.set $7
+   local.get $6
    f64.const 1416.0996898839683
    f64.sub
    call $~lib/math/NativeMath.exp
-   local.get $6
+   local.get $7
    f64.mul
-   local.get $6
+   local.get $7
    f64.mul
   end
   f64.mul
@@ -10737,6 +10822,7 @@
   (local $3 f32)
   (local $4 f32)
   (local $5 f32)
+  (local $6 f32)
   local.get $0
   i32.reinterpret_f32
   i32.const 2147483647
@@ -10801,6 +10887,8 @@
   local.get $4
   f32.mul
   block $~lib/math/expo2f|inlined.1 (result f32)
+   local.get $2
+   local.set $5
    i32.const 127
    i32.const 235
    i32.const 1
@@ -10809,14 +10897,14 @@
    i32.const 23
    i32.shl
    f32.reinterpret_i32
-   local.set $5
-   local.get $2
+   local.set $6
+   local.get $5
    f32.const 162.88958740234375
    f32.sub
    call $~lib/math/NativeMathf.exp
-   local.get $5
+   local.get $6
    f32.mul
-   local.get $5
+   local.get $6
    f32.mul
   end
   f32.mul
@@ -10832,22 +10920,25 @@
   call $std/math/check<f32>
  )
  (func $std/math/test_sqrt (; 145 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  (local $4 i32)
+  (local $4 f64)
+  (local $5 i32)
   block $~lib/math/NativeMath.sqrt|inlined.0 (result f64)
    local.get $0
+   local.set $4
+   local.get $4
    f64.sqrt
   end
   local.get $1
   local.get $2
   local.get $3
   call $std/math/check<f64>
-  local.tee $4
+  local.tee $5
   if (result i32)
    global.get $std/math/js
    i32.eqz
-   local.tee $4
+   local.tee $5
    if (result i32)
-    local.get $4
+    local.get $5
    else    
     local.get $0
     call $~lib/bindings/Math/sqrt
@@ -10857,12 +10948,15 @@
     call $std/math/check<f64>
    end
   else   
-   local.get $4
+   local.get $5
   end
  )
  (func $std/math/test_sqrtf (; 146 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+  (local $4 f32)
   block $~lib/math/NativeMathf.sqrt|inlined.0 (result f32)
    local.get $0
+   local.set $4
+   local.get $4
    f32.sqrt
   end
   local.get $1
@@ -11084,22 +11178,25 @@
   call $std/math/check<f32>
  )
  (func $std/math/test_trunc (; 151 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
-  (local $4 i32)
+  (local $4 f64)
+  (local $5 i32)
   block $~lib/math/NativeMath.trunc|inlined.0 (result f64)
    local.get $0
+   local.set $4
+   local.get $4
    f64.trunc
   end
   local.get $1
   local.get $2
   local.get $3
   call $std/math/check<f64>
-  local.tee $4
+  local.tee $5
   if (result i32)
    global.get $std/math/js
    i32.eqz
-   local.tee $4
+   local.tee $5
    if (result i32)
-    local.get $4
+    local.get $5
    else    
     local.get $0
     call $~lib/bindings/Math/trunc
@@ -11109,12 +11206,15 @@
     call $std/math/check<f64>
    end
   else   
-   local.get $4
+   local.get $5
   end
  )
  (func $std/math/test_truncf (; 152 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+  (local $4 f32)
   block $~lib/math/NativeMathf.trunc|inlined.0 (result f32)
    local.get $0
+   local.set $4
+   local.get $4
    f32.trunc
   end
   local.get $1
@@ -34849,6 +34949,8 @@
      else      
       local.get $2
      end
+     i32.const 0
+     i32.ne
      i32.eqz
      if
       i32.const 0
@@ -34868,7 +34970,7 @@
    end
    unreachable
   end
-  block
+  block $~lib/math/NativeMathf.seedRandom|inlined.0
    call $~lib/bindings/Math/random
    i64.reinterpret_f64
    local.set $3

--- a/tests/compiler/std/mod.optimized.wat
+++ b/tests/compiler/std/mod.optimized.wat
@@ -73,8 +73,8 @@
    local.get $0
    local.get $1
    f64.mul
-   local.tee $0
-   local.get $0
+   local.tee $1
+   local.get $1
    f64.div
    return
   end
@@ -324,8 +324,8 @@
    local.get $0
    local.get $1
    f32.mul
-   local.tee $0
-   local.get $0
+   local.tee $1
+   local.get $1
    f32.div
    return
   end

--- a/tests/compiler/std/mod.untouched.wat
+++ b/tests/compiler/std/mod.untouched.wat
@@ -76,7 +76,9 @@
    local.get $8
   else   
    local.get $1
-   local.get $1
+   local.set $9
+   local.get $9
+   local.get $9
    f64.ne
   end
   i32.const 0
@@ -388,7 +390,9 @@
    local.get $8
   else   
    local.get $1
-   local.get $1
+   local.set $9
+   local.get $9
+   local.get $9
    f32.ne
   end
   i32.const 0

--- a/tests/compiler/std/operator-overloading.untouched.wat
+++ b/tests/compiler/std/operator-overloading.untouched.wat
@@ -645,6 +645,8 @@
     i32.eq
    end
    local.tee $14
+   i32.const 0
+   i32.ne
    if (result i32)
     local.get $14
    else    
@@ -652,6 +654,8 @@
     i32.const 1072693248
     i32.eq
    end
+   i32.const 0
+   i32.ne
    if
     local.get $15
     local.set $16

--- a/tests/compiler/std/pointer.optimized.wat
+++ b/tests/compiler/std/pointer.optimized.wat
@@ -1477,14 +1477,12 @@
    unreachable
   end
   global.get $std/pointer/buf
-  local.tee $0
   i32.const 8
   i32.add
+  local.tee $0
   f32.const 1.2999999523162842
   f32.store
   local.get $0
-  i32.const 8
-  i32.add
   f32.load
   f32.const 1.2999999523162842
   f32.ne

--- a/tests/compiler/std/pointer.untouched.wat
+++ b/tests/compiler/std/pointer.untouched.wat
@@ -1,5 +1,4 @@
 (module
- (type $iii (func (param i32 i32) (result i32)))
  (type $iiiiv (func (param i32 i32 i32 i32)))
  (type $iiv (func (param i32 i32)))
  (type $iiiv (func (param i32 i32 i32)))
@@ -21,10 +20,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $std/pointer/Pointer<Entry>#constructor (; 1 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
-  local.get $1
- )
- (func $~lib/internal/memory/memset (; 2 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 1 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -278,7 +274,7 @@
    end
   end
  )
- (func $~lib/internal/memory/memcpy (; 3 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 2 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1479,7 +1475,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 4 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 3 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -1706,7 +1702,7 @@
    end
   end
  )
- (func $std/pointer/Pointer<Entry>#set:value (; 5 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $std/pointer/Pointer<Entry>#set:value (; 4 ;) (type $iiv) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1737,10 +1733,7 @@
    call $~lib/internal/memory/memmove
   end
  )
- (func $std/pointer/Pointer<f32>#constructor (; 6 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
-  local.get $1
- )
- (func $std/pointer/Pointer<f32>#set (; 7 ;) (type $iifv) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $std/pointer/Pointer<f32>#set (; 5 ;) (type $iifv) (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $0
   local.get $1
   i32.const 4
@@ -1749,12 +1742,12 @@
   local.get $2
   f32.store
  )
- (func $std/pointer/Pointer<f32>#set:value (; 8 ;) (type $ifv) (param $0 i32) (param $1 f32)
+ (func $std/pointer/Pointer<f32>#set:value (; 6 ;) (type $ifv) (param $0 i32) (param $1 f32)
   local.get $0
   local.get $1
   f32.store
  )
- (func $start (; 9 ;) (type $v)
+ (func $start (; 7 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 f32)
@@ -2357,6 +2350,6 @@
    unreachable
   end
  )
- (func $null (; 10 ;) (type $v)
+ (func $null (; 8 ;) (type $v)
  )
 )

--- a/tests/compiler/std/pointer.untouched.wat
+++ b/tests/compiler/std/pointer.untouched.wat
@@ -4,7 +4,6 @@
  (type $iiv (func (param i32 i32)))
  (type $iiiv (func (param i32 i32 i32)))
  (type $iifv (func (param i32 i32 f32)))
- (type $iif (func (param i32 i32) (result f32)))
  (type $ifv (func (param i32 f32)))
  (type $v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
@@ -1710,24 +1709,31 @@
  (func $std/pointer/Pointer<Entry>#set:value (; 5 ;) (type $iiv) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   local.get $1
   i32.const 0
   i32.eq
   if
-   i32.const 0
-   local.set $2
-   i32.const 8
-   local.set $3
    local.get $0
+   local.set $2
+   i32.const 0
+   local.set $3
+   i32.const 8
+   local.set $4
    local.get $2
    local.get $3
+   local.get $4
    call $~lib/internal/memory/memset
   else   
-   i32.const 8
-   local.set $3
    local.get $0
+   local.set $4
    local.get $1
+   local.set $3
+   i32.const 8
+   local.set $2
+   local.get $4
    local.get $3
+   local.get $2
    call $~lib/internal/memory/memmove
   end
  )
@@ -1743,20 +1749,12 @@
   local.get $2
   f32.store
  )
- (func $std/pointer/Pointer<f32>#get (; 8 ;) (type $iif) (param $0 i32) (param $1 i32) (result f32)
-  local.get $0
-  local.get $1
-  i32.const 4
-  i32.mul
-  i32.add
-  f32.load
- )
- (func $std/pointer/Pointer<f32>#set:value (; 9 ;) (type $ifv) (param $0 i32) (param $1 f32)
+ (func $std/pointer/Pointer<f32>#set:value (; 8 ;) (type $ifv) (param $0 i32) (param $1 f32)
   local.get $0
   local.get $1
   f32.store
  )
- (func $start (; 10 ;) (type $v)
+ (func $start (; 9 ;) (type $v)
   (local $0 i32)
   (local $1 i32)
   (local $2 f32)
@@ -2132,9 +2130,18 @@
   i32.const 1
   f32.const 1.2000000476837158
   call $std/pointer/Pointer<f32>#set
-  global.get $std/pointer/buf
-  i32.const 0
-  call $std/pointer/Pointer<f32>#get
+  block $std/pointer/Pointer<f32>#get|inlined.0 (result f32)
+   global.get $std/pointer/buf
+   local.set $1
+   i32.const 0
+   local.set $0
+   local.get $1
+   local.get $0
+   i32.const 4
+   i32.mul
+   i32.add
+   f32.load
+  end
   f32.const 1.100000023841858
   f32.eq
   i32.eqz
@@ -2146,9 +2153,18 @@
    call $~lib/env/abort
    unreachable
   end
-  global.get $std/pointer/buf
-  i32.const 1
-  call $std/pointer/Pointer<f32>#get
+  block $std/pointer/Pointer<f32>#get|inlined.1 (result f32)
+   global.get $std/pointer/buf
+   local.set $0
+   i32.const 1
+   local.set $1
+   local.get $0
+   local.get $1
+   i32.const 4
+   i32.mul
+   i32.add
+   f32.load
+  end
   f32.const 1.2000000476837158
   f32.eq
   i32.eqz
@@ -2160,7 +2176,7 @@
    call $~lib/env/abort
    unreachable
   end
-  block $std/pointer/Pointer<f32>#get|inlined.0 (result f32)
+  block $std/pointer/Pointer<f32>#get|inlined.2 (result f32)
    global.get $std/pointer/buf
    local.set $1
    i32.const 0
@@ -2183,7 +2199,7 @@
    call $~lib/env/abort
    unreachable
   end
-  block $std/pointer/Pointer<f32>#get|inlined.1 (result f32)
+  block $std/pointer/Pointer<f32>#get|inlined.3 (result f32)
    global.get $std/pointer/buf
    local.set $0
    i32.const 1
@@ -2232,7 +2248,7 @@
    call $~lib/env/abort
    unreachable
   end
-  block
+  block $std/pointer/Pointer<f32>#set|inlined.0
    global.get $std/pointer/buf
    local.set $1
    i32.const 2
@@ -2247,9 +2263,18 @@
    local.get $2
    f32.store
   end
-  global.get $std/pointer/buf
-  i32.const 2
-  call $std/pointer/Pointer<f32>#get
+  block $std/pointer/Pointer<f32>#get|inlined.4 (result f32)
+   global.get $std/pointer/buf
+   local.set $0
+   i32.const 2
+   local.set $1
+   local.get $0
+   local.get $1
+   i32.const 4
+   i32.mul
+   i32.add
+   f32.load
+  end
   f32.const 1.2999999523162842
   f32.eq
   i32.eqz
@@ -2261,13 +2286,13 @@
    call $~lib/env/abort
    unreachable
   end
-  block $std/pointer/Pointer<f32>#get|inlined.2 (result f32)
+  block $std/pointer/Pointer<f32>#get|inlined.5 (result f32)
    global.get $std/pointer/buf
-   local.set $0
-   i32.const 2
    local.set $1
-   local.get $0
+   i32.const 2
+   local.set $0
    local.get $1
+   local.get $0
    i32.const 4
    i32.mul
    i32.add
@@ -2302,8 +2327,8 @@
   call $std/pointer/Pointer<f32>#set:value
   block $std/pointer/Pointer<f32>#get:value|inlined.0 (result f32)
    global.get $std/pointer/buf
-   local.set $1
-   local.get $1
+   local.set $0
+   local.get $0
    f32.load
    br $std/pointer/Pointer<f32>#get:value|inlined.0
   end
@@ -2332,6 +2357,6 @@
    unreachable
   end
  )
- (func $null (; 11 ;) (type $v)
+ (func $null (; 10 ;) (type $v)
  )
 )

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -428,6 +428,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   global.get $~lib/internal/arraybuffer/MAX_BLENGTH
   i32.gt_u
@@ -453,9 +454,11 @@
    local.set $4
    i32.const 0
    local.set $5
+   local.get $1
+   local.set $6
    local.get $4
    local.get $5
-   local.get $1
+   local.get $6
    call $~lib/internal/memory/memset
   end
   local.get $3
@@ -573,6 +576,8 @@
       else       
        local.get $4
       end
+      i32.const 0
+      i32.ne
       if
        local.get $3
        return
@@ -844,6 +849,8 @@
   local.get $1
   block $~lib/internal/hash/HASH<i8>|inlined.1 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i32.const 24
    i32.shl
    i32.const 24
@@ -852,15 +859,15 @@
    br $~lib/internal/hash/HASH<i8>|inlined.1
   end
   call $~lib/set/Set<i8>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   i32.eqz
   if
    i32.const 0
    return
   end
-  local.get $2
-  local.get $2
+  local.get $3
+  local.get $3
   i32.load offset=4
   global.get $~lib/set/EMPTY
   i32.or
@@ -875,21 +882,21 @@
   i32.load offset=4
   i32.const 1
   i32.shr_u
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   i32.const 1
   i32.add
   global.get $~lib/set/INITIAL_CAPACITY
-  local.tee $4
+  local.tee $2
   local.get $0
   i32.load offset=20
   local.tee $5
-  local.get $4
+  local.get $2
   local.get $5
   i32.gt_u
   select
   i32.ge_u
-  local.tee $4
+  local.tee $2
   if (result i32)
    local.get $0
    i32.load offset=20
@@ -901,11 +908,11 @@
    i32.trunc_f64_s
    i32.lt_s
   else   
-   local.get $4
+   local.get $2
   end
   if
    local.get $0
-   local.get $3
+   local.get $4
    call $~lib/set/Set<i8>#rehash
   end
   i32.const 1
@@ -1295,6 +1302,8 @@
       else       
        local.get $4
       end
+      i32.const 0
+      i32.ne
       if
        local.get $3
        return
@@ -1566,21 +1575,23 @@
   local.get $1
   block $~lib/internal/hash/HASH<u8>|inlined.1 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i32.const 255
    i32.and
    call $~lib/internal/hash/hash8
    br $~lib/internal/hash/HASH<u8>|inlined.1
   end
   call $~lib/set/Set<u8>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   i32.eqz
   if
    i32.const 0
    return
   end
-  local.get $2
-  local.get $2
+  local.get $3
+  local.get $3
   i32.load offset=4
   global.get $~lib/set/EMPTY
   i32.or
@@ -1595,21 +1606,21 @@
   i32.load offset=4
   i32.const 1
   i32.shr_u
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   i32.const 1
   i32.add
   global.get $~lib/set/INITIAL_CAPACITY
-  local.tee $4
+  local.tee $2
   local.get $0
   i32.load offset=20
   local.tee $5
-  local.get $4
+  local.get $2
   local.get $5
   i32.gt_u
   select
   i32.ge_u
-  local.tee $4
+  local.tee $2
   if (result i32)
    local.get $0
    i32.load offset=20
@@ -1621,11 +1632,11 @@
    i32.trunc_f64_s
    i32.lt_s
   else   
-   local.get $4
+   local.get $2
   end
   if
    local.get $0
-   local.get $3
+   local.get $4
    call $~lib/set/Set<u8>#rehash
   end
   i32.const 1
@@ -2041,6 +2052,8 @@
       else       
        local.get $4
       end
+      i32.const 0
+      i32.ne
       if
        local.get $3
        return
@@ -2312,6 +2325,8 @@
   local.get $1
   block $~lib/internal/hash/HASH<i16>|inlined.1 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i32.const 16
    i32.shl
    i32.const 16
@@ -2320,15 +2335,15 @@
    br $~lib/internal/hash/HASH<i16>|inlined.1
   end
   call $~lib/set/Set<i16>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   i32.eqz
   if
    i32.const 0
    return
   end
-  local.get $2
-  local.get $2
+  local.get $3
+  local.get $3
   i32.load offset=4
   global.get $~lib/set/EMPTY
   i32.or
@@ -2343,21 +2358,21 @@
   i32.load offset=4
   i32.const 1
   i32.shr_u
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   i32.const 1
   i32.add
   global.get $~lib/set/INITIAL_CAPACITY
-  local.tee $4
+  local.tee $2
   local.get $0
   i32.load offset=20
   local.tee $5
-  local.get $4
+  local.get $2
   local.get $5
   i32.gt_u
   select
   i32.ge_u
-  local.tee $4
+  local.tee $2
   if (result i32)
    local.get $0
    i32.load offset=20
@@ -2369,11 +2384,11 @@
    i32.trunc_f64_s
    i32.lt_s
   else   
-   local.get $4
+   local.get $2
   end
   if
    local.get $0
-   local.get $3
+   local.get $4
    call $~lib/set/Set<i16>#rehash
   end
   i32.const 1
@@ -2763,6 +2778,8 @@
       else       
        local.get $4
       end
+      i32.const 0
+      i32.ne
       if
        local.get $3
        return
@@ -3034,21 +3051,23 @@
   local.get $1
   block $~lib/internal/hash/HASH<u16>|inlined.1 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i32.const 65535
    i32.and
    call $~lib/internal/hash/hash16
    br $~lib/internal/hash/HASH<u16>|inlined.1
   end
   call $~lib/set/Set<u16>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   i32.eqz
   if
    i32.const 0
    return
   end
-  local.get $2
-  local.get $2
+  local.get $3
+  local.get $3
   i32.load offset=4
   global.get $~lib/set/EMPTY
   i32.or
@@ -3063,21 +3082,21 @@
   i32.load offset=4
   i32.const 1
   i32.shr_u
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   i32.const 1
   i32.add
   global.get $~lib/set/INITIAL_CAPACITY
-  local.tee $4
+  local.tee $2
   local.get $0
   i32.load offset=20
   local.tee $5
-  local.get $4
+  local.get $2
   local.get $5
   i32.gt_u
   select
   i32.ge_u
-  local.tee $4
+  local.tee $2
   if (result i32)
    local.get $0
    i32.load offset=20
@@ -3089,11 +3108,11 @@
    i32.trunc_f64_s
    i32.lt_s
   else   
-   local.get $4
+   local.get $2
   end
   if
    local.get $0
-   local.get $3
+   local.get $4
    call $~lib/set/Set<u16>#rehash
   end
   i32.const 1
@@ -3521,6 +3540,8 @@
       else       
        local.get $4
       end
+      i32.const 0
+      i32.ne
       if
        local.get $3
        return
@@ -3792,19 +3813,21 @@
   local.get $1
   block $~lib/internal/hash/HASH<i32>|inlined.1 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    call $~lib/internal/hash/hash32
    br $~lib/internal/hash/HASH<i32>|inlined.1
   end
   call $~lib/set/Set<i32>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   i32.eqz
   if
    i32.const 0
    return
   end
-  local.get $2
-  local.get $2
+  local.get $3
+  local.get $3
   i32.load offset=4
   global.get $~lib/set/EMPTY
   i32.or
@@ -3819,21 +3842,21 @@
   i32.load offset=4
   i32.const 1
   i32.shr_u
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   i32.const 1
   i32.add
   global.get $~lib/set/INITIAL_CAPACITY
-  local.tee $4
+  local.tee $2
   local.get $0
   i32.load offset=20
   local.tee $5
-  local.get $4
+  local.get $2
   local.get $5
   i32.gt_u
   select
   i32.ge_u
-  local.tee $4
+  local.tee $2
   if (result i32)
    local.get $0
    i32.load offset=20
@@ -3845,11 +3868,11 @@
    i32.trunc_f64_s
    i32.lt_s
   else   
-   local.get $4
+   local.get $2
   end
   if
    local.get $0
-   local.get $3
+   local.get $4
    call $~lib/set/Set<i32>#rehash
   end
   i32.const 1
@@ -4235,6 +4258,8 @@
       else       
        local.get $4
       end
+      i32.const 0
+      i32.ne
       if
        local.get $3
        return
@@ -4506,19 +4531,21 @@
   local.get $1
   block $~lib/internal/hash/HASH<u32>|inlined.1 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    call $~lib/internal/hash/hash32
    br $~lib/internal/hash/HASH<u32>|inlined.1
   end
   call $~lib/set/Set<u32>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   i32.eqz
   if
    i32.const 0
    return
   end
-  local.get $2
-  local.get $2
+  local.get $3
+  local.get $3
   i32.load offset=4
   global.get $~lib/set/EMPTY
   i32.or
@@ -4533,21 +4560,21 @@
   i32.load offset=4
   i32.const 1
   i32.shr_u
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   i32.const 1
   i32.add
   global.get $~lib/set/INITIAL_CAPACITY
-  local.tee $4
+  local.tee $2
   local.get $0
   i32.load offset=20
   local.tee $5
-  local.get $4
+  local.get $2
   local.get $5
   i32.gt_u
   select
   i32.ge_u
-  local.tee $4
+  local.tee $2
   if (result i32)
    local.get $0
    i32.load offset=20
@@ -4559,11 +4586,11 @@
    i32.trunc_f64_s
    i32.lt_s
   else   
-   local.get $4
+   local.get $2
   end
   if
    local.get $0
-   local.get $3
+   local.get $4
    call $~lib/set/Set<u32>#rehash
   end
   i32.const 1
@@ -5037,6 +5064,8 @@
       else       
        local.get $4
       end
+      i32.const 0
+      i32.ne
       if
        local.get $3
        return
@@ -5301,27 +5330,30 @@
   i32.load offset=20
  )
  (func $~lib/set/Set<i64>#delete (; 79 ;) (type $iIi) (param $0 i32) (param $1 i64) (result i32)
-  (local $2 i32)
+  (local $2 i64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<i64>|inlined.1 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    call $~lib/internal/hash/hash64
    br $~lib/internal/hash/HASH<i64>|inlined.1
   end
   call $~lib/set/Set<i64>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   i32.eqz
   if
    i32.const 0
    return
   end
-  local.get $2
-  local.get $2
+  local.get $3
+  local.get $3
   i32.load offset=8
   global.get $~lib/set/EMPTY
   i32.or
@@ -5336,21 +5368,21 @@
   i32.load offset=4
   i32.const 1
   i32.shr_u
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   i32.const 1
   i32.add
   global.get $~lib/set/INITIAL_CAPACITY
-  local.tee $4
+  local.tee $5
   local.get $0
   i32.load offset=20
-  local.tee $5
-  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_u
   select
   i32.ge_u
-  local.tee $4
+  local.tee $5
   if (result i32)
    local.get $0
    i32.load offset=20
@@ -5362,11 +5394,11 @@
    i32.trunc_f64_s
    i32.lt_s
   else   
-   local.get $4
+   local.get $5
   end
   if
    local.get $0
-   local.get $3
+   local.get $4
    call $~lib/set/Set<i64>#rehash
   end
   i32.const 1
@@ -5752,6 +5784,8 @@
       else       
        local.get $4
       end
+      i32.const 0
+      i32.ne
       if
        local.get $3
        return
@@ -6016,27 +6050,30 @@
   i32.load offset=20
  )
  (func $~lib/set/Set<u64>#delete (; 89 ;) (type $iIi) (param $0 i32) (param $1 i64) (result i32)
-  (local $2 i32)
+  (local $2 i64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<u64>|inlined.1 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    call $~lib/internal/hash/hash64
    br $~lib/internal/hash/HASH<u64>|inlined.1
   end
   call $~lib/set/Set<u64>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   i32.eqz
   if
    i32.const 0
    return
   end
-  local.get $2
-  local.get $2
+  local.get $3
+  local.get $3
   i32.load offset=8
   global.get $~lib/set/EMPTY
   i32.or
@@ -6051,21 +6088,21 @@
   i32.load offset=4
   i32.const 1
   i32.shr_u
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   i32.const 1
   i32.add
   global.get $~lib/set/INITIAL_CAPACITY
-  local.tee $4
+  local.tee $5
   local.get $0
   i32.load offset=20
-  local.tee $5
-  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_u
   select
   i32.ge_u
-  local.tee $4
+  local.tee $5
   if (result i32)
    local.get $0
    i32.load offset=20
@@ -6077,11 +6114,11 @@
    i32.trunc_f64_s
    i32.lt_s
   else   
-   local.get $4
+   local.get $5
   end
   if
    local.get $0
-   local.get $3
+   local.get $4
    call $~lib/set/Set<u64>#rehash
   end
   i32.const 1
@@ -6468,6 +6505,8 @@
       else       
        local.get $4
       end
+      i32.const 0
+      i32.ne
       if
        local.get $3
        return
@@ -6733,28 +6772,31 @@
   i32.load offset=20
  )
  (func $~lib/set/Set<f32>#delete (; 99 ;) (type $ifi) (param $0 i32) (param $1 f32) (result i32)
-  (local $2 i32)
+  (local $2 f32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<f32>|inlined.1 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i32.reinterpret_f32
    call $~lib/internal/hash/hash32
    br $~lib/internal/hash/HASH<f32>|inlined.1
   end
   call $~lib/set/Set<f32>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   i32.eqz
   if
    i32.const 0
    return
   end
-  local.get $2
-  local.get $2
+  local.get $3
+  local.get $3
   i32.load offset=4
   global.get $~lib/set/EMPTY
   i32.or
@@ -6769,21 +6811,21 @@
   i32.load offset=4
   i32.const 1
   i32.shr_u
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   i32.const 1
   i32.add
   global.get $~lib/set/INITIAL_CAPACITY
-  local.tee $4
+  local.tee $5
   local.get $0
   i32.load offset=20
-  local.tee $5
-  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_u
   select
   i32.ge_u
-  local.tee $4
+  local.tee $5
   if (result i32)
    local.get $0
    i32.load offset=20
@@ -6795,11 +6837,11 @@
    i32.trunc_f64_s
    i32.lt_s
   else   
-   local.get $4
+   local.get $5
   end
   if
    local.get $0
-   local.get $3
+   local.get $4
    call $~lib/set/Set<f32>#rehash
   end
   i32.const 1
@@ -7186,6 +7228,8 @@
       else       
        local.get $4
       end
+      i32.const 0
+      i32.ne
       if
        local.get $3
        return
@@ -7451,28 +7495,31 @@
   i32.load offset=20
  )
  (func $~lib/set/Set<f64>#delete (; 109 ;) (type $iFi) (param $0 i32) (param $1 f64) (result i32)
-  (local $2 i32)
+  (local $2 f64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<f64>|inlined.1 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i64.reinterpret_f64
    call $~lib/internal/hash/hash64
    br $~lib/internal/hash/HASH<f64>|inlined.1
   end
   call $~lib/set/Set<f64>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   i32.eqz
   if
    i32.const 0
    return
   end
-  local.get $2
-  local.get $2
+  local.get $3
+  local.get $3
   i32.load offset=8
   global.get $~lib/set/EMPTY
   i32.or
@@ -7487,21 +7534,21 @@
   i32.load offset=4
   i32.const 1
   i32.shr_u
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   i32.const 1
   i32.add
   global.get $~lib/set/INITIAL_CAPACITY
-  local.tee $4
+  local.tee $5
   local.get $0
   i32.load offset=20
-  local.tee $5
-  local.get $4
+  local.tee $6
   local.get $5
+  local.get $6
   i32.gt_u
   select
   i32.ge_u
-  local.tee $4
+  local.tee $5
   if (result i32)
    local.get $0
    i32.load offset=20
@@ -7513,11 +7560,11 @@
    i32.trunc_f64_s
    i32.lt_s
   else   
-   local.get $4
+   local.get $5
   end
   if
    local.get $0
-   local.get $3
+   local.get $4
    call $~lib/set/Set<f64>#rehash
   end
   i32.const 1

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -45,6 +45,8 @@
  (func $~lib/array/Array<i32>#__get (; 1 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.load
   local.set $2
@@ -55,14 +57,18 @@
   i32.shr_u
   i32.lt_u
   if (result i32)
-   i32.const 0
-   local.set $3
    local.get $2
+   local.set $3
    local.get $1
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 2
    i32.shl
    i32.add
-   local.get $3
+   local.get $5
    i32.add
    i32.load offset=8
   else   
@@ -1879,6 +1885,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.load
   local.set $2
@@ -1912,46 +1919,50 @@
     local.get $1
     call $~lib/internal/arraybuffer/allocateUnsafe
     local.set $3
-    local.get $3
-    global.get $~lib/internal/arraybuffer/HEADER_SIZE
-    i32.add
-    local.set $4
-    local.get $0
-    global.get $~lib/internal/arraybuffer/HEADER_SIZE
-    i32.add
-    local.set $5
-    local.get $4
-    local.get $5
-    local.get $2
-    call $~lib/internal/memory/memmove
+    block $~lib/memory/memory.copy|inlined.0
+     local.get $3
+     global.get $~lib/internal/arraybuffer/HEADER_SIZE
+     i32.add
+     local.set $4
+     local.get $0
+     global.get $~lib/internal/arraybuffer/HEADER_SIZE
+     i32.add
+     local.set $5
+     local.get $2
+     local.set $6
+     local.get $4
+     local.get $5
+     local.get $6
+     call $~lib/internal/memory/memmove
+    end
     block $~lib/memory/memory.free|inlined.0
-     block
-      local.get $0
-      call $~lib/allocator/arena/__memory_free
-      br $~lib/memory/memory.free|inlined.0
-      unreachable
-     end
-     unreachable
+     local.get $0
+     local.set $6
+     local.get $6
+     call $~lib/allocator/arena/__memory_free
+     br $~lib/memory/memory.free|inlined.0
     end
     local.get $3
     local.set $0
    end
-   local.get $0
-   global.get $~lib/internal/arraybuffer/HEADER_SIZE
-   i32.add
-   local.get $2
-   i32.add
-   local.set $3
-   i32.const 0
-   local.set $5
-   local.get $1
-   local.get $2
-   i32.sub
-   local.set $4
-   local.get $3
-   local.get $5
-   local.get $4
-   call $~lib/internal/memory/memset
+   block $~lib/memory/memory.fill|inlined.0
+    local.get $0
+    global.get $~lib/internal/arraybuffer/HEADER_SIZE
+    i32.add
+    local.get $2
+    i32.add
+    local.set $3
+    i32.const 0
+    local.set $6
+    local.get $1
+    local.get $2
+    i32.sub
+    local.set $5
+    local.get $3
+    local.get $6
+    local.get $5
+    call $~lib/internal/memory/memset
+   end
   else   
    local.get $1
    local.get $2
@@ -1980,6 +1991,9 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   local.get $0
   i32.load
   local.set $3
@@ -2020,21 +2034,31 @@
    i32.add
    i32.store offset=4
   end
-  i32.const 0
-  local.set $5
-  local.get $3
-  local.get $1
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $5
-  i32.add
-  local.get $2
-  i32.store offset=8
+  block $~lib/internal/arraybuffer/STORE<i32,i32>|inlined.0
+   local.get $3
+   local.set $5
+   local.get $1
+   local.set $6
+   local.get $2
+   local.set $7
+   i32.const 0
+   local.set $8
+   local.get $5
+   local.get $6
+   i32.const 2
+   i32.shl
+   i32.add
+   local.get $8
+   i32.add
+   local.get $7
+   i32.store offset=8
+  end
  )
  (func $~lib/array/Array<i64>#__get (; 11 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.load
   local.set $2
@@ -2045,14 +2069,18 @@
   i32.shr_u
   i32.lt_u
   if (result i64)
-   i32.const 0
-   local.set $3
    local.get $2
+   local.set $3
    local.get $1
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 3
    i32.shl
    i32.add
-   local.get $3
+   local.get $5
    i32.add
    i64.load offset=8
   else   
@@ -2063,6 +2091,9 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i64)
+  (local $8 i32)
   local.get $0
   i32.load
   local.set $3
@@ -2103,21 +2134,31 @@
    i32.add
    i32.store offset=4
   end
-  i32.const 0
-  local.set $5
-  local.get $3
-  local.get $1
-  i32.const 3
-  i32.shl
-  i32.add
-  local.get $5
-  i32.add
-  local.get $2
-  i64.store offset=8
+  block $~lib/internal/arraybuffer/STORE<i64,i64>|inlined.0
+   local.get $3
+   local.set $5
+   local.get $1
+   local.set $6
+   local.get $2
+   local.set $7
+   i32.const 0
+   local.set $8
+   local.get $5
+   local.get $6
+   i32.const 3
+   i32.shl
+   i32.add
+   local.get $8
+   i32.add
+   local.get $7
+   i64.store offset=8
+  end
  )
  (func $~lib/array/Array<f32>#__get (; 13 ;) (type $iif) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.load
   local.set $2
@@ -2128,14 +2169,18 @@
   i32.shr_u
   i32.lt_u
   if (result f32)
-   i32.const 0
-   local.set $3
    local.get $2
+   local.set $3
    local.get $1
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 2
    i32.shl
    i32.add
-   local.get $3
+   local.get $5
    i32.add
    f32.load offset=8
   else   
@@ -2146,6 +2191,9 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 f32)
+  (local $8 i32)
   local.get $0
   i32.load
   local.set $3
@@ -2186,21 +2234,31 @@
    i32.add
    i32.store offset=4
   end
-  i32.const 0
-  local.set $5
-  local.get $3
-  local.get $1
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $5
-  i32.add
-  local.get $2
-  f32.store offset=8
+  block $~lib/internal/arraybuffer/STORE<f32,f32>|inlined.0
+   local.get $3
+   local.set $5
+   local.get $1
+   local.set $6
+   local.get $2
+   local.set $7
+   i32.const 0
+   local.set $8
+   local.get $5
+   local.get $6
+   i32.const 2
+   i32.shl
+   i32.add
+   local.get $8
+   i32.add
+   local.get $7
+   f32.store offset=8
+  end
  )
  (func $~lib/array/Array<f64>#__get (; 15 ;) (type $iiF) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.load
   local.set $2
@@ -2211,14 +2269,18 @@
   i32.shr_u
   i32.lt_u
   if (result f64)
-   i32.const 0
-   local.set $3
    local.get $2
+   local.set $3
    local.get $1
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 3
    i32.shl
    i32.add
-   local.get $3
+   local.get $5
    i32.add
    f64.load offset=8
   else   
@@ -2229,6 +2291,9 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 f64)
+  (local $8 i32)
   local.get $0
   i32.load
   local.set $3
@@ -2269,17 +2334,25 @@
    i32.add
    i32.store offset=4
   end
-  i32.const 0
-  local.set $5
-  local.get $3
-  local.get $1
-  i32.const 3
-  i32.shl
-  i32.add
-  local.get $5
-  i32.add
-  local.get $2
-  f64.store offset=8
+  block $~lib/internal/arraybuffer/STORE<f64,f64>|inlined.0
+   local.get $3
+   local.set $5
+   local.get $1
+   local.set $6
+   local.get $2
+   local.set $7
+   i32.const 0
+   local.set $8
+   local.get $5
+   local.get $6
+   i32.const 3
+   i32.shl
+   i32.add
+   local.get $8
+   i32.add
+   local.get $7
+   f64.store offset=8
+  end
  )
  (func $start (; 17 ;) (type $v)
   (local $0 i32)

--- a/tests/compiler/std/string-utf8.untouched.wat
+++ b/tests/compiler/std/string-utf8.untouched.wat
@@ -103,6 +103,8 @@
          local.get $5
         end
         local.tee $5
+        i32.const 0
+        i32.ne
         if (result i32)
          local.get $0
          local.get $2
@@ -119,6 +121,8 @@
         else         
          local.get $5
         end
+        i32.const 0
+        i32.ne
         if
          local.get $1
          i32.const 4
@@ -332,6 +336,8 @@
         else         
          local.get $7
         end
+        i32.const 0
+        i32.ne
         if
          local.get $0
          local.get $3
@@ -1926,6 +1932,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   local.get $1
   i32.const 1
   i32.lt_u
@@ -1991,6 +1998,8 @@
        else        
         local.get $6
        end
+       i32.const 0
+       i32.ne
        if
         local.get $2
         i32.const 1
@@ -2045,6 +2054,8 @@
         else         
          local.get $6
         end
+        i32.const 0
+        i32.ne
         if
          local.get $2
          i32.const 3
@@ -2223,22 +2234,26 @@
   i32.shr_u
   call $~lib/internal/string/allocateUnsafe
   local.set $7
-  local.get $7
-  global.get $~lib/internal/string/HEADER_SIZE
-  i32.add
-  local.set $3
-  local.get $3
-  local.get $4
-  local.get $5
-  call $~lib/internal/memory/memmove
+  block $~lib/memory/memory.copy|inlined.0
+   local.get $7
+   global.get $~lib/internal/string/HEADER_SIZE
+   i32.add
+   local.set $3
+   local.get $4
+   local.set $6
+   local.get $5
+   local.set $8
+   local.get $3
+   local.get $6
+   local.get $8
+   call $~lib/internal/memory/memmove
+  end
   block $~lib/memory/memory.free|inlined.0
-   block
-    local.get $4
-    call $~lib/allocator/arena/__memory_free
-    br $~lib/memory/memory.free|inlined.0
-    unreachable
-   end
-   unreachable
+   local.get $4
+   local.set $8
+   local.get $8
+   call $~lib/allocator/arena/__memory_free
+   br $~lib/memory/memory.free|inlined.0
   end
   local.get $7
  )
@@ -2607,13 +2622,9 @@
   block $~lib/memory/memory.free|inlined.1
    global.get $std/string-utf8/ptr
    local.set $0
-   block
-    local.get $0
-    call $~lib/allocator/arena/__memory_free
-    br $~lib/memory/memory.free|inlined.1
-    unreachable
-   end
-   unreachable
+   local.get $0
+   call $~lib/allocator/arena/__memory_free
+   br $~lib/memory/memory.free|inlined.1
   end
  )
  (func $null (; 12 ;) (type $v)

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -4251,32 +4251,32 @@
   (local $7 i32)
   (local $8 i64)
   (local $9 i32)
-  (local $10 i64)
+  (local $10 i32)
   (local $11 i32)
-  (local $12 i32)
+  (local $12 i64)
   (local $13 i64)
   (local $14 i64)
   local.get $3
   local.get $1
   i64.sub
-  local.set $8
+  local.set $12
   i64.const 1
   i32.const 0
   local.get $4
   i32.sub
   local.tee $11
   i64.extend_i32_s
-  local.tee $13
+  local.tee $1
   i64.shl
-  local.tee $10
+  local.tee $13
   i64.const 1
   i64.sub
   local.tee $14
   local.get $3
   i64.and
-  local.set $1
+  local.set $8
   local.get $3
-  local.get $13
+  local.get $1
   i64.shr_u
   i32.wrap_i64
   local.tee $7
@@ -4284,7 +4284,7 @@
   local.set $9
   i32.const 4624
   i32.load
-  local.set $12
+  local.set $10
   loop $continue|0
    local.get $9
    i32.const 0
@@ -4440,9 +4440,9 @@
     local.get $11
     i64.extend_i32_s
     i64.shl
-    local.get $1
+    local.get $8
     i64.add
-    local.tee $3
+    local.tee $1
     local.get $5
     i64.le_u
     if
@@ -4450,7 +4450,9 @@
      local.get $9
      i32.add
      global.set $~lib/internal/number/_K
-     local.get $12
+     local.get $5
+     local.set $3
+     local.get $10
      local.get $9
      i32.const 2
      i32.shl
@@ -4459,7 +4461,9 @@
      local.get $11
      i64.extend_i32_s
      i64.shl
-     local.set $1
+     local.set $8
+     local.get $12
+     local.set $5
      local.get $6
      i32.const 1
      i32.sub
@@ -4469,37 +4473,37 @@
      i32.add
      local.tee $2
      i32.load16_u offset=4
-     local.set $7
+     local.set $10
      loop $continue|2
-      local.get $3
-      local.get $8
+      local.get $1
+      local.get $5
       i64.lt_u
       local.tee $0
       if
-       local.get $5
        local.get $3
-       i64.sub
        local.get $1
+       i64.sub
+       local.get $8
        i64.ge_u
        local.set $0
       end
       local.get $0
       if
        local.get $1
-       local.get $3
-       i64.add
        local.get $8
+       i64.add
+       local.get $5
        i64.lt_u
        local.tee $0
        i32.eqz
        if
-        local.get $8
-        local.get $3
+        local.get $5
+        local.get $1
         i64.sub
         local.get $1
-        local.get $3
-        i64.add
         local.get $8
+        i64.add
+        local.get $5
         i64.sub
         i64.gt_u
         local.set $0
@@ -4507,19 +4511,19 @@
       end
       local.get $0
       if
-       local.get $7
+       local.get $10
        i32.const 1
        i32.sub
-       local.set $7
+       local.set $10
        local.get $1
-       local.get $3
+       local.get $8
        i64.add
-       local.set $3
+       local.set $1
        br $continue|2
       end
      end
      local.get $2
-     local.get $7
+     local.get $10
      i32.store16 offset=4
      local.get $6
      return
@@ -4532,14 +4536,14 @@
    i64.const 10
    i64.mul
    local.set $5
-   local.get $1
+   local.get $8
    i64.const 10
    i64.mul
-   local.tee $1
+   local.tee $8
    local.get $11
    i64.extend_i32_s
    i64.shr_u
-   local.tee $3
+   local.tee $1
    local.get $6
    i64.extend_i32_s
    i64.or
@@ -4556,7 +4560,7 @@
     i32.shl
     local.get $0
     i32.add
-    local.get $3
+    local.get $1
     i32.wrap_i64
     i32.const 65535
     i32.and
@@ -4568,10 +4572,10 @@
    i32.const 1
    i32.sub
    local.set $9
-   local.get $1
+   local.get $8
    local.get $14
    i64.and
-   local.tee $1
+   local.tee $8
    local.get $5
    i64.ge_u
    br_if $continue|3
@@ -4579,7 +4583,9 @@
    local.get $9
    i32.add
    global.set $~lib/internal/number/_K
-   local.get $12
+   local.get $13
+   local.set $1
+   local.get $10
    i32.const 0
    local.get $9
    i32.sub
@@ -4587,49 +4593,50 @@
    i32.shl
    i32.add
    i64.load32_u offset=8
-   local.get $8
+   local.get $12
    i64.mul
-   local.set $8
+   local.set $3
    local.get $6
+   local.tee $10
    i32.const 1
    i32.sub
    i32.const 1
    i32.shl
    local.get $0
    i32.add
-   local.tee $7
+   local.tee $4
    i32.load16_u offset=4
-   local.set $4
+   local.set $6
    loop $continue|4
-    local.get $1
     local.get $8
+    local.get $3
     i64.lt_u
     local.tee $2
     if
      local.get $5
-     local.get $1
+     local.get $8
      i64.sub
-     local.get $10
+     local.get $1
      i64.ge_u
      local.set $2
     end
     local.get $2
     if
      local.get $1
-     local.get $10
-     i64.add
      local.get $8
+     i64.add
+     local.get $3
      i64.lt_u
      local.tee $2
      i32.eqz
      if
+      local.get $3
       local.get $8
-      local.get $1
       i64.sub
       local.get $1
-      local.get $10
-      i64.add
       local.get $8
+      i64.add
+      local.get $3
       i64.sub
       i64.gt_u
       local.set $2
@@ -4637,21 +4644,21 @@
     end
     local.get $2
     if
-     local.get $4
+     local.get $6
      i32.const 1
      i32.sub
-     local.set $4
+     local.set $6
      local.get $1
-     local.get $10
+     local.get $8
      i64.add
-     local.set $1
+     local.set $8
      br $continue|4
     end
    end
-   local.get $7
    local.get $4
-   i32.store16 offset=4
    local.get $6
+   i32.store16 offset=4
+   local.get $10
   end
  )
  (func $~lib/internal/number/prettify (; 51 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -4677,74 +4684,73 @@
   local.get $1
   local.get $2
   i32.add
-  local.tee $5
-  i32.le_s
   local.tee $3
+  i32.le_s
+  local.tee $4
   if
-   local.get $5
+   local.get $3
    i32.const 21
    i32.le_s
-   local.set $3
+   local.set $4
   end
-  local.get $3
+  local.get $4
   if (result i32)
    local.get $1
-   local.set $3
+   local.set $4
    loop $repeat|0
     block $break|0
+     local.get $4
      local.get $3
-     local.get $5
      i32.ge_s
      br_if $break|0
-     local.get $3
+     local.get $4
      i32.const 1
      i32.shl
      local.get $0
      i32.add
      i32.const 48
      i32.store16 offset=4
-     local.get $3
+     local.get $4
      i32.const 1
      i32.add
-     local.set $3
+     local.set $4
      br $repeat|0
     end
    end
-   local.get $5
+   local.get $3
    i32.const 1
    i32.shl
    local.get $0
    i32.add
    i32.const 3145774
    i32.store offset=4
-   local.get $5
+   local.get $3
    i32.const 2
    i32.add
   else   
-   local.get $5
+   local.get $3
    i32.const 0
    i32.gt_s
-   local.tee $3
+   local.tee $4
    if
-    local.get $5
+    local.get $3
     i32.const 21
     i32.le_s
-    local.set $3
+    local.set $4
    end
-   local.get $3
+   local.get $4
    if (result i32)
-    local.get $5
+    local.get $3
     i32.const 1
     i32.shl
     local.get $0
     i32.add
-    local.tee $3
     i32.const 4
     i32.add
-    local.tee $0
+    local.tee $4
     i32.const 2
     i32.add
-    local.get $0
+    local.get $4
     i32.const 0
     local.get $2
     i32.sub
@@ -4752,6 +4758,10 @@
     i32.shl
     call $~lib/internal/memory/memmove
     local.get $3
+    i32.const 1
+    i32.shl
+    local.get $0
+    i32.add
     i32.const 46
     i32.store16 offset=4
     local.get $1
@@ -4759,25 +4769,25 @@
     i32.add
    else    
     i32.const -6
-    local.get $5
+    local.get $3
     i32.lt_s
-    local.tee $3
+    local.tee $4
     if
-     local.get $5
+     local.get $3
      i32.const 0
      i32.le_s
-     local.set $3
+     local.set $4
     end
-    local.get $3
+    local.get $4
     if (result i32)
      local.get $0
      i32.const 4
      i32.add
      local.tee $2
      i32.const 2
-     local.get $5
+     local.get $3
      i32.sub
-     local.tee $3
+     local.tee $4
      i32.const 1
      i32.shl
      i32.add
@@ -4790,29 +4800,29 @@
      i32.const 3014704
      i32.store offset=4
      i32.const 2
-     local.set $4
+     local.set $3
      loop $repeat|1
       block $break|1
-       local.get $4
        local.get $3
+       local.get $4
        i32.ge_s
        br_if $break|1
-       local.get $4
+       local.get $3
        i32.const 1
        i32.shl
        local.get $0
        i32.add
        i32.const 48
        i32.store16 offset=4
-       local.get $4
+       local.get $3
        i32.const 1
        i32.add
-       local.set $4
+       local.set $3
        br $repeat|1
       end
      end
      local.get $1
-     local.get $3
+     local.get $4
      i32.add
     else     
      local.get $1
@@ -4825,52 +4835,52 @@
       local.get $0
       i32.const 4
       i32.add
-      local.tee $3
+      local.tee $4
       block (result i32)
-       local.get $5
+       local.get $3
        i32.const 1
        i32.sub
-       local.tee $4
+       local.tee $3
        i32.const 0
        i32.lt_s
        local.tee $2
        if
         i32.const 0
-        local.get $4
+        local.get $3
         i32.sub
-        local.set $4
+        local.set $3
        end
-       local.get $4
+       local.get $3
       end
-      local.get $4
+      local.get $3
       call $~lib/internal/number/decimalCount32
       i32.const 1
       i32.add
-      local.tee $4
+      local.tee $5
       call $~lib/internal/number/utoa32_lut
-      local.get $3
+      local.get $4
       i32.const 45
       i32.const 43
       local.get $2
       select
       i32.store16 offset=4
-      local.get $4
+      local.get $5
       i32.const 2
       i32.add
      else      
       local.get $0
       i32.const 4
       i32.add
-      local.tee $3
+      local.tee $4
       i32.const 4
       i32.add
-      local.get $3
+      local.get $4
       i32.const 2
       i32.add
       local.get $1
       i32.const 1
       i32.shl
-      local.tee $4
+      local.tee $5
       i32.const 2
       i32.sub
       call $~lib/internal/memory/memmove
@@ -4878,7 +4888,7 @@
       i32.const 46
       i32.store16 offset=6
       local.get $0
-      local.get $4
+      local.get $5
       i32.add
       local.tee $0
       i32.const 101
@@ -4886,30 +4896,30 @@
       local.get $0
       i32.const 4
       i32.add
-      local.tee $3
+      local.tee $4
       block (result i32)
-       local.get $5
+       local.get $3
        i32.const 1
        i32.sub
-       local.tee $4
+       local.tee $3
        i32.const 0
        i32.lt_s
        local.tee $2
        if
         i32.const 0
-        local.get $4
+        local.get $3
         i32.sub
-        local.set $4
+        local.set $3
        end
-       local.get $4
+       local.get $3
       end
-      local.get $4
+      local.get $3
       call $~lib/internal/number/decimalCount32
       i32.const 1
       i32.add
       local.tee $0
       call $~lib/internal/number/utoa32_lut
-      local.get $3
+      local.get $4
       i32.const 45
       i32.const 43
       local.get $2
@@ -4931,19 +4941,18 @@
   (local $4 i32)
   (local $5 i64)
   (local $6 i32)
-  (local $7 i64)
-  (local $8 i32)
+  (local $7 i32)
+  (local $8 i64)
   (local $9 i64)
   (local $10 i64)
   (local $11 i64)
-  (local $12 i64)
-  (local $13 i32)
+  (local $12 i32)
+  (local $13 i64)
   (local $14 i32)
-  (local $15 i64)
   local.get $1
   f64.const 0
   f64.lt
-  local.tee $13
+  local.tee $12
   if (result f64)
    local.get $0
    i32.const 45
@@ -4954,32 +4963,32 @@
    local.get $1
   end
   i64.reinterpret_f64
-  local.tee $2
+  local.tee $13
   i64.const 9218868437227405312
   i64.and
   i64.const 52
   i64.shr_u
   i32.wrap_i64
-  local.set $8
-  local.get $2
+  local.set $7
+  local.get $13
   i64.const 4503599627370495
   i64.and
-  local.get $8
+  local.get $7
   i32.const 0
   i32.ne
-  local.tee $6
+  local.tee $4
   i64.extend_i32_u
   i64.const 52
   i64.shl
   i64.add
   local.set $2
-  local.get $8
+  local.get $7
   i32.const 1
-  local.get $6
+  local.get $4
   select
   i32.const 1075
   i32.sub
-  local.tee $8
+  local.tee $7
   i32.const 1
   i32.sub
   local.set $6
@@ -5008,7 +5017,7 @@
   i64.shl
   i64.const 1
   i64.sub
-  local.get $8
+  local.get $7
   local.get $14
   i32.sub
   local.get $6
@@ -5075,27 +5084,27 @@
   local.tee $2
   i64.const 4294967295
   i64.and
-  local.tee $7
+  local.tee $8
   global.get $~lib/internal/number/_frc_pow
   local.tee $5
   i64.const 4294967295
   i64.and
   local.tee $9
   i64.mul
-  local.set $10
+  local.set $3
   local.get $5
   i64.const 32
   i64.shr_u
-  local.tee $11
-  local.get $7
+  local.tee $10
+  local.get $8
   i64.mul
   local.get $2
   i64.const 32
   i64.shr_u
-  local.tee $12
+  local.tee $2
   local.get $9
   i64.mul
-  local.get $10
+  local.get $3
   i64.const 32
   i64.shr_u
   i64.add
@@ -5107,43 +5116,43 @@
   i64.add
   i64.const 32
   i64.shr_u
-  local.get $11
-  local.get $12
+  local.get $2
+  local.get $10
   i64.mul
   local.get $3
   i64.const 32
   i64.shr_u
   i64.add
   i64.add
-  local.set $2
+  local.set $13
   local.get $5
   i64.const 4294967295
   i64.and
-  local.tee $11
+  local.tee $2
   global.get $~lib/internal/number/_frc_plus
   local.tee $3
   i64.const 4294967295
   i64.and
   local.tee $10
   i64.mul
-  local.set $7
+  local.set $11
   local.get $10
   local.get $5
+  i64.const 32
+  i64.shr_u
+  local.tee $8
+  i64.mul
+  local.get $2
+  local.get $3
   i64.const 32
   i64.shr_u
   local.tee $9
   i64.mul
   local.get $11
-  local.get $3
-  i64.const 32
-  i64.shr_u
-  local.tee $12
-  i64.mul
-  local.get $7
   i64.const 32
   i64.shr_u
   i64.add
-  local.tee $3
+  local.tee $2
   i64.const 4294967295
   i64.and
   i64.add
@@ -5151,97 +5160,95 @@
   i64.add
   i64.const 32
   i64.shr_u
+  local.get $8
   local.get $9
-  local.get $12
   i64.mul
-  local.get $3
+  local.get $2
   i64.const 32
   i64.shr_u
   i64.add
   i64.add
-  local.set $15
+  local.set $11
   global.get $~lib/internal/number/_frc_minus
-  local.tee $3
+  local.tee $2
   i64.const 4294967295
   i64.and
-  local.tee $7
+  local.tee $8
   local.get $5
   i64.const 4294967295
   i64.and
   local.tee $9
   i64.mul
-  local.set $10
-  local.get $5
-  i64.const 32
-  i64.shr_u
-  local.tee $11
-  local.get $7
-  i64.mul
-  local.get $3
-  i64.const 32
-  i64.shr_u
-  local.tee $12
-  local.get $9
-  i64.mul
-  local.get $10
-  i64.const 32
-  i64.shr_u
-  i64.add
-  local.tee $3
-  i64.const 4294967295
-  i64.and
-  i64.add
-  local.set $5
-  local.get $15
+  local.set $3
+  local.get $11
   i64.const 1
   i64.sub
-  local.tee $7
-  local.get $11
-  local.get $12
+  local.tee $11
+  local.get $5
+  i64.const 32
+  i64.shr_u
+  local.tee $10
+  local.get $8
+  i64.mul
+  local.get $2
+  i64.const 32
+  i64.shr_u
+  local.tee $2
+  local.get $9
   i64.mul
   local.get $3
   i64.const 32
   i64.shr_u
   i64.add
-  local.get $5
+  local.tee $3
+  i64.const 4294967295
+  i64.and
+  i64.add
   i64.const 2147483647
   i64.add
   i64.const 32
   i64.shr_u
+  local.get $2
+  local.get $10
+  i64.mul
+  local.get $3
+  i64.const 32
+  i64.shr_u
+  i64.add
   i64.add
   i64.const 1
   i64.add
   i64.sub
   local.set $3
-  local.get $13
+  local.get $12
   i32.const 1
   i32.shl
   local.get $0
   i32.add
   local.get $0
-  local.get $2
-  local.get $8
+  local.get $13
+  global.get $~lib/internal/number/_exp_pow
+  local.tee $14
+  local.get $7
   local.get $4
   i32.sub
-  global.get $~lib/internal/number/_exp_pow
-  local.tee $4
   i32.add
   i32.const -64
   i32.sub
-  local.get $7
-  local.get $4
+  local.get $11
   global.get $~lib/internal/number/_exp
+  local.get $14
   i32.add
   i32.const -64
   i32.sub
   local.get $3
-  local.get $13
+  local.get $12
   call $~lib/internal/number/genDigits
-  local.get $13
+  local.get $12
   i32.sub
   global.get $~lib/internal/number/_K
   call $~lib/internal/number/prettify
-  local.get $13
+  local.get $12
   i32.add
  )
  (func $~lib/string/String#substring (; 53 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -2239,6 +2239,8 @@
   (local $9 i64)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $2
   i32.load
   local.set $4
@@ -2479,14 +2481,18 @@
       i32.lt_s
       i32.eqz
       br_if $break|5
-      block
+      block $~lib/memory/memory.copy|inlined.0
        local.get $6
        local.get $8
        i32.add
        local.set $11
-       local.get $11
        local.get $5
+       local.set $12
        local.get $7
+       local.set $13
+       local.get $11
+       local.get $12
+       local.get $13
        call $~lib/internal/memory/memmove
       end
       local.get $8
@@ -2966,6 +2972,8 @@
    else    
     local.get $6
    end
+   i32.const 0
+   i32.ne
    if
     block $break|0
      block $case6|0
@@ -3109,6 +3117,8 @@
       else       
        local.get $6
       end
+      i32.const 0
+      i32.ne
       if
        local.get $4
        global.get $~lib/internal/string/CharCode._0
@@ -3126,6 +3136,8 @@
        else        
         local.get $6
        end
+       i32.const 0
+       i32.ne
        if
         local.get $4
         global.get $~lib/internal/string/CharCode.A
@@ -3145,6 +3157,8 @@
         else         
          local.get $6
         end
+        i32.const 0
+        i32.ne
         if
          local.get $4
          global.get $~lib/internal/string/CharCode.a
@@ -3312,6 +3326,8 @@
             global.get $~lib/internal/string/CharCode.e
             i32.eq
            end
+           i32.const 0
+           i32.ne
            if
             i32.const 0
             i32.eqz
@@ -4203,6 +4219,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.const 268435454
   i32.gt_u
@@ -4242,50 +4259,63 @@
   local.get $0
   local.get $1
   i32.store offset=4
-  local.get $3
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  i32.const 0
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $2
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.0
+   local.get $3
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/memory/memset
+  end
   local.get $0
  )
  (func $~lib/array/Array<String>#__unchecked_set (; 41 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.load
   local.set $3
-  i32.const 0
-  local.set $4
-  local.get $3
   local.get $1
+  local.set $4
+  local.get $2
+  local.set $5
+  i32.const 0
+  local.set $6
+  local.get $3
+  local.get $4
   i32.const 2
   i32.shl
   i32.add
-  local.get $4
+  local.get $6
   i32.add
-  local.get $2
+  local.get $5
   i32.store offset=8
  )
  (func $~lib/array/Array<String>#__unchecked_get (; 42 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   local.get $0
   i32.load
   local.set $2
-  i32.const 0
-  local.set $3
-  local.get $2
   local.get $1
+  local.set $3
+  i32.const 0
+  local.set $4
+  local.get $2
+  local.get $3
   i32.const 2
   i32.shl
   i32.add
-  local.get $3
+  local.get $4
   i32.add
   i32.load offset=8
  )
@@ -4297,6 +4327,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.load
   local.set $2
@@ -4330,46 +4361,50 @@
     local.get $1
     call $~lib/internal/arraybuffer/allocateUnsafe
     local.set $3
-    local.get $3
-    global.get $~lib/internal/arraybuffer/HEADER_SIZE
-    i32.add
-    local.set $4
-    local.get $0
-    global.get $~lib/internal/arraybuffer/HEADER_SIZE
-    i32.add
-    local.set $5
-    local.get $4
-    local.get $5
-    local.get $2
-    call $~lib/internal/memory/memmove
+    block $~lib/memory/memory.copy|inlined.2
+     local.get $3
+     global.get $~lib/internal/arraybuffer/HEADER_SIZE
+     i32.add
+     local.set $4
+     local.get $0
+     global.get $~lib/internal/arraybuffer/HEADER_SIZE
+     i32.add
+     local.set $5
+     local.get $2
+     local.set $6
+     local.get $4
+     local.get $5
+     local.get $6
+     call $~lib/internal/memory/memmove
+    end
     block $~lib/memory/memory.free|inlined.0
-     block
-      local.get $0
-      call $~lib/allocator/arena/__memory_free
-      br $~lib/memory/memory.free|inlined.0
-      unreachable
-     end
-     unreachable
+     local.get $0
+     local.set $6
+     local.get $6
+     call $~lib/allocator/arena/__memory_free
+     br $~lib/memory/memory.free|inlined.0
     end
     local.get $3
     local.set $0
    end
-   local.get $0
-   global.get $~lib/internal/arraybuffer/HEADER_SIZE
-   i32.add
-   local.get $2
-   i32.add
-   local.set $3
-   i32.const 0
-   local.set $5
-   local.get $1
-   local.get $2
-   i32.sub
-   local.set $4
-   local.get $3
-   local.get $5
-   local.get $4
-   call $~lib/internal/memory/memset
+   block $~lib/memory/memory.fill|inlined.1
+    local.get $0
+    global.get $~lib/internal/arraybuffer/HEADER_SIZE
+    i32.add
+    local.get $2
+    i32.add
+    local.set $3
+    i32.const 0
+    local.set $6
+    local.get $1
+    local.get $2
+    i32.sub
+    local.set $5
+    local.get $3
+    local.get $6
+    local.get $5
+    call $~lib/internal/memory/memset
+   end
   else   
    local.get $1
    local.get $2
@@ -4400,6 +4435,9 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
   local.get $0
   i32.load offset=4
   local.set $2
@@ -4443,17 +4481,25 @@
   local.get $0
   local.get $5
   i32.store offset=4
-  i32.const 0
-  local.set $6
-  local.get $3
-  local.get $2
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $6
-  i32.add
-  local.get $1
-  i32.store offset=8
+  block $~lib/internal/arraybuffer/STORE<String,String>|inlined.2
+   local.get $3
+   local.set $6
+   local.get $2
+   local.set $7
+   local.get $1
+   local.set $8
+   i32.const 0
+   local.set $9
+   local.get $6
+   local.get $7
+   i32.const 2
+   i32.shl
+   i32.add
+   local.get $9
+   i32.add
+   local.get $8
+   i32.store offset=8
+  end
   local.get $5
  )
  (func $~lib/string/String#split (; 46 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
@@ -4469,6 +4515,9 @@
   (local $12 i32)
   (local $13 i32)
   (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
   local.get $0
   i32.const 0
   i32.ne
@@ -4567,17 +4616,25 @@
       i32.add
       i32.load16_u offset=4
       i32.store16 offset=4
-      i32.const 0
-      local.set $9
-      local.get $6
-      local.get $7
-      i32.const 2
-      i32.shl
-      i32.add
-      local.get $9
-      i32.add
-      local.get $8
-      i32.store offset=8
+      block $~lib/internal/arraybuffer/STORE<String,String>|inlined.1
+       local.get $6
+       local.set $9
+       local.get $7
+       local.set $10
+       local.get $8
+       local.set $11
+       i32.const 0
+       local.set $12
+       local.get $9
+       local.get $10
+       i32.const 2
+       i32.shl
+       i32.add
+       local.get $12
+       i32.add
+       local.get $11
+       i32.store offset=8
+      end
      end
      local.get $7
      i32.const 1
@@ -4617,26 +4674,26 @@
   i32.const 0
   i32.const 0
   call $~lib/array/Array<String>#constructor
-  local.set $10
-  i32.const 0
-  local.set $11
-  i32.const 0
-  local.set $12
-  i32.const 0
   local.set $13
+  i32.const 0
+  local.set $14
+  i32.const 0
+  local.set $15
+  i32.const 0
+  local.set $16
   block $break|1
    loop $continue|1
     local.get $0
     local.get $1
-    local.get $12
+    local.get $15
     call $~lib/string/String#indexOf
-    local.tee $11
+    local.tee $14
     i32.const -1
     i32.ne
     if
      block
-      local.get $11
-      local.get $12
+      local.get $14
+      local.get $15
       i32.sub
       local.set $6
       local.get $6
@@ -4649,39 +4706,39 @@
        local.get $3
        i32.const 0
        local.get $0
-       local.get $12
+       local.get $15
        local.get $6
        call $~lib/internal/string/copyUnsafe
-       local.get $10
+       local.get $13
        local.get $3
        call $~lib/array/Array<String>#push
        drop
       else       
-       local.get $10
+       local.get $13
        i32.const 256
        call $~lib/array/Array<String>#push
        drop
       end
-      local.get $13
+      local.get $16
       i32.const 1
       i32.add
-      local.tee $13
+      local.tee $16
       local.get $2
       i32.eq
       if
-       local.get $10
+       local.get $13
        return
       end
-      local.get $11
+      local.get $14
       local.get $5
       i32.add
-      local.set $12
+      local.set $15
      end
      br $continue|1
     end
    end
   end
-  local.get $12
+  local.get $15
   i32.eqz
   if
    i32.const 0
@@ -4704,33 +4761,33 @@
    return
   end
   local.get $4
-  local.get $12
+  local.get $15
   i32.sub
-  local.set $14
-  local.get $14
+  local.set $17
+  local.get $17
   i32.const 0
   i32.gt_s
   if
-   local.get $14
+   local.get $17
    call $~lib/internal/string/allocateUnsafe
    local.set $6
    local.get $6
    i32.const 0
    local.get $0
-   local.get $12
-   local.get $14
+   local.get $15
+   local.get $17
    call $~lib/internal/string/copyUnsafe
-   local.get $10
+   local.get $13
    local.get $6
    call $~lib/array/Array<String>#push
    drop
   else   
-   local.get $10
+   local.get $13
    i32.const 256
    call $~lib/array/Array<String>#push
    drop
   end
-  local.get $10
+  local.get $13
  )
  (func $~lib/string/String#split|trampoline (; 47 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
@@ -4756,6 +4813,8 @@
  (func $~lib/array/Array<String>#__get (; 48 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.load
   local.set $2
@@ -4766,14 +4825,18 @@
   i32.shr_u
   i32.lt_u
   if (result i32)
-   i32.const 0
-   local.set $3
    local.get $2
+   local.set $3
    local.get $1
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 2
    i32.shl
    i32.add
-   local.get $3
+   local.get $5
    i32.add
    i32.load offset=8
   else   
@@ -4856,8 +4919,10 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 i64)
-  (local $10 i64)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i64)
+  (local $12 i64)
   block $~lib/internal/number/DIGITS|inlined.0 (result i32)
    i32.const 1816
   end
@@ -4889,23 +4954,31 @@
       i32.rem_u
       local.set $7
       block $~lib/internal/arraybuffer/LOAD<u32,u64>|inlined.0 (result i64)
-       i32.const 0
-       local.set $8
        local.get $3
+       local.set $8
        local.get $6
+       local.set $9
+       i32.const 0
+       local.set $10
+       local.get $8
+       local.get $9
        i32.const 2
        i32.shl
        i32.add
-       local.get $8
+       local.get $10
        i32.add
        i64.load32_u offset=8
       end
-      local.set $9
+      local.set $11
       block $~lib/internal/arraybuffer/LOAD<u32,u64>|inlined.1 (result i64)
+       local.get $3
+       local.set $10
+       local.get $7
+       local.set $9
        i32.const 0
        local.set $8
-       local.get $3
-       local.get $7
+       local.get $10
+       local.get $9
        i32.const 2
        i32.shl
        i32.add
@@ -4913,7 +4986,7 @@
        i32.add
        i64.load32_u offset=8
       end
-      local.set $10
+      local.set $12
       local.get $2
       i32.const 4
       i32.sub
@@ -4923,8 +4996,8 @@
       i32.const 1
       i32.shl
       i32.add
-      local.get $9
-      local.get $10
+      local.get $11
+      local.get $12
       i64.const 32
       i64.shl
       i64.or
@@ -4953,24 +5026,28 @@
    i32.sub
    local.set $2
    block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.0 (result i32)
-    i32.const 0
-    local.set $5
     local.get $3
+    local.set $5
     local.get $6
+    local.set $4
+    i32.const 0
+    local.set $8
+    local.get $5
+    local.get $4
     i32.const 2
     i32.shl
     i32.add
-    local.get $5
+    local.get $8
     i32.add
     i32.load offset=8
    end
-   local.set $5
+   local.set $8
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $5
+   local.get $8
    i32.store offset=4
   end
   local.get $1
@@ -4982,24 +5059,28 @@
    i32.sub
    local.set $2
    block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.1 (result i32)
-    i32.const 0
-    local.set $5
     local.get $3
+    local.set $8
     local.get $1
+    local.set $6
+    i32.const 0
+    local.set $7
+    local.get $8
+    local.get $6
     i32.const 2
     i32.shl
     i32.add
-    local.get $5
+    local.get $7
     i32.add
     i32.load offset=8
    end
-   local.set $5
+   local.set $7
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $5
+   local.get $7
    i32.store offset=4
   else   
    local.get $2
@@ -5009,13 +5090,13 @@
    global.get $~lib/internal/string/CharCode._0
    local.get $1
    i32.add
-   local.set $5
+   local.set $7
    local.get $0
    local.get $2
    i32.const 1
    i32.shl
    i32.add
-   local.get $5
+   local.get $7
    i32.store16 offset=4
   end
  )
@@ -5023,6 +5104,9 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.eqz
   if
@@ -5048,10 +5132,18 @@
   local.get $2
   call $~lib/internal/string/allocateUnsafe
   local.set $3
-  local.get $3
-  local.get $0
-  local.get $2
-  call $~lib/internal/number/utoa32_lut
+  block $~lib/internal/number/utoa32_core|inlined.0
+   local.get $3
+   local.set $4
+   local.get $0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/number/utoa32_lut
+  end
   local.get $1
   if
    local.get $3
@@ -5063,6 +5155,9 @@
  (func $~lib/internal/number/utoa32 (; 52 ;) (type $ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.eqz
   if
@@ -5075,10 +5170,18 @@
   local.get $1
   call $~lib/internal/string/allocateUnsafe
   local.set $2
-  local.get $2
-  local.get $0
-  local.get $1
-  call $~lib/internal/number/utoa32_lut
+  block $~lib/internal/number/utoa32_core|inlined.1
+   local.get $2
+   local.set $3
+   local.get $0
+   local.set $4
+   local.get $1
+   local.set $5
+   local.get $3
+   local.get $4
+   local.get $5
+   call $~lib/internal/number/utoa32_lut
+  end
   local.get $2
  )
  (func $~lib/internal/number/decimalCount64 (; 53 ;) (type $Ii) (param $0 i64) (result i32)
@@ -5161,8 +5264,10 @@
   (local $10 i32)
   (local $11 i32)
   (local $12 i32)
-  (local $13 i64)
-  (local $14 i64)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i64)
+  (local $16 i64)
   block $~lib/internal/number/DIGITS|inlined.1 (result i32)
    i32.const 2608
   end
@@ -5213,23 +5318,31 @@
       i32.rem_u
       local.set $11
       block $~lib/internal/arraybuffer/LOAD<u32,u64>|inlined.2 (result i64)
-       i32.const 0
-       local.set $12
        local.get $3
+       local.set $12
        local.get $10
+       local.set $13
+       i32.const 0
+       local.set $14
+       local.get $12
+       local.get $13
        i32.const 2
        i32.shl
        i32.add
-       local.get $12
+       local.get $14
        i32.add
        i64.load32_u offset=8
       end
-      local.set $13
+      local.set $15
       block $~lib/internal/arraybuffer/LOAD<u32,u64>|inlined.3 (result i64)
+       local.get $3
+       local.set $14
+       local.get $11
+       local.set $13
        i32.const 0
        local.set $12
-       local.get $3
-       local.get $11
+       local.get $14
+       local.get $13
        i32.const 2
        i32.shl
        i32.add
@@ -5237,7 +5350,7 @@
        i32.add
        i64.load32_u offset=8
       end
-      local.set $14
+      local.set $16
       local.get $2
       i32.const 4
       i32.sub
@@ -5247,30 +5360,38 @@
       i32.const 1
       i32.shl
       i32.add
-      local.get $13
-      local.get $14
+      local.get $15
+      local.get $16
       i64.const 32
       i64.shl
       i64.or
       i64.store offset=4
       block $~lib/internal/arraybuffer/LOAD<u32,u64>|inlined.4 (result i64)
-       i32.const 0
-       local.set $12
        local.get $3
+       local.set $12
        local.get $8
+       local.set $13
+       i32.const 0
+       local.set $14
+       local.get $12
+       local.get $13
        i32.const 2
        i32.shl
        i32.add
-       local.get $12
+       local.get $14
        i32.add
        i64.load32_u offset=8
       end
-      local.set $13
+      local.set $15
       block $~lib/internal/arraybuffer/LOAD<u32,u64>|inlined.5 (result i64)
+       local.get $3
+       local.set $14
+       local.get $9
+       local.set $13
        i32.const 0
        local.set $12
-       local.get $3
-       local.get $9
+       local.get $14
+       local.get $13
        i32.const 2
        i32.shl
        i32.add
@@ -5278,7 +5399,7 @@
        i32.add
        i64.load32_u offset=8
       end
-      local.set $14
+      local.set $16
       local.get $2
       i32.const 4
       i32.sub
@@ -5288,8 +5409,8 @@
       i32.const 1
       i32.shl
       i32.add
-      local.get $13
-      local.get $14
+      local.get $15
+      local.get $16
       i64.const 32
       i64.shl
       i64.or
@@ -5309,6 +5430,10 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i64)
   local.get $0
   i64.eqz
   if
@@ -5329,10 +5454,18 @@
    local.get $3
    call $~lib/internal/string/allocateUnsafe
    local.set $1
-   local.get $1
-   local.get $2
-   local.get $3
-   call $~lib/internal/number/utoa32_lut
+   block $~lib/internal/number/utoa32_core|inlined.2
+    local.get $1
+    local.set $4
+    local.get $2
+    local.set $5
+    local.get $3
+    local.set $6
+    local.get $4
+    local.get $5
+    local.get $6
+    call $~lib/internal/number/utoa32_lut
+   end
   else   
    local.get $0
    call $~lib/internal/number/decimalCount64
@@ -5340,10 +5473,18 @@
    local.get $3
    call $~lib/internal/string/allocateUnsafe
    local.set $1
-   local.get $1
-   local.get $0
-   local.get $3
-   call $~lib/internal/number/utoa64_lut
+   block $~lib/internal/number/utoa64_core|inlined.0
+    local.get $1
+    local.set $2
+    local.get $0
+    local.set $7
+    local.get $3
+    local.set $6
+    local.get $2
+    local.get $7
+    local.get $6
+    call $~lib/internal/number/utoa64_lut
+   end
   end
   local.get $1
  )
@@ -5352,6 +5493,10 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i64)
   local.get $0
   i64.eqz
   if
@@ -5385,10 +5530,18 @@
    local.get $4
    call $~lib/internal/string/allocateUnsafe
    local.set $2
-   local.get $2
-   local.get $3
-   local.get $4
-   call $~lib/internal/number/utoa32_lut
+   block $~lib/internal/number/utoa32_core|inlined.3
+    local.get $2
+    local.set $5
+    local.get $3
+    local.set $6
+    local.get $4
+    local.set $7
+    local.get $5
+    local.get $6
+    local.get $7
+    call $~lib/internal/number/utoa32_lut
+   end
   else   
    local.get $0
    call $~lib/internal/number/decimalCount64
@@ -5398,10 +5551,18 @@
    local.get $4
    call $~lib/internal/string/allocateUnsafe
    local.set $2
-   local.get $2
-   local.get $0
-   local.get $4
-   call $~lib/internal/number/utoa64_lut
+   block $~lib/internal/number/utoa64_core|inlined.1
+    local.get $2
+    local.set $3
+    local.get $0
+    local.set $8
+    local.get $4
+    local.set $7
+    local.get $3
+    local.get $8
+    local.get $7
+    call $~lib/internal/number/utoa64_lut
+   end
   end
   local.get $1
   if
@@ -5437,9 +5598,14 @@
   (local $17 i32)
   (local $18 i32)
   (local $19 i64)
-  (local $20 i64)
-  (local $21 i32)
-  (local $22 i32)
+  (local $20 i32)
+  (local $21 i64)
+  (local $22 i64)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i64)
+  (local $27 i64)
   i32.const 0
   local.get $4
   i32.sub
@@ -5729,90 +5895,110 @@
        local.get $14
        i32.add
        global.set $~lib/internal/number/_K
-       block $~lib/internal/arraybuffer/LOAD<u32,u64>|inlined.6 (result i64)
-        i32.const 0
+       block $~lib/internal/number/grisuRound|inlined.0
+        local.get $0
         local.set $18
-        local.get $16
-        local.get $14
-        i32.const 2
+        local.get $15
+        local.set $20
+        local.get $5
+        local.set $21
+        local.get $19
+        local.set $22
+        block $~lib/internal/arraybuffer/LOAD<u32,u64>|inlined.6 (result i64)
+         local.get $16
+         local.set $23
+         local.get $14
+         local.set $24
+         i32.const 0
+         local.set $25
+         local.get $23
+         local.get $24
+         i32.const 2
+         i32.shl
+         i32.add
+         local.get $25
+         i32.add
+         i64.load32_u offset=8
+        end
+        local.get $7
+        i64.extend_i32_s
+        i64.shl
+        local.set $26
+        local.get $10
+        local.set $27
+        local.get $18
+        local.get $20
+        i32.const 1
+        i32.sub
+        i32.const 1
         i32.shl
         i32.add
-        local.get $18
-        i32.add
-        i64.load32_u offset=8
-       end
-       local.get $7
-       i64.extend_i32_s
-       i64.shl
-       local.set $20
-       local.get $0
-       local.get $15
-       i32.const 1
-       i32.sub
-       i32.const 1
-       i32.shl
-       i32.add
-       local.set $18
-       local.get $18
-       i32.load16_u offset=4
-       local.set $21
-       block $break|2
-        loop $continue|2
-         local.get $19
-         local.get $10
-         i64.lt_u
-         local.tee $22
-         if (result i32)
-          local.get $5
-          local.get $19
-          i64.sub
-          local.get $20
-          i64.ge_u
-         else          
+        local.set $25
+        local.get $25
+        i32.load16_u offset=4
+        local.set $24
+        block $break|2
+         loop $continue|2
           local.get $22
-         end
-         local.tee $22
-         if (result i32)
-          local.get $19
-          local.get $20
-          i64.add
-          local.get $10
+          local.get $27
           i64.lt_u
-          local.tee $22
+          local.tee $23
+          if (result i32)
+           local.get $21
+           local.get $22
+           i64.sub
+           local.get $26
+           i64.ge_u
+          else           
+           local.get $23
+          end
+          local.tee $23
+          i32.const 0
+          i32.ne
           if (result i32)
            local.get $22
+           local.get $26
+           i64.add
+           local.get $27
+           i64.lt_u
+           local.tee $23
+           if (result i32)
+            local.get $23
+           else            
+            local.get $27
+            local.get $22
+            i64.sub
+            local.get $22
+            local.get $26
+            i64.add
+            local.get $27
+            i64.sub
+            i64.gt_u
+           end
           else           
-           local.get $10
-           local.get $19
-           i64.sub
-           local.get $19
-           local.get $20
-           i64.add
-           local.get $10
-           i64.sub
-           i64.gt_u
+           local.get $23
           end
-         else          
-          local.get $22
-         end
-         if
-          block
-           local.get $21
-           i32.const 1
-           i32.sub
-           local.set $21
-           local.get $19
-           local.get $20
-           i64.add
-           local.set $19
+          i32.const 0
+          i32.ne
+          if
+           block
+            local.get $24
+            i32.const 1
+            i32.sub
+            local.set $24
+            local.get $22
+            local.get $26
+            i64.add
+            local.set $22
+           end
+           br $continue|2
           end
-          br $continue|2
          end
         end
+        local.get $25
+        local.get $24
+        i32.store16 offset=4
        end
-       local.get $18
-       local.get $21
-       i32.store16 offset=4
        local.get $15
        return
       end
@@ -5884,91 +6070,111 @@
        global.set $~lib/internal/number/_K
        local.get $10
        block $~lib/internal/arraybuffer/LOAD<u32,u64>|inlined.7 (result i64)
+        local.get $16
+        local.set $17
         i32.const 0
         local.get $14
         i32.sub
-        local.set $17
+        local.set $24
         i32.const 0
-        local.set $21
-        local.get $16
+        local.set $25
         local.get $17
+        local.get $24
         i32.const 2
         i32.shl
         i32.add
-        local.get $21
+        local.get $25
         i32.add
         i64.load32_u offset=8
        end
        i64.mul
        local.set $10
-       local.get $0
-       local.get $15
-       i32.const 1
-       i32.sub
-       i32.const 1
-       i32.shl
-       i32.add
-       local.set $21
-       local.get $21
-       i32.load16_u offset=4
-       local.set $17
-       block $break|4
-        loop $continue|4
-         local.get $13
-         local.get $10
-         i64.lt_u
-         local.tee $18
-         if (result i32)
-          local.get $5
-          local.get $13
-          i64.sub
-          local.get $8
-          i64.ge_u
-         else          
-          local.get $18
-         end
-         local.tee $18
-         if (result i32)
-          local.get $13
-          local.get $8
-          i64.add
-          local.get $10
+       block $~lib/internal/number/grisuRound|inlined.1
+        local.get $0
+        local.set $25
+        local.get $15
+        local.set $24
+        local.get $5
+        local.set $27
+        local.get $13
+        local.set $26
+        local.get $8
+        local.set $22
+        local.get $10
+        local.set $21
+        local.get $25
+        local.get $24
+        i32.const 1
+        i32.sub
+        i32.const 1
+        i32.shl
+        i32.add
+        local.set $17
+        local.get $17
+        i32.load16_u offset=4
+        local.set $20
+        block $break|4
+         loop $continue|4
+          local.get $26
+          local.get $21
           i64.lt_u
           local.tee $18
           if (result i32)
-           local.get $18
+           local.get $27
+           local.get $26
+           i64.sub
+           local.get $22
+           i64.ge_u
           else           
-           local.get $10
-           local.get $13
-           i64.sub
-           local.get $13
-           local.get $8
-           i64.add
-           local.get $10
-           i64.sub
-           i64.gt_u
+           local.get $18
           end
-         else          
-          local.get $18
-         end
-         if
-          block
-           local.get $17
-           i32.const 1
-           i32.sub
-           local.set $17
-           local.get $13
-           local.get $8
+          local.tee $18
+          i32.const 0
+          i32.ne
+          if (result i32)
+           local.get $26
+           local.get $22
            i64.add
-           local.set $13
+           local.get $21
+           i64.lt_u
+           local.tee $18
+           if (result i32)
+            local.get $18
+           else            
+            local.get $21
+            local.get $26
+            i64.sub
+            local.get $26
+            local.get $22
+            i64.add
+            local.get $21
+            i64.sub
+            i64.gt_u
+           end
+          else           
+           local.get $18
           end
-          br $continue|4
+          i32.const 0
+          i32.ne
+          if
+           block
+            local.get $20
+            i32.const 1
+            i32.sub
+            local.set $20
+            local.get $26
+            local.get $22
+            i64.add
+            local.set $26
+           end
+           br $continue|4
+          end
          end
         end
+        local.get $17
+        local.get $20
+        i32.store16 offset=4
        end
-       local.get $21
-       local.get $17
-       i32.store16 offset=4
        local.get $15
        return
       end
@@ -5986,6 +6192,9 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   local.get $2
   i32.eqz
   if
@@ -6080,26 +6289,28 @@
     i32.shl
     i32.add
     local.set $4
-    local.get $4
-    global.get $~lib/internal/string/HEADER_SIZE
-    i32.add
-    i32.const 2
-    i32.add
-    local.set $5
-    local.get $4
-    global.get $~lib/internal/string/HEADER_SIZE
-    i32.add
-    local.set $6
-    i32.const 0
-    local.get $2
-    i32.sub
-    i32.const 1
-    i32.shl
-    local.set $7
-    local.get $5
-    local.get $6
-    local.get $7
-    call $~lib/internal/memory/memmove
+    block $~lib/memory/memory.copy|inlined.3
+     local.get $4
+     global.get $~lib/internal/string/HEADER_SIZE
+     i32.add
+     i32.const 2
+     i32.add
+     local.set $5
+     local.get $4
+     global.get $~lib/internal/string/HEADER_SIZE
+     i32.add
+     local.set $6
+     i32.const 0
+     local.get $2
+     i32.sub
+     i32.const 1
+     i32.shl
+     local.set $7
+     local.get $5
+     local.get $6
+     local.get $7
+     call $~lib/internal/memory/memmove
+    end
     local.get $0
     local.get $3
     i32.const 1
@@ -6128,26 +6339,28 @@
      local.get $3
      i32.sub
      local.set $4
-     local.get $0
-     global.get $~lib/internal/string/HEADER_SIZE
-     i32.add
-     local.get $4
-     i32.const 1
-     i32.shl
-     i32.add
-     local.set $7
-     local.get $0
-     global.get $~lib/internal/string/HEADER_SIZE
-     i32.add
-     local.set $6
-     local.get $1
-     i32.const 1
-     i32.shl
-     local.set $5
-     local.get $7
-     local.get $6
-     local.get $5
-     call $~lib/internal/memory/memmove
+     block $~lib/memory/memory.copy|inlined.4
+      local.get $0
+      global.get $~lib/internal/string/HEADER_SIZE
+      i32.add
+      local.get $4
+      i32.const 1
+      i32.shl
+      i32.add
+      local.set $7
+      local.get $0
+      global.get $~lib/internal/string/HEADER_SIZE
+      i32.add
+      local.set $6
+      local.get $1
+      i32.const 1
+      i32.shl
+      local.set $5
+      local.get $7
+      local.get $6
+      local.get $5
+      call $~lib/internal/memory/memmove
+     end
      local.get $0
      global.get $~lib/internal/string/CharCode._0
      global.get $~lib/internal/string/CharCode.DOT
@@ -6217,10 +6430,18 @@
        i32.const 1
        i32.add
        local.set $7
-       local.get $4
-       local.get $5
-       local.get $7
-       call $~lib/internal/number/utoa32_lut
+       block $~lib/internal/number/utoa32_core|inlined.4
+        local.get $4
+        local.set $8
+        local.get $5
+        local.set $9
+        local.get $7
+        local.set $10
+        local.get $8
+        local.get $9
+        local.get $10
+        call $~lib/internal/number/utoa32_lut
+       end
        local.get $4
        global.get $~lib/internal/string/CharCode.MINUS
        global.get $~lib/internal/string/CharCode.PLUS
@@ -6239,26 +6460,28 @@
       i32.const 1
       i32.shl
       local.set $7
-      local.get $0
-      global.get $~lib/internal/string/HEADER_SIZE
-      i32.add
-      i32.const 4
-      i32.add
-      local.set $6
-      local.get $0
-      global.get $~lib/internal/string/HEADER_SIZE
-      i32.add
-      i32.const 2
-      i32.add
-      local.set $5
-      local.get $7
-      i32.const 2
-      i32.sub
-      local.set $4
-      local.get $6
-      local.get $5
-      local.get $4
-      call $~lib/internal/memory/memmove
+      block $~lib/memory/memory.copy|inlined.5
+       local.get $0
+       global.get $~lib/internal/string/HEADER_SIZE
+       i32.add
+       i32.const 4
+       i32.add
+       local.set $6
+       local.get $0
+       global.get $~lib/internal/string/HEADER_SIZE
+       i32.add
+       i32.const 2
+       i32.add
+       local.set $5
+       local.get $7
+       i32.const 2
+       i32.sub
+       local.set $4
+       local.get $6
+       local.get $5
+       local.get $4
+       call $~lib/internal/memory/memmove
+      end
       local.get $0
       global.get $~lib/internal/string/CharCode.DOT
       i32.store16 offset=6
@@ -6294,18 +6517,26 @@
        call $~lib/internal/number/decimalCount32
        i32.const 1
        i32.add
-       local.set $8
-       local.get $4
-       local.get $5
-       local.get $8
-       call $~lib/internal/number/utoa32_lut
+       local.set $10
+       block $~lib/internal/number/utoa32_core|inlined.5
+        local.get $4
+        local.set $9
+        local.get $5
+        local.set $8
+        local.get $10
+        local.set $11
+        local.get $9
+        local.get $8
+        local.get $11
+        call $~lib/internal/number/utoa32_lut
+       end
        local.get $4
        global.get $~lib/internal/string/CharCode.MINUS
        global.get $~lib/internal/string/CharCode.PLUS
        local.get $6
        select
        i32.store16 offset=4
-       local.get $8
+       local.get $10
       end
       i32.add
       local.set $1
@@ -6325,29 +6556,35 @@
  )
  (func $~lib/internal/number/dtoa_core (; 61 ;) (type $iFi) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
-  (local $3 i64)
+  (local $3 f64)
   (local $4 i32)
-  (local $5 i64)
+  (local $5 i32)
   (local $6 i64)
-  (local $7 i64)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 f64)
-  (local $12 i32)
+  (local $7 i32)
+  (local $8 i64)
+  (local $9 i64)
+  (local $10 i64)
+  (local $11 i32)
+  (local $12 i64)
   (local $13 i32)
   (local $14 i32)
-  (local $15 i64)
-  (local $16 i64)
-  (local $17 i64)
-  (local $18 i64)
-  (local $19 i64)
-  (local $20 i64)
+  (local $15 i32)
+  (local $16 f64)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
   (local $21 i64)
   (local $22 i64)
   (local $23 i64)
   (local $24 i64)
-  (local $25 i32)
+  (local $25 i64)
+  (local $26 i64)
+  (local $27 i64)
+  (local $28 i64)
+  (local $29 i64)
+  (local $30 i64)
+  (local $31 i32)
   local.get $1
   f64.const 0
   f64.lt
@@ -6363,31 +6600,37 @@
   end
   block $~lib/internal/number/grisu2|inlined.0 (result i32)
    local.get $1
-   i64.reinterpret_f64
    local.set $3
+   local.get $0
+   local.set $4
+   local.get $2
+   local.set $5
    local.get $3
+   i64.reinterpret_f64
+   local.set $6
+   local.get $6
    i64.const 9218868437227405312
    i64.and
    i64.const 52
    i64.shr_u
    i32.wrap_i64
-   local.set $4
-   local.get $3
+   local.set $7
+   local.get $6
    i64.const 4503599627370495
    i64.and
-   local.set $5
-   local.get $4
+   local.set $8
+   local.get $7
    i32.const 0
    i32.ne
    i64.extend_i32_u
    i64.const 52
    i64.shl
-   local.get $5
+   local.get $8
    i64.add
-   local.set $6
-   local.get $4
+   local.set $9
+   local.get $7
    i32.const 1
-   local.get $4
+   local.get $7
    i32.const 0
    i32.ne
    select
@@ -6395,86 +6638,90 @@
    i32.const 52
    i32.add
    i32.sub
-   local.set $4
-   block
-    local.get $6
+   local.set $7
+   block $~lib/internal/number/normalizedBoundaries|inlined.0
+    local.get $9
+    local.set $10
+    local.get $7
+    local.set $11
+    local.get $10
     i64.const 1
     i64.shl
     i64.const 1
     i64.add
-    local.set $7
-    local.get $4
+    local.set $12
+    local.get $11
     i32.const 1
     i32.sub
-    local.set $8
-    local.get $7
+    local.set $13
+    local.get $12
     i64.clz
     i32.wrap_i64
-    local.set $9
-    local.get $7
-    local.get $9
+    local.set $14
+    local.get $12
+    local.get $14
     i64.extend_i32_s
     i64.shl
-    local.set $7
-    local.get $8
-    local.get $9
+    local.set $12
+    local.get $13
+    local.get $14
     i32.sub
-    local.set $8
+    local.set $13
     i32.const 1
-    local.get $6
+    local.get $10
     i64.const 4503599627370496
     i64.eq
     i32.add
-    local.set $10
-    local.get $7
+    local.set $15
+    local.get $12
     global.set $~lib/internal/number/_frc_plus
-    local.get $6
     local.get $10
+    local.get $15
     i64.extend_i32_s
     i64.shl
     i64.const 1
     i64.sub
-    local.get $4
-    local.get $10
+    local.get $11
+    local.get $15
     i32.sub
-    local.get $8
+    local.get $13
     i32.sub
     i64.extend_i32_s
     i64.shl
     global.set $~lib/internal/number/_frc_minus
-    local.get $8
+    local.get $13
     global.set $~lib/internal/number/_exp
    end
-   block
+   block $~lib/internal/number/getCachedPower|inlined.0
     global.get $~lib/internal/number/_exp
-    local.set $10
+    local.set $15
     i32.const -61
-    local.get $10
+    local.get $15
     i32.sub
     f64.convert_i32_s
     f64.const 0.30102999566398114
     f64.mul
     f64.const 347
     f64.add
-    local.set $11
-    local.get $11
+    local.set $16
+    local.get $16
     i32.trunc_f64_s
-    local.set $9
-    local.get $9
-    local.get $9
+    local.set $14
+    local.get $14
+    local.get $14
     f64.convert_i32_s
-    local.get $11
+    local.get $16
     f64.ne
     i32.add
-    local.set $9
-    local.get $9
+    local.set $14
+    local.get $14
     i32.const 3
     i32.shr_s
     i32.const 1
     i32.add
-    local.set $8
+    local.set $13
     i32.const 348
-    local.get $8
+    local.get $13
     i32.const 3
     i32.shl
     i32.sub
@@ -6483,282 +6730,304 @@
      i32.const 4288
     end
     i32.load
-    local.set $12
+    local.set $11
     block $~lib/internal/number/EXP_POWERS|inlined.0 (result i32)
      i32.const 4552
     end
     i32.load
-    local.set $13
+    local.set $17
     block $~lib/internal/arraybuffer/LOAD<u64,u64>|inlined.0 (result i64)
+     local.get $11
+     local.set $18
+     local.get $13
+     local.set $19
      i32.const 0
-     local.set $14
-     local.get $12
-     local.get $8
+     local.set $20
+     local.get $18
+     local.get $19
      i32.const 3
      i32.shl
      i32.add
-     local.get $14
+     local.get $20
      i32.add
      i64.load offset=8
     end
     global.set $~lib/internal/number/_frc_pow
     block $~lib/internal/arraybuffer/LOAD<i16,i32>|inlined.0 (result i32)
-     i32.const 0
-     local.set $14
+     local.get $17
+     local.set $20
      local.get $13
-     local.get $8
+     local.set $19
+     i32.const 0
+     local.set $18
+     local.get $20
+     local.get $19
      i32.const 1
      i32.shl
      i32.add
-     local.get $14
+     local.get $18
      i32.add
      i32.load16_s offset=8
     end
     global.set $~lib/internal/number/_exp_pow
    end
-   local.get $6
+   local.get $9
    i64.clz
    i32.wrap_i64
-   local.set $13
-   local.get $6
-   local.get $13
+   local.set $17
+   local.get $9
+   local.get $17
    i64.extend_i32_s
    i64.shl
-   local.set $6
-   local.get $4
-   local.get $13
+   local.set $9
+   local.get $7
+   local.get $17
    i32.sub
-   local.set $4
-   global.get $~lib/internal/number/_frc_pow
    local.set $7
-   global.get $~lib/internal/number/_exp_pow
+   global.get $~lib/internal/number/_frc_pow
    local.set $12
+   global.get $~lib/internal/number/_exp_pow
+   local.set $11
    block $~lib/internal/number/umul64f|inlined.0 (result i64)
-    local.get $6
-    i64.const 4294967295
-    i64.and
-    local.set $15
-    local.get $7
-    i64.const 4294967295
-    i64.and
-    local.set $16
-    local.get $6
-    i64.const 32
-    i64.shr_u
-    local.set $17
-    local.get $7
-    i64.const 32
-    i64.shr_u
-    local.set $18
-    local.get $15
-    local.get $16
-    i64.mul
-    local.set $19
-    local.get $17
-    local.get $16
-    i64.mul
-    local.get $19
-    i64.const 32
-    i64.shr_u
-    i64.add
-    local.set $20
-    local.get $15
-    local.get $18
-    i64.mul
-    local.get $20
-    i64.const 4294967295
-    i64.and
-    i64.add
+    local.get $9
+    local.set $10
+    local.get $12
     local.set $21
+    local.get $10
+    i64.const 4294967295
+    i64.and
+    local.set $22
     local.get $21
+    i64.const 4294967295
+    i64.and
+    local.set $23
+    local.get $10
+    i64.const 32
+    i64.shr_u
+    local.set $24
+    local.get $21
+    i64.const 32
+    i64.shr_u
+    local.set $25
+    local.get $22
+    local.get $23
+    i64.mul
+    local.set $26
+    local.get $24
+    local.get $23
+    i64.mul
+    local.get $26
+    i64.const 32
+    i64.shr_u
+    i64.add
+    local.set $27
+    local.get $22
+    local.get $25
+    i64.mul
+    local.get $27
+    i64.const 4294967295
+    i64.and
+    i64.add
+    local.set $28
+    local.get $28
     i64.const 2147483647
     i64.add
-    local.set $21
-    local.get $20
+    local.set $28
+    local.get $27
     i64.const 32
     i64.shr_u
-    local.set $20
-    local.get $21
+    local.set $27
+    local.get $28
     i64.const 32
     i64.shr_u
-    local.set $21
-    local.get $17
-    local.get $18
+    local.set $28
+    local.get $24
+    local.get $25
     i64.mul
-    local.get $20
+    local.get $27
     i64.add
-    local.get $21
+    local.get $28
     i64.add
    end
-   local.set $21
+   local.set $28
    block $~lib/internal/number/umul64e|inlined.0 (result i32)
-    local.get $4
-    local.get $12
+    local.get $7
+    local.set $13
+    local.get $11
+    local.set $14
+    local.get $13
+    local.get $14
     i32.add
     i32.const 64
     i32.add
    end
-   local.set $8
+   local.set $14
    block $~lib/internal/number/umul64f|inlined.1 (result i64)
     global.get $~lib/internal/number/_frc_plus
-    local.set $20
-    local.get $20
+    local.set $27
+    local.get $12
+    local.set $26
+    local.get $27
     i64.const 4294967295
     i64.and
-    local.set $19
-    local.get $7
+    local.set $25
+    local.get $26
     i64.const 4294967295
     i64.and
-    local.set $18
-    local.get $20
+    local.set $24
+    local.get $27
     i64.const 32
     i64.shr_u
-    local.set $17
-    local.get $7
-    i64.const 32
-    i64.shr_u
-    local.set $16
-    local.get $19
-    local.get $18
-    i64.mul
-    local.set $15
-    local.get $17
-    local.get $18
-    i64.mul
-    local.get $15
-    i64.const 32
-    i64.shr_u
-    i64.add
-    local.set $22
-    local.get $19
-    local.get $16
-    i64.mul
-    local.get $22
-    i64.const 4294967295
-    i64.and
-    i64.add
     local.set $23
+    local.get $26
+    i64.const 32
+    i64.shr_u
+    local.set $22
+    local.get $25
+    local.get $24
+    i64.mul
+    local.set $21
     local.get $23
+    local.get $24
+    i64.mul
+    local.get $21
+    i64.const 32
+    i64.shr_u
+    i64.add
+    local.set $10
+    local.get $25
+    local.get $22
+    i64.mul
+    local.get $10
+    i64.const 4294967295
+    i64.and
+    i64.add
+    local.set $29
+    local.get $29
     i64.const 2147483647
     i64.add
-    local.set $23
-    local.get $22
+    local.set $29
+    local.get $10
     i64.const 32
     i64.shr_u
-    local.set $22
+    local.set $10
+    local.get $29
+    i64.const 32
+    i64.shr_u
+    local.set $29
     local.get $23
-    i64.const 32
-    i64.shr_u
-    local.set $23
-    local.get $17
-    local.get $16
+    local.get $22
     i64.mul
-    local.get $22
+    local.get $10
     i64.add
-    local.get $23
+    local.get $29
     i64.add
    end
    i64.const 1
    i64.sub
-   local.set $23
+   local.set $29
    block $~lib/internal/number/umul64e|inlined.1 (result i32)
     global.get $~lib/internal/number/_exp
-    local.set $9
-    local.get $9
-    local.get $12
+    local.set $13
+    local.get $11
+    local.set $15
+    local.get $13
+    local.get $15
     i32.add
     i32.const 64
     i32.add
    end
-   local.set $9
+   local.set $15
    block $~lib/internal/number/umul64f|inlined.2 (result i64)
     global.get $~lib/internal/number/_frc_minus
+    local.set $10
+    local.get $12
+    local.set $21
+    local.get $10
+    i64.const 4294967295
+    i64.and
     local.set $22
-    local.get $22
+    local.get $21
     i64.const 4294967295
     i64.and
-    local.set $15
-    local.get $7
-    i64.const 4294967295
-    i64.and
-    local.set $16
-    local.get $22
+    local.set $23
+    local.get $10
     i64.const 32
     i64.shr_u
-    local.set $17
-    local.get $7
-    i64.const 32
-    i64.shr_u
-    local.set $18
-    local.get $15
-    local.get $16
-    i64.mul
-    local.set $19
-    local.get $17
-    local.get $16
-    i64.mul
-    local.get $19
-    i64.const 32
-    i64.shr_u
-    i64.add
-    local.set $20
-    local.get $15
-    local.get $18
-    i64.mul
-    local.get $20
-    i64.const 4294967295
-    i64.and
-    i64.add
     local.set $24
+    local.get $21
+    i64.const 32
+    i64.shr_u
+    local.set $25
+    local.get $22
+    local.get $23
+    i64.mul
+    local.set $26
     local.get $24
+    local.get $23
+    i64.mul
+    local.get $26
+    i64.const 32
+    i64.shr_u
+    i64.add
+    local.set $27
+    local.get $22
+    local.get $25
+    i64.mul
+    local.get $27
+    i64.const 4294967295
+    i64.and
+    i64.add
+    local.set $30
+    local.get $30
     i64.const 2147483647
     i64.add
-    local.set $24
-    local.get $20
+    local.set $30
+    local.get $27
     i64.const 32
     i64.shr_u
-    local.set $20
+    local.set $27
+    local.get $30
+    i64.const 32
+    i64.shr_u
+    local.set $30
     local.get $24
-    i64.const 32
-    i64.shr_u
-    local.set $24
-    local.get $17
-    local.get $18
+    local.get $25
     i64.mul
-    local.get $20
+    local.get $27
     i64.add
-    local.get $24
+    local.get $30
     i64.add
    end
    i64.const 1
    i64.add
-   local.set $24
-   local.get $23
-   local.get $24
+   local.set $30
+   local.get $29
+   local.get $30
    i64.sub
-   local.set $20
-   local.get $0
-   local.get $21
-   local.get $8
-   local.get $23
-   local.get $9
-   local.get $20
-   local.get $2
+   local.set $27
+   local.get $4
+   local.get $28
+   local.get $14
+   local.get $29
+   local.get $15
+   local.get $27
+   local.get $5
    call $~lib/internal/number/genDigits
   end
-  local.set $25
+  local.set $31
   local.get $0
   local.get $2
   i32.const 1
   i32.shl
   i32.add
-  local.get $25
+  local.get $31
   local.get $2
   i32.sub
   global.get $~lib/internal/number/_K
   call $~lib/internal/number/prettify
-  local.set $25
-  local.get $25
+  local.set $31
+  local.get $31
   local.get $2
   i32.add
  )
@@ -6876,6 +7145,8 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   f64.const 0
   f64.eq
@@ -6913,24 +7184,26 @@
   local.get $2
   call $~lib/string/String#substring
   local.set $3
-  local.get $1
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 112
-   i32.const 28
-   i32.const 4
-   call $~lib/env/abort
-   unreachable
-  end
-  block $~lib/memory/memory.free|inlined.1
-   block
-    local.get $1
-    call $~lib/allocator/arena/__memory_free
-    br $~lib/memory/memory.free|inlined.1
+  block $~lib/internal/string/freeUnsafe|inlined.0
+   local.get $1
+   local.set $4
+   local.get $4
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 112
+    i32.const 28
+    i32.const 4
+    call $~lib/env/abort
     unreachable
    end
-   unreachable
+   block $~lib/memory/memory.free|inlined.1
+    local.get $4
+    local.set $5
+    local.get $5
+    call $~lib/allocator/arena/__memory_free
+    br $~lib/memory/memory.free|inlined.1
+   end
   end
   local.get $3
  )

--- a/tests/compiler/std/symbol.untouched.wat
+++ b/tests/compiler/std/symbol.untouched.wat
@@ -476,6 +476,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   global.get $~lib/internal/arraybuffer/MAX_BLENGTH
   i32.gt_u
@@ -501,9 +502,11 @@
    local.set $4
    i32.const 0
    local.set $5
+   local.get $1
+   local.set $6
    local.get $4
    local.get $5
-   local.get $1
+   local.get $6
    call $~lib/internal/memory/memset
   end
   local.get $3
@@ -800,6 +803,8 @@
       else       
        local.get $4
       end
+      i32.const 0
+      i32.ne
       if
        local.get $3
        return
@@ -819,10 +824,13 @@
   i32.const 0
  )
  (func $~lib/map/Map<String,usize>#has (; 16 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<String>|inlined.0 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    call $~lib/internal/hash/hashStr
    br $~lib/internal/hash/HASH<String>|inlined.0
   end
@@ -832,18 +840,21 @@
  )
  (func $~lib/map/Map<String,usize>#get (; 17 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
+  (local $3 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<String>|inlined.1 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    call $~lib/internal/hash/hashStr
    br $~lib/internal/hash/HASH<String>|inlined.1
   end
   call $~lib/map/Map<String,usize>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   if (result i32)
-   local.get $2
+   local.get $3
    i32.load offset=4
   else   
    unreachable
@@ -996,18 +1007,20 @@
   (local $6 i32)
   block $~lib/internal/hash/HASH<String>|inlined.2 (result i32)
    local.get $1
+   local.set $3
+   local.get $3
    call $~lib/internal/hash/hashStr
    br $~lib/internal/hash/HASH<String>|inlined.2
   end
-  local.set $3
+  local.set $4
   local.get $0
   local.get $1
-  local.get $3
-  call $~lib/map/Map<String,usize>#find
-  local.set $4
   local.get $4
+  call $~lib/map/Map<String,usize>#find
+  local.set $5
+  local.get $5
   if
-   local.get $4
+   local.get $5
    local.get $2
    i32.store offset=4
   else   
@@ -1042,8 +1055,8 @@
    end
    local.get $0
    i32.load offset=8
-   local.set $5
-   local.get $5
+   local.set $3
+   local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
    block (result i32)
@@ -1061,11 +1074,11 @@
    end
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    local.get $1
    i32.store
-   local.get $4
+   local.get $5
    local.get $2
    i32.store offset=4
    local.get $0
@@ -1076,7 +1089,7 @@
    i32.store offset=20
    local.get $0
    i32.load
-   local.get $3
+   local.get $4
    local.get $0
    i32.load offset=4
    i32.and
@@ -1084,12 +1097,12 @@
    i32.mul
    i32.add
    local.set $6
-   local.get $4
+   local.get $5
    local.get $6
    i32.load offset=8
    i32.store offset=8
    local.get $6
-   local.get $4
+   local.get $5
    i32.store offset=8
   end
  )
@@ -1168,6 +1181,8 @@
       else       
        local.get $4
       end
+      i32.const 0
+      i32.ne
       if
        local.get $3
        return
@@ -1333,18 +1348,20 @@
   (local $6 i32)
   block $~lib/internal/hash/HASH<usize>|inlined.0 (result i32)
    local.get $1
+   local.set $3
+   local.get $3
    call $~lib/internal/hash/hash32
    br $~lib/internal/hash/HASH<usize>|inlined.0
   end
-  local.set $3
+  local.set $4
   local.get $0
   local.get $1
-  local.get $3
-  call $~lib/map/Map<usize,String>#find
-  local.set $4
   local.get $4
+  call $~lib/map/Map<usize,String>#find
+  local.set $5
+  local.get $5
   if
-   local.get $4
+   local.get $5
    local.get $2
    i32.store offset=4
   else   
@@ -1379,8 +1396,8 @@
    end
    local.get $0
    i32.load offset=8
-   local.set $5
-   local.get $5
+   local.set $3
+   local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
    block (result i32)
@@ -1398,11 +1415,11 @@
    end
    i32.mul
    i32.add
-   local.set $4
-   local.get $4
+   local.set $5
+   local.get $5
    local.get $1
    i32.store
-   local.get $4
+   local.get $5
    local.get $2
    i32.store offset=4
    local.get $0
@@ -1413,7 +1430,7 @@
    i32.store offset=20
    local.get $0
    i32.load
-   local.get $3
+   local.get $4
    local.get $0
    i32.load offset=4
    i32.and
@@ -1421,12 +1438,12 @@
    i32.mul
    i32.add
    local.set $6
-   local.get $4
+   local.get $5
    local.get $6
    i32.load offset=8
    i32.store offset=8
    local.get $6
-   local.get $4
+   local.get $5
    i32.store offset=8
   end
  )
@@ -1478,10 +1495,13 @@
   local.get $2
  )
  (func $~lib/map/Map<usize,String>#has (; 25 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<usize>|inlined.2 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    call $~lib/internal/hash/hash32
    br $~lib/internal/hash/HASH<usize>|inlined.2
   end
@@ -1491,18 +1511,21 @@
  )
  (func $~lib/map/Map<usize,String>#get (; 26 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
+  (local $3 i32)
   local.get $0
   local.get $1
   block $~lib/internal/hash/HASH<usize>|inlined.3 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    call $~lib/internal/hash/hash32
    br $~lib/internal/hash/HASH<usize>|inlined.3
   end
   call $~lib/map/Map<usize,String>#find
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   if (result i32)
-   local.get $2
+   local.get $3
    i32.load offset=4
   else   
    unreachable
@@ -3264,6 +3287,8 @@
     else     
      local.get $3
     end
+    i32.const 0
+    i32.ne
     if
      global.get $~lib/symbol/idToString
      local.get $1

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -66,7 +66,7 @@
  (data (i32.const 608) "\02")
  (data (i32.const 616) "H\02\00\00\05")
  (table $0 101 funcref)
- (elem (i32.const 0) $null $~lib/typedarray/Float64Array#sort|trampoline~anonymous|1 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 $std/typedarray/testReduce<Float32Array,f32>~anonymous|11 $std/typedarray/testReduce<Float64Array,f64>~anonymous|12 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 $std/typedarray/testReduce<Float32Array,f32>~anonymous|11 $std/typedarray/testReduce<Float64Array,f64>~anonymous|12 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|33 $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|34 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|36 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|36 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|36 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|42 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|42 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|46 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|46 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|50 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|50 $std/typedarray/testArraySome<Float32Array,f32>~anonymous|53 $std/typedarray/testArraySome<Float32Array,f32>~anonymous|54 $std/typedarray/testArraySome<Float64Array,f64>~anonymous|55 $std/typedarray/testArraySome<Float64Array,f64>~anonymous|56 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|58 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|58 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|58 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|64 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|64 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|68 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|68 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|72 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|72 $std/typedarray/testArraySome<Float32Array,f32>~anonymous|53 $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|76 $std/typedarray/testArraySome<Float64Array,f64>~anonymous|55 $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|78 $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|79 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|81 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|81 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|85 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|81 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|89 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|81 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|93 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|95 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|97 $std/typedarray/testArraySome<Float32Array,f32>~anonymous|53 $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|99 $std/typedarray/testArraySome<Float64Array,f64>~anonymous|55)
+ (elem (i32.const 0) $null $~lib/internal/sort/COMPARATOR<f64>~anonymous|1 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 $std/typedarray/testReduce<Float32Array,f32>~anonymous|11 $std/typedarray/testReduce<Float64Array,f64>~anonymous|12 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 $std/typedarray/testReduce<Float32Array,f32>~anonymous|11 $std/typedarray/testReduce<Float64Array,f64>~anonymous|12 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|33 $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|34 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|36 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|36 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|36 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|42 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|42 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|46 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|46 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|50 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|50 $std/typedarray/testArraySome<Float32Array,f32>~anonymous|53 $std/typedarray/testArraySome<Float32Array,f32>~anonymous|54 $std/typedarray/testArraySome<Float64Array,f64>~anonymous|55 $std/typedarray/testArraySome<Float64Array,f64>~anonymous|56 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|58 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|58 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|58 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|64 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|64 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|68 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|68 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|72 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|72 $std/typedarray/testArraySome<Float32Array,f32>~anonymous|53 $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|76 $std/typedarray/testArraySome<Float64Array,f64>~anonymous|55 $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|78 $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|79 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|81 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|81 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|85 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|81 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|89 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|81 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|93 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|95 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|97 $std/typedarray/testArraySome<Float32Array,f32>~anonymous|53 $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|99 $std/typedarray/testArraySome<Float64Array,f64>~anonymous|55)
  (global $~lib/allocator/arena/startOffset (mut i32) (i32.const 0))
  (global $~lib/allocator/arena/offset (mut i32) (i32.const 0))
  (global $std/typedarray/arr (mut i32) (i32.const 0))
@@ -1366,9 +1366,9 @@
  (func $~lib/internal/sort/weakHeapSort<f64> (; 20 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
+  (local $6 f64)
   (local $7 f64)
-  (local $8 f64)
+  (local $8 i32)
   (local $9 i32)
   local.get $2
   i32.const 31
@@ -1377,36 +1377,36 @@
   i32.shr_s
   i32.const 2
   i32.shl
-  local.tee $6
+  local.tee $4
   call $~lib/allocator/arena/__memory_allocate
-  local.tee $9
+  local.tee $8
   i32.const 0
-  local.get $6
+  local.get $4
   call $~lib/internal/memory/memset
   local.get $2
   i32.const 1
   i32.sub
-  local.set $4
+  local.set $5
   loop $repeat|0
-   local.get $4
+   local.get $5
    i32.const 0
    i32.gt_s
    if
-    local.get $4
-    local.set $6
+    local.get $5
+    local.set $4
     loop $continue|1
-     local.get $6
+     local.get $4
      i32.const 1
      i32.and
-     local.get $6
+     local.get $4
      i32.const 6
      i32.shr_s
      i32.const 2
      i32.shl
-     local.get $9
+     local.get $8
      i32.add
      i32.load
-     local.get $6
+     local.get $4
      i32.const 1
      i32.shr_s
      i32.const 31
@@ -1416,26 +1416,17 @@
      i32.and
      i32.eq
      if
-      local.get $6
+      local.get $4
       i32.const 1
       i32.shr_s
-      local.set $6
+      local.set $4
       br $continue|1
      end
     end
-    local.get $6
+    local.get $4
     i32.const 1
     i32.shr_s
-    local.tee $5
-    i32.const 3
-    i32.shl
-    local.get $0
-    i32.add
-    local.get $1
-    i32.add
-    f64.load offset=8
-    local.set $8
-    local.get $4
+    local.tee $4
     i32.const 3
     i32.shl
     local.get $0
@@ -1444,41 +1435,41 @@
     i32.add
     f64.load offset=8
     local.set $7
+    local.get $5
+    i32.const 3
+    i32.shl
+    local.get $0
+    i32.add
+    local.get $1
+    i32.add
+    f64.load offset=8
+    local.set $6
     i32.const 2
     global.set $~argc
-    local.get $8
     local.get $7
+    local.get $6
     local.get $3
     call_indirect (type $FFi)
     i32.const 0
     i32.lt_s
     if
-     local.get $4
+     local.get $5
      i32.const 5
      i32.shr_s
      i32.const 2
      i32.shl
-     local.get $9
+     local.get $8
      i32.add
-     local.tee $6
-     local.get $6
+     local.tee $9
+     local.get $9
      i32.load
      i32.const 1
-     local.get $4
+     local.get $5
      i32.const 31
      i32.and
      i32.shl
      i32.xor
      i32.store
-     local.get $4
-     i32.const 3
-     i32.shl
-     local.get $0
-     i32.add
-     local.get $1
-     i32.add
-     local.get $8
-     f64.store offset=8
      local.get $5
      i32.const 3
      i32.shl
@@ -1488,20 +1479,29 @@
      i32.add
      local.get $7
      f64.store offset=8
+     local.get $4
+     i32.const 3
+     i32.shl
+     local.get $0
+     i32.add
+     local.get $1
+     i32.add
+     local.get $6
+     f64.store offset=8
     end
-    local.get $4
+    local.get $5
     i32.const 1
     i32.sub
-    local.set $4
+    local.set $5
     br $repeat|0
    end
   end
   local.get $2
   i32.const 1
   i32.sub
-  local.set $4
+  local.set $5
   loop $repeat|2
-   local.get $4
+   local.get $5
    i32.const 2
    i32.ge_s
    if
@@ -1510,9 +1510,9 @@
     i32.add
     local.tee $2
     f64.load offset=8
-    local.set $7
+    local.set $6
     local.get $2
-    local.get $4
+    local.get $5
     i32.const 3
     i32.shl
     local.get $0
@@ -1523,40 +1523,40 @@
     f64.load offset=8
     f64.store offset=8
     local.get $2
-    local.get $7
+    local.get $6
     f64.store offset=8
     i32.const 1
-    local.set $5
+    local.set $2
     loop $continue|3
-     local.get $5
+     local.get $2
      i32.const 5
      i32.shr_s
      i32.const 2
      i32.shl
-     local.get $9
+     local.get $8
      i32.add
      i32.load
-     local.get $5
+     local.get $2
      i32.const 31
      i32.and
      i32.shr_u
      i32.const 1
      i32.and
-     local.get $5
+     local.get $2
      i32.const 1
      i32.shl
      i32.add
-     local.tee $6
-     local.get $4
+     local.tee $4
+     local.get $5
      i32.lt_s
      if
-      local.get $6
-      local.set $5
+      local.get $4
+      local.set $2
       br $continue|3
      end
     end
     loop $continue|4
-     local.get $5
+     local.get $2
      i32.const 0
      i32.gt_s
      if
@@ -1564,8 +1564,8 @@
       local.get $1
       i32.add
       f64.load offset=8
-      local.set $7
-      local.get $5
+      local.set $6
+      local.get $2
       i32.const 3
       i32.shl
       local.get $0
@@ -1573,59 +1573,59 @@
       local.get $1
       i32.add
       f64.load offset=8
-      local.set $8
+      local.set $7
       i32.const 2
       global.set $~argc
+      local.get $6
       local.get $7
-      local.get $8
       local.get $3
       call_indirect (type $FFi)
       i32.const 0
       i32.lt_s
       if
-       local.get $5
+       local.get $2
        i32.const 5
        i32.shr_s
        i32.const 2
        i32.shl
-       local.get $9
+       local.get $8
        i32.add
-       local.tee $2
-       local.get $2
+       local.tee $4
+       local.get $4
        i32.load
        i32.const 1
-       local.get $5
+       local.get $2
        i32.const 31
        i32.and
        i32.shl
        i32.xor
        i32.store
-       local.get $5
+       local.get $2
        i32.const 3
        i32.shl
        local.get $0
        i32.add
        local.get $1
        i32.add
-       local.get $7
+       local.get $6
        f64.store offset=8
        local.get $0
        local.get $1
        i32.add
-       local.get $8
+       local.get $7
        f64.store offset=8
       end
-      local.get $5
+      local.get $2
       i32.const 1
       i32.shr_s
-      local.set $5
+      local.set $2
       br $continue|4
      end
     end
-    local.get $4
+    local.get $5
     i32.const 1
     i32.sub
-    local.set $4
+    local.set $5
     br $repeat|2
    end
   end
@@ -1636,7 +1636,7 @@
   i32.add
   local.tee $2
   f64.load offset=8
-  local.set $7
+  local.set $6
   local.get $2
   local.get $0
   local.get $1
@@ -1645,90 +1645,97 @@
   f64.load offset=8
   f64.store offset=8
   local.get $0
-  local.get $7
+  local.get $6
   f64.store offset=8
  )
  (func $~lib/typedarray/Float64Array#sort (; 21 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 f64)
+  (local $5 i32)
   (local $6 f64)
+  (local $7 f64)
+  local.get $1
+  local.set $4
   local.get $0
   i32.load offset=4
-  local.set $2
+  local.set $3
   block $~lib/internal/typedarray/SORT<Float64Array,f64>|inlined.0
    local.get $0
    i32.load offset=8
    i32.const 3
    i32.shr_u
-   local.tee $4
+   local.tee $5
    i32.const 1
    i32.le_s
    br_if $~lib/internal/typedarray/SORT<Float64Array,f64>|inlined.0
    local.get $0
    i32.load
-   local.set $3
-   local.get $4
+   local.set $1
+   local.get $5
    i32.const 2
    i32.eq
    if
-    local.get $3
+    local.get $1
     i32.const 8
     i32.add
-    local.get $2
-    i32.add
-    f64.load offset=8
-    local.set $5
-    local.get $2
     local.get $3
     i32.add
     f64.load offset=8
     local.set $6
+    local.get $1
+    local.get $3
+    local.tee $2
+    i32.add
+    f64.load offset=8
+    local.set $7
     i32.const 2
     global.set $~argc
-    local.get $5
     local.get $6
-    local.get $1
+    local.get $7
+    local.get $4
     call_indirect (type $FFi)
     i32.const 0
     i32.lt_s
     if
-     local.get $3
+     local.get $1
      i32.const 8
      i32.add
      local.get $2
      i32.add
-     local.get $6
+     local.get $7
      f64.store offset=8
+     local.get $1
      local.get $2
-     local.get $3
      i32.add
-     local.get $5
+     local.get $6
      f64.store offset=8
     end
     br $~lib/internal/typedarray/SORT<Float64Array,f64>|inlined.0
    end
-   local.get $4
+   local.get $1
+   local.set $2
+   local.get $5
+   local.tee $1
    i32.const 256
    i32.lt_s
    if
-    local.get $3
     local.get $2
-    local.get $4
+    local.get $3
     local.get $1
+    local.get $4
     call $~lib/internal/sort/insertionSort<f64>
    else    
-    local.get $3
     local.get $2
-    local.get $4
+    local.get $3
     local.get $1
+    local.get $4
     call $~lib/internal/sort/weakHeapSort<f64>
    end
   end
   local.get $0
  )
- (func $~lib/typedarray/Float64Array#sort|trampoline~anonymous|1 (; 22 ;) (type $FFi) (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<f64>~anonymous|1 (; 22 ;) (type $FFi) (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   local.get $0
@@ -1852,6 +1859,7 @@
   (local $6 i32)
   (local $7 i32)
   local.get $0
+  local.tee $5
   i32.load
   local.set $6
   local.get $0
@@ -1867,16 +1875,17 @@
    local.get $2
    local.get $4
    i32.add
-   local.tee $5
+   local.tee $0
    i32.const 0
-   local.get $5
+   local.get $0
    i32.const 0
    i32.gt_s
    select
   else   
    local.get $2
+   local.tee $0
    local.get $4
-   local.get $2
+   local.get $0
    local.get $4
    i32.lt_s
    select
@@ -1889,16 +1898,17 @@
    local.get $3
    local.get $4
    i32.add
-   local.tee $5
+   local.tee $0
    i32.const 0
-   local.get $5
+   local.get $0
    i32.const 0
    i32.gt_s
    select
   else   
    local.get $3
+   local.tee $0
    local.get $4
-   local.get $3
+   local.get $0
    local.get $4
    i32.lt_s
    select
@@ -1919,7 +1929,7 @@
    i32.sub
    call $~lib/internal/memory/memset
   end
-  local.get $0
+  local.get $5
  )
  (func $~lib/internal/typedarray/TypedArray<i8>#__get (; 28 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
@@ -2090,9 +2100,12 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  local.get $1
+  local.set $5
   local.get $0
+  local.tee $6
   i32.load
-  local.set $6
+  local.set $1
   local.get $0
   i32.load offset=4
   local.set $7
@@ -2108,16 +2121,17 @@
    local.get $2
    local.get $4
    i32.add
-   local.tee $5
+   local.tee $0
    i32.const 0
-   local.get $5
+   local.get $0
    i32.const 0
    i32.gt_s
    select
   else   
    local.get $2
+   local.tee $0
    local.get $4
-   local.get $2
+   local.get $0
    local.get $4
    i32.lt_s
    select
@@ -2130,16 +2144,17 @@
    local.get $3
    local.get $4
    i32.add
-   local.tee $5
+   local.tee $0
    i32.const 0
-   local.get $5
+   local.get $0
    i32.const 0
    i32.gt_s
    select
   else   
    local.get $3
+   local.tee $0
    local.get $4
-   local.get $3
+   local.get $0
    local.get $4
    i32.lt_s
    select
@@ -2154,11 +2169,11 @@
     local.get $2
     i32.const 2
     i32.shl
-    local.get $6
+    local.get $1
     i32.add
     local.get $7
     i32.add
-    local.get $1
+    local.get $5
     i32.store offset=8
     local.get $2
     i32.const 1
@@ -2167,7 +2182,7 @@
     br $repeat|0
    end
   end
-  local.get $0
+  local.get $6
  )
  (func $std/typedarray/isInt32ArrayEqual (; 33 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -5969,44 +5984,47 @@
   (local $5 i32)
   local.get $0
   i32.load offset=8
-  local.set $3
+  local.set $2
   local.get $0
+  local.tee $3
   i32.load
   local.set $4
   local.get $0
   i32.load offset=4
   local.set $5
+  i32.const 0
+  local.set $0
   block $~lib/internal/typedarray/FIND_INDEX<Int8Array,i8>|inlined.0
    loop $repeat|0
     block $break|0
+     local.get $0
      local.get $2
-     local.get $3
      i32.ge_s
      br_if $break|0
      i32.const 3
      global.set $~argc
-     local.get $2
+     local.get $0
      local.get $4
      i32.add
      local.get $5
      i32.add
      i32.load8_s offset=8
-     local.get $2
      local.get $0
+     local.get $3
      local.get $1
      call_indirect (type $iiii)
      br_if $~lib/internal/typedarray/FIND_INDEX<Int8Array,i8>|inlined.0
-     local.get $2
+     local.get $0
      i32.const 1
      i32.add
-     local.set $2
+     local.set $0
      br $repeat|0
     end
    end
    i32.const -1
-   local.set $2
+   local.set $0
   end
-  local.get $2
+  local.get $0
  )
  (func $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|58 (; 140 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
@@ -6066,44 +6084,47 @@
   (local $5 i32)
   local.get $0
   i32.load offset=8
-  local.set $3
+  local.set $2
   local.get $0
+  local.tee $3
   i32.load
   local.set $4
   local.get $0
   i32.load offset=4
   local.set $5
+  i32.const 0
+  local.set $0
   block $~lib/internal/typedarray/FIND_INDEX<Uint8Array,u8>|inlined.0
    loop $repeat|0
     block $break|0
+     local.get $0
      local.get $2
-     local.get $3
      i32.ge_s
      br_if $break|0
      i32.const 3
      global.set $~argc
-     local.get $2
+     local.get $0
      local.get $4
      i32.add
      local.get $5
      i32.add
      i32.load8_u offset=8
-     local.get $2
      local.get $0
+     local.get $3
      local.get $1
      call_indirect (type $iiii)
      br_if $~lib/internal/typedarray/FIND_INDEX<Uint8Array,u8>|inlined.0
-     local.get $2
+     local.get $0
      i32.const 1
      i32.add
-     local.set $2
+     local.set $0
      br $repeat|0
     end
    end
    i32.const -1
-   local.set $2
+   local.set $0
   end
-  local.get $2
+  local.get $0
  )
  (func $std/typedarray/testArrayFindIndex<Uint8Array,u8> (; 143 ;) (type $v)
   (local $0 i32)
@@ -6201,23 +6222,26 @@
   i32.load offset=8
   i32.const 1
   i32.shr_u
-  local.set $3
+  local.set $2
   local.get $0
+  local.tee $3
   i32.load
   local.set $4
   local.get $0
   i32.load offset=4
   local.set $5
+  i32.const 0
+  local.set $0
   block $~lib/internal/typedarray/FIND_INDEX<Int16Array,i16>|inlined.0
    loop $repeat|0
     block $break|0
+     local.get $0
      local.get $2
-     local.get $3
      i32.ge_s
      br_if $break|0
      i32.const 3
      global.set $~argc
-     local.get $2
+     local.get $0
      i32.const 1
      i32.shl
      local.get $4
@@ -6225,22 +6249,22 @@
      local.get $5
      i32.add
      i32.load16_s offset=8
-     local.get $2
      local.get $0
+     local.get $3
      local.get $1
      call_indirect (type $iiii)
      br_if $~lib/internal/typedarray/FIND_INDEX<Int16Array,i16>|inlined.0
-     local.get $2
+     local.get $0
      i32.const 1
      i32.add
-     local.set $2
+     local.set $0
      br $repeat|0
     end
    end
    i32.const -1
-   local.set $2
+   local.set $0
   end
-  local.get $2
+  local.get $0
  )
  (func $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|64 (; 146 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
@@ -6301,23 +6325,26 @@
   i32.load offset=8
   i32.const 1
   i32.shr_u
-  local.set $3
+  local.set $2
   local.get $0
+  local.tee $3
   i32.load
   local.set $4
   local.get $0
   i32.load offset=4
   local.set $5
+  i32.const 0
+  local.set $0
   block $~lib/internal/typedarray/FIND_INDEX<Uint16Array,u16>|inlined.0
    loop $repeat|0
     block $break|0
+     local.get $0
      local.get $2
-     local.get $3
      i32.ge_s
      br_if $break|0
      i32.const 3
      global.set $~argc
-     local.get $2
+     local.get $0
      i32.const 1
      i32.shl
      local.get $4
@@ -6325,22 +6352,22 @@
      local.get $5
      i32.add
      i32.load16_u offset=8
-     local.get $2
      local.get $0
+     local.get $3
      local.get $1
      call_indirect (type $iiii)
      br_if $~lib/internal/typedarray/FIND_INDEX<Uint16Array,u16>|inlined.0
-     local.get $2
+     local.get $0
      i32.const 1
      i32.add
-     local.set $2
+     local.set $0
      br $repeat|0
     end
    end
    i32.const -1
-   local.set $2
+   local.set $0
   end
-  local.get $2
+  local.get $0
  )
  (func $std/typedarray/testArrayFindIndex<Uint16Array,u16> (; 149 ;) (type $v)
   (local $0 i32)
@@ -6394,23 +6421,26 @@
   i32.load offset=8
   i32.const 2
   i32.shr_u
-  local.set $3
+  local.set $2
   local.get $0
+  local.tee $3
   i32.load
   local.set $4
   local.get $0
   i32.load offset=4
   local.set $5
+  i32.const 0
+  local.set $0
   block $~lib/internal/typedarray/FIND_INDEX<Int32Array,i32>|inlined.0
    loop $repeat|0
     block $break|0
+     local.get $0
      local.get $2
-     local.get $3
      i32.ge_s
      br_if $break|0
      i32.const 3
      global.set $~argc
-     local.get $2
+     local.get $0
      i32.const 2
      i32.shl
      local.get $4
@@ -6418,22 +6448,22 @@
      local.get $5
      i32.add
      i32.load offset=8
-     local.get $2
      local.get $0
+     local.get $3
      local.get $1
      call_indirect (type $iiii)
      br_if $~lib/internal/typedarray/FIND_INDEX<Int32Array,i32>|inlined.0
-     local.get $2
+     local.get $0
      i32.const 1
      i32.add
-     local.set $2
+     local.set $0
      br $repeat|0
     end
    end
    i32.const -1
-   local.set $2
+   local.set $0
   end
-  local.get $2
+  local.get $0
  )
  (func $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|68 (; 151 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
@@ -6535,23 +6565,26 @@
   i32.load offset=8
   i32.const 3
   i32.shr_u
-  local.set $3
+  local.set $2
   local.get $0
+  local.tee $3
   i32.load
   local.set $4
   local.get $0
   i32.load offset=4
   local.set $5
+  i32.const 0
+  local.set $0
   block $~lib/internal/typedarray/FIND_INDEX<Int64Array,i64>|inlined.0
    loop $repeat|0
     block $break|0
+     local.get $0
      local.get $2
-     local.get $3
      i32.ge_s
      br_if $break|0
      i32.const 3
      global.set $~argc
-     local.get $2
+     local.get $0
      i32.const 3
      i32.shl
      local.get $4
@@ -6559,22 +6592,22 @@
      local.get $5
      i32.add
      i64.load offset=8
-     local.get $2
      local.get $0
+     local.get $3
      local.get $1
      call_indirect (type $Iiii)
      br_if $~lib/internal/typedarray/FIND_INDEX<Int64Array,i64>|inlined.0
-     local.get $2
+     local.get $0
      i32.const 1
      i32.add
-     local.set $2
+     local.set $0
      br $repeat|0
     end
    end
    i32.const -1
-   local.set $2
+   local.set $0
   end
-  local.get $2
+  local.get $0
  )
  (func $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|72 (; 155 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
@@ -6676,23 +6709,26 @@
   i32.load offset=8
   i32.const 2
   i32.shr_u
-  local.set $3
+  local.set $2
   local.get $0
+  local.tee $3
   i32.load
   local.set $4
   local.get $0
   i32.load offset=4
   local.set $5
+  i32.const 0
+  local.set $0
   block $~lib/internal/typedarray/FIND_INDEX<Float32Array,f32>|inlined.0
    loop $repeat|0
     block $break|0
+     local.get $0
      local.get $2
-     local.get $3
      i32.ge_s
      br_if $break|0
      i32.const 3
      global.set $~argc
-     local.get $2
+     local.get $0
      i32.const 2
      i32.shl
      local.get $4
@@ -6700,22 +6736,22 @@
      local.get $5
      i32.add
      f32.load offset=8
-     local.get $2
      local.get $0
+     local.get $3
      local.get $1
      call_indirect (type $fiii)
      br_if $~lib/internal/typedarray/FIND_INDEX<Float32Array,f32>|inlined.0
-     local.get $2
+     local.get $0
      i32.const 1
      i32.add
-     local.set $2
+     local.set $0
      br $repeat|0
     end
    end
    i32.const -1
-   local.set $2
+   local.set $0
   end
-  local.get $2
+  local.get $0
  )
  (func $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|76 (; 159 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
@@ -6774,23 +6810,26 @@
   i32.load offset=8
   i32.const 3
   i32.shr_u
-  local.set $3
+  local.set $2
   local.get $0
+  local.tee $3
   i32.load
   local.set $4
   local.get $0
   i32.load offset=4
   local.set $5
+  i32.const 0
+  local.set $0
   block $~lib/internal/typedarray/FIND_INDEX<Float64Array,f64>|inlined.0
    loop $repeat|0
     block $break|0
+     local.get $0
      local.get $2
-     local.get $3
      i32.ge_s
      br_if $break|0
      i32.const 3
      global.set $~argc
-     local.get $2
+     local.get $0
      i32.const 3
      i32.shl
      local.get $4
@@ -6798,22 +6837,22 @@
      local.get $5
      i32.add
      f64.load offset=8
-     local.get $2
      local.get $0
+     local.get $3
      local.get $1
      call_indirect (type $Fiii)
      br_if $~lib/internal/typedarray/FIND_INDEX<Float64Array,f64>|inlined.0
-     local.get $2
+     local.get $0
      i32.const 1
      i32.add
-     local.set $2
+     local.set $0
      br $repeat|0
     end
    end
    i32.const -1
-   local.set $2
+   local.set $0
   end
-  local.get $2
+  local.get $0
  )
  (func $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|78 (; 162 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -62,7 +62,7 @@
  (data (i32.const 584) "\14\00\00\00\00\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\00\00\00\00")
  (data (i32.const 616) "H\02\00\00\05\00\00\00")
  (table $0 101 funcref)
- (elem (i32.const 0) $null $~lib/typedarray/Float64Array#sort|trampoline~anonymous|1 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Uint8Array,u8>~anonymous|3 $std/typedarray/testReduce<Uint8ClampedArray,u8>~anonymous|4 $std/typedarray/testReduce<Int16Array,i16>~anonymous|5 $std/typedarray/testReduce<Uint16Array,u16>~anonymous|6 $std/typedarray/testReduce<Int32Array,i32>~anonymous|7 $std/typedarray/testReduce<Uint32Array,u32>~anonymous|8 $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 $std/typedarray/testReduce<Uint64Array,u64>~anonymous|10 $std/typedarray/testReduce<Float32Array,f32>~anonymous|11 $std/typedarray/testReduce<Float64Array,f64>~anonymous|12 $std/typedarray/testReduceRight<Int8Array,i8>~anonymous|13 $std/typedarray/testReduceRight<Uint8Array,u8>~anonymous|14 $std/typedarray/testReduceRight<Uint8ClampedArray,u8>~anonymous|15 $std/typedarray/testReduceRight<Int16Array,i16>~anonymous|16 $std/typedarray/testReduceRight<Uint16Array,u16>~anonymous|17 $std/typedarray/testReduceRight<Int32Array,i32>~anonymous|18 $std/typedarray/testReduceRight<Uint32Array,u32>~anonymous|19 $std/typedarray/testReduceRight<Int64Array,i64>~anonymous|20 $std/typedarray/testReduceRight<Uint64Array,u64>~anonymous|21 $std/typedarray/testReduceRight<Float32Array,f32>~anonymous|22 $std/typedarray/testReduceRight<Float64Array,f64>~anonymous|23 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Uint8Array,u8>~anonymous|25 $std/typedarray/testArrayMap<Uint8ClampedArray,u8>~anonymous|26 $std/typedarray/testArrayMap<Int16Array,i16>~anonymous|27 $std/typedarray/testArrayMap<Uint16Array,u16>~anonymous|28 $std/typedarray/testArrayMap<Int32Array,i32>~anonymous|29 $std/typedarray/testArrayMap<Uint32Array,u32>~anonymous|30 $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 $std/typedarray/testArrayMap<Uint64Array,u64>~anonymous|32 $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|33 $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|34 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|36 $std/typedarray/testArraySome<Uint8Array,u8>~anonymous|37 $std/typedarray/testArraySome<Uint8Array,u8>~anonymous|38 $std/typedarray/testArraySome<Uint8ClampedArray,u8>~anonymous|39 $std/typedarray/testArraySome<Uint8ClampedArray,u8>~anonymous|40 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|42 $std/typedarray/testArraySome<Uint16Array,u16>~anonymous|43 $std/typedarray/testArraySome<Uint16Array,u16>~anonymous|44 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|46 $std/typedarray/testArraySome<Uint32Array,u32>~anonymous|47 $std/typedarray/testArraySome<Uint32Array,u32>~anonymous|48 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|50 $std/typedarray/testArraySome<Uint64Array,u64>~anonymous|51 $std/typedarray/testArraySome<Uint64Array,u64>~anonymous|52 $std/typedarray/testArraySome<Float32Array,f32>~anonymous|53 $std/typedarray/testArraySome<Float32Array,f32>~anonymous|54 $std/typedarray/testArraySome<Float64Array,f64>~anonymous|55 $std/typedarray/testArraySome<Float64Array,f64>~anonymous|56 $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|57 $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|58 $std/typedarray/testArrayFindIndex<Uint8Array,u8>~anonymous|59 $std/typedarray/testArrayFindIndex<Uint8Array,u8>~anonymous|60 $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8>~anonymous|61 $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8>~anonymous|62 $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|63 $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|64 $std/typedarray/testArrayFindIndex<Uint16Array,u16>~anonymous|65 $std/typedarray/testArrayFindIndex<Uint16Array,u16>~anonymous|66 $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|67 $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|68 $std/typedarray/testArrayFindIndex<Uint32Array,u32>~anonymous|69 $std/typedarray/testArrayFindIndex<Uint32Array,u32>~anonymous|70 $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|71 $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|72 $std/typedarray/testArrayFindIndex<Uint64Array,u64>~anonymous|73 $std/typedarray/testArrayFindIndex<Uint64Array,u64>~anonymous|74 $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|75 $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|76 $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|77 $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|78 $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|79 $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|80 $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|81 $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|82 $std/typedarray/testArrayEvery<Uint8ClampedArray,u8>~anonymous|83 $std/typedarray/testArrayEvery<Uint8ClampedArray,u8>~anonymous|84 $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|85 $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|86 $std/typedarray/testArrayEvery<Uint16Array,u16>~anonymous|87 $std/typedarray/testArrayEvery<Uint16Array,u16>~anonymous|88 $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|89 $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|90 $std/typedarray/testArrayEvery<Uint32Array,u32>~anonymous|91 $std/typedarray/testArrayEvery<Uint32Array,u32>~anonymous|92 $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|93 $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|94 $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|95 $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|96 $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|97 $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|98 $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|99 $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|100)
+ (elem (i32.const 0) $null $~lib/internal/sort/COMPARATOR<f64>~anonymous|1 $std/typedarray/testReduce<Int8Array,i8>~anonymous|2 $std/typedarray/testReduce<Uint8Array,u8>~anonymous|3 $std/typedarray/testReduce<Uint8ClampedArray,u8>~anonymous|4 $std/typedarray/testReduce<Int16Array,i16>~anonymous|5 $std/typedarray/testReduce<Uint16Array,u16>~anonymous|6 $std/typedarray/testReduce<Int32Array,i32>~anonymous|7 $std/typedarray/testReduce<Uint32Array,u32>~anonymous|8 $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 $std/typedarray/testReduce<Uint64Array,u64>~anonymous|10 $std/typedarray/testReduce<Float32Array,f32>~anonymous|11 $std/typedarray/testReduce<Float64Array,f64>~anonymous|12 $std/typedarray/testReduceRight<Int8Array,i8>~anonymous|13 $std/typedarray/testReduceRight<Uint8Array,u8>~anonymous|14 $std/typedarray/testReduceRight<Uint8ClampedArray,u8>~anonymous|15 $std/typedarray/testReduceRight<Int16Array,i16>~anonymous|16 $std/typedarray/testReduceRight<Uint16Array,u16>~anonymous|17 $std/typedarray/testReduceRight<Int32Array,i32>~anonymous|18 $std/typedarray/testReduceRight<Uint32Array,u32>~anonymous|19 $std/typedarray/testReduceRight<Int64Array,i64>~anonymous|20 $std/typedarray/testReduceRight<Uint64Array,u64>~anonymous|21 $std/typedarray/testReduceRight<Float32Array,f32>~anonymous|22 $std/typedarray/testReduceRight<Float64Array,f64>~anonymous|23 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|24 $std/typedarray/testArrayMap<Uint8Array,u8>~anonymous|25 $std/typedarray/testArrayMap<Uint8ClampedArray,u8>~anonymous|26 $std/typedarray/testArrayMap<Int16Array,i16>~anonymous|27 $std/typedarray/testArrayMap<Uint16Array,u16>~anonymous|28 $std/typedarray/testArrayMap<Int32Array,i32>~anonymous|29 $std/typedarray/testArrayMap<Uint32Array,u32>~anonymous|30 $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|31 $std/typedarray/testArrayMap<Uint64Array,u64>~anonymous|32 $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|33 $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|34 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|35 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|36 $std/typedarray/testArraySome<Uint8Array,u8>~anonymous|37 $std/typedarray/testArraySome<Uint8Array,u8>~anonymous|38 $std/typedarray/testArraySome<Uint8ClampedArray,u8>~anonymous|39 $std/typedarray/testArraySome<Uint8ClampedArray,u8>~anonymous|40 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|41 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|42 $std/typedarray/testArraySome<Uint16Array,u16>~anonymous|43 $std/typedarray/testArraySome<Uint16Array,u16>~anonymous|44 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|45 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|46 $std/typedarray/testArraySome<Uint32Array,u32>~anonymous|47 $std/typedarray/testArraySome<Uint32Array,u32>~anonymous|48 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|49 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|50 $std/typedarray/testArraySome<Uint64Array,u64>~anonymous|51 $std/typedarray/testArraySome<Uint64Array,u64>~anonymous|52 $std/typedarray/testArraySome<Float32Array,f32>~anonymous|53 $std/typedarray/testArraySome<Float32Array,f32>~anonymous|54 $std/typedarray/testArraySome<Float64Array,f64>~anonymous|55 $std/typedarray/testArraySome<Float64Array,f64>~anonymous|56 $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|57 $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|58 $std/typedarray/testArrayFindIndex<Uint8Array,u8>~anonymous|59 $std/typedarray/testArrayFindIndex<Uint8Array,u8>~anonymous|60 $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8>~anonymous|61 $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8>~anonymous|62 $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|63 $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|64 $std/typedarray/testArrayFindIndex<Uint16Array,u16>~anonymous|65 $std/typedarray/testArrayFindIndex<Uint16Array,u16>~anonymous|66 $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|67 $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|68 $std/typedarray/testArrayFindIndex<Uint32Array,u32>~anonymous|69 $std/typedarray/testArrayFindIndex<Uint32Array,u32>~anonymous|70 $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|71 $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|72 $std/typedarray/testArrayFindIndex<Uint64Array,u64>~anonymous|73 $std/typedarray/testArrayFindIndex<Uint64Array,u64>~anonymous|74 $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|75 $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|76 $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|77 $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|78 $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|79 $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|80 $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|81 $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|82 $std/typedarray/testArrayEvery<Uint8ClampedArray,u8>~anonymous|83 $std/typedarray/testArrayEvery<Uint8ClampedArray,u8>~anonymous|84 $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|85 $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|86 $std/typedarray/testArrayEvery<Uint16Array,u16>~anonymous|87 $std/typedarray/testArrayEvery<Uint16Array,u16>~anonymous|88 $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|89 $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|90 $std/typedarray/testArrayEvery<Uint32Array,u32>~anonymous|91 $std/typedarray/testArrayEvery<Uint32Array,u32>~anonymous|92 $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|93 $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|94 $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|95 $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|96 $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|97 $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|98 $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|99 $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|100)
  (global $~lib/typedarray/Int8Array.BYTES_PER_ELEMENT i32 (i32.const 1))
  (global $~lib/typedarray/Uint8Array.BYTES_PER_ELEMENT i32 (i32.const 1))
  (global $~lib/typedarray/Uint8ClampedArray.BYTES_PER_ELEMENT i32 (i32.const 1))
@@ -484,6 +484,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.const 1073741816
   i32.gt_u
@@ -502,16 +503,20 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  local.get $3
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  i32.const 0
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $2
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.0
+   local.get $3
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/memory/memset
+  end
   block (result i32)
    local.get $0
    i32.eqz
@@ -560,6 +565,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.const 1073741816
   i32.gt_u
@@ -578,16 +584,20 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  local.get $3
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  i32.const 0
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $2
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.1
+   local.get $3
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/memory/memset
+  end
   block (result i32)
    local.get $0
    i32.eqz
@@ -650,6 +660,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.const 536870908
   i32.gt_u
@@ -668,16 +679,20 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  local.get $3
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  i32.const 0
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $2
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.2
+   local.get $3
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/memory/memset
+  end
   block (result i32)
    local.get $0
    i32.eqz
@@ -726,6 +741,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.const 536870908
   i32.gt_u
@@ -744,16 +760,20 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  local.get $3
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  i32.const 0
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $2
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.3
+   local.get $3
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/memory/memset
+  end
   block (result i32)
    local.get $0
    i32.eqz
@@ -802,6 +822,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.const 268435454
   i32.gt_u
@@ -820,16 +841,20 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  local.get $3
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  i32.const 0
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $2
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.4
+   local.get $3
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/memory/memset
+  end
   block (result i32)
    local.get $0
    i32.eqz
@@ -878,6 +903,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.const 268435454
   i32.gt_u
@@ -896,16 +922,20 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  local.get $3
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  i32.const 0
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $2
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.5
+   local.get $3
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/memory/memset
+  end
   block (result i32)
    local.get $0
    i32.eqz
@@ -954,6 +984,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.const 134217727
   i32.gt_u
@@ -972,16 +1003,20 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  local.get $3
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  i32.const 0
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $2
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.6
+   local.get $3
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/memory/memset
+  end
   block (result i32)
    local.get $0
    i32.eqz
@@ -1030,6 +1065,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.const 134217727
   i32.gt_u
@@ -1048,16 +1084,20 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  local.get $3
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  i32.const 0
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $2
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.7
+   local.get $3
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/memory/memset
+  end
   block (result i32)
    local.get $0
    i32.eqz
@@ -1106,6 +1146,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.const 268435454
   i32.gt_u
@@ -1124,16 +1165,20 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  local.get $3
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  i32.const 0
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $2
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.8
+   local.get $3
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/memory/memset
+  end
   block (result i32)
    local.get $0
    i32.eqz
@@ -1182,6 +1227,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $1
   i32.const 134217727
   i32.gt_u
@@ -1200,16 +1246,20 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  local.get $3
-  global.get $~lib/internal/arraybuffer/HEADER_SIZE
-  i32.add
-  local.set $4
-  i32.const 0
-  local.set $5
-  local.get $4
-  local.get $5
-  local.get $2
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.9
+   local.get $3
+   global.get $~lib/internal/arraybuffer/HEADER_SIZE
+   i32.add
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $2
+   local.set $6
+   local.get $4
+   local.get $5
+   local.get $6
+   call $~lib/internal/memory/memset
+  end
   block (result i32)
    local.get $0
    i32.eqz
@@ -1265,6 +1315,7 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
+  (local $12 i32)
   i32.const 0
   local.get $0
   call $~lib/typedarray/Int8Array#constructor
@@ -1299,6 +1350,8 @@
   end
   block $~lib/internal/typedarray/TypedArray<i8>#get:length|inlined.0 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i32.load offset=8
    i32.const 0
    i32.shr_u
@@ -1317,8 +1370,8 @@
   i32.const 0
   local.get $0
   call $~lib/typedarray/Uint8Array#constructor
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   i32.load offset=4
   i32.const 0
   i32.eq
@@ -1331,7 +1384,7 @@
    call $~lib/env/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   i32.load offset=8
   local.get $0
   global.get $~lib/typedarray/Uint8Array.BYTES_PER_ELEMENT
@@ -1347,6 +1400,8 @@
    unreachable
   end
   block $~lib/internal/typedarray/TypedArray<u8>#get:length|inlined.0 (result i32)
+   local.get $3
+   local.set $2
    local.get $2
    i32.load offset=8
    i32.const 0
@@ -1366,8 +1421,8 @@
   i32.const 0
   local.get $0
   call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.set $3
-  local.get $3
+  local.set $4
+  local.get $4
   i32.load offset=4
   i32.const 0
   i32.eq
@@ -1380,7 +1435,7 @@
    call $~lib/env/abort
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.load offset=8
   local.get $0
   global.get $~lib/typedarray/Uint8Array.BYTES_PER_ELEMENT
@@ -1396,7 +1451,9 @@
    unreachable
   end
   block $~lib/internal/typedarray/TypedArray<u8>#get:length|inlined.1 (result i32)
-   local.get $3
+   local.get $4
+   local.set $2
+   local.get $2
    i32.load offset=8
    i32.const 0
    i32.shr_u
@@ -1415,8 +1472,8 @@
   i32.const 0
   local.get $0
   call $~lib/typedarray/Int16Array#constructor
-  local.set $4
-  local.get $4
+  local.set $5
+  local.get $5
   i32.load offset=4
   i32.const 0
   i32.eq
@@ -1429,7 +1486,7 @@
    call $~lib/env/abort
    unreachable
   end
-  local.get $4
+  local.get $5
   i32.load offset=8
   local.get $0
   global.get $~lib/typedarray/Int16Array.BYTES_PER_ELEMENT
@@ -1445,7 +1502,9 @@
    unreachable
   end
   block $~lib/internal/typedarray/TypedArray<i16>#get:length|inlined.0 (result i32)
-   local.get $4
+   local.get $5
+   local.set $2
+   local.get $2
    i32.load offset=8
    i32.const 1
    i32.shr_u
@@ -1464,8 +1523,8 @@
   i32.const 0
   local.get $0
   call $~lib/typedarray/Uint16Array#constructor
-  local.set $5
-  local.get $5
+  local.set $6
+  local.get $6
   i32.load offset=4
   i32.const 0
   i32.eq
@@ -1478,7 +1537,7 @@
    call $~lib/env/abort
    unreachable
   end
-  local.get $5
+  local.get $6
   i32.load offset=8
   local.get $0
   global.get $~lib/typedarray/Uint16Array.BYTES_PER_ELEMENT
@@ -1494,7 +1553,9 @@
    unreachable
   end
   block $~lib/internal/typedarray/TypedArray<u16>#get:length|inlined.0 (result i32)
-   local.get $5
+   local.get $6
+   local.set $2
+   local.get $2
    i32.load offset=8
    i32.const 1
    i32.shr_u
@@ -1513,8 +1574,8 @@
   i32.const 0
   local.get $0
   call $~lib/typedarray/Int32Array#constructor
-  local.set $6
-  local.get $6
+  local.set $7
+  local.get $7
   i32.load offset=4
   i32.const 0
   i32.eq
@@ -1527,7 +1588,7 @@
    call $~lib/env/abort
    unreachable
   end
-  local.get $6
+  local.get $7
   i32.load offset=8
   local.get $0
   global.get $~lib/typedarray/Int32Array.BYTES_PER_ELEMENT
@@ -1543,7 +1604,9 @@
    unreachable
   end
   block $~lib/internal/typedarray/TypedArray<i32>#get:length|inlined.0 (result i32)
-   local.get $6
+   local.get $7
+   local.set $2
+   local.get $2
    i32.load offset=8
    i32.const 2
    i32.shr_u
@@ -1562,8 +1625,8 @@
   i32.const 0
   local.get $0
   call $~lib/typedarray/Uint32Array#constructor
-  local.set $7
-  local.get $7
+  local.set $8
+  local.get $8
   i32.load offset=4
   i32.const 0
   i32.eq
@@ -1576,7 +1639,7 @@
    call $~lib/env/abort
    unreachable
   end
-  local.get $7
+  local.get $8
   i32.load offset=8
   local.get $0
   global.get $~lib/typedarray/Uint32Array.BYTES_PER_ELEMENT
@@ -1592,7 +1655,9 @@
    unreachable
   end
   block $~lib/internal/typedarray/TypedArray<u32>#get:length|inlined.0 (result i32)
-   local.get $7
+   local.get $8
+   local.set $2
+   local.get $2
    i32.load offset=8
    i32.const 2
    i32.shr_u
@@ -1611,8 +1676,8 @@
   i32.const 0
   local.get $0
   call $~lib/typedarray/Int64Array#constructor
-  local.set $8
-  local.get $8
+  local.set $9
+  local.get $9
   i32.load offset=4
   i32.const 0
   i32.eq
@@ -1625,7 +1690,7 @@
    call $~lib/env/abort
    unreachable
   end
-  local.get $8
+  local.get $9
   i32.load offset=8
   local.get $0
   global.get $~lib/typedarray/Int64Array.BYTES_PER_ELEMENT
@@ -1641,7 +1706,9 @@
    unreachable
   end
   block $~lib/internal/typedarray/TypedArray<i64>#get:length|inlined.0 (result i32)
-   local.get $8
+   local.get $9
+   local.set $2
+   local.get $2
    i32.load offset=8
    i32.const 3
    i32.shr_u
@@ -1660,8 +1727,8 @@
   i32.const 0
   local.get $0
   call $~lib/typedarray/Uint64Array#constructor
-  local.set $9
-  local.get $9
+  local.set $10
+  local.get $10
   i32.load offset=4
   i32.const 0
   i32.eq
@@ -1674,7 +1741,7 @@
    call $~lib/env/abort
    unreachable
   end
-  local.get $9
+  local.get $10
   i32.load offset=8
   local.get $0
   global.get $~lib/typedarray/Uint64Array.BYTES_PER_ELEMENT
@@ -1690,7 +1757,9 @@
    unreachable
   end
   block $~lib/internal/typedarray/TypedArray<u64>#get:length|inlined.0 (result i32)
-   local.get $9
+   local.get $10
+   local.set $2
+   local.get $2
    i32.load offset=8
    i32.const 3
    i32.shr_u
@@ -1709,8 +1778,8 @@
   i32.const 0
   local.get $0
   call $~lib/typedarray/Float32Array#constructor
-  local.set $10
-  local.get $10
+  local.set $11
+  local.get $11
   i32.load offset=4
   i32.const 0
   i32.eq
@@ -1723,7 +1792,7 @@
    call $~lib/env/abort
    unreachable
   end
-  local.get $10
+  local.get $11
   i32.load offset=8
   local.get $0
   global.get $~lib/typedarray/Float32Array.BYTES_PER_ELEMENT
@@ -1739,7 +1808,9 @@
    unreachable
   end
   block $~lib/internal/typedarray/TypedArray<f32>#get:length|inlined.0 (result i32)
-   local.get $10
+   local.get $11
+   local.set $2
+   local.get $2
    i32.load offset=8
    i32.const 2
    i32.shr_u
@@ -1758,8 +1829,8 @@
   i32.const 0
   local.get $0
   call $~lib/typedarray/Float64Array#constructor
-  local.set $11
-  local.get $11
+  local.set $12
+  local.get $12
   i32.load offset=4
   i32.const 0
   i32.eq
@@ -1772,7 +1843,7 @@
    call $~lib/env/abort
    unreachable
   end
-  local.get $11
+  local.get $12
   i32.load offset=8
   local.get $0
   global.get $~lib/typedarray/Float64Array.BYTES_PER_ELEMENT
@@ -1788,7 +1859,9 @@
    unreachable
   end
   block $~lib/internal/typedarray/TypedArray<f64>#get:length|inlined.0 (result i32)
-   local.get $11
+   local.get $12
+   local.set $2
+   local.get $2
    i32.load offset=8
    i32.const 3
    i32.shr_u
@@ -1808,6 +1881,8 @@
  (func $~lib/internal/typedarray/TypedArray<i32>#__set (; 28 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1822,25 +1897,32 @@
    call $~lib/env/abort
    unreachable
   end
-  local.get $0
-  i32.load
-  local.set $3
-  local.get $0
-  i32.load offset=4
-  local.set $4
-  local.get $3
-  local.get $1
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $4
-  i32.add
-  local.get $2
-  i32.store offset=8
+  block $~lib/internal/arraybuffer/STORE<i32,i32>|inlined.0
+   local.get $0
+   i32.load
+   local.set $3
+   local.get $1
+   local.set $4
+   local.get $2
+   local.set $5
+   local.get $0
+   i32.load offset=4
+   local.set $6
+   local.get $3
+   local.get $4
+   i32.const 2
+   i32.shl
+   i32.add
+   local.get $6
+   i32.add
+   local.get $5
+   i32.store offset=8
+  end
  )
  (func $~lib/internal/typedarray/TypedArray<i32>#__get (; 29 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1859,15 +1941,17 @@
    local.get $0
    i32.load
    local.set $2
+   local.get $1
+   local.set $3
    local.get $0
    i32.load offset=4
-   local.set $3
+   local.set $4
    local.get $2
-   local.get $1
+   local.get $3
    i32.const 2
    i32.shl
    i32.add
-   local.get $3
+   local.get $4
    i32.add
    i32.load offset=8
   end
@@ -1876,104 +1960,117 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $0
+  local.set $3
+  local.get $1
+  local.set $4
+  local.get $2
+  local.set $5
   block $~lib/internal/typedarray/TypedArray<i32>#get:length|inlined.2 (result i32)
-   local.get $0
+   local.get $3
+   local.set $6
+   local.get $6
    i32.load offset=8
    i32.const 2
    i32.shr_u
   end
-  local.set $3
-  local.get $1
+  local.set $6
+  local.get $4
   i32.const 0
   i32.lt_s
   if
-   local.get $3
-   local.get $1
+   local.get $6
+   local.get $4
    i32.add
-   local.tee $4
+   local.tee $7
    i32.const 0
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $8
+   local.get $7
+   local.get $8
    i32.gt_s
    select
-   local.set $1
+   local.set $4
   else   
-   local.get $1
-   local.tee $4
-   local.get $3
-   local.tee $5
    local.get $4
-   local.get $5
+   local.tee $7
+   local.get $6
+   local.tee $8
+   local.get $7
+   local.get $8
    i32.lt_s
    select
-   local.set $1
+   local.set $4
   end
-  local.get $2
+  local.get $5
   i32.const 0
   i32.lt_s
   if
-   local.get $3
-   local.get $2
-   i32.add
-   local.tee $4
-   local.get $1
-   local.tee $5
-   local.get $4
+   local.get $6
    local.get $5
+   i32.add
+   local.tee $7
+   local.get $4
+   local.tee $8
+   local.get $7
+   local.get $8
    i32.gt_s
    select
-   local.set $2
+   local.set $5
   else   
-   local.get $2
-   local.tee $4
-   local.get $3
-   local.tee $5
-   local.get $4
    local.get $5
+   local.tee $7
+   local.get $6
+   local.tee $8
+   local.get $7
+   local.get $8
    i32.lt_s
    select
-   local.tee $4
-   local.get $1
-   local.tee $5
+   local.tee $7
    local.get $4
-   local.get $5
+   local.tee $8
+   local.get $7
+   local.get $8
    i32.gt_s
    select
-   local.set $2
+   local.set $5
   end
   block $~lib/memory/memory.allocate|inlined.1 (result i32)
    i32.const 12
-   local.set $4
-   local.get $4
+   local.set $7
+   local.get $7
    call $~lib/allocator/arena/__memory_allocate
    br $~lib/memory/memory.allocate|inlined.1
   end
-  local.set $4
-  local.get $4
-  local.get $0
+  local.set $7
+  local.get $7
+  local.get $3
   i32.load
   i32.store
-  local.get $4
-  local.get $0
+  local.get $7
+  local.get $3
   i32.load offset=4
-  local.get $1
+  local.get $4
   i32.const 2
   i32.shl
   i32.add
   i32.store offset=4
+  local.get $7
+  local.get $5
   local.get $4
-  local.get $2
-  local.get $1
   i32.sub
   i32.const 2
   i32.shl
   i32.store offset=8
-  local.get $4
+  local.get $7
  )
  (func $~lib/internal/typedarray/TypedArray<f64>#__set (; 31 ;) (type $iiFv) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (local $4 i32)
+  (local $5 f64)
+  (local $6 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1988,127 +2085,147 @@
    call $~lib/env/abort
    unreachable
   end
-  local.get $0
-  i32.load
-  local.set $3
-  local.get $0
-  i32.load offset=4
-  local.set $4
-  local.get $3
-  local.get $1
-  i32.const 3
-  i32.shl
-  i32.add
-  local.get $4
-  i32.add
-  local.get $2
-  f64.store offset=8
+  block $~lib/internal/arraybuffer/STORE<f64,f64>|inlined.0
+   local.get $0
+   i32.load
+   local.set $3
+   local.get $1
+   local.set $4
+   local.get $2
+   local.set $5
+   local.get $0
+   i32.load offset=4
+   local.set $6
+   local.get $3
+   local.get $4
+   i32.const 3
+   i32.shl
+   i32.add
+   local.get $6
+   i32.add
+   local.get $5
+   f64.store offset=8
+  end
  )
  (func $~lib/typedarray/Float64Array#subarray (; 32 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $0
+  local.set $3
+  local.get $1
+  local.set $4
+  local.get $2
+  local.set $5
   block $~lib/internal/typedarray/TypedArray<f64>#get:length|inlined.1 (result i32)
-   local.get $0
+   local.get $3
+   local.set $6
+   local.get $6
    i32.load offset=8
    i32.const 3
    i32.shr_u
   end
-  local.set $3
-  local.get $1
+  local.set $6
+  local.get $4
   i32.const 0
   i32.lt_s
   if
-   local.get $3
-   local.get $1
+   local.get $6
+   local.get $4
    i32.add
-   local.tee $4
+   local.tee $7
    i32.const 0
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $8
+   local.get $7
+   local.get $8
    i32.gt_s
    select
-   local.set $1
+   local.set $4
   else   
-   local.get $1
-   local.tee $4
-   local.get $3
-   local.tee $5
    local.get $4
-   local.get $5
+   local.tee $7
+   local.get $6
+   local.tee $8
+   local.get $7
+   local.get $8
    i32.lt_s
    select
-   local.set $1
+   local.set $4
   end
-  local.get $2
+  local.get $5
   i32.const 0
   i32.lt_s
   if
-   local.get $3
-   local.get $2
-   i32.add
-   local.tee $4
-   local.get $1
-   local.tee $5
-   local.get $4
+   local.get $6
    local.get $5
+   i32.add
+   local.tee $7
+   local.get $4
+   local.tee $8
+   local.get $7
+   local.get $8
    i32.gt_s
    select
-   local.set $2
+   local.set $5
   else   
-   local.get $2
-   local.tee $4
-   local.get $3
-   local.tee $5
-   local.get $4
    local.get $5
+   local.tee $7
+   local.get $6
+   local.tee $8
+   local.get $7
+   local.get $8
    i32.lt_s
    select
-   local.tee $4
-   local.get $1
-   local.tee $5
+   local.tee $7
    local.get $4
-   local.get $5
+   local.tee $8
+   local.get $7
+   local.get $8
    i32.gt_s
    select
-   local.set $2
+   local.set $5
   end
   block $~lib/memory/memory.allocate|inlined.2 (result i32)
    i32.const 12
-   local.set $4
-   local.get $4
+   local.set $7
+   local.get $7
    call $~lib/allocator/arena/__memory_allocate
    br $~lib/memory/memory.allocate|inlined.2
   end
-  local.set $4
-  local.get $4
-  local.get $0
+  local.set $7
+  local.get $7
+  local.get $3
   i32.load
   i32.store
-  local.get $4
-  local.get $0
+  local.get $7
+  local.get $3
   i32.load offset=4
-  local.get $1
+  local.get $4
   i32.const 3
   i32.shl
   i32.add
   i32.store offset=4
+  local.get $7
+  local.get $5
   local.get $4
-  local.get $2
-  local.get $1
   i32.sub
   i32.const 3
   i32.shl
   i32.store offset=8
-  local.get $4
+  local.get $7
  )
  (func $~lib/internal/sort/insertionSort<f64> (; 33 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
-  (local $5 f64)
+  (local $5 i32)
   (local $6 i32)
-  (local $7 f64)
-  (local $8 i32)
+  (local $7 i32)
+  (local $8 f64)
+  (local $9 i32)
+  (local $10 f64)
+  (local $11 f64)
   block $break|0
    i32.const 0
    local.set $4
@@ -2121,67 +2238,85 @@
     block
      block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.2 (result f64)
       local.get $0
+      local.set $5
       local.get $4
+      local.set $6
+      local.get $1
+      local.set $7
+      local.get $5
+      local.get $6
       i32.const 3
       i32.shl
       i32.add
-      local.get $1
+      local.get $7
       i32.add
       f64.load offset=8
      end
-     local.set $5
+     local.set $8
      local.get $4
      i32.const 1
      i32.sub
-     local.set $6
+     local.set $7
      block $break|1
       loop $continue|1
-       local.get $6
+       local.get $7
        i32.const 0
        i32.ge_s
        if
         block
          block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.3 (result f64)
           local.get $0
+          local.set $6
+          local.get $7
+          local.set $5
+          local.get $1
+          local.set $9
           local.get $6
+          local.get $5
           i32.const 3
           i32.shl
           i32.add
-          local.get $1
+          local.get $9
           i32.add
           f64.load offset=8
          end
-         local.set $7
+         local.set $10
          block (result i32)
           i32.const 2
           global.set $~argc
-          local.get $5
-          local.get $7
+          local.get $8
+          local.get $10
           local.get $3
           call_indirect (type $FFi)
          end
          i32.const 0
          i32.lt_s
          if
+          local.get $0
+          local.set $9
           block (result i32)
-           local.get $6
-           local.tee $8
+           local.get $7
+           local.tee $5
            i32.const 1
            i32.sub
-           local.set $6
-           local.get $8
+           local.set $7
+           local.get $5
           end
           i32.const 1
           i32.add
-          local.set $8
-          local.get $0
-          local.get $8
+          local.set $5
+          local.get $10
+          local.set $11
+          local.get $1
+          local.set $6
+          local.get $9
+          local.get $5
           i32.const 3
           i32.shl
           i32.add
-          local.get $1
+          local.get $6
           i32.add
-          local.get $7
+          local.get $11
           f64.store offset=8
          else          
           br $break|1
@@ -2191,19 +2326,27 @@
        end
       end
      end
-     local.get $6
-     i32.const 1
-     i32.add
-     local.set $8
-     local.get $0
-     local.get $8
-     i32.const 3
-     i32.shl
-     i32.add
-     local.get $1
-     i32.add
-     local.get $5
-     f64.store offset=8
+     block $~lib/internal/arraybuffer/STORE<f64,f64>|inlined.4
+      local.get $0
+      local.set $6
+      local.get $7
+      i32.const 1
+      i32.add
+      local.set $5
+      local.get $8
+      local.set $10
+      local.get $1
+      local.set $9
+      local.get $6
+      local.get $5
+      i32.const 3
+      i32.shl
+      i32.add
+      local.get $9
+      i32.add
+      local.get $10
+      f64.store offset=8
+     end
     end
     local.get $4
     i32.const 1
@@ -2224,10 +2367,13 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 f64)
-  (local $10 f64)
+  (local $9 i32)
+  (local $10 i32)
   (local $11 i32)
   (local $12 f64)
+  (local $13 f64)
+  (local $14 f64)
+  (local $15 f64)
   local.get $2
   i32.const 31
   i32.add
@@ -2238,36 +2384,44 @@
   local.set $4
   block $~lib/memory/memory.allocate|inlined.3 (result i32)
    local.get $4
+   local.set $5
+   local.get $5
    call $~lib/allocator/arena/__memory_allocate
    br $~lib/memory/memory.allocate|inlined.3
   end
-  local.set $5
-  i32.const 0
   local.set $6
-  local.get $5
-  local.get $6
-  local.get $4
-  call $~lib/internal/memory/memset
+  block $~lib/memory/memory.fill|inlined.10
+   local.get $6
+   local.set $5
+   i32.const 0
+   local.set $7
+   local.get $4
+   local.set $8
+   local.get $5
+   local.get $7
+   local.get $8
+   call $~lib/internal/memory/memset
+  end
   block $break|0
    local.get $2
    i32.const 1
    i32.sub
-   local.set $6
+   local.set $8
    loop $repeat|0
-    local.get $6
+    local.get $8
     i32.const 0
     i32.gt_s
     i32.eqz
     br_if $break|0
     block
-     local.get $6
+     local.get $8
      local.set $7
      block $break|1
       loop $continue|1
        local.get $7
        i32.const 1
        i32.and
-       local.get $5
+       local.get $6
        local.get $7
        i32.const 6
        i32.shr_s
@@ -2296,49 +2450,61 @@
      local.get $7
      i32.const 1
      i32.shr_s
-     local.set $8
+     local.set $5
      block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.4 (result f64)
       local.get $0
-      local.get $8
+      local.set $9
+      local.get $5
+      local.set $10
+      local.get $1
+      local.set $11
+      local.get $9
+      local.get $10
       i32.const 3
       i32.shl
       i32.add
-      local.get $1
+      local.get $11
       i32.add
       f64.load offset=8
      end
-     local.set $9
+     local.set $12
      block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.5 (result f64)
       local.get $0
-      local.get $6
+      local.set $11
+      local.get $8
+      local.set $10
+      local.get $1
+      local.set $9
+      local.get $11
+      local.get $10
       i32.const 3
       i32.shl
       i32.add
-      local.get $1
+      local.get $9
       i32.add
       f64.load offset=8
      end
-     local.set $10
+     local.set $13
      block (result i32)
       i32.const 2
       global.set $~argc
-      local.get $9
-      local.get $10
+      local.get $12
+      local.get $13
       local.get $3
       call_indirect (type $FFi)
      end
      i32.const 0
      i32.lt_s
      if
-      local.get $5
       local.get $6
+      local.get $8
       i32.const 5
       i32.shr_s
       i32.const 2
       i32.shl
       i32.add
-      local.get $5
       local.get $6
+      local.get $8
       i32.const 5
       i32.shr_s
       i32.const 2
@@ -2346,36 +2512,56 @@
       i32.add
       i32.load
       i32.const 1
-      local.get $6
+      local.get $8
       i32.const 31
       i32.and
       i32.shl
       i32.xor
       i32.store
-      local.get $0
-      local.get $6
-      i32.const 3
-      i32.shl
-      i32.add
-      local.get $1
-      i32.add
-      local.get $9
-      f64.store offset=8
-      local.get $0
-      local.get $8
-      i32.const 3
-      i32.shl
-      i32.add
-      local.get $1
-      i32.add
-      local.get $10
-      f64.store offset=8
+      block $~lib/internal/arraybuffer/STORE<f64,f64>|inlined.5
+       local.get $0
+       local.set $9
+       local.get $8
+       local.set $10
+       local.get $12
+       local.set $14
+       local.get $1
+       local.set $11
+       local.get $9
+       local.get $10
+       i32.const 3
+       i32.shl
+       i32.add
+       local.get $11
+       i32.add
+       local.get $14
+       f64.store offset=8
+      end
+      block $~lib/internal/arraybuffer/STORE<f64,f64>|inlined.6
+       local.get $0
+       local.set $11
+       local.get $5
+       local.set $10
+       local.get $13
+       local.set $14
+       local.get $1
+       local.set $9
+       local.get $11
+       local.get $10
+       i32.const 3
+       i32.shl
+       i32.add
+       local.get $9
+       i32.add
+       local.get $14
+       f64.store offset=8
+      end
      end
     end
-    local.get $6
+    local.get $8
     i32.const 1
     i32.sub
-    local.set $6
+    local.set $8
     br $repeat|0
     unreachable
    end
@@ -2385,74 +2571,100 @@
    local.get $2
    i32.const 1
    i32.sub
-   local.set $6
+   local.set $8
    loop $repeat|2
-    local.get $6
+    local.get $8
     i32.const 2
     i32.ge_s
     i32.eqz
     br_if $break|2
     block
      block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.6 (result f64)
+      local.get $0
+      local.set $5
       i32.const 0
-      local.set $8
+      local.set $7
+      local.get $1
+      local.set $9
+      local.get $5
+      local.get $7
+      i32.const 3
+      i32.shl
+      i32.add
+      local.get $9
+      i32.add
+      f64.load offset=8
+     end
+     local.set $13
+     block $~lib/internal/arraybuffer/STORE<f64,f64>|inlined.7
       local.get $0
+      local.set $9
+      i32.const 0
+      local.set $7
+      block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.7 (result f64)
+       local.get $0
+       local.set $5
+       local.get $8
+       local.set $10
+       local.get $1
+       local.set $11
+       local.get $5
+       local.get $10
+       i32.const 3
+       i32.shl
+       i32.add
+       local.get $11
+       i32.add
+       f64.load offset=8
+      end
+      local.set $12
+      local.get $1
+      local.set $11
+      local.get $9
+      local.get $7
+      i32.const 3
+      i32.shl
+      i32.add
+      local.get $11
+      i32.add
+      local.get $12
+      f64.store offset=8
+     end
+     block $~lib/internal/arraybuffer/STORE<f64,f64>|inlined.8
+      local.get $0
+      local.set $11
       local.get $8
+      local.set $7
+      local.get $13
+      local.set $12
+      local.get $1
+      local.set $9
+      local.get $11
+      local.get $7
       i32.const 3
       i32.shl
       i32.add
-      local.get $1
+      local.get $9
       i32.add
-      f64.load offset=8
+      local.get $12
+      f64.store offset=8
      end
-     local.set $10
-     i32.const 0
-     local.set $8
-     block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.7 (result f64)
-      local.get $0
-      local.get $6
-      i32.const 3
-      i32.shl
-      i32.add
-      local.get $1
-      i32.add
-      f64.load offset=8
-     end
-     local.set $9
-     local.get $0
-     local.get $8
-     i32.const 3
-     i32.shl
-     i32.add
-     local.get $1
-     i32.add
-     local.get $9
-     f64.store offset=8
-     local.get $0
-     local.get $6
-     i32.const 3
-     i32.shl
-     i32.add
-     local.get $1
-     i32.add
-     local.get $10
-     f64.store offset=8
      i32.const 1
-     local.set $8
+     local.set $9
      block $break|3
       loop $continue|3
-       local.get $8
+       local.get $9
        i32.const 1
        i32.shl
-       local.get $5
-       local.get $8
+       local.get $6
+       local.get $9
        i32.const 5
        i32.shr_s
        i32.const 2
        i32.shl
        i32.add
        i32.load
-       local.get $8
+       local.get $9
        i32.const 31
        i32.and
        i32.shr_u
@@ -2460,66 +2672,76 @@
        i32.and
        i32.add
        local.tee $7
-       local.get $6
+       local.get $8
        i32.lt_s
        if
         local.get $7
-        local.set $8
+        local.set $9
         br $continue|3
        end
       end
      end
      block $break|4
       loop $continue|4
-       local.get $8
+       local.get $9
        i32.const 0
        i32.gt_s
        if
         block
          block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.8 (result f64)
-          i32.const 0
-          local.set $11
           local.get $0
+          local.set $11
+          i32.const 0
+          local.set $10
+          local.get $1
+          local.set $5
           local.get $11
+          local.get $10
           i32.const 3
           i32.shl
           i32.add
-          local.get $1
+          local.get $5
           i32.add
           f64.load offset=8
          end
-         local.set $10
+         local.set $13
          block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.9 (result f64)
           local.get $0
-          local.get $8
+          local.set $5
+          local.get $9
+          local.set $10
+          local.get $1
+          local.set $11
+          local.get $5
+          local.get $10
           i32.const 3
           i32.shl
           i32.add
-          local.get $1
+          local.get $11
           i32.add
           f64.load offset=8
          end
-         local.set $9
+         local.set $12
          block (result i32)
           i32.const 2
           global.set $~argc
-          local.get $10
-          local.get $9
+          local.get $13
+          local.get $12
           local.get $3
           call_indirect (type $FFi)
          end
          i32.const 0
          i32.lt_s
          if
-          local.get $5
-          local.get $8
+          local.get $6
+          local.get $9
           i32.const 5
           i32.shr_s
           i32.const 2
           i32.shl
           i32.add
-          local.get $5
-          local.get $8
+          local.get $6
+          local.get $9
           i32.const 5
           i32.shr_s
           i32.const 2
@@ -2527,225 +2749,309 @@
           i32.add
           i32.load
           i32.const 1
-          local.get $8
+          local.get $9
           i32.const 31
           i32.and
           i32.shl
           i32.xor
           i32.store
-          local.get $0
-          local.get $8
-          i32.const 3
-          i32.shl
-          i32.add
-          local.get $1
-          i32.add
-          local.get $10
-          f64.store offset=8
-          i32.const 0
-          local.set $11
-          local.get $0
-          local.get $11
-          i32.const 3
-          i32.shl
-          i32.add
-          local.get $1
-          i32.add
-          local.get $9
-          f64.store offset=8
+          block $~lib/internal/arraybuffer/STORE<f64,f64>|inlined.9
+           local.get $0
+           local.set $11
+           local.get $9
+           local.set $10
+           local.get $13
+           local.set $14
+           local.get $1
+           local.set $5
+           local.get $11
+           local.get $10
+           i32.const 3
+           i32.shl
+           i32.add
+           local.get $5
+           i32.add
+           local.get $14
+           f64.store offset=8
+          end
+          block $~lib/internal/arraybuffer/STORE<f64,f64>|inlined.10
+           local.get $0
+           local.set $5
+           i32.const 0
+           local.set $10
+           local.get $12
+           local.set $14
+           local.get $1
+           local.set $11
+           local.get $5
+           local.get $10
+           i32.const 3
+           i32.shl
+           i32.add
+           local.get $11
+           i32.add
+           local.get $14
+           f64.store offset=8
+          end
          end
-         local.get $8
+         local.get $9
          i32.const 1
          i32.shr_s
-         local.set $8
+         local.set $9
         end
         br $continue|4
        end
       end
      end
     end
-    local.get $6
+    local.get $8
     i32.const 1
     i32.sub
-    local.set $6
+    local.set $8
     br $repeat|2
     unreachable
    end
    unreachable
   end
   block $~lib/memory/memory.free|inlined.0
-   block
-    local.get $5
-    call $~lib/allocator/arena/__memory_free
-    br $~lib/memory/memory.free|inlined.0
-    unreachable
-   end
-   unreachable
+   local.get $6
+   local.set $8
+   local.get $8
+   call $~lib/allocator/arena/__memory_free
+   br $~lib/memory/memory.free|inlined.0
   end
   block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.10 (result f64)
+   local.get $0
+   local.set $8
    i32.const 1
-   local.set $6
-   local.get $0
-   local.get $6
-   i32.const 3
-   i32.shl
-   i32.add
-   local.get $1
-   i32.add
-   f64.load offset=8
-  end
-  local.set $12
-  i32.const 1
-  local.set $6
-  block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.11 (result f64)
-   i32.const 0
    local.set $7
-   local.get $0
+   local.get $1
+   local.set $9
+   local.get $8
    local.get $7
    i32.const 3
    i32.shl
    i32.add
-   local.get $1
+   local.get $9
    i32.add
    f64.load offset=8
   end
-  local.set $10
-  local.get $0
-  local.get $6
-  i32.const 3
-  i32.shl
-  i32.add
-  local.get $1
-  i32.add
-  local.get $10
-  f64.store offset=8
-  i32.const 0
-  local.set $6
-  local.get $0
-  local.get $6
-  i32.const 3
-  i32.shl
-  i32.add
-  local.get $1
-  i32.add
-  local.get $12
-  f64.store offset=8
+  local.set $15
+  block $~lib/internal/arraybuffer/STORE<f64,f64>|inlined.11
+   local.get $0
+   local.set $9
+   i32.const 1
+   local.set $7
+   block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.11 (result f64)
+    local.get $0
+    local.set $8
+    i32.const 0
+    local.set $11
+    local.get $1
+    local.set $10
+    local.get $8
+    local.get $11
+    i32.const 3
+    i32.shl
+    i32.add
+    local.get $10
+    i32.add
+    f64.load offset=8
+   end
+   local.set $13
+   local.get $1
+   local.set $10
+   local.get $9
+   local.get $7
+   i32.const 3
+   i32.shl
+   i32.add
+   local.get $10
+   i32.add
+   local.get $13
+   f64.store offset=8
+  end
+  block $~lib/internal/arraybuffer/STORE<f64,f64>|inlined.12
+   local.get $0
+   local.set $10
+   i32.const 0
+   local.set $7
+   local.get $15
+   local.set $13
+   local.get $1
+   local.set $9
+   local.get $10
+   local.get $7
+   i32.const 3
+   i32.shl
+   i32.add
+   local.get $9
+   i32.add
+   local.get $13
+   f64.store offset=8
+  end
  )
  (func $~lib/typedarray/Float64Array#sort (; 36 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 f64)
-  (local $7 f64)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 f64)
+  (local $11 f64)
+  (local $12 f64)
+  (local $13 i32)
   block $~lib/internal/typedarray/SORT<Float64Array,f64>|inlined.0 (result i32)
    local.get $0
-   i32.load offset=4
    local.set $2
+   local.get $1
+   local.set $3
+   local.get $2
+   i32.load offset=4
+   local.set $4
    block $~lib/internal/typedarray/TypedArray<f64>#get:length|inlined.3 (result i32)
-    local.get $0
+    local.get $2
+    local.set $5
+    local.get $5
     i32.load offset=8
     i32.const 3
     i32.shr_u
    end
-   local.set $3
-   local.get $3
+   local.set $5
+   local.get $5
    i32.const 1
    i32.le_s
    if
-    local.get $0
+    local.get $2
     br $~lib/internal/typedarray/SORT<Float64Array,f64>|inlined.0
    end
-   local.get $0
+   local.get $2
    i32.load
-   local.set $4
-   local.get $3
+   local.set $6
+   local.get $5
    i32.const 2
    i32.eq
    if
     block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.0 (result f64)
+     local.get $6
+     local.set $7
      i32.const 1
-     local.set $5
+     local.set $8
      local.get $4
-     local.get $5
+     local.set $9
+     local.get $7
+     local.get $8
      i32.const 3
      i32.shl
      i32.add
-     local.get $2
+     local.get $9
      i32.add
      f64.load offset=8
     end
-    local.set $6
+    local.set $10
     block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.1 (result f64)
+     local.get $6
+     local.set $9
      i32.const 0
-     local.set $5
+     local.set $8
      local.get $4
-     local.get $5
+     local.set $7
+     local.get $9
+     local.get $8
      i32.const 3
      i32.shl
      i32.add
-     local.get $2
+     local.get $7
      i32.add
      f64.load offset=8
     end
-    local.set $7
+    local.set $11
     block (result i32)
      i32.const 2
      global.set $~argc
-     local.get $6
-     local.get $7
-     local.get $1
+     local.get $10
+     local.get $11
+     local.get $3
      call_indirect (type $FFi)
     end
     i32.const 0
     i32.lt_s
     if
-     i32.const 1
-     local.set $5
-     local.get $4
-     local.get $5
-     i32.const 3
-     i32.shl
-     i32.add
-     local.get $2
-     i32.add
-     local.get $7
-     f64.store offset=8
-     i32.const 0
-     local.set $5
-     local.get $4
-     local.get $5
-     i32.const 3
-     i32.shl
-     i32.add
-     local.get $2
-     i32.add
-     local.get $6
-     f64.store offset=8
+     block $~lib/internal/arraybuffer/STORE<f64,f64>|inlined.1
+      local.get $6
+      local.set $7
+      i32.const 1
+      local.set $8
+      local.get $11
+      local.set $12
+      local.get $4
+      local.set $9
+      local.get $7
+      local.get $8
+      i32.const 3
+      i32.shl
+      i32.add
+      local.get $9
+      i32.add
+      local.get $12
+      f64.store offset=8
+     end
+     block $~lib/internal/arraybuffer/STORE<f64,f64>|inlined.2
+      local.get $6
+      local.set $9
+      i32.const 0
+      local.set $8
+      local.get $10
+      local.set $12
+      local.get $4
+      local.set $7
+      local.get $9
+      local.get $8
+      i32.const 3
+      i32.shl
+      i32.add
+      local.get $7
+      i32.add
+      local.get $12
+      f64.store offset=8
+     end
     end
-    local.get $0
+    local.get $2
     br $~lib/internal/typedarray/SORT<Float64Array,f64>|inlined.0
    end
-   local.get $3
-   i32.const 256
-   i32.lt_s
-   if
+   block $~lib/internal/sort/SORT<f64>|inlined.0
+    local.get $6
+    local.set $7
     local.get $4
-    local.get $2
+    local.set $8
+    local.get $5
+    local.set $9
     local.get $3
-    local.get $1
-    call $~lib/internal/sort/insertionSort<f64>
-   else    
-    local.get $4
-    local.get $2
-    local.get $3
-    local.get $1
-    call $~lib/internal/sort/weakHeapSort<f64>
+    local.set $13
+    local.get $9
+    i32.const 256
+    i32.lt_s
+    if
+     local.get $7
+     local.get $8
+     local.get $9
+     local.get $13
+     call $~lib/internal/sort/insertionSort<f64>
+    else     
+     local.get $7
+     local.get $8
+     local.get $9
+     local.get $13
+     call $~lib/internal/sort/weakHeapSort<f64>
+    end
    end
-   local.get $0
+   local.get $2
   end
  )
- (func $~lib/typedarray/Float64Array#sort|trampoline~anonymous|1 (; 37 ;) (type $FFi) (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<f64>~anonymous|1 (; 37 ;) (type $FFi) (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   local.get $0
@@ -2800,6 +3106,7 @@
  (func $~lib/internal/typedarray/TypedArray<f64>#__get (; 39 ;) (type $iiF) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2818,15 +3125,17 @@
    local.get $0
    i32.load
    local.set $2
+   local.get $1
+   local.set $3
    local.get $0
    i32.load offset=4
-   local.set $3
+   local.set $4
    local.get $2
-   local.get $1
+   local.get $3
    i32.const 3
    i32.shl
    i32.add
-   local.get $3
+   local.get $4
    i32.add
    f64.load offset=8
   end
@@ -2834,6 +3143,8 @@
  (func $~lib/internal/typedarray/TypedArray<u8>#__set (; 40 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2848,21 +3159,27 @@
    call $~lib/env/abort
    unreachable
   end
-  local.get $0
-  i32.load
-  local.set $3
-  local.get $0
-  i32.load offset=4
-  local.set $4
-  local.get $3
-  local.get $1
-  i32.const 0
-  i32.shl
-  i32.add
-  local.get $4
-  i32.add
-  local.get $2
-  i32.store8 offset=8
+  block $~lib/internal/arraybuffer/STORE<u8,u32>|inlined.0
+   local.get $0
+   i32.load
+   local.set $3
+   local.get $1
+   local.set $4
+   local.get $2
+   local.set $5
+   local.get $0
+   i32.load offset=4
+   local.set $6
+   local.get $3
+   local.get $4
+   i32.const 0
+   i32.shl
+   i32.add
+   local.get $6
+   i32.add
+   local.get $5
+   i32.store8 offset=8
+  end
  )
  (func $~lib/typedarray/Uint8ClampedArray#__set (; 41 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
@@ -2889,6 +3206,7 @@
  (func $~lib/internal/typedarray/TypedArray<u8>#__get (; 42 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2907,15 +3225,17 @@
    local.get $0
    i32.load
    local.set $2
+   local.get $1
+   local.set $3
    local.get $0
    i32.load offset=4
-   local.set $3
+   local.set $4
    local.get $2
-   local.get $1
+   local.get $3
    i32.const 0
    i32.shl
    i32.add
-   local.get $3
+   local.get $4
    i32.add
    i32.load8_u offset=8
   end
@@ -2923,6 +3243,8 @@
  (func $~lib/internal/typedarray/TypedArray<i8>#__set (; 43 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2937,21 +3259,27 @@
    call $~lib/env/abort
    unreachable
   end
-  local.get $0
-  i32.load
-  local.set $3
-  local.get $0
-  i32.load offset=4
-  local.set $4
-  local.get $3
-  local.get $1
-  i32.const 0
-  i32.shl
-  i32.add
-  local.get $4
-  i32.add
-  local.get $2
-  i32.store8 offset=8
+  block $~lib/internal/arraybuffer/STORE<i8,i32>|inlined.0
+   local.get $0
+   i32.load
+   local.set $3
+   local.get $1
+   local.set $4
+   local.get $2
+   local.set $5
+   local.get $0
+   i32.load offset=4
+   local.set $6
+   local.get $3
+   local.get $4
+   i32.const 0
+   i32.shl
+   i32.add
+   local.get $6
+   i32.add
+   local.get $5
+   i32.store8 offset=8
+  end
  )
  (func $~lib/typedarray/Int8Array#fill (; 44 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
@@ -2959,95 +3287,113 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
   local.get $0
-  i32.load
   local.set $4
-  local.get $0
-  i32.load offset=4
+  local.get $1
   local.set $5
+  local.get $2
+  local.set $6
+  local.get $3
+  local.set $7
+  local.get $4
+  i32.load
+  local.set $8
+  local.get $4
+  i32.load offset=4
+  local.set $9
   block $~lib/internal/typedarray/TypedArray<i8>#get:length|inlined.1 (result i32)
-   local.get $0
+   local.get $4
+   local.set $10
+   local.get $10
    i32.load offset=8
    i32.const 0
    i32.shr_u
   end
+  local.set $10
+  local.get $6
+  i32.const 0
+  i32.lt_s
+  if (result i32)
+   local.get $10
+   local.get $6
+   i32.add
+   local.tee $11
+   i32.const 0
+   local.tee $12
+   local.get $11
+   local.get $12
+   i32.gt_s
+   select
+  else   
+   local.get $6
+   local.tee $11
+   local.get $10
+   local.tee $12
+   local.get $11
+   local.get $12
+   i32.lt_s
+   select
+  end
   local.set $6
-  local.get $2
+  local.get $7
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $6
-   local.get $2
-   i32.add
-   local.tee $7
-   i32.const 0
-   local.tee $8
+   local.get $10
    local.get $7
-   local.get $8
+   i32.add
+   local.tee $11
+   i32.const 0
+   local.tee $12
+   local.get $11
+   local.get $12
    i32.gt_s
    select
   else   
-   local.get $2
-   local.tee $7
-   local.get $6
-   local.tee $8
    local.get $7
-   local.get $8
+   local.tee $11
+   local.get $10
+   local.tee $12
+   local.get $11
+   local.get $12
    i32.lt_s
    select
   end
-  local.set $2
-  local.get $3
-  i32.const 0
-  i32.lt_s
-  if (result i32)
-   local.get $6
-   local.get $3
-   i32.add
-   local.tee $7
-   i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
-   i32.gt_s
-   select
-  else   
-   local.get $3
-   local.tee $7
-   local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
-   i32.lt_s
-   select
-  end
-  local.set $3
-  local.get $2
-  local.get $3
+  local.set $7
+  local.get $6
+  local.get $7
   i32.lt_s
   if
-   local.get $4
-   local.get $2
+   local.get $8
+   local.get $6
    i32.add
-   local.get $5
+   local.get $9
    i32.add
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
-   local.set $7
-   local.get $3
-   local.get $2
-   i32.sub
-   local.set $8
+   local.set $11
+   local.get $5
+   local.set $12
    local.get $7
-   local.get $1
-   local.get $8
+   local.get $6
+   i32.sub
+   local.set $13
+   local.get $11
+   local.get $12
+   local.get $13
    call $~lib/internal/memory/memset
   end
-  local.get $0
+  local.get $4
  )
  (func $~lib/internal/typedarray/TypedArray<i8>#__get (; 45 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -3066,15 +3412,17 @@
    local.get $0
    i32.load
    local.set $2
+   local.get $1
+   local.set $3
    local.get $0
    i32.load offset=4
-   local.set $3
+   local.set $4
    local.get $2
-   local.get $1
+   local.get $3
    i32.const 0
    i32.shl
    i32.add
-   local.get $3
+   local.get $4
    i32.add
    i32.load8_s offset=8
   end
@@ -3082,6 +3430,8 @@
  (func $~lib/array/Array<i8>#__get (; 46 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.load
   local.set $2
@@ -3092,14 +3442,18 @@
   i32.shr_u
   i32.lt_u
   if (result i32)
-   i32.const 0
-   local.set $3
    local.get $2
+   local.set $3
    local.get $1
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 0
    i32.shl
    i32.add
-   local.get $3
+   local.get $5
    i32.add
    i32.load8_s offset=8
   else   
@@ -3111,12 +3465,16 @@
   (local $3 i32)
   block $~lib/internal/typedarray/TypedArray<i8>#get:length|inlined.3 (result i32)
    local.get $0
+   local.set $2
+   local.get $2
    i32.load offset=8
    i32.const 0
    i32.shr_u
   end
   block $~lib/array/Array<i8>#get:length|inlined.1 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i32.load offset=4
   end
   i32.ne
@@ -3130,6 +3488,8 @@
     local.set $2
     block $~lib/internal/typedarray/TypedArray<i8>#get:length|inlined.4 (result i32)
      local.get $0
+     local.set $3
+     local.get $3
      i32.load offset=8
      i32.const 0
      i32.shr_u
@@ -3200,100 +3560,111 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $0
+  local.set $3
+  local.get $1
+  local.set $4
+  local.get $2
+  local.set $5
   block $~lib/internal/typedarray/TypedArray<i8>#get:length|inlined.5 (result i32)
-   local.get $0
+   local.get $3
+   local.set $6
+   local.get $6
    i32.load offset=8
    i32.const 0
    i32.shr_u
   end
-  local.set $3
-  local.get $1
+  local.set $6
+  local.get $4
   i32.const 0
   i32.lt_s
   if
-   local.get $3
-   local.get $1
+   local.get $6
+   local.get $4
    i32.add
-   local.tee $4
+   local.tee $7
    i32.const 0
-   local.tee $5
-   local.get $4
-   local.get $5
+   local.tee $8
+   local.get $7
+   local.get $8
    i32.gt_s
    select
-   local.set $1
+   local.set $4
   else   
-   local.get $1
-   local.tee $4
-   local.get $3
-   local.tee $5
    local.get $4
-   local.get $5
+   local.tee $7
+   local.get $6
+   local.tee $8
+   local.get $7
+   local.get $8
    i32.lt_s
    select
-   local.set $1
+   local.set $4
   end
-  local.get $2
+  local.get $5
   i32.const 0
   i32.lt_s
   if
-   local.get $3
-   local.get $2
-   i32.add
-   local.tee $4
-   local.get $1
-   local.tee $5
-   local.get $4
+   local.get $6
    local.get $5
+   i32.add
+   local.tee $7
+   local.get $4
+   local.tee $8
+   local.get $7
+   local.get $8
    i32.gt_s
    select
-   local.set $2
+   local.set $5
   else   
-   local.get $2
-   local.tee $4
-   local.get $3
-   local.tee $5
-   local.get $4
    local.get $5
+   local.tee $7
+   local.get $6
+   local.tee $8
+   local.get $7
+   local.get $8
    i32.lt_s
    select
-   local.tee $4
-   local.get $1
-   local.tee $5
+   local.tee $7
    local.get $4
-   local.get $5
+   local.tee $8
+   local.get $7
+   local.get $8
    i32.gt_s
    select
-   local.set $2
+   local.set $5
   end
   block $~lib/memory/memory.allocate|inlined.4 (result i32)
    i32.const 12
-   local.set $4
-   local.get $4
+   local.set $7
+   local.get $7
    call $~lib/allocator/arena/__memory_allocate
    br $~lib/memory/memory.allocate|inlined.4
   end
-  local.set $4
-  local.get $4
-  local.get $0
+  local.set $7
+  local.get $7
+  local.get $3
   i32.load
   i32.store
-  local.get $4
-  local.get $0
+  local.get $7
+  local.get $3
   i32.load offset=4
-  local.get $1
+  local.get $4
   i32.const 0
   i32.shl
   i32.add
   i32.store offset=4
+  local.get $7
+  local.get $5
   local.get $4
-  local.get $2
-  local.get $1
   i32.sub
   i32.const 0
   i32.shl
   i32.store offset=8
-  local.get $4
+  local.get $7
  )
  (func $~lib/typedarray/Int32Array#fill (; 50 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
@@ -3301,99 +3672,127 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
   local.get $0
-  i32.load
   local.set $4
-  local.get $0
-  i32.load offset=4
+  local.get $1
   local.set $5
+  local.get $2
+  local.set $6
+  local.get $3
+  local.set $7
+  local.get $4
+  i32.load
+  local.set $8
+  local.get $4
+  i32.load offset=4
+  local.set $9
   block $~lib/internal/typedarray/TypedArray<i32>#get:length|inlined.4 (result i32)
-   local.get $0
+   local.get $4
+   local.set $10
+   local.get $10
    i32.load offset=8
    i32.const 2
    i32.shr_u
   end
+  local.set $10
+  local.get $6
+  i32.const 0
+  i32.lt_s
+  if (result i32)
+   local.get $10
+   local.get $6
+   i32.add
+   local.tee $11
+   i32.const 0
+   local.tee $12
+   local.get $11
+   local.get $12
+   i32.gt_s
+   select
+  else   
+   local.get $6
+   local.tee $11
+   local.get $10
+   local.tee $12
+   local.get $11
+   local.get $12
+   i32.lt_s
+   select
+  end
   local.set $6
-  local.get $2
+  local.get $7
   i32.const 0
   i32.lt_s
   if (result i32)
-   local.get $6
-   local.get $2
-   i32.add
-   local.tee $7
-   i32.const 0
-   local.tee $8
+   local.get $10
    local.get $7
-   local.get $8
+   i32.add
+   local.tee $11
+   i32.const 0
+   local.tee $12
+   local.get $11
+   local.get $12
    i32.gt_s
    select
   else   
-   local.get $2
-   local.tee $7
-   local.get $6
-   local.tee $8
    local.get $7
-   local.get $8
+   local.tee $11
+   local.get $10
+   local.tee $12
+   local.get $11
+   local.get $12
    i32.lt_s
    select
   end
-  local.set $2
-  local.get $3
-  i32.const 0
-  i32.lt_s
-  if (result i32)
-   local.get $6
-   local.get $3
-   i32.add
-   local.tee $7
-   i32.const 0
-   local.tee $8
-   local.get $7
-   local.get $8
-   i32.gt_s
-   select
-  else   
-   local.get $3
-   local.tee $7
-   local.get $6
-   local.tee $8
-   local.get $7
-   local.get $8
-   i32.lt_s
-   select
-  end
-  local.set $3
+  local.set $7
   block $break|0
    loop $repeat|0
-    local.get $2
-    local.get $3
+    local.get $6
+    local.get $7
     i32.lt_s
     i32.eqz
     br_if $break|0
-    local.get $4
-    local.get $2
-    i32.const 2
-    i32.shl
-    i32.add
-    local.get $5
-    i32.add
-    local.get $1
-    i32.store offset=8
-    local.get $2
+    block $~lib/internal/arraybuffer/STORE<i32,i32>|inlined.1
+     local.get $8
+     local.set $11
+     local.get $6
+     local.set $12
+     local.get $5
+     local.set $13
+     local.get $9
+     local.set $14
+     local.get $11
+     local.get $12
+     i32.const 2
+     i32.shl
+     i32.add
+     local.get $14
+     i32.add
+     local.get $13
+     i32.store offset=8
+    end
+    local.get $6
     i32.const 1
     i32.add
-    local.set $2
+    local.set $6
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $0
+  local.get $4
  )
  (func $~lib/array/Array<i32>#__get (; 51 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.load
   local.set $2
@@ -3404,14 +3803,18 @@
   i32.shr_u
   i32.lt_u
   if (result i32)
-   i32.const 0
-   local.set $3
    local.get $2
+   local.set $3
    local.get $1
+   local.set $4
+   i32.const 0
+   local.set $5
+   local.get $3
+   local.get $4
    i32.const 2
    i32.shl
    i32.add
-   local.get $3
+   local.get $5
    i32.add
    i32.load offset=8
   else   
@@ -3423,12 +3826,16 @@
   (local $3 i32)
   block $~lib/internal/typedarray/TypedArray<i32>#get:length|inlined.6 (result i32)
    local.get $0
+   local.set $2
+   local.get $2
    i32.load offset=8
    i32.const 2
    i32.shr_u
   end
   block $~lib/array/Array<i32>#get:length|inlined.1 (result i32)
    local.get $1
+   local.set $2
+   local.get $2
    i32.load offset=4
   end
   i32.ne
@@ -3442,6 +3849,8 @@
     local.set $2
     block $~lib/internal/typedarray/TypedArray<i32>#get:length|inlined.7 (result i32)
      local.get $0
+     local.set $3
+     local.get $3
      i32.load offset=8
      i32.const 2
      i32.shr_u
@@ -3510,58 +3919,78 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $0
+  local.set $3
+  local.get $1
+  local.set $4
+  local.get $2
+  local.set $5
   block $~lib/internal/typedarray/TypedArray<i8>#get:length|inlined.10 (result i32)
-   local.get $0
+   local.get $3
+   local.set $6
+   local.get $6
    i32.load offset=8
    i32.const 0
    i32.shr_u
   end
-  local.set $3
-  local.get $0
+  local.set $6
+  local.get $3
   i32.load
-  local.set $4
-  local.get $0
+  local.set $7
+  local.get $3
   i32.load offset=4
-  local.set $5
+  local.set $8
   block $break|0
    i32.const 0
-   local.set $6
+   local.set $9
    loop $repeat|0
+    local.get $9
     local.get $6
-    local.get $3
     i32.lt_s
     i32.eqz
     br_if $break|0
     block (result i32)
      i32.const 4
      global.set $~argc
-     local.get $2
+     local.get $5
      block $~lib/internal/arraybuffer/LOAD<i8,i8>|inlined.2 (result i32)
-      local.get $4
-      local.get $6
+      local.get $7
+      local.set $10
+      local.get $9
+      local.set $11
+      local.get $8
+      local.set $12
+      local.get $10
+      local.get $11
       i32.const 0
       i32.shl
       i32.add
-      local.get $5
+      local.get $12
       i32.add
       i32.load8_s offset=8
      end
-     local.get $6
-     local.get $0
-     local.get $1
+     local.get $9
+     local.get $3
+     local.get $4
      call_indirect (type $iiiii)
     end
-    local.set $2
-    local.get $6
+    local.set $5
+    local.get $9
     i32.const 1
     i32.add
-    local.set $6
+    local.set $9
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $2
+  local.get $5
  )
  (func $std/typedarray/testReduce<Int8Array,i8> (; 56 ;) (type $v)
   (local $0 i32)
@@ -3614,58 +4043,78 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $0
+  local.set $3
+  local.get $1
+  local.set $4
+  local.get $2
+  local.set $5
   block $~lib/internal/typedarray/TypedArray<u8>#get:length|inlined.2 (result i32)
-   local.get $0
+   local.get $3
+   local.set $6
+   local.get $6
    i32.load offset=8
    i32.const 0
    i32.shr_u
   end
-  local.set $3
-  local.get $0
+  local.set $6
+  local.get $3
   i32.load
-  local.set $4
-  local.get $0
+  local.set $7
+  local.get $3
   i32.load offset=4
-  local.set $5
+  local.set $8
   block $break|0
    i32.const 0
-   local.set $6
+   local.set $9
    loop $repeat|0
+    local.get $9
     local.get $6
-    local.get $3
     i32.lt_s
     i32.eqz
     br_if $break|0
     block (result i32)
      i32.const 4
      global.set $~argc
-     local.get $2
+     local.get $5
      block $~lib/internal/arraybuffer/LOAD<u8,u8>|inlined.1 (result i32)
-      local.get $4
-      local.get $6
+      local.get $7
+      local.set $10
+      local.get $9
+      local.set $11
+      local.get $8
+      local.set $12
+      local.get $10
+      local.get $11
       i32.const 0
       i32.shl
       i32.add
-      local.get $5
+      local.get $12
       i32.add
       i32.load8_u offset=8
      end
-     local.get $6
-     local.get $0
-     local.get $1
+     local.get $9
+     local.get $3
+     local.get $4
      call_indirect (type $iiiii)
     end
-    local.set $2
-    local.get $6
+    local.set $5
+    local.get $9
     i32.const 1
     i32.add
-    local.set $6
+    local.set $9
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $2
+  local.get $5
  )
  (func $std/typedarray/testReduce<Uint8Array,u8> (; 59 ;) (type $v)
   (local $0 i32)
@@ -3753,6 +4202,8 @@
  (func $~lib/internal/typedarray/TypedArray<i16>#__set (; 62 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -3767,21 +4218,27 @@
    call $~lib/env/abort
    unreachable
   end
-  local.get $0
-  i32.load
-  local.set $3
-  local.get $0
-  i32.load offset=4
-  local.set $4
-  local.get $3
-  local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.get $4
-  i32.add
-  local.get $2
-  i32.store16 offset=8
+  block $~lib/internal/arraybuffer/STORE<i16,i32>|inlined.0
+   local.get $0
+   i32.load
+   local.set $3
+   local.get $1
+   local.set $4
+   local.get $2
+   local.set $5
+   local.get $0
+   i32.load offset=4
+   local.set $6
+   local.get $3
+   local.get $4
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $6
+   i32.add
+   local.get $5
+   i32.store16 offset=8
+  end
  )
  (func $std/typedarray/testReduce<Int16Array,i16>~anonymous|5 (; 63 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
@@ -3793,58 +4250,78 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $0
+  local.set $3
+  local.get $1
+  local.set $4
+  local.get $2
+  local.set $5
   block $~lib/internal/typedarray/TypedArray<i16>#get:length|inlined.1 (result i32)
-   local.get $0
+   local.get $3
+   local.set $6
+   local.get $6
    i32.load offset=8
    i32.const 1
    i32.shr_u
   end
-  local.set $3
-  local.get $0
+  local.set $6
+  local.get $3
   i32.load
-  local.set $4
-  local.get $0
+  local.set $7
+  local.get $3
   i32.load offset=4
-  local.set $5
+  local.set $8
   block $break|0
    i32.const 0
-   local.set $6
+   local.set $9
    loop $repeat|0
+    local.get $9
     local.get $6
-    local.get $3
     i32.lt_s
     i32.eqz
     br_if $break|0
     block (result i32)
      i32.const 4
      global.set $~argc
-     local.get $2
+     local.get $5
      block $~lib/internal/arraybuffer/LOAD<i16,i16>|inlined.0 (result i32)
-      local.get $4
-      local.get $6
+      local.get $7
+      local.set $10
+      local.get $9
+      local.set $11
+      local.get $8
+      local.set $12
+      local.get $10
+      local.get $11
       i32.const 1
       i32.shl
       i32.add
-      local.get $5
+      local.get $12
       i32.add
       i32.load16_s offset=8
      end
-     local.get $6
-     local.get $0
-     local.get $1
+     local.get $9
+     local.get $3
+     local.get $4
      call_indirect (type $iiiii)
     end
-    local.set $2
-    local.get $6
+    local.set $5
+    local.get $9
     i32.const 1
     i32.add
-    local.set $6
+    local.set $9
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $2
+  local.get $5
  )
  (func $std/typedarray/testReduce<Int16Array,i16> (; 65 ;) (type $v)
   (local $0 i32)
@@ -3890,6 +4367,8 @@
  (func $~lib/internal/typedarray/TypedArray<u16>#__set (; 66 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -3904,21 +4383,27 @@
    call $~lib/env/abort
    unreachable
   end
-  local.get $0
-  i32.load
-  local.set $3
-  local.get $0
-  i32.load offset=4
-  local.set $4
-  local.get $3
-  local.get $1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.get $4
-  i32.add
-  local.get $2
-  i32.store16 offset=8
+  block $~lib/internal/arraybuffer/STORE<u16,u32>|inlined.0
+   local.get $0
+   i32.load
+   local.set $3
+   local.get $1
+   local.set $4
+   local.get $2
+   local.set $5
+   local.get $0
+   i32.load offset=4
+   local.set $6
+   local.get $3
+   local.get $4
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $6
+   i32.add
+   local.get $5
+   i32.store16 offset=8
+  end
  )
  (func $std/typedarray/testReduce<Uint16Array,u16>~anonymous|6 (; 67 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
@@ -3930,58 +4415,78 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $0
+  local.set $3
+  local.get $1
+  local.set $4
+  local.get $2
+  local.set $5
   block $~lib/internal/typedarray/TypedArray<u16>#get:length|inlined.1 (result i32)
-   local.get $0
+   local.get $3
+   local.set $6
+   local.get $6
    i32.load offset=8
    i32.const 1
    i32.shr_u
   end
-  local.set $3
-  local.get $0
+  local.set $6
+  local.get $3
   i32.load
-  local.set $4
-  local.get $0
+  local.set $7
+  local.get $3
   i32.load offset=4
-  local.set $5
+  local.set $8
   block $break|0
    i32.const 0
-   local.set $6
+   local.set $9
    loop $repeat|0
+    local.get $9
     local.get $6
-    local.get $3
     i32.lt_s
     i32.eqz
     br_if $break|0
     block (result i32)
      i32.const 4
      global.set $~argc
-     local.get $2
+     local.get $5
      block $~lib/internal/arraybuffer/LOAD<u16,u16>|inlined.0 (result i32)
-      local.get $4
-      local.get $6
+      local.get $7
+      local.set $10
+      local.get $9
+      local.set $11
+      local.get $8
+      local.set $12
+      local.get $10
+      local.get $11
       i32.const 1
       i32.shl
       i32.add
-      local.get $5
+      local.get $12
       i32.add
       i32.load16_u offset=8
      end
-     local.get $6
-     local.get $0
-     local.get $1
+     local.get $9
+     local.get $3
+     local.get $4
      call_indirect (type $iiiii)
     end
-    local.set $2
-    local.get $6
+    local.set $5
+    local.get $9
     i32.const 1
     i32.add
-    local.set $6
+    local.set $9
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $2
+  local.get $5
  )
  (func $std/typedarray/testReduce<Uint16Array,u16> (; 69 ;) (type $v)
   (local $0 i32)
@@ -4032,58 +4537,78 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $0
+  local.set $3
+  local.get $1
+  local.set $4
+  local.get $2
+  local.set $5
   block $~lib/internal/typedarray/TypedArray<i32>#get:length|inlined.9 (result i32)
-   local.get $0
+   local.get $3
+   local.set $6
+   local.get $6
    i32.load offset=8
    i32.const 2
    i32.shr_u
   end
-  local.set $3
-  local.get $0
+  local.set $6
+  local.get $3
   i32.load
-  local.set $4
-  local.get $0
+  local.set $7
+  local.get $3
   i32.load offset=4
-  local.set $5
+  local.set $8
   block $break|0
    i32.const 0
-   local.set $6
+   local.set $9
    loop $repeat|0
+    local.get $9
     local.get $6
-    local.get $3
     i32.lt_s
     i32.eqz
     br_if $break|0
     block (result i32)
      i32.const 4
      global.set $~argc
-     local.get $2
+     local.get $5
      block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.2 (result i32)
-      local.get $4
-      local.get $6
+      local.get $7
+      local.set $10
+      local.get $9
+      local.set $11
+      local.get $8
+      local.set $12
+      local.get $10
+      local.get $11
       i32.const 2
       i32.shl
       i32.add
-      local.get $5
+      local.get $12
       i32.add
       i32.load offset=8
      end
-     local.get $6
-     local.get $0
-     local.get $1
+     local.get $9
+     local.get $3
+     local.get $4
      call_indirect (type $iiiii)
     end
-    local.set $2
-    local.get $6
+    local.set $5
+    local.get $9
     i32.const 1
     i32.add
-    local.set $6
+    local.set $9
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $2
+  local.get $5
  )
  (func $std/typedarray/testReduce<Int32Array,i32> (; 72 ;) (type $v)
   (local $0 i32)
@@ -4125,6 +4650,8 @@
  (func $~lib/internal/typedarray/TypedArray<u32>#__set (; 73 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -4139,21 +4666,27 @@
    call $~lib/env/abort
    unreachable
   end
-  local.get $0
-  i32.load
-  local.set $3
-  local.get $0
-  i32.load offset=4
-  local.set $4
-  local.get $3
-  local.get $1
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $4
-  i32.add
-  local.get $2
-  i32.store offset=8
+  block $~lib/internal/arraybuffer/STORE<u32,u32>|inlined.0
+   local.get $0
+   i32.load
+   local.set $3
+   local.get $1
+   local.set $4
+   local.get $2
+   local.set $5
+   local.get $0
+   i32.load offset=4
+   local.set $6
+   local.get $3
+   local.get $4
+   i32.const 2
+   i32.shl
+   i32.add
+   local.get $6
+   i32.add
+   local.get $5
+   i32.store offset=8
+  end
  )
  (func $std/typedarray/testReduce<Uint32Array,u32>~anonymous|8 (; 74 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
@@ -4165,58 +4698,78 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $0
+  local.set $3
+  local.get $1
+  local.set $4
+  local.get $2
+  local.set $5
   block $~lib/internal/typedarray/TypedArray<u32>#get:length|inlined.1 (result i32)
-   local.get $0
+   local.get $3
+   local.set $6
+   local.get $6
    i32.load offset=8
    i32.const 2
    i32.shr_u
   end
-  local.set $3
-  local.get $0
+  local.set $6
+  local.get $3
   i32.load
-  local.set $4
-  local.get $0
+  local.set $7
+  local.get $3
   i32.load offset=4
-  local.set $5
+  local.set $8
   block $break|0
    i32.const 0
-   local.set $6
+   local.set $9
    loop $repeat|0
+    local.get $9
     local.get $6
-    local.get $3
     i32.lt_s
     i32.eqz
     br_if $break|0
     block (result i32)
      i32.const 4
      global.set $~argc
-     local.get $2
+     local.get $5
      block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.0 (result i32)
-      local.get $4
-      local.get $6
+      local.get $7
+      local.set $10
+      local.get $9
+      local.set $11
+      local.get $8
+      local.set $12
+      local.get $10
+      local.get $11
       i32.const 2
       i32.shl
       i32.add
-      local.get $5
+      local.get $12
       i32.add
       i32.load offset=8
      end
-     local.get $6
-     local.get $0
-     local.get $1
+     local.get $9
+     local.get $3
+     local.get $4
      call_indirect (type $iiiii)
     end
-    local.set $2
-    local.get $6
+    local.set $5
+    local.get $9
     i32.const 1
     i32.add
-    local.set $6
+    local.set $9
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $2
+  local.get $5
  )
  (func $std/typedarray/testReduce<Uint32Array,u32> (; 76 ;) (type $v)
   (local $0 i32)
@@ -4258,6 +4811,8 @@
  (func $~lib/internal/typedarray/TypedArray<i64>#__set (; 77 ;) (type $iiIv) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i64)
+  (local $6 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -4272,21 +4827,27 @@
    call $~lib/env/abort
    unreachable
   end
-  local.get $0
-  i32.load
-  local.set $3
-  local.get $0
-  i32.load offset=4
-  local.set $4
-  local.get $3
-  local.get $1
-  i32.const 3
-  i32.shl
-  i32.add
-  local.get $4
-  i32.add
-  local.get $2
-  i64.store offset=8
+  block $~lib/internal/arraybuffer/STORE<i64,i64>|inlined.0
+   local.get $0
+   i32.load
+   local.set $3
+   local.get $1
+   local.set $4
+   local.get $2
+   local.set $5
+   local.get $0
+   i32.load offset=4
+   local.set $6
+   local.get $3
+   local.get $4
+   i32.const 3
+   i32.shl
+   i32.add
+   local.get $6
+   i32.add
+   local.get $5
+   i64.store offset=8
+  end
  )
  (func $std/typedarray/testReduce<Int64Array,i64>~anonymous|9 (; 78 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   local.get $0
@@ -4296,60 +4857,80 @@
  (func $~lib/typedarray/Int64Array#reduce<i64> (; 79 ;) (type $iiII) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
+  (local $5 i64)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $0
+  local.set $3
+  local.get $1
+  local.set $4
+  local.get $2
+  local.set $5
   block $~lib/internal/typedarray/TypedArray<i64>#get:length|inlined.1 (result i32)
-   local.get $0
+   local.get $3
+   local.set $6
+   local.get $6
    i32.load offset=8
    i32.const 3
    i32.shr_u
   end
-  local.set $3
-  local.get $0
+  local.set $6
+  local.get $3
   i32.load
-  local.set $4
-  local.get $0
+  local.set $7
+  local.get $3
   i32.load offset=4
-  local.set $5
+  local.set $8
   block $break|0
    i32.const 0
-   local.set $6
+   local.set $9
    loop $repeat|0
+    local.get $9
     local.get $6
-    local.get $3
     i32.lt_s
     i32.eqz
     br_if $break|0
     block (result i64)
      i32.const 4
      global.set $~argc
-     local.get $2
+     local.get $5
      block $~lib/internal/arraybuffer/LOAD<i64,i64>|inlined.0 (result i64)
-      local.get $4
-      local.get $6
+      local.get $7
+      local.set $10
+      local.get $9
+      local.set $11
+      local.get $8
+      local.set $12
+      local.get $10
+      local.get $11
       i32.const 3
       i32.shl
       i32.add
-      local.get $5
+      local.get $12
       i32.add
       i64.load offset=8
      end
-     local.get $6
-     local.get $0
-     local.get $1
+     local.get $9
+     local.get $3
+     local.get $4
      call_indirect (type $IIiiI)
     end
-    local.set $2
-    local.get $6
+    local.set $5
+    local.get $9
     i32.const 1
     i32.add
-    local.set $6
+    local.set $9
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $2
+  local.get $5
  )
  (func $std/typedarray/testReduce<Int64Array,i64> (; 80 ;) (type $v)
   (local $0 i32)
@@ -4391,6 +4972,8 @@
  (func $~lib/internal/typedarray/TypedArray<u64>#__set (; 81 ;) (type $iiIv) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i64)
+  (local $6 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -4405,21 +4988,27 @@
    call $~lib/env/abort
    unreachable
   end
-  local.get $0
-  i32.load
-  local.set $3
-  local.get $0
-  i32.load offset=4
-  local.set $4
-  local.get $3
-  local.get $1
-  i32.const 3
-  i32.shl
-  i32.add
-  local.get $4
-  i32.add
-  local.get $2
-  i64.store offset=8
+  block $~lib/internal/arraybuffer/STORE<u64,u64>|inlined.0
+   local.get $0
+   i32.load
+   local.set $3
+   local.get $1
+   local.set $4
+   local.get $2
+   local.set $5
+   local.get $0
+   i32.load offset=4
+   local.set $6
+   local.get $3
+   local.get $4
+   i32.const 3
+   i32.shl
+   i32.add
+   local.get $6
+   i32.add
+   local.get $5
+   i64.store offset=8
+  end
  )
  (func $std/typedarray/testReduce<Uint64Array,u64>~anonymous|10 (; 82 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   local.get $0
@@ -4429,60 +5018,80 @@
  (func $~lib/typedarray/Uint64Array#reduce<u64> (; 83 ;) (type $iiII) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
+  (local $5 i64)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $0
+  local.set $3
+  local.get $1
+  local.set $4
+  local.get $2
+  local.set $5
   block $~lib/internal/typedarray/TypedArray<u64>#get:length|inlined.1 (result i32)
-   local.get $0
+   local.get $3
+   local.set $6
+   local.get $6
    i32.load offset=8
    i32.const 3
    i32.shr_u
   end
-  local.set $3
-  local.get $0
+  local.set $6
+  local.get $3
   i32.load
-  local.set $4
-  local.get $0
+  local.set $7
+  local.get $3
   i32.load offset=4
-  local.set $5
+  local.set $8
   block $break|0
    i32.const 0
-   local.set $6
+   local.set $9
    loop $repeat|0
+    local.get $9
     local.get $6
-    local.get $3
     i32.lt_s
     i32.eqz
     br_if $break|0
     block (result i64)
      i32.const 4
      global.set $~argc
-     local.get $2
+     local.get $5
      block $~lib/internal/arraybuffer/LOAD<u64,u64>|inlined.0 (result i64)
-      local.get $4
-      local.get $6
+      local.get $7
+      local.set $10
+      local.get $9
+      local.set $11
+      local.get $8
+      local.set $12
+      local.get $10
+      local.get $11
       i32.const 3
       i32.shl
       i32.add
-      local.get $5
+      local.get $12
       i32.add
       i64.load offset=8
      end
-     local.get $6
-     local.get $0
-     local.get $1
+     local.get $9
+     local.get $3
+     local.get $4
      call_indirect (type $IIiiI)
     end
-    local.set $2
-    local.get $6
+    local.set $5
+    local.get $9
     i32.const 1
     i32.add
-    local.set $6
+    local.set $9
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $2
+  local.get $5
  )
  (func $std/typedarray/testReduce<Uint64Array,u64> (; 84 ;) (type $v)
   (local $0 i32)
@@ -4524,6 +5133,8 @@
  (func $~lib/internal/typedarray/TypedArray<f32>#__set (; 85 ;) (type $iifv) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 f32)
+  (local $6 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -4538,21 +5149,27 @@
    call $~lib/env/abort
    unreachable
   end
-  local.get $0
-  i32.load
-  local.set $3
-  local.get $0
-  i32.load offset=4
-  local.set $4
-  local.get $3
-  local.get $1
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $4
-  i32.add
-  local.get $2
-  f32.store offset=8
+  block $~lib/internal/arraybuffer/STORE<f32,f32>|inlined.0
+   local.get $0
+   i32.load
+   local.set $3
+   local.get $1
+   local.set $4
+   local.get $2
+   local.set $5
+   local.get $0
+   i32.load offset=4
+   local.set $6
+   local.get $3
+   local.get $4
+   i32.const 2
+   i32.shl
+   i32.add
+   local.get $6
+   i32.add
+   local.get $5
+   f32.store offset=8
+  end
  )
  (func $std/typedarray/testReduce<Float32Array,f32>~anonymous|11 (; 86 ;) (type $ffiif) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
   local.get $0
@@ -4562,60 +5179,80 @@
  (func $~lib/typedarray/Float32Array#reduce<f32> (; 87 ;) (type $iiff) (param $0 i32) (param $1 i32) (param $2 f32) (result f32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
+  (local $5 f32)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $0
+  local.set $3
+  local.get $1
+  local.set $4
+  local.get $2
+  local.set $5
   block $~lib/internal/typedarray/TypedArray<f32>#get:length|inlined.1 (result i32)
-   local.get $0
+   local.get $3
+   local.set $6
+   local.get $6
    i32.load offset=8
    i32.const 2
    i32.shr_u
   end
-  local.set $3
-  local.get $0
+  local.set $6
+  local.get $3
   i32.load
-  local.set $4
-  local.get $0
+  local.set $7
+  local.get $3
   i32.load offset=4
-  local.set $5
+  local.set $8
   block $break|0
    i32.const 0
-   local.set $6
+   local.set $9
    loop $repeat|0
+    local.get $9
     local.get $6
-    local.get $3
     i32.lt_s
     i32.eqz
     br_if $break|0
     block (result f32)
      i32.const 4
      global.set $~argc
-     local.get $2
+     local.get $5
      block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.0 (result f32)
-      local.get $4
-      local.get $6
+      local.get $7
+      local.set $10
+      local.get $9
+      local.set $11
+      local.get $8
+      local.set $12
+      local.get $10
+      local.get $11
       i32.const 2
       i32.shl
       i32.add
-      local.get $5
+      local.get $12
       i32.add
       f32.load offset=8
      end
-     local.get $6
-     local.get $0
-     local.get $1
+     local.get $9
+     local.get $3
+     local.get $4
      call_indirect (type $ffiif)
     end
-    local.set $2
-    local.get $6
+    local.set $5
+    local.get $9
     i32.const 1
     i32.add
-    local.set $6
+    local.set $9
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $2
+  local.get $5
  )
  (func $std/typedarray/testReduce<Float32Array,f32> (; 88 ;) (type $v)
   (local $0 i32)
@@ -4662,60 +5299,80 @@
  (func $~lib/typedarray/Float64Array#reduce<f64> (; 90 ;) (type $iiFF) (param $0 i32) (param $1 i32) (param $2 f64) (result f64)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
+  (local $5 f64)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $0
+  local.set $3
+  local.get $1
+  local.set $4
+  local.get $2
+  local.set $5
   block $~lib/internal/typedarray/TypedArray<f64>#get:length|inlined.4 (result i32)
-   local.get $0
+   local.get $3
+   local.set $6
+   local.get $6
    i32.load offset=8
    i32.const 3
    i32.shr_u
   end
-  local.set $3
-  local.get $0
+  local.set $6
+  local.get $3
   i32.load
-  local.set $4
-  local.get $0
+  local.set $7
+  local.get $3
   i32.load offset=4
-  local.set $5
+  local.set $8
   block $break|0
    i32.const 0
-   local.set $6
+   local.set $9
    loop $repeat|0
+    local.get $9
     local.get $6
-    local.get $3
     i32.lt_s
     i32.eqz
     br_if $break|0
     block (result f64)
      i32.const 4
      global.set $~argc
-     local.get $2
+     local.get $5
      block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.13 (result f64)
-      local.get $4
-      local.get $6
+      local.get $7
+      local.set $10
+      local.get $9
+      local.set $11
+      local.get $8
+      local.set $12
+      local.get $10
+      local.get $11
       i32.const 3
       i32.shl
       i32.add
-      local.get $5
+      local.get $12
       i32.add
       f64.load offset=8
      end
-     local.get $6
-     local.get $0
-     local.get $1
+     local.get $9
+     local.get $3
+     local.get $4
      call_indirect (type $FFiiF)
     end
-    local.set $2
-    local.get $6
+    local.set $5
+    local.get $9
     i32.const 1
     i32.add
-    local.set $6
+    local.set $9
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $2
+  local.get $5
  )
  (func $std/typedarray/testReduce<Float64Array,f64> (; 91 ;) (type $v)
   (local $0 i32)
@@ -4763,24 +5420,38 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   local.get $0
-  i32.load
   local.set $3
-  local.get $0
-  i32.load offset=4
+  local.get $1
   local.set $4
+  local.get $2
+  local.set $5
+  local.get $3
+  i32.load
+  local.set $6
+  local.get $3
+  i32.load offset=4
+  local.set $7
   block $break|0
    block $~lib/internal/typedarray/TypedArray<i8>#get:length|inlined.11 (result i32)
-    local.get $0
+    local.get $3
+    local.set $8
+    local.get $8
     i32.load offset=8
     i32.const 0
     i32.shr_u
    end
    i32.const 1
    i32.sub
-   local.set $5
+   local.set $8
    loop $repeat|0
-    local.get $5
+    local.get $8
     i32.const 0
     i32.ge_s
     i32.eqz
@@ -4788,33 +5459,39 @@
     block (result i32)
      i32.const 4
      global.set $~argc
-     local.get $2
+     local.get $5
      block $~lib/internal/arraybuffer/LOAD<i8,i8>|inlined.3 (result i32)
-      local.get $3
-      local.get $5
+      local.get $6
+      local.set $9
+      local.get $8
+      local.set $10
+      local.get $7
+      local.set $11
+      local.get $9
+      local.get $10
       i32.const 0
       i32.shl
       i32.add
-      local.get $4
+      local.get $11
       i32.add
       i32.load8_s offset=8
      end
-     local.get $5
-     local.get $0
-     local.get $1
+     local.get $8
+     local.get $3
+     local.get $4
      call_indirect (type $iiiii)
     end
-    local.set $2
-    local.get $5
+    local.set $5
+    local.get $8
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $8
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $2
+  local.get $5
  )
  (func $std/typedarray/testReduceRight<Int8Array,i8> (; 94 ;) (type $v)
   (local $0 i32)
@@ -4866,24 +5543,38 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   local.get $0
-  i32.load
   local.set $3
-  local.get $0
-  i32.load offset=4
+  local.get $1
   local.set $4
+  local.get $2
+  local.set $5
+  local.get $3
+  i32.load
+  local.set $6
+  local.get $3
+  i32.load offset=4
+  local.set $7
   block $break|0
    block $~lib/internal/typedarray/TypedArray<u8>#get:length|inlined.3 (result i32)
-    local.get $0
+    local.get $3
+    local.set $8
+    local.get $8
     i32.load offset=8
     i32.const 0
     i32.shr_u
    end
    i32.const 1
    i32.sub
-   local.set $5
+   local.set $8
    loop $repeat|0
-    local.get $5
+    local.get $8
     i32.const 0
     i32.ge_s
     i32.eqz
@@ -4891,33 +5582,39 @@
     block (result i32)
      i32.const 4
      global.set $~argc
-     local.get $2
+     local.get $5
      block $~lib/internal/arraybuffer/LOAD<u8,u8>|inlined.2 (result i32)
-      local.get $3
-      local.get $5
+      local.get $6
+      local.set $9
+      local.get $8
+      local.set $10
+      local.get $7
+      local.set $11
+      local.get $9
+      local.get $10
       i32.const 0
       i32.shl
       i32.add
-      local.get $4
+      local.get $11
       i32.add
       i32.load8_u offset=8
      end
-     local.get $5
-     local.get $0
-     local.get $1
+     local.get $8
+     local.get $3
+     local.get $4
      call_indirect (type $iiiii)
     end
-    local.set $2
-    local.get $5
+    local.set $5
+    local.get $8
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $8
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $2
+  local.get $5
  )
  (func $std/typedarray/testReduceRight<Uint8Array,u8> (; 97 ;) (type $v)
   (local $0 i32)
@@ -5011,24 +5708,38 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   local.get $0
-  i32.load
   local.set $3
-  local.get $0
-  i32.load offset=4
+  local.get $1
   local.set $4
+  local.get $2
+  local.set $5
+  local.get $3
+  i32.load
+  local.set $6
+  local.get $3
+  i32.load offset=4
+  local.set $7
   block $break|0
    block $~lib/internal/typedarray/TypedArray<i16>#get:length|inlined.2 (result i32)
-    local.get $0
+    local.get $3
+    local.set $8
+    local.get $8
     i32.load offset=8
     i32.const 1
     i32.shr_u
    end
    i32.const 1
    i32.sub
-   local.set $5
+   local.set $8
    loop $repeat|0
-    local.get $5
+    local.get $8
     i32.const 0
     i32.ge_s
     i32.eqz
@@ -5036,33 +5747,39 @@
     block (result i32)
      i32.const 4
      global.set $~argc
-     local.get $2
+     local.get $5
      block $~lib/internal/arraybuffer/LOAD<i16,i16>|inlined.1 (result i32)
-      local.get $3
-      local.get $5
+      local.get $6
+      local.set $9
+      local.get $8
+      local.set $10
+      local.get $7
+      local.set $11
+      local.get $9
+      local.get $10
       i32.const 1
       i32.shl
       i32.add
-      local.get $4
+      local.get $11
       i32.add
       i32.load16_s offset=8
      end
-     local.get $5
-     local.get $0
-     local.get $1
+     local.get $8
+     local.get $3
+     local.get $4
      call_indirect (type $iiiii)
     end
-    local.set $2
-    local.get $5
+    local.set $5
+    local.get $8
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $8
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $2
+  local.get $5
  )
  (func $std/typedarray/testReduceRight<Int16Array,i16> (; 102 ;) (type $v)
   (local $0 i32)
@@ -5114,24 +5831,38 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   local.get $0
-  i32.load
   local.set $3
-  local.get $0
-  i32.load offset=4
+  local.get $1
   local.set $4
+  local.get $2
+  local.set $5
+  local.get $3
+  i32.load
+  local.set $6
+  local.get $3
+  i32.load offset=4
+  local.set $7
   block $break|0
    block $~lib/internal/typedarray/TypedArray<u16>#get:length|inlined.2 (result i32)
-    local.get $0
+    local.get $3
+    local.set $8
+    local.get $8
     i32.load offset=8
     i32.const 1
     i32.shr_u
    end
    i32.const 1
    i32.sub
-   local.set $5
+   local.set $8
    loop $repeat|0
-    local.get $5
+    local.get $8
     i32.const 0
     i32.ge_s
     i32.eqz
@@ -5139,33 +5870,39 @@
     block (result i32)
      i32.const 4
      global.set $~argc
-     local.get $2
+     local.get $5
      block $~lib/internal/arraybuffer/LOAD<u16,u16>|inlined.1 (result i32)
-      local.get $3
-      local.get $5
+      local.get $6
+      local.set $9
+      local.get $8
+      local.set $10
+      local.get $7
+      local.set $11
+      local.get $9
+      local.get $10
       i32.const 1
       i32.shl
       i32.add
-      local.get $4
+      local.get $11
       i32.add
       i32.load16_u offset=8
      end
-     local.get $5
-     local.get $0
-     local.get $1
+     local.get $8
+     local.get $3
+     local.get $4
      call_indirect (type $iiiii)
     end
-    local.set $2
-    local.get $5
+    local.set $5
+    local.get $8
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $8
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $2
+  local.get $5
  )
  (func $std/typedarray/testReduceRight<Uint16Array,u16> (; 105 ;) (type $v)
   (local $0 i32)
@@ -5215,24 +5952,38 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   local.get $0
-  i32.load
   local.set $3
-  local.get $0
-  i32.load offset=4
+  local.get $1
   local.set $4
+  local.get $2
+  local.set $5
+  local.get $3
+  i32.load
+  local.set $6
+  local.get $3
+  i32.load offset=4
+  local.set $7
   block $break|0
    block $~lib/internal/typedarray/TypedArray<i32>#get:length|inlined.10 (result i32)
-    local.get $0
+    local.get $3
+    local.set $8
+    local.get $8
     i32.load offset=8
     i32.const 2
     i32.shr_u
    end
    i32.const 1
    i32.sub
-   local.set $5
+   local.set $8
    loop $repeat|0
-    local.get $5
+    local.get $8
     i32.const 0
     i32.ge_s
     i32.eqz
@@ -5240,33 +5991,39 @@
     block (result i32)
      i32.const 4
      global.set $~argc
-     local.get $2
+     local.get $5
      block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.3 (result i32)
-      local.get $3
-      local.get $5
+      local.get $6
+      local.set $9
+      local.get $8
+      local.set $10
+      local.get $7
+      local.set $11
+      local.get $9
+      local.get $10
       i32.const 2
       i32.shl
       i32.add
-      local.get $4
+      local.get $11
       i32.add
       i32.load offset=8
      end
-     local.get $5
-     local.get $0
-     local.get $1
+     local.get $8
+     local.get $3
+     local.get $4
      call_indirect (type $iiiii)
     end
-    local.set $2
-    local.get $5
+    local.set $5
+    local.get $8
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $8
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $2
+  local.get $5
  )
  (func $std/typedarray/testReduceRight<Int32Array,i32> (; 108 ;) (type $v)
   (local $0 i32)
@@ -5314,24 +6071,38 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   local.get $0
-  i32.load
   local.set $3
-  local.get $0
-  i32.load offset=4
+  local.get $1
   local.set $4
+  local.get $2
+  local.set $5
+  local.get $3
+  i32.load
+  local.set $6
+  local.get $3
+  i32.load offset=4
+  local.set $7
   block $break|0
    block $~lib/internal/typedarray/TypedArray<u32>#get:length|inlined.2 (result i32)
-    local.get $0
+    local.get $3
+    local.set $8
+    local.get $8
     i32.load offset=8
     i32.const 2
     i32.shr_u
    end
    i32.const 1
    i32.sub
-   local.set $5
+   local.set $8
    loop $repeat|0
-    local.get $5
+    local.get $8
     i32.const 0
     i32.ge_s
     i32.eqz
@@ -5339,33 +6110,39 @@
     block (result i32)
      i32.const 4
      global.set $~argc
-     local.get $2
+     local.get $5
      block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.1 (result i32)
-      local.get $3
-      local.get $5
+      local.get $6
+      local.set $9
+      local.get $8
+      local.set $10
+      local.get $7
+      local.set $11
+      local.get $9
+      local.get $10
       i32.const 2
       i32.shl
       i32.add
-      local.get $4
+      local.get $11
       i32.add
       i32.load offset=8
      end
-     local.get $5
-     local.get $0
-     local.get $1
+     local.get $8
+     local.get $3
+     local.get $4
      call_indirect (type $iiiii)
     end
-    local.set $2
-    local.get $5
+    local.set $5
+    local.get $8
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $8
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $2
+  local.get $5
  )
  (func $std/typedarray/testReduceRight<Uint32Array,u32> (; 111 ;) (type $v)
   (local $0 i32)
@@ -5412,25 +6189,39 @@
  (func $~lib/typedarray/Int64Array#reduceRight<i64> (; 113 ;) (type $iiII) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
+  (local $5 i64)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   local.get $0
-  i32.load
   local.set $3
-  local.get $0
-  i32.load offset=4
+  local.get $1
   local.set $4
+  local.get $2
+  local.set $5
+  local.get $3
+  i32.load
+  local.set $6
+  local.get $3
+  i32.load offset=4
+  local.set $7
   block $break|0
    block $~lib/internal/typedarray/TypedArray<i64>#get:length|inlined.2 (result i32)
-    local.get $0
+    local.get $3
+    local.set $8
+    local.get $8
     i32.load offset=8
     i32.const 3
     i32.shr_u
    end
    i32.const 1
    i32.sub
-   local.set $5
+   local.set $8
    loop $repeat|0
-    local.get $5
+    local.get $8
     i32.const 0
     i32.ge_s
     i32.eqz
@@ -5438,33 +6229,39 @@
     block (result i64)
      i32.const 4
      global.set $~argc
-     local.get $2
+     local.get $5
      block $~lib/internal/arraybuffer/LOAD<i64,i64>|inlined.1 (result i64)
-      local.get $3
-      local.get $5
+      local.get $6
+      local.set $9
+      local.get $8
+      local.set $10
+      local.get $7
+      local.set $11
+      local.get $9
+      local.get $10
       i32.const 3
       i32.shl
       i32.add
-      local.get $4
+      local.get $11
       i32.add
       i64.load offset=8
      end
-     local.get $5
-     local.get $0
-     local.get $1
+     local.get $8
+     local.get $3
+     local.get $4
      call_indirect (type $IIiiI)
     end
-    local.set $2
-    local.get $5
+    local.set $5
+    local.get $8
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $8
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $2
+  local.get $5
  )
  (func $std/typedarray/testReduceRight<Int64Array,i64> (; 114 ;) (type $v)
   (local $0 i32)
@@ -5511,25 +6308,39 @@
  (func $~lib/typedarray/Uint64Array#reduceRight<u64> (; 116 ;) (type $iiII) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
+  (local $5 i64)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   local.get $0
-  i32.load
   local.set $3
-  local.get $0
-  i32.load offset=4
+  local.get $1
   local.set $4
+  local.get $2
+  local.set $5
+  local.get $3
+  i32.load
+  local.set $6
+  local.get $3
+  i32.load offset=4
+  local.set $7
   block $break|0
    block $~lib/internal/typedarray/TypedArray<u64>#get:length|inlined.2 (result i32)
-    local.get $0
+    local.get $3
+    local.set $8
+    local.get $8
     i32.load offset=8
     i32.const 3
     i32.shr_u
    end
    i32.const 1
    i32.sub
-   local.set $5
+   local.set $8
    loop $repeat|0
-    local.get $5
+    local.get $8
     i32.const 0
     i32.ge_s
     i32.eqz
@@ -5537,33 +6348,39 @@
     block (result i64)
      i32.const 4
      global.set $~argc
-     local.get $2
+     local.get $5
      block $~lib/internal/arraybuffer/LOAD<u64,u64>|inlined.1 (result i64)
-      local.get $3
-      local.get $5
+      local.get $6
+      local.set $9
+      local.get $8
+      local.set $10
+      local.get $7
+      local.set $11
+      local.get $9
+      local.get $10
       i32.const 3
       i32.shl
       i32.add
-      local.get $4
+      local.get $11
       i32.add
       i64.load offset=8
      end
-     local.get $5
-     local.get $0
-     local.get $1
+     local.get $8
+     local.get $3
+     local.get $4
      call_indirect (type $IIiiI)
     end
-    local.set $2
-    local.get $5
+    local.set $5
+    local.get $8
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $8
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $2
+  local.get $5
  )
  (func $std/typedarray/testReduceRight<Uint64Array,u64> (; 117 ;) (type $v)
   (local $0 i32)
@@ -5610,25 +6427,39 @@
  (func $~lib/typedarray/Float32Array#reduceRight<f32> (; 119 ;) (type $iiff) (param $0 i32) (param $1 i32) (param $2 f32) (result f32)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
+  (local $5 f32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   local.get $0
-  i32.load
   local.set $3
-  local.get $0
-  i32.load offset=4
+  local.get $1
   local.set $4
+  local.get $2
+  local.set $5
+  local.get $3
+  i32.load
+  local.set $6
+  local.get $3
+  i32.load offset=4
+  local.set $7
   block $break|0
    block $~lib/internal/typedarray/TypedArray<f32>#get:length|inlined.2 (result i32)
-    local.get $0
+    local.get $3
+    local.set $8
+    local.get $8
     i32.load offset=8
     i32.const 2
     i32.shr_u
    end
    i32.const 1
    i32.sub
-   local.set $5
+   local.set $8
    loop $repeat|0
-    local.get $5
+    local.get $8
     i32.const 0
     i32.ge_s
     i32.eqz
@@ -5636,33 +6467,39 @@
     block (result f32)
      i32.const 4
      global.set $~argc
-     local.get $2
+     local.get $5
      block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.1 (result f32)
-      local.get $3
-      local.get $5
+      local.get $6
+      local.set $9
+      local.get $8
+      local.set $10
+      local.get $7
+      local.set $11
+      local.get $9
+      local.get $10
       i32.const 2
       i32.shl
       i32.add
-      local.get $4
+      local.get $11
       i32.add
       f32.load offset=8
      end
-     local.get $5
-     local.get $0
-     local.get $1
+     local.get $8
+     local.get $3
+     local.get $4
      call_indirect (type $ffiif)
     end
-    local.set $2
-    local.get $5
+    local.set $5
+    local.get $8
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $8
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $2
+  local.get $5
  )
  (func $std/typedarray/testReduceRight<Float32Array,f32> (; 120 ;) (type $v)
   (local $0 i32)
@@ -5709,25 +6546,39 @@
  (func $~lib/typedarray/Float64Array#reduceRight<f64> (; 122 ;) (type $iiFF) (param $0 i32) (param $1 i32) (param $2 f64) (result f64)
   (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
+  (local $5 f64)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
   local.get $0
-  i32.load
   local.set $3
-  local.get $0
-  i32.load offset=4
+  local.get $1
   local.set $4
+  local.get $2
+  local.set $5
+  local.get $3
+  i32.load
+  local.set $6
+  local.get $3
+  i32.load offset=4
+  local.set $7
   block $break|0
    block $~lib/internal/typedarray/TypedArray<f64>#get:length|inlined.5 (result i32)
-    local.get $0
+    local.get $3
+    local.set $8
+    local.get $8
     i32.load offset=8
     i32.const 3
     i32.shr_u
    end
    i32.const 1
    i32.sub
-   local.set $5
+   local.set $8
    loop $repeat|0
-    local.get $5
+    local.get $8
     i32.const 0
     i32.ge_s
     i32.eqz
@@ -5735,33 +6586,39 @@
     block (result f64)
      i32.const 4
      global.set $~argc
-     local.get $2
+     local.get $5
      block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.14 (result f64)
-      local.get $3
-      local.get $5
+      local.get $6
+      local.set $9
+      local.get $8
+      local.set $10
+      local.get $7
+      local.set $11
+      local.get $9
+      local.get $10
       i32.const 3
       i32.shl
       i32.add
-      local.get $4
+      local.get $11
       i32.add
       f64.load offset=8
      end
-     local.get $5
-     local.get $0
-     local.get $1
+     local.get $8
+     local.get $3
+     local.get $4
      call_indirect (type $FFiiF)
     end
-    local.set $2
-    local.get $5
+    local.set $5
+    local.get $8
     i32.const 1
     i32.sub
-    local.set $5
+    local.set $8
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $2
+  local.get $5
  )
  (func $std/typedarray/testReduceRight<Float64Array,f64> (; 123 ;) (type $v)
   (local $0 i32)
@@ -5814,81 +6671,102 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  local.get $0
+  local.set $2
+  local.get $1
+  local.set $3
   block $~lib/internal/typedarray/TypedArray<i8>#get:length|inlined.12 (result i32)
-   local.get $0
+   local.get $2
+   local.set $4
+   local.get $4
    i32.load offset=8
    i32.const 0
    i32.shr_u
   end
-  local.set $2
-  local.get $0
-  i32.load
-  local.set $3
-  local.get $0
-  i32.load offset=4
   local.set $4
-  i32.const 0
   local.get $2
-  call $~lib/typedarray/Int8Array#constructor
-  local.set $5
-  local.get $5
   i32.load
+  local.set $5
+  local.get $2
+  i32.load offset=4
   local.set $6
+  i32.const 0
+  local.get $4
+  call $~lib/typedarray/Int8Array#constructor
+  local.set $7
+  local.get $7
+  i32.load
+  local.set $8
   block $break|0
    i32.const 0
-   local.set $7
+   local.set $9
    loop $repeat|0
-    local.get $7
-    local.get $2
+    local.get $9
+    local.get $4
     i32.lt_s
     i32.eqz
     br_if $break|0
-    block
+    block $~lib/internal/arraybuffer/STORE<i8,i32>|inlined.1
+     local.get $8
+     local.set $10
+     local.get $9
+     local.set $11
      block (result i32)
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<i8,i8>|inlined.4 (result i32)
-       local.get $3
-       local.get $7
+       local.get $5
+       local.set $12
+       local.get $9
+       local.set $13
+       local.get $6
+       local.set $14
+       local.get $12
+       local.get $13
        i32.const 0
        i32.shl
        i32.add
-       local.get $4
+       local.get $14
        i32.add
        i32.load8_s offset=8
       end
-      local.get $7
-      local.get $0
-      local.get $1
+      local.get $9
+      local.get $2
+      local.get $3
       call_indirect (type $iiii)
      end
      i32.const 24
      i32.shl
      i32.const 24
      i32.shr_s
-     local.set $8
+     local.set $14
      i32.const 0
-     local.set $9
-     local.get $6
-     local.get $7
+     local.set $13
+     local.get $10
+     local.get $11
      i32.const 0
      i32.shl
      i32.add
-     local.get $9
+     local.get $13
      i32.add
-     local.get $8
+     local.get $14
      i32.store8 offset=8
     end
-    local.get $7
+    local.get $9
     i32.const 1
     i32.add
-    local.set $7
+    local.set $9
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $5
+  local.get $7
  )
  (func $std/typedarray/testArrayMap<Int8Array,i8> (; 126 ;) (type $v)
   (local $0 i32)
@@ -5982,79 +6860,100 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  local.get $0
+  local.set $2
+  local.get $1
+  local.set $3
   block $~lib/internal/typedarray/TypedArray<u8>#get:length|inlined.4 (result i32)
-   local.get $0
+   local.get $2
+   local.set $4
+   local.get $4
    i32.load offset=8
    i32.const 0
    i32.shr_u
   end
-  local.set $2
-  local.get $0
-  i32.load
-  local.set $3
-  local.get $0
-  i32.load offset=4
   local.set $4
-  i32.const 0
   local.get $2
-  call $~lib/typedarray/Uint8Array#constructor
-  local.set $5
-  local.get $5
   i32.load
+  local.set $5
+  local.get $2
+  i32.load offset=4
   local.set $6
+  i32.const 0
+  local.get $4
+  call $~lib/typedarray/Uint8Array#constructor
+  local.set $7
+  local.get $7
+  i32.load
+  local.set $8
   block $break|0
    i32.const 0
-   local.set $7
+   local.set $9
    loop $repeat|0
-    local.get $7
-    local.get $2
+    local.get $9
+    local.get $4
     i32.lt_s
     i32.eqz
     br_if $break|0
-    block
+    block $~lib/internal/arraybuffer/STORE<u8,u32>|inlined.1
+     local.get $8
+     local.set $10
+     local.get $9
+     local.set $11
      block (result i32)
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<u8,u8>|inlined.3 (result i32)
-       local.get $3
-       local.get $7
+       local.get $5
+       local.set $12
+       local.get $9
+       local.set $13
+       local.get $6
+       local.set $14
+       local.get $12
+       local.get $13
        i32.const 0
        i32.shl
        i32.add
-       local.get $4
+       local.get $14
        i32.add
        i32.load8_u offset=8
       end
-      local.get $7
-      local.get $0
-      local.get $1
+      local.get $9
+      local.get $2
+      local.get $3
       call_indirect (type $iiii)
      end
      i32.const 255
      i32.and
-     local.set $8
+     local.set $14
      i32.const 0
-     local.set $9
-     local.get $6
-     local.get $7
+     local.set $13
+     local.get $10
+     local.get $11
      i32.const 0
      i32.shl
      i32.add
-     local.get $9
+     local.get $13
      i32.add
-     local.get $8
+     local.get $14
      i32.store8 offset=8
     end
-    local.get $7
+    local.get $9
     i32.const 1
     i32.add
-    local.set $7
+    local.set $9
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $5
+  local.get $7
  )
  (func $std/typedarray/testArrayMap<Uint8Array,u8> (; 129 ;) (type $v)
   (local $0 i32)
@@ -6142,79 +7041,100 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  local.get $0
+  local.set $2
+  local.get $1
+  local.set $3
   block $~lib/internal/typedarray/TypedArray<u8>#get:length|inlined.5 (result i32)
-   local.get $0
+   local.get $2
+   local.set $4
+   local.get $4
    i32.load offset=8
    i32.const 0
    i32.shr_u
   end
-  local.set $2
-  local.get $0
-  i32.load
-  local.set $3
-  local.get $0
-  i32.load offset=4
   local.set $4
-  i32.const 0
   local.get $2
-  call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.set $5
-  local.get $5
   i32.load
+  local.set $5
+  local.get $2
+  i32.load offset=4
   local.set $6
+  i32.const 0
+  local.get $4
+  call $~lib/typedarray/Uint8ClampedArray#constructor
+  local.set $7
+  local.get $7
+  i32.load
+  local.set $8
   block $break|0
    i32.const 0
-   local.set $7
+   local.set $9
    loop $repeat|0
-    local.get $7
-    local.get $2
+    local.get $9
+    local.get $4
     i32.lt_s
     i32.eqz
     br_if $break|0
-    block
+    block $~lib/internal/arraybuffer/STORE<u8,u32>|inlined.2
+     local.get $8
+     local.set $10
+     local.get $9
+     local.set $11
      block (result i32)
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<u8,u8>|inlined.4 (result i32)
-       local.get $3
-       local.get $7
+       local.get $5
+       local.set $12
+       local.get $9
+       local.set $13
+       local.get $6
+       local.set $14
+       local.get $12
+       local.get $13
        i32.const 0
        i32.shl
        i32.add
-       local.get $4
+       local.get $14
        i32.add
        i32.load8_u offset=8
       end
-      local.get $7
-      local.get $0
-      local.get $1
+      local.get $9
+      local.get $2
+      local.get $3
       call_indirect (type $iiii)
      end
      i32.const 255
      i32.and
-     local.set $8
+     local.set $14
      i32.const 0
-     local.set $9
-     local.get $6
-     local.get $7
+     local.set $13
+     local.get $10
+     local.get $11
      i32.const 0
      i32.shl
      i32.add
-     local.get $9
+     local.get $13
      i32.add
-     local.get $8
+     local.get $14
      i32.store8 offset=8
     end
-    local.get $7
+    local.get $9
     i32.const 1
     i32.add
-    local.set $7
+    local.set $9
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $5
+  local.get $7
  )
  (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8> (; 132 ;) (type $v)
   (local $0 i32)
@@ -6302,85 +7222,107 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  local.get $0
+  local.set $2
+  local.get $1
+  local.set $3
   block $~lib/internal/typedarray/TypedArray<i16>#get:length|inlined.3 (result i32)
-   local.get $0
+   local.get $2
+   local.set $4
+   local.get $4
    i32.load offset=8
    i32.const 1
    i32.shr_u
   end
-  local.set $2
-  local.get $0
-  i32.load
-  local.set $3
-  local.get $0
-  i32.load offset=4
   local.set $4
-  i32.const 0
   local.get $2
-  call $~lib/typedarray/Int16Array#constructor
-  local.set $5
-  local.get $5
   i32.load
+  local.set $5
+  local.get $2
+  i32.load offset=4
   local.set $6
+  i32.const 0
+  local.get $4
+  call $~lib/typedarray/Int16Array#constructor
+  local.set $7
+  local.get $7
+  i32.load
+  local.set $8
   block $break|0
    i32.const 0
-   local.set $7
+   local.set $9
    loop $repeat|0
-    local.get $7
-    local.get $2
+    local.get $9
+    local.get $4
     i32.lt_s
     i32.eqz
     br_if $break|0
-    block
+    block $~lib/internal/arraybuffer/STORE<i16,i32>|inlined.1
+     local.get $8
+     local.set $10
+     local.get $9
+     local.set $11
      block (result i32)
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<i16,i16>|inlined.2 (result i32)
-       local.get $3
-       local.get $7
+       local.get $5
+       local.set $12
+       local.get $9
+       local.set $13
+       local.get $6
+       local.set $14
+       local.get $12
+       local.get $13
        i32.const 1
        i32.shl
        i32.add
-       local.get $4
+       local.get $14
        i32.add
        i32.load16_s offset=8
       end
-      local.get $7
-      local.get $0
-      local.get $1
+      local.get $9
+      local.get $2
+      local.get $3
       call_indirect (type $iiii)
      end
      i32.const 16
      i32.shl
      i32.const 16
      i32.shr_s
-     local.set $8
+     local.set $14
      i32.const 0
-     local.set $9
-     local.get $6
-     local.get $7
+     local.set $13
+     local.get $10
+     local.get $11
      i32.const 1
      i32.shl
      i32.add
-     local.get $9
+     local.get $13
      i32.add
-     local.get $8
+     local.get $14
      i32.store16 offset=8
     end
-    local.get $7
+    local.get $9
     i32.const 1
     i32.add
-    local.set $7
+    local.set $9
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $5
+  local.get $7
  )
  (func $~lib/internal/typedarray/TypedArray<i16>#__get (; 135 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -6399,15 +7341,17 @@
    local.get $0
    i32.load
    local.set $2
+   local.get $1
+   local.set $3
    local.get $0
    i32.load offset=4
-   local.set $3
+   local.set $4
    local.get $2
-   local.get $1
+   local.get $3
    i32.const 1
    i32.shl
    i32.add
-   local.get $3
+   local.get $4
    i32.add
    i32.load16_s offset=8
   end
@@ -6504,83 +7448,105 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  local.get $0
+  local.set $2
+  local.get $1
+  local.set $3
   block $~lib/internal/typedarray/TypedArray<u16>#get:length|inlined.3 (result i32)
-   local.get $0
+   local.get $2
+   local.set $4
+   local.get $4
    i32.load offset=8
    i32.const 1
    i32.shr_u
   end
-  local.set $2
-  local.get $0
-  i32.load
-  local.set $3
-  local.get $0
-  i32.load offset=4
   local.set $4
-  i32.const 0
   local.get $2
-  call $~lib/typedarray/Uint16Array#constructor
-  local.set $5
-  local.get $5
   i32.load
+  local.set $5
+  local.get $2
+  i32.load offset=4
   local.set $6
+  i32.const 0
+  local.get $4
+  call $~lib/typedarray/Uint16Array#constructor
+  local.set $7
+  local.get $7
+  i32.load
+  local.set $8
   block $break|0
    i32.const 0
-   local.set $7
+   local.set $9
    loop $repeat|0
-    local.get $7
-    local.get $2
+    local.get $9
+    local.get $4
     i32.lt_s
     i32.eqz
     br_if $break|0
-    block
+    block $~lib/internal/arraybuffer/STORE<u16,u32>|inlined.1
+     local.get $8
+     local.set $10
+     local.get $9
+     local.set $11
      block (result i32)
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<u16,u16>|inlined.2 (result i32)
-       local.get $3
-       local.get $7
+       local.get $5
+       local.set $12
+       local.get $9
+       local.set $13
+       local.get $6
+       local.set $14
+       local.get $12
+       local.get $13
        i32.const 1
        i32.shl
        i32.add
-       local.get $4
+       local.get $14
        i32.add
        i32.load16_u offset=8
       end
-      local.get $7
-      local.get $0
-      local.get $1
+      local.get $9
+      local.get $2
+      local.get $3
       call_indirect (type $iiii)
      end
      i32.const 65535
      i32.and
-     local.set $8
+     local.set $14
      i32.const 0
-     local.set $9
-     local.get $6
-     local.get $7
+     local.set $13
+     local.get $10
+     local.get $11
      i32.const 1
      i32.shl
      i32.add
-     local.get $9
+     local.get $13
      i32.add
-     local.get $8
+     local.get $14
      i32.store16 offset=8
     end
-    local.get $7
+    local.get $9
     i32.const 1
     i32.add
-    local.set $7
+    local.set $9
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $5
+  local.get $7
  )
  (func $~lib/internal/typedarray/TypedArray<u16>#__get (; 139 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -6599,15 +7565,17 @@
    local.get $0
    i32.load
    local.set $2
+   local.get $1
+   local.set $3
    local.get $0
    i32.load offset=4
-   local.set $3
+   local.set $4
    local.get $2
-   local.get $1
+   local.get $3
    i32.const 1
    i32.shl
    i32.add
-   local.get $3
+   local.get $4
    i32.add
    i32.load16_u offset=8
   end
@@ -6698,77 +7666,98 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  local.get $0
+  local.set $2
+  local.get $1
+  local.set $3
   block $~lib/internal/typedarray/TypedArray<i32>#get:length|inlined.11 (result i32)
-   local.get $0
+   local.get $2
+   local.set $4
+   local.get $4
    i32.load offset=8
    i32.const 2
    i32.shr_u
   end
-  local.set $2
-  local.get $0
-  i32.load
-  local.set $3
-  local.get $0
-  i32.load offset=4
   local.set $4
-  i32.const 0
   local.get $2
-  call $~lib/typedarray/Int32Array#constructor
-  local.set $5
-  local.get $5
   i32.load
+  local.set $5
+  local.get $2
+  i32.load offset=4
   local.set $6
+  i32.const 0
+  local.get $4
+  call $~lib/typedarray/Int32Array#constructor
+  local.set $7
+  local.get $7
+  i32.load
+  local.set $8
   block $break|0
    i32.const 0
-   local.set $7
+   local.set $9
    loop $repeat|0
-    local.get $7
-    local.get $2
+    local.get $9
+    local.get $4
     i32.lt_s
     i32.eqz
     br_if $break|0
-    block
+    block $~lib/internal/arraybuffer/STORE<i32,i32>|inlined.2
+     local.get $8
+     local.set $10
+     local.get $9
+     local.set $11
      block (result i32)
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.4 (result i32)
-       local.get $3
-       local.get $7
+       local.get $5
+       local.set $12
+       local.get $9
+       local.set $13
+       local.get $6
+       local.set $14
+       local.get $12
+       local.get $13
        i32.const 2
        i32.shl
        i32.add
-       local.get $4
+       local.get $14
        i32.add
        i32.load offset=8
       end
-      local.get $7
-      local.get $0
-      local.get $1
+      local.get $9
+      local.get $2
+      local.get $3
       call_indirect (type $iiii)
      end
-     local.set $8
+     local.set $14
      i32.const 0
-     local.set $9
-     local.get $6
-     local.get $7
+     local.set $13
+     local.get $10
+     local.get $11
      i32.const 2
      i32.shl
      i32.add
-     local.get $9
+     local.get $13
      i32.add
-     local.get $8
+     local.get $14
      i32.store offset=8
     end
-    local.get $7
+    local.get $9
     i32.const 1
     i32.add
-    local.set $7
+    local.set $9
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $5
+  local.get $7
  )
  (func $std/typedarray/testArrayMap<Int32Array,i32> (; 143 ;) (type $v)
   (local $0 i32)
@@ -6850,81 +7839,103 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  local.get $0
+  local.set $2
+  local.get $1
+  local.set $3
   block $~lib/internal/typedarray/TypedArray<u32>#get:length|inlined.3 (result i32)
-   local.get $0
+   local.get $2
+   local.set $4
+   local.get $4
    i32.load offset=8
    i32.const 2
    i32.shr_u
   end
-  local.set $2
-  local.get $0
-  i32.load
-  local.set $3
-  local.get $0
-  i32.load offset=4
   local.set $4
-  i32.const 0
   local.get $2
-  call $~lib/typedarray/Uint32Array#constructor
-  local.set $5
-  local.get $5
   i32.load
+  local.set $5
+  local.get $2
+  i32.load offset=4
   local.set $6
+  i32.const 0
+  local.get $4
+  call $~lib/typedarray/Uint32Array#constructor
+  local.set $7
+  local.get $7
+  i32.load
+  local.set $8
   block $break|0
    i32.const 0
-   local.set $7
+   local.set $9
    loop $repeat|0
-    local.get $7
-    local.get $2
+    local.get $9
+    local.get $4
     i32.lt_s
     i32.eqz
     br_if $break|0
-    block
+    block $~lib/internal/arraybuffer/STORE<u32,u32>|inlined.1
+     local.get $8
+     local.set $10
+     local.get $9
+     local.set $11
      block (result i32)
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.2 (result i32)
-       local.get $3
-       local.get $7
+       local.get $5
+       local.set $12
+       local.get $9
+       local.set $13
+       local.get $6
+       local.set $14
+       local.get $12
+       local.get $13
        i32.const 2
        i32.shl
        i32.add
-       local.get $4
+       local.get $14
        i32.add
        i32.load offset=8
       end
-      local.get $7
-      local.get $0
-      local.get $1
+      local.get $9
+      local.get $2
+      local.get $3
       call_indirect (type $iiii)
      end
-     local.set $8
+     local.set $14
      i32.const 0
-     local.set $9
-     local.get $6
-     local.get $7
+     local.set $13
+     local.get $10
+     local.get $11
      i32.const 2
      i32.shl
      i32.add
-     local.get $9
+     local.get $13
      i32.add
-     local.get $8
+     local.get $14
      i32.store offset=8
     end
-    local.get $7
+    local.get $9
     i32.const 1
     i32.add
-    local.set $7
+    local.set $9
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $5
+  local.get $7
  )
  (func $~lib/internal/typedarray/TypedArray<u32>#__get (; 146 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -6943,15 +7954,17 @@
    local.get $0
    i32.load
    local.set $2
+   local.get $1
+   local.set $3
    local.get $0
    i32.load offset=4
-   local.set $3
+   local.set $4
    local.get $2
-   local.get $1
+   local.get $3
    i32.const 2
    i32.shl
    i32.add
-   local.get $3
+   local.get $4
    i32.add
    i32.load offset=8
   end
@@ -7034,83 +8047,106 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i64)
+  (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i64)
+  local.get $0
+  local.set $2
+  local.get $1
+  local.set $3
   block $~lib/internal/typedarray/TypedArray<i64>#get:length|inlined.3 (result i32)
-   local.get $0
+   local.get $2
+   local.set $4
+   local.get $4
    i32.load offset=8
    i32.const 3
    i32.shr_u
   end
-  local.set $2
-  local.get $0
-  i32.load
-  local.set $3
-  local.get $0
-  i32.load offset=4
   local.set $4
-  i32.const 0
   local.get $2
-  call $~lib/typedarray/Int64Array#constructor
-  local.set $5
-  local.get $5
   i32.load
+  local.set $5
+  local.get $2
+  i32.load offset=4
   local.set $6
+  i32.const 0
+  local.get $4
+  call $~lib/typedarray/Int64Array#constructor
+  local.set $7
+  local.get $7
+  i32.load
+  local.set $8
   block $break|0
    i32.const 0
-   local.set $7
+   local.set $9
    loop $repeat|0
-    local.get $7
-    local.get $2
+    local.get $9
+    local.get $4
     i32.lt_s
     i32.eqz
     br_if $break|0
-    block
+    block $~lib/internal/arraybuffer/STORE<i64,i64>|inlined.1
+     local.get $8
+     local.set $10
+     local.get $9
+     local.set $11
      block (result i64)
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<i64,i64>|inlined.2 (result i64)
-       local.get $3
-       local.get $7
+       local.get $5
+       local.set $12
+       local.get $9
+       local.set $13
+       local.get $6
+       local.set $14
+       local.get $12
+       local.get $13
        i32.const 3
        i32.shl
        i32.add
-       local.get $4
+       local.get $14
        i32.add
        i64.load offset=8
       end
-      local.get $7
-      local.get $0
-      local.get $1
+      local.get $9
+      local.get $2
+      local.get $3
       call_indirect (type $IiiI)
      end
-     local.set $8
+     local.set $15
      i32.const 0
-     local.set $9
-     local.get $6
-     local.get $7
+     local.set $14
+     local.get $10
+     local.get $11
      i32.const 3
      i32.shl
      i32.add
-     local.get $9
+     local.get $14
      i32.add
-     local.get $8
+     local.get $15
      i64.store offset=8
     end
-    local.get $7
+    local.get $9
     i32.const 1
     i32.add
-    local.set $7
+    local.set $9
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $5
+  local.get $7
  )
  (func $~lib/internal/typedarray/TypedArray<i64>#__get (; 150 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -7129,15 +8165,17 @@
    local.get $0
    i32.load
    local.set $2
+   local.get $1
+   local.set $3
    local.get $0
    i32.load offset=4
-   local.set $3
+   local.set $4
    local.get $2
-   local.get $1
+   local.get $3
    i32.const 3
    i32.shl
    i32.add
-   local.get $3
+   local.get $4
    i32.add
    i64.load offset=8
   end
@@ -7220,83 +8258,106 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i64)
+  (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i64)
+  local.get $0
+  local.set $2
+  local.get $1
+  local.set $3
   block $~lib/internal/typedarray/TypedArray<u64>#get:length|inlined.3 (result i32)
-   local.get $0
+   local.get $2
+   local.set $4
+   local.get $4
    i32.load offset=8
    i32.const 3
    i32.shr_u
   end
-  local.set $2
-  local.get $0
-  i32.load
-  local.set $3
-  local.get $0
-  i32.load offset=4
   local.set $4
-  i32.const 0
   local.get $2
-  call $~lib/typedarray/Uint64Array#constructor
-  local.set $5
-  local.get $5
   i32.load
+  local.set $5
+  local.get $2
+  i32.load offset=4
   local.set $6
+  i32.const 0
+  local.get $4
+  call $~lib/typedarray/Uint64Array#constructor
+  local.set $7
+  local.get $7
+  i32.load
+  local.set $8
   block $break|0
    i32.const 0
-   local.set $7
+   local.set $9
    loop $repeat|0
-    local.get $7
-    local.get $2
+    local.get $9
+    local.get $4
     i32.lt_s
     i32.eqz
     br_if $break|0
-    block
+    block $~lib/internal/arraybuffer/STORE<u64,u64>|inlined.1
+     local.get $8
+     local.set $10
+     local.get $9
+     local.set $11
      block (result i64)
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<u64,u64>|inlined.2 (result i64)
-       local.get $3
-       local.get $7
+       local.get $5
+       local.set $12
+       local.get $9
+       local.set $13
+       local.get $6
+       local.set $14
+       local.get $12
+       local.get $13
        i32.const 3
        i32.shl
        i32.add
-       local.get $4
+       local.get $14
        i32.add
        i64.load offset=8
       end
-      local.get $7
-      local.get $0
-      local.get $1
+      local.get $9
+      local.get $2
+      local.get $3
       call_indirect (type $IiiI)
      end
-     local.set $8
+     local.set $15
      i32.const 0
-     local.set $9
-     local.get $6
-     local.get $7
+     local.set $14
+     local.get $10
+     local.get $11
      i32.const 3
      i32.shl
      i32.add
-     local.get $9
+     local.get $14
      i32.add
-     local.get $8
+     local.get $15
      i64.store offset=8
     end
-    local.get $7
+    local.get $9
     i32.const 1
     i32.add
-    local.set $7
+    local.set $9
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $5
+  local.get $7
  )
  (func $~lib/internal/typedarray/TypedArray<u64>#__get (; 154 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -7315,15 +8376,17 @@
    local.get $0
    i32.load
    local.set $2
+   local.get $1
+   local.set $3
    local.get $0
    i32.load offset=4
-   local.set $3
+   local.set $4
    local.get $2
-   local.get $1
+   local.get $3
    i32.const 3
    i32.shl
    i32.add
-   local.get $3
+   local.get $4
    i32.add
    i64.load offset=8
   end
@@ -7406,83 +8469,106 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 f32)
+  (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 f32)
+  local.get $0
+  local.set $2
+  local.get $1
+  local.set $3
   block $~lib/internal/typedarray/TypedArray<f32>#get:length|inlined.3 (result i32)
-   local.get $0
+   local.get $2
+   local.set $4
+   local.get $4
    i32.load offset=8
    i32.const 2
    i32.shr_u
   end
-  local.set $2
-  local.get $0
-  i32.load
-  local.set $3
-  local.get $0
-  i32.load offset=4
   local.set $4
-  i32.const 0
   local.get $2
-  call $~lib/typedarray/Float32Array#constructor
-  local.set $5
-  local.get $5
   i32.load
+  local.set $5
+  local.get $2
+  i32.load offset=4
   local.set $6
+  i32.const 0
+  local.get $4
+  call $~lib/typedarray/Float32Array#constructor
+  local.set $7
+  local.get $7
+  i32.load
+  local.set $8
   block $break|0
    i32.const 0
-   local.set $7
+   local.set $9
    loop $repeat|0
-    local.get $7
-    local.get $2
+    local.get $9
+    local.get $4
     i32.lt_s
     i32.eqz
     br_if $break|0
-    block
+    block $~lib/internal/arraybuffer/STORE<f32,f32>|inlined.1
+     local.get $8
+     local.set $10
+     local.get $9
+     local.set $11
      block (result f32)
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.2 (result f32)
-       local.get $3
-       local.get $7
+       local.get $5
+       local.set $12
+       local.get $9
+       local.set $13
+       local.get $6
+       local.set $14
+       local.get $12
+       local.get $13
        i32.const 2
        i32.shl
        i32.add
-       local.get $4
+       local.get $14
        i32.add
        f32.load offset=8
       end
-      local.get $7
-      local.get $0
-      local.get $1
+      local.get $9
+      local.get $2
+      local.get $3
       call_indirect (type $fiif)
      end
-     local.set $8
+     local.set $15
      i32.const 0
-     local.set $9
-     local.get $6
-     local.get $7
+     local.set $14
+     local.get $10
+     local.get $11
      i32.const 2
      i32.shl
      i32.add
-     local.get $9
+     local.get $14
      i32.add
-     local.get $8
+     local.get $15
      f32.store offset=8
     end
-    local.get $7
+    local.get $9
     i32.const 1
     i32.add
-    local.set $7
+    local.set $9
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $5
+  local.get $7
  )
  (func $~lib/internal/typedarray/TypedArray<f32>#__get (; 158 ;) (type $iif) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -7501,15 +8587,17 @@
    local.get $0
    i32.load
    local.set $2
+   local.get $1
+   local.set $3
    local.get $0
    i32.load offset=4
-   local.set $3
+   local.set $4
    local.get $2
-   local.get $1
+   local.get $3
    i32.const 2
    i32.shl
    i32.add
-   local.get $3
+   local.get $4
    i32.add
    f32.load offset=8
   end
@@ -7592,79 +8680,101 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 f64)
+  (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 f64)
+  local.get $0
+  local.set $2
+  local.get $1
+  local.set $3
   block $~lib/internal/typedarray/TypedArray<f64>#get:length|inlined.6 (result i32)
-   local.get $0
+   local.get $2
+   local.set $4
+   local.get $4
    i32.load offset=8
    i32.const 3
    i32.shr_u
   end
-  local.set $2
-  local.get $0
-  i32.load
-  local.set $3
-  local.get $0
-  i32.load offset=4
   local.set $4
-  i32.const 0
   local.get $2
-  call $~lib/typedarray/Float64Array#constructor
-  local.set $5
-  local.get $5
   i32.load
+  local.set $5
+  local.get $2
+  i32.load offset=4
   local.set $6
+  i32.const 0
+  local.get $4
+  call $~lib/typedarray/Float64Array#constructor
+  local.set $7
+  local.get $7
+  i32.load
+  local.set $8
   block $break|0
    i32.const 0
-   local.set $7
+   local.set $9
    loop $repeat|0
-    local.get $7
-    local.get $2
+    local.get $9
+    local.get $4
     i32.lt_s
     i32.eqz
     br_if $break|0
-    block
+    block $~lib/internal/arraybuffer/STORE<f64,f64>|inlined.13
+     local.get $8
+     local.set $10
+     local.get $9
+     local.set $11
      block (result f64)
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.15 (result f64)
-       local.get $3
-       local.get $7
+       local.get $5
+       local.set $12
+       local.get $9
+       local.set $13
+       local.get $6
+       local.set $14
+       local.get $12
+       local.get $13
        i32.const 3
        i32.shl
        i32.add
-       local.get $4
+       local.get $14
        i32.add
        f64.load offset=8
       end
-      local.get $7
-      local.get $0
-      local.get $1
+      local.get $9
+      local.get $2
+      local.get $3
       call_indirect (type $FiiF)
      end
-     local.set $8
+     local.set $15
      i32.const 0
-     local.set $9
-     local.get $6
-     local.get $7
+     local.set $14
+     local.get $10
+     local.get $11
      i32.const 3
      i32.shl
      i32.add
-     local.get $9
+     local.get $14
      i32.add
-     local.get $8
+     local.get $15
      f64.store offset=8
     end
-    local.get $7
+    local.get $9
     i32.const 1
     i32.add
-    local.set $7
+    local.set $9
     br $repeat|0
     unreachable
    end
    unreachable
   end
-  local.get $5
+  local.get $7
  )
  (func $std/typedarray/testArrayMap<Float64Array,f64> (; 162 ;) (type $v)
   (local $0 i32)
@@ -7746,26 +8856,37 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/SOME<Int8Array,i8>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<i8>#get:length|inlined.13 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 0
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
-     local.get $5
-     local.get $2
+     local.get $7
+     local.get $4
      i32.lt_s
      i32.eqz
      br_if $break|0
@@ -7773,18 +8894,24 @@
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<i8,i8>|inlined.6 (result i32)
-       local.get $3
        local.get $5
+       local.set $10
+       local.get $7
+       local.set $9
+       local.get $6
+       local.set $8
+       local.get $10
+       local.get $9
        i32.const 0
        i32.shl
        i32.add
-       local.get $4
+       local.get $8
        i32.add
        i32.load8_s offset=8
       end
-      local.get $5
-      local.get $0
-      local.get $1
+      local.get $7
+      local.get $2
+      local.get $3
       call_indirect (type $iiii)
      end
      i32.const 0
@@ -7793,10 +8920,10 @@
       i32.const 1
       br $~lib/internal/typedarray/SOME<Int8Array,i8>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -7880,26 +9007,37 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/SOME<Uint8Array,u8>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<u8>#get:length|inlined.6 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 0
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
-     local.get $5
-     local.get $2
+     local.get $7
+     local.get $4
      i32.lt_s
      i32.eqz
      br_if $break|0
@@ -7907,18 +9045,24 @@
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<u8,u8>|inlined.6 (result i32)
-       local.get $3
        local.get $5
+       local.set $10
+       local.get $7
+       local.set $9
+       local.get $6
+       local.set $8
+       local.get $10
+       local.get $9
        i32.const 0
        i32.shl
        i32.add
-       local.get $4
+       local.get $8
        i32.add
        i32.load8_u offset=8
       end
-      local.get $5
-      local.get $0
-      local.get $1
+      local.get $7
+      local.get $2
+      local.get $3
       call_indirect (type $iiii)
      end
      i32.const 0
@@ -7927,10 +9071,10 @@
       i32.const 1
       br $~lib/internal/typedarray/SOME<Uint8Array,u8>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -8012,26 +9156,37 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/SOME<Uint8ClampedArray,u8>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<u8>#get:length|inlined.7 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 0
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
-     local.get $5
-     local.get $2
+     local.get $7
+     local.get $4
      i32.lt_s
      i32.eqz
      br_if $break|0
@@ -8039,18 +9194,24 @@
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<u8,u8>|inlined.8 (result i32)
-       local.get $3
        local.get $5
+       local.set $10
+       local.get $7
+       local.set $9
+       local.get $6
+       local.set $8
+       local.get $10
+       local.get $9
        i32.const 0
        i32.shl
        i32.add
-       local.get $4
+       local.get $8
        i32.add
        i32.load8_u offset=8
       end
-      local.get $5
-      local.get $0
-      local.get $1
+      local.get $7
+      local.get $2
+      local.get $3
       call_indirect (type $iiii)
      end
      i32.const 0
@@ -8059,10 +9220,10 @@
       i32.const 1
       br $~lib/internal/typedarray/SOME<Uint8ClampedArray,u8>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -8146,26 +9307,37 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/SOME<Int16Array,i16>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<i16>#get:length|inlined.4 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 1
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
-     local.get $5
-     local.get $2
+     local.get $7
+     local.get $4
      i32.lt_s
      i32.eqz
      br_if $break|0
@@ -8173,18 +9345,24 @@
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<i16,i16>|inlined.5 (result i32)
-       local.get $3
        local.get $5
+       local.set $10
+       local.get $7
+       local.set $9
+       local.get $6
+       local.set $8
+       local.get $10
+       local.get $9
        i32.const 1
        i32.shl
        i32.add
-       local.get $4
+       local.get $8
        i32.add
        i32.load16_s offset=8
       end
-      local.get $5
-      local.get $0
-      local.get $1
+      local.get $7
+      local.get $2
+      local.get $3
       call_indirect (type $iiii)
      end
      i32.const 0
@@ -8193,10 +9371,10 @@
       i32.const 1
       br $~lib/internal/typedarray/SOME<Int16Array,i16>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -8280,26 +9458,37 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/SOME<Uint16Array,u16>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<u16>#get:length|inlined.4 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 1
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
-     local.get $5
-     local.get $2
+     local.get $7
+     local.get $4
      i32.lt_s
      i32.eqz
      br_if $break|0
@@ -8307,18 +9496,24 @@
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<u16,u16>|inlined.5 (result i32)
-       local.get $3
        local.get $5
+       local.set $10
+       local.get $7
+       local.set $9
+       local.get $6
+       local.set $8
+       local.get $10
+       local.get $9
        i32.const 1
        i32.shl
        i32.add
-       local.get $4
+       local.get $8
        i32.add
        i32.load16_u offset=8
       end
-      local.get $5
-      local.get $0
-      local.get $1
+      local.get $7
+      local.get $2
+      local.get $3
       call_indirect (type $iiii)
      end
      i32.const 0
@@ -8327,10 +9522,10 @@
       i32.const 1
       br $~lib/internal/typedarray/SOME<Uint16Array,u16>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -8410,26 +9605,37 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/SOME<Int32Array,i32>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<i32>#get:length|inlined.12 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 2
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
-     local.get $5
-     local.get $2
+     local.get $7
+     local.get $4
      i32.lt_s
      i32.eqz
      br_if $break|0
@@ -8437,18 +9643,24 @@
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.6 (result i32)
-       local.get $3
        local.get $5
+       local.set $10
+       local.get $7
+       local.set $9
+       local.get $6
+       local.set $8
+       local.get $10
+       local.get $9
        i32.const 2
        i32.shl
        i32.add
-       local.get $4
+       local.get $8
        i32.add
        i32.load offset=8
       end
-      local.get $5
-      local.get $0
-      local.get $1
+      local.get $7
+      local.get $2
+      local.get $3
       call_indirect (type $iiii)
      end
      i32.const 0
@@ -8457,10 +9669,10 @@
       i32.const 1
       br $~lib/internal/typedarray/SOME<Int32Array,i32>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -8538,26 +9750,37 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/SOME<Uint32Array,u32>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<u32>#get:length|inlined.4 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 2
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
-     local.get $5
-     local.get $2
+     local.get $7
+     local.get $4
      i32.lt_s
      i32.eqz
      br_if $break|0
@@ -8565,18 +9788,24 @@
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.5 (result i32)
-       local.get $3
        local.get $5
+       local.set $10
+       local.get $7
+       local.set $9
+       local.get $6
+       local.set $8
+       local.get $10
+       local.get $9
        i32.const 2
        i32.shl
        i32.add
-       local.get $4
+       local.get $8
        i32.add
        i32.load offset=8
       end
-      local.get $5
-      local.get $0
-      local.get $1
+      local.get $7
+      local.get $2
+      local.get $3
       call_indirect (type $iiii)
      end
      i32.const 0
@@ -8585,10 +9814,10 @@
       i32.const 1
       br $~lib/internal/typedarray/SOME<Uint32Array,u32>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -8666,26 +9895,37 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/SOME<Int64Array,i64>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<i64>#get:length|inlined.4 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 3
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
-     local.get $5
-     local.get $2
+     local.get $7
+     local.get $4
      i32.lt_s
      i32.eqz
      br_if $break|0
@@ -8693,18 +9933,24 @@
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<i64,i64>|inlined.5 (result i64)
-       local.get $3
        local.get $5
+       local.set $10
+       local.get $7
+       local.set $9
+       local.get $6
+       local.set $8
+       local.get $10
+       local.get $9
        i32.const 3
        i32.shl
        i32.add
-       local.get $4
+       local.get $8
        i32.add
        i64.load offset=8
       end
-      local.get $5
-      local.get $0
-      local.get $1
+      local.get $7
+      local.get $2
+      local.get $3
       call_indirect (type $Iiii)
      end
      i32.const 0
@@ -8713,10 +9959,10 @@
       i32.const 1
       br $~lib/internal/typedarray/SOME<Int64Array,i64>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -8794,26 +10040,37 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/SOME<Uint64Array,u64>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<u64>#get:length|inlined.4 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 3
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
-     local.get $5
-     local.get $2
+     local.get $7
+     local.get $4
      i32.lt_s
      i32.eqz
      br_if $break|0
@@ -8821,18 +10078,24 @@
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<u64,u64>|inlined.5 (result i64)
-       local.get $3
        local.get $5
+       local.set $10
+       local.get $7
+       local.set $9
+       local.get $6
+       local.set $8
+       local.get $10
+       local.get $9
        i32.const 3
        i32.shl
        i32.add
-       local.get $4
+       local.get $8
        i32.add
        i64.load offset=8
       end
-      local.get $5
-      local.get $0
-      local.get $1
+      local.get $7
+      local.get $2
+      local.get $3
       call_indirect (type $Iiii)
      end
      i32.const 0
@@ -8841,10 +10104,10 @@
       i32.const 1
       br $~lib/internal/typedarray/SOME<Uint64Array,u64>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -8922,26 +10185,37 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/SOME<Float32Array,f32>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<f32>#get:length|inlined.4 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 2
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
-     local.get $5
-     local.get $2
+     local.get $7
+     local.get $4
      i32.lt_s
      i32.eqz
      br_if $break|0
@@ -8949,18 +10223,24 @@
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.5 (result f32)
-       local.get $3
        local.get $5
+       local.set $10
+       local.get $7
+       local.set $9
+       local.get $6
+       local.set $8
+       local.get $10
+       local.get $9
        i32.const 2
        i32.shl
        i32.add
-       local.get $4
+       local.get $8
        i32.add
        f32.load offset=8
       end
-      local.get $5
-      local.get $0
-      local.get $1
+      local.get $7
+      local.get $2
+      local.get $3
       call_indirect (type $fiii)
      end
      i32.const 0
@@ -8969,10 +10249,10 @@
       i32.const 1
       br $~lib/internal/typedarray/SOME<Float32Array,f32>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -9050,26 +10330,37 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/SOME<Float64Array,f64>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<f64>#get:length|inlined.7 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 3
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
-     local.get $5
-     local.get $2
+     local.get $7
+     local.get $4
      i32.lt_s
      i32.eqz
      br_if $break|0
@@ -9077,18 +10368,24 @@
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.17 (result f64)
-       local.get $3
        local.get $5
+       local.set $10
+       local.get $7
+       local.set $9
+       local.get $6
+       local.set $8
+       local.get $10
+       local.get $9
        i32.const 3
        i32.shl
        i32.add
-       local.get $4
+       local.get $8
        i32.add
        f64.load offset=8
       end
-      local.get $5
-      local.get $0
-      local.get $1
+      local.get $7
+      local.get $2
+      local.get $3
       call_indirect (type $Fiii)
      end
      i32.const 0
@@ -9097,10 +10394,10 @@
       i32.const 1
       br $~lib/internal/typedarray/SOME<Float64Array,f64>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -9182,26 +10479,37 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/FIND_INDEX<Int8Array,i8>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<i8>#get:length|inlined.14 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 0
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
-     local.get $5
-     local.get $2
+     local.get $7
+     local.get $4
      i32.lt_s
      i32.eqz
      br_if $break|0
@@ -9209,30 +10517,36 @@
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<i8,i8>|inlined.8 (result i32)
-       local.get $3
        local.get $5
+       local.set $10
+       local.get $7
+       local.set $9
+       local.get $6
+       local.set $8
+       local.get $10
+       local.get $9
        i32.const 0
        i32.shl
        i32.add
-       local.get $4
+       local.get $8
        i32.add
        i32.load8_s offset=8
       end
-      local.get $5
-      local.get $0
-      local.get $1
+      local.get $7
+      local.get $2
+      local.get $3
       call_indirect (type $iiii)
      end
      i32.const 0
      i32.ne
      if
-      local.get $5
+      local.get $7
       br $~lib/internal/typedarray/FIND_INDEX<Int8Array,i8>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -9315,26 +10629,37 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/FIND_INDEX<Uint8Array,u8>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<u8>#get:length|inlined.8 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 0
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
-     local.get $5
-     local.get $2
+     local.get $7
+     local.get $4
      i32.lt_s
      i32.eqz
      br_if $break|0
@@ -9342,30 +10667,36 @@
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<u8,u8>|inlined.10 (result i32)
-       local.get $3
        local.get $5
+       local.set $10
+       local.get $7
+       local.set $9
+       local.get $6
+       local.set $8
+       local.get $10
+       local.get $9
        i32.const 0
        i32.shl
        i32.add
-       local.get $4
+       local.get $8
        i32.add
        i32.load8_u offset=8
       end
-      local.get $5
-      local.get $0
-      local.get $1
+      local.get $7
+      local.get $2
+      local.get $3
       call_indirect (type $iiii)
      end
      i32.const 0
      i32.ne
      if
-      local.get $5
+      local.get $7
       br $~lib/internal/typedarray/FIND_INDEX<Uint8Array,u8>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -9446,26 +10777,37 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/FIND_INDEX<Uint8ClampedArray,u8>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<u8>#get:length|inlined.9 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 0
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
-     local.get $5
-     local.get $2
+     local.get $7
+     local.get $4
      i32.lt_s
      i32.eqz
      br_if $break|0
@@ -9473,30 +10815,36 @@
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<u8,u8>|inlined.12 (result i32)
-       local.get $3
        local.get $5
+       local.set $10
+       local.get $7
+       local.set $9
+       local.get $6
+       local.set $8
+       local.get $10
+       local.get $9
        i32.const 0
        i32.shl
        i32.add
-       local.get $4
+       local.get $8
        i32.add
        i32.load8_u offset=8
       end
-      local.get $5
-      local.get $0
-      local.get $1
+      local.get $7
+      local.get $2
+      local.get $3
       call_indirect (type $iiii)
      end
      i32.const 0
      i32.ne
      if
-      local.get $5
+      local.get $7
       br $~lib/internal/typedarray/FIND_INDEX<Uint8ClampedArray,u8>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -9579,26 +10927,37 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/FIND_INDEX<Int16Array,i16>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<i16>#get:length|inlined.5 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 1
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
-     local.get $5
-     local.get $2
+     local.get $7
+     local.get $4
      i32.lt_s
      i32.eqz
      br_if $break|0
@@ -9606,30 +10965,36 @@
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<i16,i16>|inlined.7 (result i32)
-       local.get $3
        local.get $5
+       local.set $10
+       local.get $7
+       local.set $9
+       local.get $6
+       local.set $8
+       local.get $10
+       local.get $9
        i32.const 1
        i32.shl
        i32.add
-       local.get $4
+       local.get $8
        i32.add
        i32.load16_s offset=8
       end
-      local.get $5
-      local.get $0
-      local.get $1
+      local.get $7
+      local.get $2
+      local.get $3
       call_indirect (type $iiii)
      end
      i32.const 0
      i32.ne
      if
-      local.get $5
+      local.get $7
       br $~lib/internal/typedarray/FIND_INDEX<Int16Array,i16>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -9712,26 +11077,37 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/FIND_INDEX<Uint16Array,u16>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<u16>#get:length|inlined.5 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 1
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
-     local.get $5
-     local.get $2
+     local.get $7
+     local.get $4
      i32.lt_s
      i32.eqz
      br_if $break|0
@@ -9739,30 +11115,36 @@
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<u16,u16>|inlined.7 (result i32)
-       local.get $3
        local.get $5
+       local.set $10
+       local.get $7
+       local.set $9
+       local.get $6
+       local.set $8
+       local.get $10
+       local.get $9
        i32.const 1
        i32.shl
        i32.add
-       local.get $4
+       local.get $8
        i32.add
        i32.load16_u offset=8
       end
-      local.get $5
-      local.get $0
-      local.get $1
+      local.get $7
+      local.get $2
+      local.get $3
       call_indirect (type $iiii)
      end
      i32.const 0
      i32.ne
      if
-      local.get $5
+      local.get $7
       br $~lib/internal/typedarray/FIND_INDEX<Uint16Array,u16>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -9841,26 +11223,37 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/FIND_INDEX<Int32Array,i32>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<i32>#get:length|inlined.13 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 2
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
-     local.get $5
-     local.get $2
+     local.get $7
+     local.get $4
      i32.lt_s
      i32.eqz
      br_if $break|0
@@ -9868,30 +11261,36 @@
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.8 (result i32)
-       local.get $3
        local.get $5
+       local.set $10
+       local.get $7
+       local.set $9
+       local.get $6
+       local.set $8
+       local.get $10
+       local.get $9
        i32.const 2
        i32.shl
        i32.add
-       local.get $4
+       local.get $8
        i32.add
        i32.load offset=8
       end
-      local.get $5
-      local.get $0
-      local.get $1
+      local.get $7
+      local.get $2
+      local.get $3
       call_indirect (type $iiii)
      end
      i32.const 0
      i32.ne
      if
-      local.get $5
+      local.get $7
       br $~lib/internal/typedarray/FIND_INDEX<Int32Array,i32>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -9968,26 +11367,37 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/FIND_INDEX<Uint32Array,u32>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<u32>#get:length|inlined.5 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 2
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
-     local.get $5
-     local.get $2
+     local.get $7
+     local.get $4
      i32.lt_s
      i32.eqz
      br_if $break|0
@@ -9995,30 +11405,36 @@
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.7 (result i32)
-       local.get $3
        local.get $5
+       local.set $10
+       local.get $7
+       local.set $9
+       local.get $6
+       local.set $8
+       local.get $10
+       local.get $9
        i32.const 2
        i32.shl
        i32.add
-       local.get $4
+       local.get $8
        i32.add
        i32.load offset=8
       end
-      local.get $5
-      local.get $0
-      local.get $1
+      local.get $7
+      local.get $2
+      local.get $3
       call_indirect (type $iiii)
      end
      i32.const 0
      i32.ne
      if
-      local.get $5
+      local.get $7
       br $~lib/internal/typedarray/FIND_INDEX<Uint32Array,u32>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -10095,26 +11511,37 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/FIND_INDEX<Int64Array,i64>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<i64>#get:length|inlined.5 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 3
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
-     local.get $5
-     local.get $2
+     local.get $7
+     local.get $4
      i32.lt_s
      i32.eqz
      br_if $break|0
@@ -10122,30 +11549,36 @@
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<i64,i64>|inlined.7 (result i64)
-       local.get $3
        local.get $5
+       local.set $10
+       local.get $7
+       local.set $9
+       local.get $6
+       local.set $8
+       local.get $10
+       local.get $9
        i32.const 3
        i32.shl
        i32.add
-       local.get $4
+       local.get $8
        i32.add
        i64.load offset=8
       end
-      local.get $5
-      local.get $0
-      local.get $1
+      local.get $7
+      local.get $2
+      local.get $3
       call_indirect (type $Iiii)
      end
      i32.const 0
      i32.ne
      if
-      local.get $5
+      local.get $7
       br $~lib/internal/typedarray/FIND_INDEX<Int64Array,i64>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -10222,26 +11655,37 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/FIND_INDEX<Uint64Array,u64>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<u64>#get:length|inlined.5 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 3
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
-     local.get $5
-     local.get $2
+     local.get $7
+     local.get $4
      i32.lt_s
      i32.eqz
      br_if $break|0
@@ -10249,30 +11693,36 @@
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<u64,u64>|inlined.7 (result i64)
-       local.get $3
        local.get $5
+       local.set $10
+       local.get $7
+       local.set $9
+       local.get $6
+       local.set $8
+       local.get $10
+       local.get $9
        i32.const 3
        i32.shl
        i32.add
-       local.get $4
+       local.get $8
        i32.add
        i64.load offset=8
       end
-      local.get $5
-      local.get $0
-      local.get $1
+      local.get $7
+      local.get $2
+      local.get $3
       call_indirect (type $Iiii)
      end
      i32.const 0
      i32.ne
      if
-      local.get $5
+      local.get $7
       br $~lib/internal/typedarray/FIND_INDEX<Uint64Array,u64>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -10349,26 +11799,37 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/FIND_INDEX<Float32Array,f32>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<f32>#get:length|inlined.5 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 2
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
-     local.get $5
-     local.get $2
+     local.get $7
+     local.get $4
      i32.lt_s
      i32.eqz
      br_if $break|0
@@ -10376,30 +11837,36 @@
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.7 (result f32)
-       local.get $3
        local.get $5
+       local.set $10
+       local.get $7
+       local.set $9
+       local.get $6
+       local.set $8
+       local.get $10
+       local.get $9
        i32.const 2
        i32.shl
        i32.add
-       local.get $4
+       local.get $8
        i32.add
        f32.load offset=8
       end
-      local.get $5
-      local.get $0
-      local.get $1
+      local.get $7
+      local.get $2
+      local.get $3
       call_indirect (type $fiii)
      end
      i32.const 0
      i32.ne
      if
-      local.get $5
+      local.get $7
       br $~lib/internal/typedarray/FIND_INDEX<Float32Array,f32>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -10476,26 +11943,37 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/FIND_INDEX<Float64Array,f64>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<f64>#get:length|inlined.8 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 3
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
-     local.get $5
-     local.get $2
+     local.get $7
+     local.get $4
      i32.lt_s
      i32.eqz
      br_if $break|0
@@ -10503,30 +11981,36 @@
       i32.const 3
       global.set $~argc
       block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.19 (result f64)
-       local.get $3
        local.get $5
+       local.set $10
+       local.get $7
+       local.set $9
+       local.get $6
+       local.set $8
+       local.get $10
+       local.get $9
        i32.const 3
        i32.shl
        i32.add
-       local.get $4
+       local.get $8
        i32.add
        f64.load offset=8
       end
-      local.get $5
-      local.get $0
-      local.get $1
+      local.get $7
+      local.get $2
+      local.get $3
       call_indirect (type $Fiii)
      end
      i32.const 0
      i32.ne
      if
-      local.get $5
+      local.get $7
       br $~lib/internal/typedarray/FIND_INDEX<Float64Array,f64>|inlined.0
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -10609,27 +12093,38 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/EVERY<Int8Array,i8>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<i8>#get:length|inlined.15 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 0
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
      block $continue|0
-      local.get $5
-      local.get $2
+      local.get $7
+      local.get $4
       i32.lt_s
       i32.eqz
       br_if $break|0
@@ -10638,18 +12133,24 @@
         i32.const 3
         global.set $~argc
         block $~lib/internal/arraybuffer/LOAD<i8,i8>|inlined.10 (result i32)
-         local.get $3
          local.get $5
+         local.set $10
+         local.get $7
+         local.set $9
+         local.get $6
+         local.set $8
+         local.get $10
+         local.get $9
          i32.const 0
          i32.shl
          i32.add
-         local.get $4
+         local.get $8
          i32.add
          i32.load8_s offset=8
         end
-        local.get $5
-        local.get $0
-        local.get $1
+        local.get $7
+        local.get $2
+        local.get $3
         call_indirect (type $iiii)
        end
        i32.const 0
@@ -10663,10 +12164,10 @@
       end
       unreachable
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -10752,27 +12253,38 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/EVERY<Uint8Array,u8>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<u8>#get:length|inlined.10 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 0
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
      block $continue|0
-      local.get $5
-      local.get $2
+      local.get $7
+      local.get $4
       i32.lt_s
       i32.eqz
       br_if $break|0
@@ -10781,18 +12293,24 @@
         i32.const 3
         global.set $~argc
         block $~lib/internal/arraybuffer/LOAD<u8,u8>|inlined.14 (result i32)
-         local.get $3
          local.get $5
+         local.set $10
+         local.get $7
+         local.set $9
+         local.get $6
+         local.set $8
+         local.get $10
+         local.get $9
          i32.const 0
          i32.shl
          i32.add
-         local.get $4
+         local.get $8
          i32.add
          i32.load8_u offset=8
         end
-        local.get $5
-        local.get $0
-        local.get $1
+        local.get $7
+        local.get $2
+        local.get $3
         call_indirect (type $iiii)
        end
        i32.const 0
@@ -10806,10 +12324,10 @@
       end
       unreachable
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -10893,27 +12411,38 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/EVERY<Uint8ClampedArray,u8>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<u8>#get:length|inlined.11 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 0
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
      block $continue|0
-      local.get $5
-      local.get $2
+      local.get $7
+      local.get $4
       i32.lt_s
       i32.eqz
       br_if $break|0
@@ -10922,18 +12451,24 @@
         i32.const 3
         global.set $~argc
         block $~lib/internal/arraybuffer/LOAD<u8,u8>|inlined.16 (result i32)
-         local.get $3
          local.get $5
+         local.set $10
+         local.get $7
+         local.set $9
+         local.get $6
+         local.set $8
+         local.get $10
+         local.get $9
          i32.const 0
          i32.shl
          i32.add
-         local.get $4
+         local.get $8
          i32.add
          i32.load8_u offset=8
         end
-        local.get $5
-        local.get $0
-        local.get $1
+        local.get $7
+        local.get $2
+        local.get $3
         call_indirect (type $iiii)
        end
        i32.const 0
@@ -10947,10 +12482,10 @@
       end
       unreachable
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -11036,27 +12571,38 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/EVERY<Int16Array,i16>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<i16>#get:length|inlined.6 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 1
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
      block $continue|0
-      local.get $5
-      local.get $2
+      local.get $7
+      local.get $4
       i32.lt_s
       i32.eqz
       br_if $break|0
@@ -11065,18 +12611,24 @@
         i32.const 3
         global.set $~argc
         block $~lib/internal/arraybuffer/LOAD<i16,i16>|inlined.9 (result i32)
-         local.get $3
          local.get $5
+         local.set $10
+         local.get $7
+         local.set $9
+         local.get $6
+         local.set $8
+         local.get $10
+         local.get $9
          i32.const 1
          i32.shl
          i32.add
-         local.get $4
+         local.get $8
          i32.add
          i32.load16_s offset=8
         end
-        local.get $5
-        local.get $0
-        local.get $1
+        local.get $7
+        local.get $2
+        local.get $3
         call_indirect (type $iiii)
        end
        i32.const 0
@@ -11090,10 +12642,10 @@
       end
       unreachable
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -11179,27 +12731,38 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/EVERY<Uint16Array,u16>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<u16>#get:length|inlined.6 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 1
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
      block $continue|0
-      local.get $5
-      local.get $2
+      local.get $7
+      local.get $4
       i32.lt_s
       i32.eqz
       br_if $break|0
@@ -11208,18 +12771,24 @@
         i32.const 3
         global.set $~argc
         block $~lib/internal/arraybuffer/LOAD<u16,u16>|inlined.9 (result i32)
-         local.get $3
          local.get $5
+         local.set $10
+         local.get $7
+         local.set $9
+         local.get $6
+         local.set $8
+         local.get $10
+         local.get $9
          i32.const 1
          i32.shl
          i32.add
-         local.get $4
+         local.get $8
          i32.add
          i32.load16_u offset=8
         end
-        local.get $5
-        local.get $0
-        local.get $1
+        local.get $7
+        local.get $2
+        local.get $3
         call_indirect (type $iiii)
        end
        i32.const 0
@@ -11233,10 +12802,10 @@
       end
       unreachable
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -11318,27 +12887,38 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/EVERY<Int32Array,i32>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<i32>#get:length|inlined.14 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 2
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
      block $continue|0
-      local.get $5
-      local.get $2
+      local.get $7
+      local.get $4
       i32.lt_s
       i32.eqz
       br_if $break|0
@@ -11347,18 +12927,24 @@
         i32.const 3
         global.set $~argc
         block $~lib/internal/arraybuffer/LOAD<i32,i32>|inlined.10 (result i32)
-         local.get $3
          local.get $5
+         local.set $10
+         local.get $7
+         local.set $9
+         local.get $6
+         local.set $8
+         local.get $10
+         local.get $9
          i32.const 2
          i32.shl
          i32.add
-         local.get $4
+         local.get $8
          i32.add
          i32.load offset=8
         end
-        local.get $5
-        local.get $0
-        local.get $1
+        local.get $7
+        local.get $2
+        local.get $3
         call_indirect (type $iiii)
        end
        i32.const 0
@@ -11372,10 +12958,10 @@
       end
       unreachable
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -11455,27 +13041,38 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/EVERY<Uint32Array,u32>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<u32>#get:length|inlined.6 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 2
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
      block $continue|0
-      local.get $5
-      local.get $2
+      local.get $7
+      local.get $4
       i32.lt_s
       i32.eqz
       br_if $break|0
@@ -11484,18 +13081,24 @@
         i32.const 3
         global.set $~argc
         block $~lib/internal/arraybuffer/LOAD<u32,u32>|inlined.9 (result i32)
-         local.get $3
          local.get $5
+         local.set $10
+         local.get $7
+         local.set $9
+         local.get $6
+         local.set $8
+         local.get $10
+         local.get $9
          i32.const 2
          i32.shl
          i32.add
-         local.get $4
+         local.get $8
          i32.add
          i32.load offset=8
         end
-        local.get $5
-        local.get $0
-        local.get $1
+        local.get $7
+        local.get $2
+        local.get $3
         call_indirect (type $iiii)
        end
        i32.const 0
@@ -11509,10 +13112,10 @@
       end
       unreachable
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -11592,27 +13195,38 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/EVERY<Int64Array,i64>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<i64>#get:length|inlined.6 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 3
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
      block $continue|0
-      local.get $5
-      local.get $2
+      local.get $7
+      local.get $4
       i32.lt_s
       i32.eqz
       br_if $break|0
@@ -11621,18 +13235,24 @@
         i32.const 3
         global.set $~argc
         block $~lib/internal/arraybuffer/LOAD<i64,i64>|inlined.9 (result i64)
-         local.get $3
          local.get $5
+         local.set $10
+         local.get $7
+         local.set $9
+         local.get $6
+         local.set $8
+         local.get $10
+         local.get $9
          i32.const 3
          i32.shl
          i32.add
-         local.get $4
+         local.get $8
          i32.add
          i64.load offset=8
         end
-        local.get $5
-        local.get $0
-        local.get $1
+        local.get $7
+        local.get $2
+        local.get $3
         call_indirect (type $Iiii)
        end
        i32.const 0
@@ -11646,10 +13266,10 @@
       end
       unreachable
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -11729,27 +13349,38 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/EVERY<Uint64Array,u64>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<u64>#get:length|inlined.6 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 3
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
      block $continue|0
-      local.get $5
-      local.get $2
+      local.get $7
+      local.get $4
       i32.lt_s
       i32.eqz
       br_if $break|0
@@ -11758,18 +13389,24 @@
         i32.const 3
         global.set $~argc
         block $~lib/internal/arraybuffer/LOAD<u64,u64>|inlined.9 (result i64)
-         local.get $3
          local.get $5
+         local.set $10
+         local.get $7
+         local.set $9
+         local.get $6
+         local.set $8
+         local.get $10
+         local.get $9
          i32.const 3
          i32.shl
          i32.add
-         local.get $4
+         local.get $8
          i32.add
          i64.load offset=8
         end
-        local.get $5
-        local.get $0
-        local.get $1
+        local.get $7
+        local.get $2
+        local.get $3
         call_indirect (type $Iiii)
        end
        i32.const 0
@@ -11783,10 +13420,10 @@
       end
       unreachable
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -11907,7 +13544,9 @@
    local.get $8
   else   
    local.get $1
-   local.get $1
+   local.set $9
+   local.get $9
+   local.get $9
    f32.ne
   end
   i32.const 0
@@ -12120,27 +13759,38 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/EVERY<Float32Array,f32>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<f32>#get:length|inlined.6 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 2
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
      block $continue|0
-      local.get $5
-      local.get $2
+      local.get $7
+      local.get $4
       i32.lt_s
       i32.eqz
       br_if $break|0
@@ -12149,18 +13799,24 @@
         i32.const 3
         global.set $~argc
         block $~lib/internal/arraybuffer/LOAD<f32,f32>|inlined.9 (result f32)
-         local.get $3
          local.get $5
+         local.set $10
+         local.get $7
+         local.set $9
+         local.get $6
+         local.set $8
+         local.get $10
+         local.get $9
          i32.const 2
          i32.shl
          i32.add
-         local.get $4
+         local.get $8
          i32.add
          f32.load offset=8
         end
-        local.get $5
-        local.get $0
-        local.get $1
+        local.get $7
+        local.get $2
+        local.get $3
         call_indirect (type $fiii)
        end
        i32.const 0
@@ -12174,10 +13830,10 @@
       end
       unreachable
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end
@@ -12298,7 +13954,9 @@
    local.get $8
   else   
    local.get $1
-   local.get $1
+   local.set $9
+   local.get $9
+   local.get $9
    f64.ne
   end
   i32.const 0
@@ -12513,27 +14171,38 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
   block $~lib/internal/typedarray/EVERY<Float64Array,f64>|inlined.0 (result i32)
+   local.get $0
+   local.set $2
+   local.get $1
+   local.set $3
    block $~lib/internal/typedarray/TypedArray<f64>#get:length|inlined.9 (result i32)
-    local.get $0
+    local.get $2
+    local.set $4
+    local.get $4
     i32.load offset=8
     i32.const 3
     i32.shr_u
    end
-   local.set $2
-   local.get $0
-   i32.load
-   local.set $3
-   local.get $0
-   i32.load offset=4
    local.set $4
+   local.get $2
+   i32.load
+   local.set $5
+   local.get $2
+   i32.load offset=4
+   local.set $6
    block $break|0
     i32.const 0
-    local.set $5
+    local.set $7
     loop $repeat|0
      block $continue|0
-      local.get $5
-      local.get $2
+      local.get $7
+      local.get $4
       i32.lt_s
       i32.eqz
       br_if $break|0
@@ -12542,18 +14211,24 @@
         i32.const 3
         global.set $~argc
         block $~lib/internal/arraybuffer/LOAD<f64,f64>|inlined.21 (result f64)
-         local.get $3
          local.get $5
+         local.set $10
+         local.get $7
+         local.set $9
+         local.get $6
+         local.set $8
+         local.get $10
+         local.get $9
          i32.const 3
          i32.shl
          i32.add
-         local.get $4
+         local.get $8
          i32.add
          f64.load offset=8
         end
-        local.get $5
-        local.get $0
-        local.get $1
+        local.get $7
+        local.get $2
+        local.get $3
         call_indirect (type $Fiii)
        end
        i32.const 0
@@ -12567,10 +14242,10 @@
       end
       unreachable
      end
-     local.get $5
+     local.get $7
      i32.const 1
      i32.add
-     local.set $5
+     local.set $7
      br $repeat|0
      unreachable
     end


### PR DESCRIPTION
As an alternative to https://github.com/AssemblyScript/assemblyscript/pull/460 this PR makes inlining a first class citizen by integrating it into flows, and in turn makes flows the primary concept of holding compilation state. As a result we can differentiate between the function we are generating and the actual function being compiled inline at any time, allowing us to inline constructors, super calls and whatnot more easily.

In general it appears that this is the way to go since we are heavily relying on inlining, for example when it comes to internal macros, and we'd like to have as much control over it as possible.