### PR TITLE
Implement bulk memory operations

### DIFF
--- a/cli/asc.json
+++ b/cli/asc.json
@@ -161,6 +161,7 @@
       "",
       " sign-extension  Enables sign-extension operations",
       " mutable-global  Enables mutable global imports and exports",
+      " bulk-memory     Enables bulk memory operations",
       ""
     ],
     "type": "s"

--- a/package-lock.json
+++ b/package-lock.json
@@ -552,9 +552,9 @@
       "dev": true
     },
     "binaryen": {
-      "version": "67.0.0-nightly.20190203",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-67.0.0-nightly.20190203.tgz",
-      "integrity": "sha512-2ngv8pWSckIsIq0VfY/PqOPXDEzcdQU4rm8Oi5AVqjAy18yexfaxQRWC3hx1ypDhj7Xydcb22IBAlZrlco2TKw=="
+      "version": "67.0.0-nightly.20190207",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-67.0.0-nightly.20190207.tgz",
+      "integrity": "sha512-ljJUoPRASK7OsqLzHPBiDW/Vg3QPvVNSKECfyvL2ZoKvYHcK9Z/2Ebo5JfyFAyiAud5RHdTJ2tq7FJo8SSyTXg=="
     },
     "bluebird": {
       "version": "3.5.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@protobufjs/utf8": "^1.1.0",
-    "binaryen": "67.0.0-nightly.20190203",
+    "binaryen": "67.0.0-nightly.20190207",
     "glob": "^7.1.3",
     "long": "^4.0.0"
   },

--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -2022,9 +2022,10 @@ export function compileCall(
         compiler.currentType = Type.void;
         return module.createUnreachable();
       }
+      let usizeType = compiler.options.usizeType;
       arg0 = compiler.compileExpression(
         operands[0],
-        compiler.options.usizeType,
+        usizeType,
         ConversionKind.IMPLICIT,
         WrapMode.NONE
       );
@@ -2036,7 +2037,7 @@ export function compileCall(
       );
       arg2 = compiler.compileExpression(
         operands[2],
-        compiler.options.usizeType,
+        usizeType,
         ConversionKind.IMPLICIT,
         WrapMode.NONE
       );

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -233,7 +233,9 @@ export const enum Feature {
   /** Sign extension operations. */
   SIGN_EXTENSION = 1 << 0, // see: https://github.com/WebAssembly/sign-extension-ops
   /** Mutable global imports and exports. */
-  MUTABLE_GLOBAL = 1 << 1  // see: https://github.com/WebAssembly/mutable-global
+  MUTABLE_GLOBAL = 1 << 1, // see: https://github.com/WebAssembly/mutable-global
+  /** Bulk memory operations. */
+  BULK_MEMORY = 1 << 2 // see: https://github.com/WebAssembly/bulk-memory-operations
 }
 
 /** Indicates the desired kind of a conversion. */

--- a/src/glue/binaryen.d.ts
+++ b/src/glue/binaryen.d.ts
@@ -55,6 +55,10 @@ declare function _BinaryenSIMDReplaceId(): BinaryenExpressionId;
 declare function _BinaryenSIMDShuffleId(): BinaryenExpressionId;
 declare function _BinaryenSIMDBitselectId(): BinaryenExpressionId;
 declare function _BinaryenSIMDShiftId(): BinaryenExpressionId;
+declare function _BinaryenMemoryInitId(): BinaryenExpressionId;
+declare function _BinaryenDataDropId(): BinaryenExpressionId;
+declare function _BinaryenMemoryCopyId(): BinaryenExpressionId;
+declare function _BinaryenMemoryFillId(): BinaryenExpressionId;
 
 declare type BinaryenModuleRef = usize;
 declare type v128ptr = usize; // TODO: LLVM C-abi for const uint8_t[16]?
@@ -63,7 +67,8 @@ declare function _BinaryenModuleCreate(): BinaryenModuleRef;
 declare function _BinaryenModuleDispose(module: BinaryenModuleRef): void;
 
 // LLVM C ABI with `out` being a large enough buffer receiving the
-// BinaryenLiteral struct.
+// BinaryenLiteral struct of size `_BinaryenSizeofLiteral()`.
+declare function _BinaryenSizeofLiteral(): usize;
 declare function _BinaryenLiteralInt32(out: usize, x: i32): void;
 declare function _BinaryenLiteralInt64(out: usize, x: i32, y: i32): void;
 declare function _BinaryenLiteralFloat32(out: usize, x: f32): void;
@@ -394,6 +399,11 @@ declare function _BinaryenSIMDShuffle(module: BinaryenModuleRef, left: BinaryenE
 declare function _BinaryenSIMDBitselect(module: BinaryenModuleRef, left: BinaryenExpressionRef, right: BinaryenExpressionRef, cond: BinaryenExpressionRef): BinaryenExpressionRef;
 declare function _BinaryenSIMDShift(module: BinaryenModuleRef, op: BinaryenSIMDOp, vec: BinaryenExpressionRef, shift: BinaryenExpressionRef): BinaryenExpressionRef;
 
+declare function _BinaryenMemoryInit(module: BinaryenModuleRef, segment: u32, dest: BinaryenExpressionRef, offset: BinaryenExpressionRef, size: BinaryenExpressionRef): BinaryenExpressionRef;
+declare function _BinaryenDataDrop(module: BinaryenModuleRef, segment: u32): BinaryenExpressionRef;
+declare function _BinaryenMemoryCopy(module: BinaryenModuleRef, dest: BinaryenExpressionRef, source: BinaryenExpressionRef, size: BinaryenExpressionRef): BinaryenExpressionRef;
+declare function _BinaryenMemoryFill(module: BinaryenModuleRef, dest: BinaryenExpressionRef, value: BinaryenExpressionRef, size: BinaryenExpressionRef): BinaryenExpressionRef;
+
 declare function _BinaryenExpressionGetId(expr: BinaryenExpressionRef): BinaryenExpressionId;
 declare function _BinaryenExpressionGetType(expr: BinaryenExpressionRef): BinaryenType;
 declare function _BinaryenExpressionPrint(expr: BinaryenExpressionRef): void;
@@ -518,6 +528,21 @@ declare function _BinaryenSIMDBitselectGetCond(expr: BinaryenExpressionRef): Bin
 declare function _BinaryenSIMDShiftGetOp(expr: BinaryenExpressionRef): BinaryenSIMDOp;
 declare function _BinaryenSIMDShiftGetVec(expr: BinaryenExpressionRef): BinaryenExpressionRef;
 declare function _BinaryenSIMDShiftGetShift(expr: BinaryenExpressionRef): BinaryenExpressionRef;
+
+declare function _BinaryenMemoryInitGetSegment(expr: BinaryenExpressionRef): u32;
+declare function _BinaryenMemoryInitGetDest(expr: BinaryenExpressionRef): BinaryenExpressionRef;
+declare function _BinaryenMemoryInitGetOffset(expr: BinaryenExpressionRef): BinaryenExpressionRef;
+declare function _BinaryenMemoryInitGetSize(expr: BinaryenExpressionRef): BinaryenExpressionRef;
+
+declare function _BinaryenDataDropGetSegment(expr: BinaryenExpressionRef): u32;
+
+declare function _BinaryenMemoryCopyGetDest(expr: BinaryenExpressionRef): BinaryenExpressionRef;
+declare function _BinaryenMemoryCopyGetSource(expr: BinaryenExpressionRef): BinaryenExpressionRef;
+declare function _BinaryenMemoryCopyGetSize(expr: BinaryenExpressionRef): BinaryenExpressionRef;
+
+declare function _BinaryenMemoryFillGetDest(expr: BinaryenExpressionRef): BinaryenExpressionRef;
+declare function _BinaryenMemoryFillGetValue(expr: BinaryenExpressionRef): BinaryenExpressionRef;
+declare function _BinaryenMemoryFillGetSize(expr: BinaryenExpressionRef): BinaryenExpressionRef;
 
 declare type BinaryenFunctionTypeRef = usize;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,6 +128,8 @@ export function setGlobalAlias(options: Options, name: string, alias: string): v
 export const FEATURE_SIGN_EXTENSION = Feature.SIGN_EXTENSION;
 /** Mutable global imports and exports. */
 export const FEATURE_MUTABLE_GLOBAL = Feature.MUTABLE_GLOBAL;
+/** Bulk memory operations. */
+export const FEATURE_BULK_MEMORY = Feature.BULK_MEMORY;
 
 /** Enables a specific feature. */
 export function enableFeature(options: Options, feature: Feature): void {

--- a/src/module.ts
+++ b/src/module.ts
@@ -55,12 +55,16 @@ export enum ExpressionId {
   AtomicCmpxchg = _BinaryenAtomicCmpxchgId(),
   AtomicRMW = _BinaryenAtomicRMWId(),
   AtomicWait = _BinaryenAtomicWaitId(),
-  AtomicWake = _BinaryenAtomicWakeId()
-  // SIMDExtract = _BinaryenSIMDExtractId(),
-  // SIMDReplace = _BinaryenSIMDReplaceId(),
-  // SIMDShuffle = _BinaryenSIMDShuffleId(),
-  // SIMDBitselect = _BinaryenSIMDBitselectId(),
-  // SIMDShift = _BinaryenSIMDShiftId()
+  AtomicWake = _BinaryenAtomicWakeId(),
+  SIMDExtract = _BinaryenSIMDExtractId(),
+  SIMDReplace = _BinaryenSIMDReplaceId(),
+  SIMDShuffle = _BinaryenSIMDShuffleId(),
+  SIMDBitselect = _BinaryenSIMDBitselectId(),
+  SIMDShift = _BinaryenSIMDShiftId(),
+  MemoryInit = _BinaryenMemoryInitId(),
+  DataDrop = _BinaryenDataDropId(),
+  MemoryCopy = _BinaryenMemoryCopyId(),
+  MemoryFill = _BinaryenMemoryFillId()
 }
 
 export enum UnaryOp {
@@ -227,117 +231,117 @@ export enum AtomicRMWOp {
   Xchg = _BinaryenAtomicRMWXchg()
 }
 
-// export enum SIMDOp {
-//   SplatVecI8x16 = _BinaryenSplatVecI8x16(),
-//   SplatVecI16x8 = _BinaryenSplatVecI16x8(),
-//   SplatVecI32x4 = _BinaryenSplatVecI32x4(),
-//   SplatVecI64x2 = _BinaryenSplatVecI64x2(),
-//   SplatVecF32x4 = _BinaryenSplatVecF32x4(),
-//   SplatVecF64x2 = _BinaryenSplatVecF64x2(),
-//   NotVec128 = _BinaryenNotVec128(),
-//   NegVecI8x16 = _BinaryenNegVecI8x16(),
-//   AnyTrueVecI8x16 = _BinaryenAnyTrueVecI8x16(),
-//   AllTrueVecI8x16 = _BinaryenAllTrueVecI8x16(),
-//   NegVecI16x8 = _BinaryenNegVecI16x8(),
-//   AnyTrueVecI16x8 = _BinaryenAnyTrueVecI16x8(),
-//   AllTrueVecI16x8 = _BinaryenAllTrueVecI16x8(),
-//   NegVecI32x4 = _BinaryenNegVecI32x4(),
-//   AnyTrueVecI32x4 = _BinaryenAnyTrueVecI32x4(),
-//   AllTrueVecI32x4 = _BinaryenAllTrueVecI32x4(),
-//   NegVecI64x2 = _BinaryenNegVecI64x2(),
-//   AnyTrueVecI64x2 = _BinaryenAnyTrueVecI64x2(),
-//   AllTrueVecI64x2 = _BinaryenAllTrueVecI64x2(),
-//   AbsVecF32x4 = _BinaryenAbsVecF32x4(),
-//   NegVecF32x4 = _BinaryenNegVecF32x4(),
-//   SqrtVecF32x4 = _BinaryenSqrtVecF32x4(),
-//   AbsVecF64x2 = _BinaryenAbsVecF64x2(),
-//   NegVecF64x2 = _BinaryenNegVecF64x2(),
-//   SqrtVecF64x2 = _BinaryenSqrtVecF64x2(),
-//   TruncSatSVecF32x4ToVecI32x4 = _BinaryenTruncSatSVecF32x4ToVecI32x4(),
-//   TruncSatUVecF32x4ToVecI32x4 = _BinaryenTruncSatUVecF32x4ToVecI32x4(),
-//   TruncSatSVecF64x2ToVecI64x2 = _BinaryenTruncSatSVecF64x2ToVecI64x2(),
-//   TruncSatUVecF64x2ToVecI64x2 = _BinaryenTruncSatUVecF64x2ToVecI64x2(),
-//   ConvertSVecI32x4ToVecF32x4 = _BinaryenConvertSVecI32x4ToVecF32x4(),
-//   ConvertUVecI32x4ToVecF32x4 = _BinaryenConvertUVecI32x4ToVecF32x4(),
-//   ConvertSVecI64x2ToVecF64x2 = _BinaryenConvertSVecI64x2ToVecF64x2(),
-//   ConvertUVecI64x2ToVecF64x2 = _BinaryenConvertUVecI64x2ToVecF64x2(),
-//   EqVecI8x16 = _BinaryenEqVecI8x16(),
-//   NeVecI8x16 = _BinaryenNeVecI8x16(),
-//   LtSVecI8x16 = _BinaryenLtSVecI8x16(),
-//   LtUVecI8x16 = _BinaryenLtUVecI8x16(),
-//   LeSVecI8x16 = _BinaryenLeSVecI8x16(),
-//   LeUVecI8x16 = _BinaryenLeUVecI8x16(),
-//   GtSVecI8x16 = _BinaryenGtSVecI8x16(),
-//   GtUVecI8x16 = _BinaryenGtUVecI8x16(),
-//   GeSVecI8x16 = _BinaryenGeSVecI8x16(),
-//   GeUVecI8x16 = _BinaryenGeUVecI8x16(),
-//   EqVecI16x8 = _BinaryenEqVecI16x8(),
-//   NeVecI16x8 = _BinaryenNeVecI16x8(),
-//   LtSVecI16x8 = _BinaryenLtSVecI16x8(),
-//   LtUVecI16x8 = _BinaryenLtUVecI16x8(),
-//   LeSVecI16x8 = _BinaryenLeSVecI16x8(),
-//   LeUVecI16x8 = _BinaryenLeUVecI16x8(),
-//   GtSVecI16x8 = _BinaryenGtSVecI16x8(),
-//   GtUVecI16x8 = _BinaryenGtUVecI16x8(),
-//   GeSVecI16x8 = _BinaryenGeSVecI16x8(),
-//   GeUVecI16x8 = _BinaryenGeUVecI16x8(),
-//   EqVecI32x4 = _BinaryenEqVecI32x4(),
-//   NeVecI32x4 = _BinaryenNeVecI32x4(),
-//   LtSVecI32x4 = _BinaryenLtSVecI32x4(),
-//   LtUVecI32x4 = _BinaryenLtUVecI32x4(),
-//   LeSVecI32x4 = _BinaryenLeSVecI32x4(),
-//   LeUVecI32x4 = _BinaryenLeUVecI32x4(),
-//   GtSVecI32x4 = _BinaryenGtSVecI32x4(),
-//   GtUVecI32x4 = _BinaryenGtUVecI32x4(),
-//   GeSVecI32x4 = _BinaryenGeSVecI32x4(),
-//   GeUVecI32x4 = _BinaryenGeUVecI32x4(),
-//   EqVecF32x4 = _BinaryenEqVecF32x4(),
-//   NeVecF32x4 = _BinaryenNeVecF32x4(),
-//   LtVecF32x4 = _BinaryenLtVecF32x4(),
-//   LeVecF32x4 = _BinaryenLeVecF32x4(),
-//   GtVecF32x4 = _BinaryenGtVecF32x4(),
-//   GeVecF32x4 = _BinaryenGeVecF32x4(),
-//   EqVecF64x2 = _BinaryenEqVecF64x2(),
-//   NeVecF64x2 = _BinaryenNeVecF64x2(),
-//   LtVecF64x2 = _BinaryenLtVecF64x2(),
-//   LeVecF64x2 = _BinaryenLeVecF64x2(),
-//   GtVecF64x2 = _BinaryenGtVecF64x2(),
-//   GeVecF64x2 = _BinaryenGeVecF64x2(),
-//   AndVec128 = _BinaryenAndVec128(),
-//   OrVec128 = _BinaryenOrVec128(),
-//   XorVec128 = _BinaryenXorVec128(),
-//   AddVecI8x16 = _BinaryenAddVecI8x16(),
-//   AddSatSVecI8x16 = _BinaryenAddSatSVecI8x16(),
-//   AddSatUVecI8x16 = _BinaryenAddSatUVecI8x16(),
-//   SubVecI8x16 = _BinaryenSubVecI8x16(),
-//   SubSatSVecI8x16 = _BinaryenSubSatSVecI8x16(),
-//   SubSatUVecI8x16 = _BinaryenSubSatUVecI8x16(),
-//   MulVecI8x16 = _BinaryenMulVecI8x16(),
-//   AddVecI16x8 = _BinaryenAddVecI16x8(),
-//   AddSatSVecI16x8 = _BinaryenAddSatSVecI16x8(),
-//   AddSatUVecI16x8 = _BinaryenAddSatUVecI16x8(),
-//   SubVecI16x8 = _BinaryenSubVecI16x8(),
-//   SubSatSVecI16x8 = _BinaryenSubSatSVecI16x8(),
-//   SubSatUVecI16x8 = _BinaryenSubSatUVecI16x8(),
-//   MulVecI16x8 = _BinaryenMulVecI16x8(),
-//   AddVecI32x4 = _BinaryenAddVecI32x4(),
-//   SubVecI32x4 = _BinaryenSubVecI32x4(),
-//   MulVecI32x4 = _BinaryenMulVecI32x4(),
-//   AddVecI64x2 = _BinaryenAddVecI64x2(),
-//   SubVecI64x2 = _BinaryenSubVecI64x2(),
-//   AddVecF32x4 = _BinaryenAddVecF32x4(),
-//   SubVecF32x4 = _BinaryenSubVecF32x4(),
-//   MulVecF32x4 = _BinaryenMulVecF32x4(),
-//   DivVecF32x4 = _BinaryenDivVecF32x4(),
-//   MinVecF32x4 = _BinaryenMinVecF32x4(),
-//   MaxVecF32x4 = _BinaryenMaxVecF32x4(),
-//   AddVecF64x2 = _BinaryenAddVecF64x2(),
-//   SubVecF64x2 = _BinaryenSubVecF64x2(),
-//   MulVecF64x2 = _BinaryenMulVecF64x2(),
-//   DivVecF64x2 = _BinaryenDivVecF64x2(),
-//   MinVecF64x2 = _BinaryenMinVecF64x2(),
-//   MaxVecF64x2 = _BinaryenMaxVecF64x2()
-// }
+export enum SIMDOp {
+  SplatVecI8x16 = _BinaryenSplatVecI8x16(),
+  SplatVecI16x8 = _BinaryenSplatVecI16x8(),
+  SplatVecI32x4 = _BinaryenSplatVecI32x4(),
+  SplatVecI64x2 = _BinaryenSplatVecI64x2(),
+  SplatVecF32x4 = _BinaryenSplatVecF32x4(),
+  SplatVecF64x2 = _BinaryenSplatVecF64x2(),
+  NotVec128 = _BinaryenNotVec128(),
+  NegVecI8x16 = _BinaryenNegVecI8x16(),
+  AnyTrueVecI8x16 = _BinaryenAnyTrueVecI8x16(),
+  AllTrueVecI8x16 = _BinaryenAllTrueVecI8x16(),
+  NegVecI16x8 = _BinaryenNegVecI16x8(),
+  AnyTrueVecI16x8 = _BinaryenAnyTrueVecI16x8(),
+  AllTrueVecI16x8 = _BinaryenAllTrueVecI16x8(),
+  NegVecI32x4 = _BinaryenNegVecI32x4(),
+  AnyTrueVecI32x4 = _BinaryenAnyTrueVecI32x4(),
+  AllTrueVecI32x4 = _BinaryenAllTrueVecI32x4(),
+  NegVecI64x2 = _BinaryenNegVecI64x2(),
+  AnyTrueVecI64x2 = _BinaryenAnyTrueVecI64x2(),
+  AllTrueVecI64x2 = _BinaryenAllTrueVecI64x2(),
+  AbsVecF32x4 = _BinaryenAbsVecF32x4(),
+  NegVecF32x4 = _BinaryenNegVecF32x4(),
+  SqrtVecF32x4 = _BinaryenSqrtVecF32x4(),
+  AbsVecF64x2 = _BinaryenAbsVecF64x2(),
+  NegVecF64x2 = _BinaryenNegVecF64x2(),
+  SqrtVecF64x2 = _BinaryenSqrtVecF64x2(),
+  TruncSatSVecF32x4ToVecI32x4 = _BinaryenTruncSatSVecF32x4ToVecI32x4(),
+  TruncSatUVecF32x4ToVecI32x4 = _BinaryenTruncSatUVecF32x4ToVecI32x4(),
+  TruncSatSVecF64x2ToVecI64x2 = _BinaryenTruncSatSVecF64x2ToVecI64x2(),
+  TruncSatUVecF64x2ToVecI64x2 = _BinaryenTruncSatUVecF64x2ToVecI64x2(),
+  ConvertSVecI32x4ToVecF32x4 = _BinaryenConvertSVecI32x4ToVecF32x4(),
+  ConvertUVecI32x4ToVecF32x4 = _BinaryenConvertUVecI32x4ToVecF32x4(),
+  ConvertSVecI64x2ToVecF64x2 = _BinaryenConvertSVecI64x2ToVecF64x2(),
+  ConvertUVecI64x2ToVecF64x2 = _BinaryenConvertUVecI64x2ToVecF64x2(),
+  EqVecI8x16 = _BinaryenEqVecI8x16(),
+  NeVecI8x16 = _BinaryenNeVecI8x16(),
+  LtSVecI8x16 = _BinaryenLtSVecI8x16(),
+  LtUVecI8x16 = _BinaryenLtUVecI8x16(),
+  LeSVecI8x16 = _BinaryenLeSVecI8x16(),
+  LeUVecI8x16 = _BinaryenLeUVecI8x16(),
+  GtSVecI8x16 = _BinaryenGtSVecI8x16(),
+  GtUVecI8x16 = _BinaryenGtUVecI8x16(),
+  GeSVecI8x16 = _BinaryenGeSVecI8x16(),
+  GeUVecI8x16 = _BinaryenGeUVecI8x16(),
+  EqVecI16x8 = _BinaryenEqVecI16x8(),
+  NeVecI16x8 = _BinaryenNeVecI16x8(),
+  LtSVecI16x8 = _BinaryenLtSVecI16x8(),
+  LtUVecI16x8 = _BinaryenLtUVecI16x8(),
+  LeSVecI16x8 = _BinaryenLeSVecI16x8(),
+  LeUVecI16x8 = _BinaryenLeUVecI16x8(),
+  GtSVecI16x8 = _BinaryenGtSVecI16x8(),
+  GtUVecI16x8 = _BinaryenGtUVecI16x8(),
+  GeSVecI16x8 = _BinaryenGeSVecI16x8(),
+  GeUVecI16x8 = _BinaryenGeUVecI16x8(),
+  EqVecI32x4 = _BinaryenEqVecI32x4(),
+  NeVecI32x4 = _BinaryenNeVecI32x4(),
+  LtSVecI32x4 = _BinaryenLtSVecI32x4(),
+  LtUVecI32x4 = _BinaryenLtUVecI32x4(),
+  LeSVecI32x4 = _BinaryenLeSVecI32x4(),
+  LeUVecI32x4 = _BinaryenLeUVecI32x4(),
+  GtSVecI32x4 = _BinaryenGtSVecI32x4(),
+  GtUVecI32x4 = _BinaryenGtUVecI32x4(),
+  GeSVecI32x4 = _BinaryenGeSVecI32x4(),
+  GeUVecI32x4 = _BinaryenGeUVecI32x4(),
+  EqVecF32x4 = _BinaryenEqVecF32x4(),
+  NeVecF32x4 = _BinaryenNeVecF32x4(),
+  LtVecF32x4 = _BinaryenLtVecF32x4(),
+  LeVecF32x4 = _BinaryenLeVecF32x4(),
+  GtVecF32x4 = _BinaryenGtVecF32x4(),
+  GeVecF32x4 = _BinaryenGeVecF32x4(),
+  EqVecF64x2 = _BinaryenEqVecF64x2(),
+  NeVecF64x2 = _BinaryenNeVecF64x2(),
+  LtVecF64x2 = _BinaryenLtVecF64x2(),
+  LeVecF64x2 = _BinaryenLeVecF64x2(),
+  GtVecF64x2 = _BinaryenGtVecF64x2(),
+  GeVecF64x2 = _BinaryenGeVecF64x2(),
+  AndVec128 = _BinaryenAndVec128(),
+  OrVec128 = _BinaryenOrVec128(),
+  XorVec128 = _BinaryenXorVec128(),
+  AddVecI8x16 = _BinaryenAddVecI8x16(),
+  AddSatSVecI8x16 = _BinaryenAddSatSVecI8x16(),
+  AddSatUVecI8x16 = _BinaryenAddSatUVecI8x16(),
+  SubVecI8x16 = _BinaryenSubVecI8x16(),
+  SubSatSVecI8x16 = _BinaryenSubSatSVecI8x16(),
+  SubSatUVecI8x16 = _BinaryenSubSatUVecI8x16(),
+  MulVecI8x16 = _BinaryenMulVecI8x16(),
+  AddVecI16x8 = _BinaryenAddVecI16x8(),
+  AddSatSVecI16x8 = _BinaryenAddSatSVecI16x8(),
+  AddSatUVecI16x8 = _BinaryenAddSatUVecI16x8(),
+  SubVecI16x8 = _BinaryenSubVecI16x8(),
+  SubSatSVecI16x8 = _BinaryenSubSatSVecI16x8(),
+  SubSatUVecI16x8 = _BinaryenSubSatUVecI16x8(),
+  MulVecI16x8 = _BinaryenMulVecI16x8(),
+  AddVecI32x4 = _BinaryenAddVecI32x4(),
+  SubVecI32x4 = _BinaryenSubVecI32x4(),
+  MulVecI32x4 = _BinaryenMulVecI32x4(),
+  AddVecI64x2 = _BinaryenAddVecI64x2(),
+  SubVecI64x2 = _BinaryenSubVecI64x2(),
+  AddVecF32x4 = _BinaryenAddVecF32x4(),
+  SubVecF32x4 = _BinaryenSubVecF32x4(),
+  MulVecF32x4 = _BinaryenMulVecF32x4(),
+  DivVecF32x4 = _BinaryenDivVecF32x4(),
+  MinVecF32x4 = _BinaryenMinVecF32x4(),
+  MaxVecF32x4 = _BinaryenMaxVecF32x4(),
+  AddVecF64x2 = _BinaryenAddVecF64x2(),
+  SubVecF64x2 = _BinaryenSubVecF64x2(),
+  MulVecF64x2 = _BinaryenMulVecF64x2(),
+  DivVecF64x2 = _BinaryenDivVecF64x2(),
+  MinVecF64x2 = _BinaryenMinVecF64x2(),
+  MaxVecF64x2 = _BinaryenMaxVecF64x2()
+}
 
 export class MemorySegment {
 
@@ -356,12 +360,12 @@ export class Module {
 
   ref: ModuleRef;
 
-  private cachedByValue: usize;
+  private lit: usize;
 
   static create(): Module {
     var module = new Module();
     module.ref = _BinaryenModuleCreate();
-    module.cachedByValue = memory.allocate(16);
+    module.lit = memory.allocate(_BinaryenSizeofLiteral());
     return module;
   }
 
@@ -370,7 +374,7 @@ export class Module {
     try {
       let module = new Module();
       module.ref = _BinaryenModuleRead(cArr, buffer.length);
-      module.cachedByValue = memory.allocate(3 * 8); // LLVM C-ABI, max used is 3 * usize
+      module.lit = memory.allocate(_BinaryenSizeofLiteral());
       return module;
     } finally {
       memory.free(changetype<usize>(cArr));
@@ -415,25 +419,25 @@ export class Module {
   // constants
 
   createI32(value: i32): ExpressionRef {
-    var out = this.cachedByValue;
+    var out = this.lit;
     _BinaryenLiteralInt32(out, value);
     return _BinaryenConst(this.ref, out);
   }
 
   createI64(valueLow: i32, valueHigh: i32 = 0): ExpressionRef {
-    var out = this.cachedByValue;
+    var out = this.lit;
     _BinaryenLiteralInt64(out, valueLow, valueHigh);
     return _BinaryenConst(this.ref, out);
   }
 
   createF32(value: f32): ExpressionRef {
-    var out = this.cachedByValue;
+    var out = this.lit;
     _BinaryenLiteralFloat32(out, value);
     return _BinaryenConst(this.ref, out);
   }
 
   createF64(value: f64): ExpressionRef {
-    var out = this.cachedByValue;
+    var out = this.lit;
     _BinaryenLiteralFloat64(out, value);
     return _BinaryenConst(this.ref, out);
   }
@@ -698,6 +702,24 @@ export class Module {
 
   createUnreachable(): ExpressionRef {
     return _BinaryenUnreachable(this.ref);
+  }
+
+  // bulk memory
+
+  createMemoryCopy(
+    dest: ExpressionRef,
+    source: ExpressionRef,
+    size: ExpressionRef
+  ): ExpressionRef {
+    return _BinaryenMemoryCopy(this.ref, dest, source, size);
+  }
+
+  createMemoryFill(
+    dest: ExpressionRef,
+    value: ExpressionRef,
+    size: ExpressionRef
+  ): ExpressionRef {
+    return _BinaryenMemoryFill(this.ref, dest, value, size);
   }
 
   // meta
@@ -993,7 +1015,8 @@ export class Module {
   }
 
   toBinary(sourceMapUrl: string | null): BinaryModule {
-    var out = this.cachedByValue;
+    var out = this.lit; // safe to reuse as long as..
+    assert(_BinaryenSizeofLiteral() >= 12);
     var cStr = allocString(sourceMapUrl);
     var binaryPtr: usize = 0;
     var sourceMapPtr: usize = 0;
@@ -1035,7 +1058,7 @@ export class Module {
     assert(this.ref);
     for (let ptr of this.cachedStrings.values()) memory.free(ptr);
     this.cachedStrings = new Map();
-    memory.free(this.cachedByValue);
+    memory.free(this.lit);
     memory.free(this.cachedPrecomputeNames);
     this.cachedPrecomputeNames = 0;
     _BinaryenModuleDispose(this.ref);

--- a/src/program.ts
+++ b/src/program.ts
@@ -106,7 +106,9 @@ import {
 } from "./module";
 
 import {
-  CharCode
+  CharCode,
+  bitsetIs,
+  bitsetSet
 } from "./util";
 
 import {
@@ -1239,7 +1241,7 @@ export class Program extends DiagnosticEmitter {
             } else {
               this.error(
                 DiagnosticCode.Expected_0_arguments_but_got_1,
-                decorator.range, "1", numArgs.toString(0)
+                decorator.range, "1", numArgs.toString(10)
               );
             }
           }
@@ -3237,68 +3239,30 @@ export class Flow {
 
   /** Tests if the value of the local at the specified index is considered wrapped. */
   isLocalWrapped(index: i32): bool {
-    var map: I64;
-    var ext: I64[] | null;
-    if (index < 64) {
-      if (index < 0) return true; // inlined constant
-      map = this.wrappedLocals;
-    } else if (ext = this.wrappedLocalsExt) {
-      let i = ((index - 64) / 64) | 0;
-      if (i >= ext.length) return false;
-      map = ext[i];
-      index -= (i + 1) * 64;
-    } else {
-      return false;
-    }
-    return i64_ne(
-      i64_and(
-        map,
-        i64_shl(
-          i64_one,
-          i64_new(index)
-        )
-      ),
-      i64_zero
-    );
+    if (index < 0) return true; // inlined constant
+    if (index < 64) return bitsetIs(this.wrappedLocals, index);
+    var ext = this.wrappedLocalsExt;
+    var i = ((index - 64) / 64) | 0;
+    if (!(ext && i < ext.length)) return false;
+    return bitsetIs(ext[i], index - (i + 1) * 64);
   }
 
   /** Sets if the value of the local at the specified index is considered wrapped. */
   setLocalWrapped(index: i32, wrapped: bool): void {
-    var map: I64;
-    var off: i32 = -1;
+    if (index < 0) return; // inlined constant
     if (index < 64) {
-      if (index < 0) return; // inlined constant
-      map = this.wrappedLocals;
-    } else {
-      let ext = this.wrappedLocalsExt;
-      off = ((index - 64) / 64) | 0;
-      if (!ext) {
-        this.wrappedLocalsExt = ext = new Array(off + 1);
-        ext.length = 0;
-      }
-      while (ext.length <= off) ext.push(i64_new(0));
-      map = ext[off];
-      index -= (off + 1) * 64;
+      this.wrappedLocals = bitsetSet(this.wrappedLocals, index, wrapped);
+      return;
     }
-    map = wrapped
-      ? i64_or(
-          map,
-          i64_shl(
-            i64_one,
-            i64_new(index)
-          )
-        )
-      : i64_and(
-          map,
-          i64_not(
-            i64_shl(
-              i64_one,
-              i64_new(index)
-            )
-          )
-        );
-    if (off >= 0) (<I64[]>this.wrappedLocalsExt)[off] = map;
-    else this.wrappedLocals = map;
+    var ext = this.wrappedLocalsExt;
+    var i = ((index - 64) / 64) | 0;
+    if (!ext) {
+      this.wrappedLocalsExt = ext = new Array(i + 1);
+      for (let j = 0; j <= i; ++j) ext[j] = i64_new(0);
+    } else {
+      while (ext.length <= i) ext.push(i64_new(0));
+    }
+    ext[i] = bitsetSet(ext[i], index - (i + 1) * 64, wrapped);
   }
 
   /** Pushes a new break label to the stack, for example when entering a loop that one can `break` from. */

--- a/src/util/bitset.ts
+++ b/src/util/bitset.ts
@@ -1,0 +1,38 @@
+/** @module util *//***/
+
+/** Tests if the bit at the specified index is set within a 64-bit map. */
+export function bitsetIs(map: I64, index: i32): bool {
+  assert(index >= 0 && index < 64);
+  return i64_ne(
+    i64_and(
+      map,
+      i64_shl(
+        i64_one,
+        i64_new(index)
+      )
+    ),
+    i64_zero
+  );
+}
+
+/** Sets or unsets the bit at the specified index within a 64-bit map and returns the new map. */
+export function bitsetSet(map: I64, index: i32, isSet: bool): I64 {
+  assert(index >= 0 && index < 64);
+  return isSet
+    ? i64_or(
+        map,
+        i64_shl(
+          i64_one,
+          i64_new(index)
+        )
+      )
+    : i64_and(
+        map,
+        i64_not(
+          i64_shl(
+            i64_one,
+            i64_new(index)
+          )
+        )
+      );
+}

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -4,6 +4,7 @@
  * @preferred
  *//***/
 
+export * from "./bitset";
 export * from "./charcode";
 export * from "./collections";
 export * from "./path";

--- a/std/assembly/memory.ts
+++ b/std/assembly/memory.ts
@@ -10,18 +10,17 @@ export namespace memory {
 
   @builtin export declare function grow(pages: i32): i32;
 
-  @inline export function fill(dest: usize, c: u8, n: usize): void { // see: musl/src/string/memset
-    if (isDefined(__memory_fill)) { __memory_fill(dest, c, n); return; }
-    memset(dest, c, n);
+  @builtin @inline
+  export function fill(dest: usize, c: u8, n: usize): void { // see: musl/src/string/memset
+    memset(dest, c, n); // fallback if "bulk-memory" isn't enabled
   }
 
-  @inline export function copy(dest: usize, src: usize, n: usize): void { // see: musl/src/string/memmove.c
-    if (isDefined(__memory_copy)) { __memory_copy(dest, src, n); return; }
-    memmove(dest, src, n);
+  @builtin @inline
+  export function copy(dest: usize, src: usize, n: usize): void { // see: musl/src/string/memmove.c
+    memmove(dest, src, n); // fallback if "bulk-memory" isn't enabled
   }
 
   @inline export function compare(vl: usize, vr: usize, n: usize): i32 { // see: musl/src/string/memcmp.c
-    if (isDefined(__memory_compare)) return __memory_compare(vl, vr, n);
     return memcmp(vl, vr, n);
   }
 

--- a/tests/compiler/number.untouched.wat
+++ b/tests/compiler/number.untouched.wat
@@ -2771,7 +2771,7 @@
     i32.shl
     i32.add
     local.set $4
-    block $~lib/memory/memory.copy|inlined.0
+    block $memory.copy|inlined.0
      local.get $4
      global.get $~lib/internal/string/HEADER_SIZE
      i32.add
@@ -2821,7 +2821,7 @@
      local.get $3
      i32.sub
      local.set $4
-     block $~lib/memory/memory.copy|inlined.1
+     block $memory.copy|inlined.1
       local.get $0
       global.get $~lib/internal/string/HEADER_SIZE
       i32.add
@@ -2942,7 +2942,7 @@
       i32.const 1
       i32.shl
       local.set $7
-      block $~lib/memory/memory.copy|inlined.2
+      block $memory.copy|inlined.2
        local.get $0
        global.get $~lib/internal/string/HEADER_SIZE
        i32.add

--- a/tests/compiler/std/allocator_arena.untouched.wat
+++ b/tests/compiler/std/allocator_arena.untouched.wat
@@ -1888,7 +1888,7 @@
    call $~lib/env/abort
    unreachable
   end
-  block $~lib/memory/memory.fill|inlined.0
+  block $memory.fill|inlined.0
    global.get $std/allocator_arena/ptr1
    local.set $0
    i32.const 18
@@ -1933,7 +1933,7 @@
    end
    unreachable
   end
-  block $~lib/memory/memory.copy|inlined.0
+  block $memory.copy|inlined.0
    global.get $std/allocator_arena/ptr2
    local.set $2
    global.get $std/allocator_arena/ptr1

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -527,7 +527,7 @@
   local.get $0
   local.get $1
   i32.store offset=4
-  block $~lib/memory/memory.fill|inlined.0
+  block $memory.fill|inlined.0
    local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
@@ -612,7 +612,7 @@
   local.get $0
   local.get $1
   i32.store offset=4
-  block $~lib/memory/memory.fill|inlined.1
+  block $memory.fill|inlined.1
    local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
@@ -707,7 +707,7 @@
   local.get $0
   local.get $1
   i32.store offset=4
-  block $~lib/memory/memory.fill|inlined.2
+  block $memory.fill|inlined.2
    local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
@@ -802,7 +802,7 @@
   local.get $0
   local.get $1
   i32.store offset=4
-  block $~lib/memory/memory.fill|inlined.3
+  block $memory.fill|inlined.3
    local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -865,7 +865,7 @@
   local.get $0
   local.get $1
   i32.store offset=4
-  block $~lib/memory/memory.fill|inlined.0
+  block $memory.fill|inlined.0
    local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
@@ -945,7 +945,7 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  block $~lib/memory/memory.fill|inlined.1
+  block $memory.fill|inlined.1
    local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
@@ -2941,7 +2941,7 @@
     local.get $1
     call $~lib/internal/arraybuffer/allocateUnsafe
     local.set $3
-    block $~lib/memory/memory.copy|inlined.0
+    block $memory.copy|inlined.0
      local.get $3
      global.get $~lib/internal/arraybuffer/HEADER_SIZE
      i32.add
@@ -2967,7 +2967,7 @@
     local.get $3
     local.set $0
    end
-   block $~lib/memory/memory.fill|inlined.3
+   block $memory.fill|inlined.3
     local.get $0
     global.get $~lib/internal/arraybuffer/HEADER_SIZE
     i32.add
@@ -3598,7 +3598,7 @@
    local.get $2
    i32.store
   end
-  block $~lib/memory/memory.copy|inlined.4
+  block $memory.copy|inlined.4
    local.get $2
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
@@ -3691,7 +3691,7 @@
   i32.const 1
   i32.sub
   local.set $7
-  block $~lib/memory/memory.copy|inlined.5
+  block $memory.copy|inlined.5
    local.get $2
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
@@ -4006,7 +4006,7 @@
   i32.shl
   i32.add
   local.set $8
-  block $~lib/memory/memory.copy|inlined.6
+  block $memory.copy|inlined.6
    local.get $7
    i32.load
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
@@ -4715,7 +4715,7 @@
   local.get $0
   local.get $1
   i32.store offset=4
-  block $~lib/memory/memory.fill|inlined.4
+  block $memory.fill|inlined.4
    local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
@@ -5724,7 +5724,7 @@
    br $~lib/memory/memory.allocate|inlined.1
   end
   local.set $6
-  block $~lib/memory/memory.fill|inlined.5
+  block $memory.fill|inlined.5
    local.get $6
    local.set $5
    i32.const 0
@@ -6683,7 +6683,7 @@
    br $~lib/memory/memory.allocate|inlined.2
   end
   local.set $6
-  block $~lib/memory/memory.fill|inlined.6
+  block $memory.fill|inlined.6
    local.get $6
    local.set $5
    i32.const 0
@@ -7675,7 +7675,7 @@
    br $~lib/memory/memory.allocate|inlined.3
   end
   local.set $6
-  block $~lib/memory/memory.fill|inlined.7
+  block $memory.fill|inlined.7
    local.get $6
    local.set $5
    i32.const 0
@@ -8521,7 +8521,7 @@
    br $~lib/memory/memory.allocate|inlined.4
   end
   local.set $6
-  block $~lib/memory/memory.fill|inlined.8
+  block $memory.fill|inlined.8
    local.get $6
    local.set $5
    i32.const 0
@@ -9496,7 +9496,7 @@
   local.get $0
   local.get $1
   i32.store offset=4
-  block $~lib/memory/memory.fill|inlined.9
+  block $memory.fill|inlined.9
    local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
@@ -10071,7 +10071,7 @@
   local.get $0
   local.get $1
   i32.store offset=4
-  block $~lib/memory/memory.fill|inlined.10
+  block $memory.fill|inlined.10
    local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
@@ -11336,7 +11336,7 @@
   local.get $0
   local.get $1
   i32.store offset=4
-  block $~lib/memory/memory.fill|inlined.11
+  block $memory.fill|inlined.11
    local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
@@ -13554,7 +13554,7 @@
     i32.shl
     i32.add
     local.set $4
-    block $~lib/memory/memory.copy|inlined.9
+    block $memory.copy|inlined.9
      local.get $4
      global.get $~lib/internal/string/HEADER_SIZE
      i32.add
@@ -13604,7 +13604,7 @@
      local.get $3
      i32.sub
      local.set $4
-     block $~lib/memory/memory.copy|inlined.10
+     block $memory.copy|inlined.10
       local.get $0
       global.get $~lib/internal/string/HEADER_SIZE
       i32.add
@@ -13725,7 +13725,7 @@
       i32.const 1
       i32.shl
       local.set $7
-      block $~lib/memory/memory.copy|inlined.11
+      block $memory.copy|inlined.11
        local.get $0
        global.get $~lib/internal/string/HEADER_SIZE
        i32.add
@@ -14423,7 +14423,7 @@
     local.get $3
     select
     local.set $5
-    block $~lib/memory/memory.copy|inlined.12
+    block $memory.copy|inlined.12
      local.get $0
      global.get $~lib/internal/string/HEADER_SIZE
      i32.add
@@ -14908,7 +14908,7 @@
   local.get $0
   local.get $1
   i32.store offset=4
-  block $~lib/memory/memory.fill|inlined.12
+  block $memory.fill|inlined.12
    local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add

--- a/tests/compiler/std/arraybuffer.untouched.wat
+++ b/tests/compiler/std/arraybuffer.untouched.wat
@@ -1951,7 +1951,7 @@
   local.get $6
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $7
-  block $~lib/memory/memory.copy|inlined.0
+  block $memory.copy|inlined.0
    local.get $7
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
@@ -2074,7 +2074,7 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  block $~lib/memory/memory.fill|inlined.1
+  block $memory.fill|inlined.1
    local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
@@ -2155,7 +2155,7 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  block $~lib/memory/memory.fill|inlined.2
+  block $memory.fill|inlined.2
    local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add

--- a/tests/compiler/std/dataview.untouched.wat
+++ b/tests/compiler/std/dataview.untouched.wat
@@ -439,7 +439,7 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  block $~lib/memory/memory.fill|inlined.0
+  block $memory.fill|inlined.0
    local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add

--- a/tests/compiler/std/gc-array.untouched.wat
+++ b/tests/compiler/std/gc-array.untouched.wat
@@ -2310,7 +2310,7 @@
     local.get $1
     call $~lib/internal/arraybuffer/allocateUnsafe
     local.set $3
-    block $~lib/memory/memory.copy|inlined.0
+    block $memory.copy|inlined.0
      local.get $3
      global.get $~lib/internal/arraybuffer/HEADER_SIZE
      i32.add
@@ -2329,7 +2329,7 @@
     local.get $3
     local.set $0
    end
-   block $~lib/memory/memory.fill|inlined.0
+   block $memory.fill|inlined.0
     local.get $0
     global.get $~lib/internal/arraybuffer/HEADER_SIZE
     i32.add

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -1919,7 +1919,7 @@
     local.get $1
     call $~lib/internal/arraybuffer/allocateUnsafe
     local.set $3
-    block $~lib/memory/memory.copy|inlined.0
+    block $memory.copy|inlined.0
      local.get $3
      global.get $~lib/internal/arraybuffer/HEADER_SIZE
      i32.add
@@ -1945,7 +1945,7 @@
     local.get $3
     local.set $0
    end
-   block $~lib/memory/memory.fill|inlined.0
+   block $memory.fill|inlined.0
     local.get $0
     global.get $~lib/internal/arraybuffer/HEADER_SIZE
     i32.add

--- a/tests/compiler/std/string-utf8.untouched.wat
+++ b/tests/compiler/std/string-utf8.untouched.wat
@@ -2224,7 +2224,7 @@
   i32.shr_u
   call $~lib/internal/string/allocateUnsafe
   local.set $7
-  block $~lib/memory/memory.copy|inlined.0
+  block $memory.copy|inlined.0
    local.get $7
    global.get $~lib/internal/string/HEADER_SIZE
    i32.add

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -2481,7 +2481,7 @@
       i32.lt_s
       i32.eqz
       br_if $break|5
-      block $~lib/memory/memory.copy|inlined.0
+      block $memory.copy|inlined.0
        local.get $6
        local.get $8
        i32.add
@@ -4249,7 +4249,7 @@
   local.get $0
   local.get $1
   i32.store offset=4
-  block $~lib/memory/memory.fill|inlined.0
+  block $memory.fill|inlined.0
    local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
@@ -4351,7 +4351,7 @@
     local.get $1
     call $~lib/internal/arraybuffer/allocateUnsafe
     local.set $3
-    block $~lib/memory/memory.copy|inlined.2
+    block $memory.copy|inlined.2
      local.get $3
      global.get $~lib/internal/arraybuffer/HEADER_SIZE
      i32.add
@@ -4377,7 +4377,7 @@
     local.get $3
     local.set $0
    end
-   block $~lib/memory/memory.fill|inlined.1
+   block $memory.fill|inlined.1
     local.get $0
     global.get $~lib/internal/arraybuffer/HEADER_SIZE
     i32.add
@@ -6271,7 +6271,7 @@
     i32.shl
     i32.add
     local.set $4
-    block $~lib/memory/memory.copy|inlined.3
+    block $memory.copy|inlined.3
      local.get $4
      global.get $~lib/internal/string/HEADER_SIZE
      i32.add
@@ -6321,7 +6321,7 @@
      local.get $3
      i32.sub
      local.set $4
-     block $~lib/memory/memory.copy|inlined.4
+     block $memory.copy|inlined.4
       local.get $0
       global.get $~lib/internal/string/HEADER_SIZE
       i32.add
@@ -6442,7 +6442,7 @@
       i32.const 1
       i32.shl
       local.set $7
-      block $~lib/memory/memory.copy|inlined.5
+      block $memory.copy|inlined.5
        local.get $0
        global.get $~lib/internal/string/HEADER_SIZE
        i32.add

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -503,7 +503,7 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  block $~lib/memory/memory.fill|inlined.0
+  block $memory.fill|inlined.0
    local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
@@ -584,7 +584,7 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  block $~lib/memory/memory.fill|inlined.1
+  block $memory.fill|inlined.1
    local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
@@ -679,7 +679,7 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  block $~lib/memory/memory.fill|inlined.2
+  block $memory.fill|inlined.2
    local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
@@ -760,7 +760,7 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  block $~lib/memory/memory.fill|inlined.3
+  block $memory.fill|inlined.3
    local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
@@ -841,7 +841,7 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  block $~lib/memory/memory.fill|inlined.4
+  block $memory.fill|inlined.4
    local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
@@ -922,7 +922,7 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  block $~lib/memory/memory.fill|inlined.5
+  block $memory.fill|inlined.5
    local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
@@ -1003,7 +1003,7 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  block $~lib/memory/memory.fill|inlined.6
+  block $memory.fill|inlined.6
    local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
@@ -1084,7 +1084,7 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  block $~lib/memory/memory.fill|inlined.7
+  block $memory.fill|inlined.7
    local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
@@ -1165,7 +1165,7 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  block $~lib/memory/memory.fill|inlined.8
+  block $memory.fill|inlined.8
    local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
@@ -1246,7 +1246,7 @@
   local.get $2
   call $~lib/internal/arraybuffer/allocateUnsafe
   local.set $3
-  block $~lib/memory/memory.fill|inlined.9
+  block $memory.fill|inlined.9
    local.get $3
    global.get $~lib/internal/arraybuffer/HEADER_SIZE
    i32.add
@@ -2390,7 +2390,7 @@
    br $~lib/memory/memory.allocate|inlined.3
   end
   local.set $6
-  block $~lib/memory/memory.fill|inlined.10
+  block $memory.fill|inlined.10
    local.get $6
    local.set $5
    i32.const 0


### PR DESCRIPTION
This PR updates Binaryen to latest and adds definitions and logic to support bulk memory operations.

* If `--enable bulk-memory` is specified, native `memory.copy` and `memory.fill` are emitted
* By default, the compiler falls back to our implementations of `memmove` and `memset` as usual
* This doesn't bother with `memory.init` and `memory.drop` yet.