### PR TITLE
Add SIMD prerequisites

### DIFF
--- a/cli/asc.json
+++ b/cli/asc.json
@@ -162,6 +162,7 @@
       " sign-extension  Enables sign-extension operations",
       " mutable-global  Enables mutable global imports and exports",
       " bulk-memory     Enables bulk memory operations",
+      " simd            Enables SIMD types and operations.",
       ""
     ],
     "type": "s"

--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -3013,7 +3013,7 @@ export function compileIterateRoots(compiler: Compiler): void {
                 ? module.createI64(i64_low(value), i64_high(value))
                 : module.createI32(i64_low(value))
             ],
-            "iv"
+            "i_"
           )
         );
       } else {
@@ -3026,7 +3026,7 @@ export function compileIterateRoots(compiler: Compiler): void {
                 compiler.options.nativeSizeType
               )
             ],
-            "iv"
+            "i_"
           )
         );
       }
@@ -3110,7 +3110,7 @@ export function ensureGCHook(
         [
           module.createGetLocal(0, nativeSizeType)
         ],
-        nativeSizeType == NativeType.I64 ? "Iv" : "iv"
+        nativeSizeType == NativeType.I64 ? "I_" : "i_"
       )
     );
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -235,7 +235,9 @@ export const enum Feature {
   /** Mutable global imports and exports. */
   MUTABLE_GLOBAL = 1 << 1, // see: https://github.com/WebAssembly/mutable-global
   /** Bulk memory operations. */
-  BULK_MEMORY = 1 << 2 // see: https://github.com/WebAssembly/bulk-memory-operations
+  BULK_MEMORY = 1 << 2, // see: https://github.com/WebAssembly/bulk-memory-operations
+  /** SIMD types and operations. */
+  SIMD = 1 << 3 // see: https://github.com/WebAssembly/simd
 }
 
 /** Indicates the desired kind of a conversion. */

--- a/src/decompiler.ts
+++ b/src/decompiler.ts
@@ -880,6 +880,7 @@ function nativeTypeToType(type: NativeType): string {
     case NativeType.I64: return "i64";
     case NativeType.F32: return "f32";
     case NativeType.F64: return "f64";
+    case NativeType.V128: return "v128";
     case NativeType.Unreachable: throw new Error("unreachable type");
     case NativeType.Auto: throw new Error("auto type");
     default: throw new Error("unexpected type");

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -480,6 +480,7 @@ export class TSDBuilder extends ExportsWalker {
       case TypeKind.BOOL: return "bool";
       case TypeKind.F32: return "f32";
       case TypeKind.F64: return "f64";
+      case TypeKind.V128: return "v128";
       case TypeKind.VOID: return "void";
       default: {
         assert(false);

--- a/src/glue/binaryen.d.ts
+++ b/src/glue/binaryen.d.ts
@@ -18,6 +18,7 @@ declare function _BinaryenTypeInt32(): BinaryenType;
 declare function _BinaryenTypeInt64(): BinaryenType;
 declare function _BinaryenTypeFloat32(): BinaryenType;
 declare function _BinaryenTypeFloat64(): BinaryenType;
+declare function _BinaryenTypeVec128(): BinaryenType;
 declare function _BinaryenTypeUnreachable(): BinaryenType;
 declare function _BinaryenTypeAuto(): BinaryenType;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,6 +130,8 @@ export const FEATURE_SIGN_EXTENSION = Feature.SIGN_EXTENSION;
 export const FEATURE_MUTABLE_GLOBAL = Feature.MUTABLE_GLOBAL;
 /** Bulk memory operations. */
 export const FEATURE_BULK_MEMORY = Feature.BULK_MEMORY;
+/** SIMD types and operations. */
+export const FEATURE_SIMD = Feature.SIMD;
 
 /** Enables a specific feature. */
 export function enableFeature(options: Options, feature: Feature): void {

--- a/src/module.ts
+++ b/src/module.ts
@@ -18,14 +18,15 @@ export type RelooperRef = usize;
 export type RelooperBlockRef = usize;
 export type Index = u32;
 
-export const enum NativeType {
-  None = 0,        // _BinaryenTypeNone(),
-  I32  = 1,        // _BinaryenTypeInt32(),
-  I64  = 2,        // _BinaryenTypeInt64(),
-  F32  = 3,        // _BinaryenTypeFloat32(),
-  F64  = 4,        // _BinaryenTypeFloat64(),
-  Unreachable = 5, // _BinaryenTypeUnreachable(),
-  Auto = -1        // _BinaryenTypeAuto()
+export enum NativeType {
+  None = _BinaryenTypeNone(),
+  I32  = _BinaryenTypeInt32(),
+  I64  = _BinaryenTypeInt64(),
+  F32  = _BinaryenTypeFloat32(),
+  F64  = _BinaryenTypeFloat64(),
+  V128 = _BinaryenTypeVec128(),
+  Unreachable = _BinaryenTypeUnreachable(),
+  Auto = _BinaryenTypeAuto()
 }
 
 export enum ExpressionId {
@@ -439,6 +440,15 @@ export class Module {
   createF64(value: f64): ExpressionRef {
     var out = this.lit;
     _BinaryenLiteralFloat64(out, value);
+    return _BinaryenConst(this.ref, out);
+  }
+
+  createV128(bytes: Uint8Array): ExpressionRef {
+    assert(bytes.length == 16);
+    var out = this.lit;
+    // FIXME: does this work or do we need to malloc?
+    for (let i = 0; i < 16; ++i) store<u8>(out + i, bytes[i]);
+    _BinaryenLiteralVec128(out, out);
     return _BinaryenConst(this.ref, out);
   }
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -411,11 +411,11 @@ export class Program extends DiagnosticEmitter {
       ["bool", Type.bool],
       ["f32", Type.f32],
       ["f64", Type.f64],
-      // ["v128", Type.v128],
       ["void", Type.void],
       ["number", Type.f64],
       ["boolean", Type.bool]
     ]);
+    if (options.hasFeature(Feature.SIMD)) this.typesLookup.set("v128", Type.v128);
 
     // add compiler hints
     this.setConstantInteger("ASC_TARGET", Type.i32,
@@ -660,6 +660,7 @@ export class Program extends DiagnosticEmitter {
     this.registerBasicClass(TypeKind.BOOL, "Bool");
     this.registerBasicClass(TypeKind.F32, "F32");
     this.registerBasicClass(TypeKind.F64, "F64");
+    if (options.hasFeature(Feature.SIMD)) this.registerBasicClass(TypeKind.V128, "V128");
 
     // register 'start'
     {

--- a/src/program.ts
+++ b/src/program.ts
@@ -411,6 +411,7 @@ export class Program extends DiagnosticEmitter {
       ["bool", Type.bool],
       ["f32", Type.f32],
       ["f64", Type.f64],
+      // ["v128", Type.v128],
       ["void", Type.void],
       ["number", Type.f64],
       ["boolean", Type.bool]

--- a/src/program.ts
+++ b/src/program.ts
@@ -434,6 +434,10 @@ export class Program extends DiagnosticEmitter {
       i64_new(options.hasFeature(Feature.MUTABLE_GLOBAL) ? 1 : 0, 0));
     this.setConstantInteger("ASC_FEATURE_SIGN_EXTENSION", Type.bool,
       i64_new(options.hasFeature(Feature.SIGN_EXTENSION) ? 1 : 0, 0));
+    this.setConstantInteger("ASC_FEATURE_BULK_MEMORY", Type.bool,
+      i64_new(options.hasFeature(Feature.BULK_MEMORY) ? 1 : 0, 0));
+    this.setConstantInteger("ASC_FEATURE_SIMD", Type.bool,
+      i64_new(options.hasFeature(Feature.SIMD) ? 1 : 0, 0));
 
     // remember deferred elements
     var queuedImports = new Array<QueuedImport>();

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -234,6 +234,7 @@ export class Resolver extends DiagnosticEmitter {
         case TypeKind.U64: return Type.u64;
         case TypeKind.F32: return Type.f32;
         case TypeKind.F64: return Type.f64;
+        case TypeKind.V128: return Type.v128;
         case TypeKind.VOID: return Type.void;
         default: assert(false);
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,9 @@ export const enum TypeKind {
   /** A 64-bit double. */
   F64,
 
+  // vectors
+  V128,
+
   // other
 
   /** No return type. */
@@ -82,8 +85,12 @@ export const enum TypeFlags {
   /** Is a reference type. */
   REFERENCE = 1 << 8,
   /** Is a nullable type. */
-  NULLABLE = 1 << 9
+  NULLABLE = 1 << 9,
+  /** Is a vector type. */
+  VECTOR = 1 << 10
 }
+
+const v128_zero = new Uint8Array(16);
 
 /** Represents a resolved type. */
 export class Type {
@@ -229,6 +236,10 @@ export class Type {
         if (target.is(TypeFlags.FLOAT)) {
           return this.size <= target.size;
         }
+      } else if (this.is(TypeFlags.VECTOR)) {
+        if (target.is(TypeFlags.VECTOR)) {
+          return this.size == target.size;
+        }
       }
     }
     return false;
@@ -272,6 +283,7 @@ export class Type {
       case TypeKind.BOOL: return "bool";
       case TypeKind.F32: return "f32";
       case TypeKind.F64: return "f64";
+      case TypeKind.V128: return "v128";
       default: assert(false);
       case TypeKind.VOID: return "void";
     }
@@ -289,6 +301,7 @@ export class Type {
       case TypeKind.USIZE: return this.size == 64 ? NativeType.I64 : NativeType.I32;
       case TypeKind.F32: return NativeType.F32;
       case TypeKind.F64: return NativeType.F64;
+      case TypeKind.V128: return NativeType.V128;
       case TypeKind.VOID:  return NativeType.None;
     }
   }
@@ -304,12 +317,14 @@ export class Type {
       case TypeKind.U64: return module.createI64(0);
       case TypeKind.F32: return module.createF32(0);
       case TypeKind.F64: return module.createF64(0);
+      case TypeKind.V128: return module.createV128(v128_zero);
     }
   }
 
   /** Converts this type to its native `1` value. */
   toNativeOne(module: Module): ExpressionRef {
     switch (this.kind) {
+      case TypeKind.V128:
       case TypeKind.VOID: assert(false);
       default: return module.createI32(1);
       case TypeKind.ISIZE:
@@ -324,6 +339,7 @@ export class Type {
   /** Converts this type to its native `-1` value. */
   toNativeNegOne(module: Module): ExpressionRef {
     switch (this.kind) {
+      case TypeKind.V128:
       case TypeKind.VOID: assert(false);
       default: return module.createI32(-1);
       case TypeKind.ISIZE:
@@ -345,7 +361,8 @@ export class Type {
       case TypeKind.USIZE: return this.size == 64 ? "I" : "i";
       case TypeKind.F32: return "f";
       case TypeKind.F64: return "F";
-      case TypeKind.VOID: return "v";
+      case TypeKind.V128: return "v";
+      case TypeKind.VOID: return "_";
     }
   }
 
@@ -468,6 +485,12 @@ export class Type {
     TypeFlags.LONG     |
     TypeFlags.FLOAT    |
     TypeFlags.VALUE,  64
+  );
+
+  /** A 128-bit vector. */
+  static readonly v128: Type = new Type(TypeKind.V128,
+    TypeFlags.VECTOR   |
+    TypeFlags.VALUE, 128
   );
 
   /** No return type. */

--- a/std/assembly/vector.ts
+++ b/std/assembly/vector.ts
@@ -1,0 +1,3 @@
+@sealed
+export abstract class V128 {
+}

--- a/std/portable/index.js
+++ b/std/portable/index.js
@@ -10,6 +10,8 @@ globalScope.ASC_OPTIMIZE_LEVEL = 3;
 globalScope.ASC_SHRINK_LEVEL = 0;
 globalScope.ASC_FEATURE_MUTABLE_GLOBAL = false;
 globalScope.ASC_FEATURE_SIGN_EXTENSION = false;
+globalScope.ASC_FEATURE_BULK_MEMORY = false;
+globalScope.ASC_FEATURE_SIMD = false;
 
 var F64 = new Float64Array(1);
 var U64 = new Uint32Array(F64.buffer);

--- a/tests/compiler/abi.optimized.wat
+++ b/tests/compiler/abi.optimized.wat
@@ -1,7 +1,7 @@
 (module
  (type $i (func (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\06\00\00\00a\00b\00i\00.\00t\00s")
@@ -18,7 +18,7 @@
  (func $abi/exported (; 1 ;) (type $i) (result i32)
   i32.const -128
  )
- (func $start (; 2 ;) (type $v)
+ (func $start (; 2 ;) (type $_)
   i32.const 1
   global.set $abi/condition
   i32.const 0
@@ -33,7 +33,7 @@
    unreachable
   end
  )
- (func $null (; 3 ;) (type $v)
+ (func $null (; 3 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/abi.untouched.wat
+++ b/tests/compiler/abi.untouched.wat
@@ -1,7 +1,7 @@
 (module
  (type $i (func (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\06\00\00\00a\00b\00i\00.\00t\00s\00")
@@ -36,7 +36,7 @@
   i32.const 24
   i32.shr_s
  )
- (func $start (; 5 ;) (type $v)
+ (func $start (; 5 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   call $abi/internal
@@ -211,6 +211,6 @@
    end
   end
  )
- (func $null (; 6 ;) (type $v)
+ (func $null (; 6 ;) (type $_)
  )
 )

--- a/tests/compiler/asc-constants.optimized.wat
+++ b/tests/compiler/asc-constants.optimized.wat
@@ -1,11 +1,11 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $start (; 0 ;) (type $v)
+ (func $start (; 0 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/asc-constants.untouched.wat
+++ b/tests/compiler/asc-constants.untouched.wat
@@ -1,5 +1,5 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -15,7 +15,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 0 ;) (type $v)
+ (func $start (; 0 ;) (type $_)
   i32.const 1
   drop
   i32.const 0
@@ -33,6 +33,6 @@
   i32.const 0
   drop
  )
- (func $null (; 1 ;) (type $v)
+ (func $null (; 1 ;) (type $_)
  )
 )

--- a/tests/compiler/assert.optimized.wat
+++ b/tests/compiler/assert.optimized.wat
@@ -1,5 +1,5 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 1)
  (data (i32.const 8) "\t\00\00\00a\00s\00s\00e\00r\00t\00.\00t\00s")
  (data (i32.const 32) "\0c\00\00\00m\00u\00s\00t\00 \00b\00e\00 \00t\00r\00u\00e")
@@ -7,7 +7,7 @@
  (elem (i32.const 0) $start)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $start (; 0 ;) (type $v)
+ (func $start (; 0 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/assert.untouched.wat
+++ b/tests/compiler/assert.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\t\00\00\00a\00s\00s\00e\00r\00t\00.\00t\00s\00")
@@ -11,7 +11,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   (local $0 i32)
   i32.const 1
   i32.eqz
@@ -107,6 +107,6 @@
    unreachable
   end
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
  )
 )

--- a/tests/compiler/binary.optimized.wat
+++ b/tests/compiler/binary.optimized.wat
@@ -1,5 +1,5 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (type $FUNCSIG$dd (func (param f64) (result f64)))
  (type $FUNCSIG$ff (func (param f32) (result f32)))
  (memory $0 0)
@@ -406,7 +406,7 @@
   local.get $0
   f64.mul
  )
- (func $start (; 4 ;) (type $v)
+ (func $start (; 4 ;) (type $_)
   (local $0 i32)
   (local $1 i64)
   (local $2 f32)
@@ -749,7 +749,7 @@
   call $~lib/math/NativeMath.pow
   global.set $binary/F
  )
- (func $null (; 5 ;) (type $v)
+ (func $null (; 5 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/binary.untouched.wat
+++ b/tests/compiler/binary.untouched.wat
@@ -3,7 +3,7 @@
  (type $FiF (func (param f64 i32) (result f64)))
  (type $fff (func (param f32 f32) (result f32)))
  (type $fif (func (param f32 i32) (result f32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -2738,7 +2738,7 @@
   local.get $2
   f64.reinterpret_i64
  )
- (func $start (; 6 ;) (type $v)
+ (func $start (; 6 ;) (type $_)
   global.get $binary/i
   i32.const 1
   i32.lt_s
@@ -3346,6 +3346,6 @@
   call $~lib/math/NativeMath.pow
   global.set $binary/F
  )
- (func $null (; 7 ;) (type $v)
+ (func $null (; 7 ;) (type $_)
  )
 )

--- a/tests/compiler/bool.optimized.wat
+++ b/tests/compiler/bool.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\07\00\00\00b\00o\00o\00l\00.\00t\00s")
@@ -16,7 +16,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   global.get $bool/i
   i32.const 0
   i32.ne
@@ -109,7 +109,7 @@
    unreachable
   end
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/bool.untouched.wat
+++ b/tests/compiler/bool.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\07\00\00\00b\00o\00o\00l\00.\00t\00s\00")
@@ -17,7 +17,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   global.get $bool/i
   i32.const 0
   i32.ne
@@ -117,6 +117,6 @@
    unreachable
   end
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
  )
 )

--- a/tests/compiler/builtins.optimized.wat
+++ b/tests/compiler/builtins.optimized.wat
@@ -1,7 +1,7 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $iiv (func (param i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $ii_ (func (param i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0b\00\00\00b\00u\00i\00l\00t\00i\00n\00s\00.\00t\00s")
@@ -21,13 +21,13 @@
  (export "table" (table $0))
  (export "test" (func $builtins/test))
  (start $start)
- (func $start~anonymous|1 (; 1 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $start~anonymous|1 (; 1 ;) (type $ii_) (param $0 i32) (param $1 i32)
   nop
  )
- (func $builtins/test (; 2 ;) (type $v)
+ (func $builtins/test (; 2 ;) (type $_)
   nop
  )
- (func $start (; 3 ;) (type $v)
+ (func $start (; 3 ;) (type $_)
   i32.const 31
   global.set $builtins/i
   i32.const 0
@@ -376,7 +376,7 @@
   i32.const 1
   i32.const 2
   global.get $builtins/fn
-  call_indirect (type $iiv)
+  call_indirect (type $ii_)
   i32.const 8
   i32.load8_s
   drop

--- a/tests/compiler/builtins.untouched.wat
+++ b/tests/compiler/builtins.untouched.wat
@@ -1,7 +1,7 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $iiv (func (param i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $ii_ (func (param i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0b\00\00\00b\00u\00i\00l\00t\00i\00n\00s\00.\00t\00s\00")
@@ -55,13 +55,13 @@
  (export "table" (table $0))
  (export "test" (func $builtins/test))
  (start $start)
- (func $start~anonymous|1 (; 1 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $start~anonymous|1 (; 1 ;) (type $ii_) (param $0 i32) (param $1 i32)
   nop
  )
- (func $builtins/test (; 2 ;) (type $v)
+ (func $builtins/test (; 2 ;) (type $_)
   nop
  )
- (func $start (; 3 ;) (type $v)
+ (func $start (; 3 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i64)
@@ -1222,7 +1222,7 @@
   i32.const 1
   i32.const 2
   global.get $builtins/fn
-  call_indirect (type $iiv)
+  call_indirect (type $ii_)
   i32.const 1
   i32.const 1
   i32.eq
@@ -2179,6 +2179,6 @@
   end
   drop
  )
- (func $null (; 4 ;) (type $v)
+ (func $null (; 4 ;) (type $_)
  )
 )

--- a/tests/compiler/call-inferred.optimized.wat
+++ b/tests/compiler/call-inferred.optimized.wat
@@ -1,12 +1,12 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 1)
  (data (i32.const 8) "\10\00\00\00c\00a\00l\00l\00-\00i\00n\00f\00e\00r\00r\00e\00d\00.\00t\00s")
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $start (; 0 ;) (type $v)
+ (func $start (; 0 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/call-inferred.untouched.wat
+++ b/tests/compiler/call-inferred.untouched.wat
@@ -1,9 +1,9 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $FF (func (param f64) (result f64)))
  (type $ff (func (param f32) (result f32)))
- (type $v (func))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\10\00\00\00c\00a\00l\00l\00-\00i\00n\00f\00e\00r\00r\00e\00d\00.\00t\00s\00")
@@ -25,7 +25,7 @@
  (func $call-inferred/bar<f32> (; 4 ;) (type $ff) (param $0 f32) (result f32)
   local.get $0
  )
- (func $start (; 5 ;) (type $v)
+ (func $start (; 5 ;) (type $_)
   i32.const 42
   call $call-inferred/foo<i32>
   i32.const 42
@@ -79,6 +79,6 @@
    unreachable
   end
  )
- (func $null (; 6 ;) (type $v)
+ (func $null (; 6 ;) (type $_)
  )
 )

--- a/tests/compiler/call-optional.optimized.wat
+++ b/tests/compiler/call-optional.optimized.wat
@@ -1,7 +1,7 @@
 (module
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\10\00\00\00c\00a\00l\00l\00-\00o\00p\00t\00i\00o\00n\00a\00l\00.\00t\00s")
@@ -36,7 +36,7 @@
   local.get $2
   i32.add
  )
- (func $start (; 2 ;) (type $v)
+ (func $start (; 2 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 1
@@ -159,7 +159,7 @@
    unreachable
   end
  )
- (func $null (; 3 ;) (type $v)
+ (func $null (; 3 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/call-optional.untouched.wat
+++ b/tests/compiler/call-optional.untouched.wat
@@ -1,7 +1,7 @@
 (module
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\10\00\00\00c\00a\00l\00l\00-\00o\00p\00t\00i\00o\00n\00a\00l\00.\00t\00s\00")
@@ -43,7 +43,7 @@
   local.get $2
   call $call-optional/opt
  )
- (func $start (; 3 ;) (type $v)
+ (func $start (; 3 ;) (type $_)
   block (result i32)
    i32.const 1
    global.set $~argc
@@ -158,6 +158,6 @@
    unreachable
   end
  )
- (func $null (; 4 ;) (type $v)
+ (func $null (; 4 ;) (type $_)
  )
 )

--- a/tests/compiler/call-super.optimized.wat
+++ b/tests/compiler/call-super.optimized.wat
@@ -1,7 +1,7 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (type $ii (func (param i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$i (func (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -134,7 +134,7 @@
   end
   local.get $0
  )
- (func $call-super/test1 (; 4 ;) (type $v)
+ (func $call-super/test1 (; 4 ;) (type $_)
   (local $0 i32)
   call $call-super/B#constructor
   local.tee $0
@@ -209,7 +209,7 @@
   end
   local.get $0
  )
- (func $call-super/test2 (; 7 ;) (type $v)
+ (func $call-super/test2 (; 7 ;) (type $_)
   (local $0 i32)
   call $call-super/D#constructor
   local.tee $0
@@ -262,7 +262,7 @@
   end
   local.get $0
  )
- (func $call-super/test3 (; 9 ;) (type $v)
+ (func $call-super/test3 (; 9 ;) (type $_)
   (local $0 i32)
   i32.const 8
   call $~lib/allocator/arena/__memory_allocate
@@ -305,7 +305,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $call-super/test4 (; 11 ;) (type $v)
+ (func $call-super/test4 (; 11 ;) (type $_)
   (local $0 i32)
   call $call-super/H#constructor
   local.tee $0
@@ -333,7 +333,7 @@
    unreachable
   end
  )
- (func $call-super/test5 (; 12 ;) (type $v)
+ (func $call-super/test5 (; 12 ;) (type $_)
   (local $0 i32)
   call $call-super/H#constructor
   local.tee $0
@@ -361,7 +361,7 @@
    unreachable
   end
  )
- (func $start (; 13 ;) (type $v)
+ (func $start (; 13 ;) (type $_)
   i32.const 40
   global.set $~lib/allocator/arena/startOffset
   global.get $~lib/allocator/arena/startOffset
@@ -372,7 +372,7 @@
   call $call-super/test4
   call $call-super/test5
  )
- (func $null (; 14 ;) (type $v)
+ (func $null (; 14 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/call-super.untouched.wat
+++ b/tests/compiler/call-super.untouched.wat
@@ -1,7 +1,7 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (type $ii (func (param i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0d\00\00\00c\00a\00l\00l\00-\00s\00u\00p\00e\00r\00.\00t\00s\00")
@@ -170,7 +170,7 @@
   end
   local.get $0
  )
- (func $call-super/test1 (; 5 ;) (type $v)
+ (func $call-super/test1 (; 5 ;) (type $_)
   (local $0 i32)
   i32.const 0
   call $call-super/B#constructor
@@ -256,7 +256,7 @@
   end
   local.get $0
  )
- (func $call-super/test2 (; 8 ;) (type $v)
+ (func $call-super/test2 (; 8 ;) (type $_)
   (local $0 i32)
   i32.const 0
   call $call-super/D#constructor
@@ -332,7 +332,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $call-super/test3 (; 11 ;) (type $v)
+ (func $call-super/test3 (; 11 ;) (type $_)
   (local $0 i32)
   i32.const 0
   call $call-super/F#constructor
@@ -393,7 +393,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $call-super/test4 (; 14 ;) (type $v)
+ (func $call-super/test4 (; 14 ;) (type $_)
   (local $0 i32)
   i32.const 0
   call $call-super/H#constructor
@@ -454,7 +454,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $call-super/test5 (; 17 ;) (type $v)
+ (func $call-super/test5 (; 17 ;) (type $_)
   (local $0 i32)
   i32.const 0
   call $call-super/J#constructor
@@ -486,7 +486,7 @@
    unreachable
   end
  )
- (func $start (; 18 ;) (type $v)
+ (func $start (; 18 ;) (type $_)
   global.get $HEAP_BASE
   global.get $~lib/internal/allocator/AL_MASK
   i32.add
@@ -503,6 +503,6 @@
   call $call-super/test4
   call $call-super/test5
  )
- (func $null (; 19 ;) (type $v)
+ (func $null (; 19 ;) (type $_)
  )
 )

--- a/tests/compiler/class-extends.optimized.wat
+++ b/tests/compiler/class-extends.optimized.wat
@@ -1,13 +1,13 @@
 (module
- (type $iv (func (param i32)))
- (type $v (func))
+ (type $i_ (func (param i32)))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "test" (func $class-extends/test))
- (func $class-extends/test (; 0 ;) (type $iv) (param $0 i32)
+ (func $class-extends/test (; 0 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.load
   drop
@@ -21,7 +21,7 @@
   i32.const 3
   i32.store16 offset=4
  )
- (func $null (; 1 ;) (type $v)
+ (func $null (; 1 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/class-extends.untouched.wat
+++ b/tests/compiler/class-extends.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iv (func (param i32)))
- (type $v (func))
+ (type $i_ (func (param i32)))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -8,7 +8,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "test" (func $class-extends/test))
- (func $class-extends/test (; 0 ;) (type $iv) (param $0 i32)
+ (func $class-extends/test (; 0 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.load
   drop
@@ -22,6 +22,6 @@
   i32.const 3
   i32.store16 offset=4
  )
- (func $null (; 1 ;) (type $v)
+ (func $null (; 1 ;) (type $_)
  )
 )

--- a/tests/compiler/class-overloading.optimized.wat
+++ b/tests/compiler/class-overloading.optimized.wat
@@ -1,16 +1,16 @@
 (module
- (type $iv (func (param i32)))
- (type $v (func))
+ (type $i_ (func (param i32)))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "test" (func $class-overloading/test))
- (func $class-overloading/test (; 0 ;) (type $iv) (param $0 i32)
+ (func $class-overloading/test (; 0 ;) (type $i_) (param $0 i32)
   nop
  )
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/class-overloading.untouched.wat
+++ b/tests/compiler/class-overloading.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iv (func (param i32)))
- (type $v (func))
+ (type $i_ (func (param i32)))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -9,17 +9,17 @@
  (export "table" (table $0))
  (export "test" (func $class-overloading/test))
  (start $start)
- (func $class-overloading/Foo#baz (; 0 ;) (type $iv) (param $0 i32)
+ (func $class-overloading/Foo#baz (; 0 ;) (type $i_) (param $0 i32)
   nop
  )
- (func $class-overloading/test (; 1 ;) (type $iv) (param $0 i32)
+ (func $class-overloading/test (; 1 ;) (type $i_) (param $0 i32)
   local.get $0
   call $class-overloading/Foo#baz
  )
- (func $start (; 2 ;) (type $v)
+ (func $start (; 2 ;) (type $_)
   i32.const 0
   call $class-overloading/test
  )
- (func $null (; 3 ;) (type $v)
+ (func $null (; 3 ;) (type $_)
  )
 )

--- a/tests/compiler/class-with-boolean-field.optimized.wat
+++ b/tests/compiler/class-with-boolean-field.optimized.wat
@@ -1,6 +1,6 @@
 (module
  (type $i (func (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -16,7 +16,7 @@
   i32.const 0
   i32.ne
  )
- (func $null (; 1 ;) (type $v)
+ (func $null (; 1 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/class-with-boolean-field.untouched.wat
+++ b/tests/compiler/class-with-boolean-field.untouched.wat
@@ -1,6 +1,6 @@
 (module
  (type $i (func (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -18,6 +18,6 @@
   i32.const 0
   i32.ne
  )
- (func $null (; 1 ;) (type $v)
+ (func $null (; 1 ;) (type $_)
  )
 )

--- a/tests/compiler/class.optimized.wat
+++ b/tests/compiler/class.optimized.wat
@@ -1,6 +1,6 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 1)
  (data (i32.const 8) "\08\00\00\00c\00l\00a\00s\00s\00.\00t\00s")
  (table $0 1 funcref)
@@ -29,7 +29,7 @@
   i32.store8 offset=6
   local.get $0
  )
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/class.untouched.wat
+++ b/tests/compiler/class.untouched.wat
@@ -1,11 +1,11 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $iii (func (param i32 i32) (result i32)))
  (type $fff (func (param f32 f32) (result f32)))
  (type $ii (func (param i32) (result i32)))
  (type $iiii (func (param i32 i32 i32) (result i32)))
  (type $ifff (func (param i32 f32 f32) (result f32)))
- (type $v (func))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\08\00\00\00c\00l\00a\00s\00s\00.\00t\00s\00")
@@ -92,7 +92,7 @@
   local.set $2
   local.get $2
  )
- (func $start (; 6 ;) (type $v)
+ (func $start (; 6 ;) (type $_)
   i32.const 4
   i32.const 4
   i32.eq
@@ -116,6 +116,6 @@
   call $class/Animal.sub<f32>
   drop
  )
- (func $null (; 7 ;) (type $v)
+ (func $null (; 7 ;) (type $_)
  )
 )

--- a/tests/compiler/closure.optimized.wat
+++ b/tests/compiler/closure.optimized.wat
@@ -1,11 +1,11 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $null (; 0 ;) (type $v)
+ (func $null (; 0 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/closure.untouched.wat
+++ b/tests/compiler/closure.untouched.wat
@@ -1,11 +1,11 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (global $HEAP_BASE i32 (i32.const 8))
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $null (; 0 ;) (type $v)
+ (func $null (; 0 ;) (type $_)
  )
 )

--- a/tests/compiler/comma.optimized.wat
+++ b/tests/compiler/comma.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\08\00\00\00c\00o\00m\00m\00a\00.\00t\00s")
@@ -11,7 +11,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   (local $0 i32)
   global.get $comma/a
   local.tee $0
@@ -163,7 +163,7 @@
    unreachable
   end
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/comma.untouched.wat
+++ b/tests/compiler/comma.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\08\00\00\00c\00o\00m\00m\00a\00.\00t\00s\00")
@@ -12,7 +12,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   block
@@ -204,6 +204,6 @@
    drop
   end
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
  )
 )

--- a/tests/compiler/declare.optimized.wat
+++ b/tests/compiler/declare.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $v (func))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $_ (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (import "declare" "externalConstant" (global $declare/externalConstant i32))
  (import "declare" "my.externalConstant" (global $declare/my.externalConstant i32))
  (import "declare" "externalFunction" (func $declare/externalFunction))
@@ -13,7 +13,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 3 ;) (type $v)
+ (func $start (; 3 ;) (type $_)
   call $declare/externalFunction
   global.get $declare/externalConstant
   i32.const 1
@@ -39,7 +39,7 @@
    unreachable
   end
  )
- (func $null (; 4 ;) (type $v)
+ (func $null (; 4 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/declare.untouched.wat
+++ b/tests/compiler/declare.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $v (func))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $_ (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (import "declare" "externalConstant" (global $declare/externalConstant i32))
  (import "declare" "my.externalConstant" (global $declare/my.externalConstant i32))
  (import "declare" "externalFunction" (func $declare/externalFunction))
@@ -14,7 +14,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 3 ;) (type $v)
+ (func $start (; 3 ;) (type $_)
   call $declare/externalFunction
   global.get $declare/externalConstant
   i32.const 1
@@ -42,6 +42,6 @@
    unreachable
   end
  )
- (func $null (; 4 ;) (type $v)
+ (func $null (; 4 ;) (type $_)
  )
 )

--- a/tests/compiler/do.optimized.wat
+++ b/tests/compiler/do.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\05\00\00\00d\00o\00.\00t\00s")
@@ -12,7 +12,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   (local $0 i32)
   loop $continue|0
    global.get $do/n
@@ -148,7 +148,7 @@
    unreachable
   end
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/do.untouched.wat
+++ b/tests/compiler/do.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\05\00\00\00d\00o\00.\00t\00s\00")
@@ -13,7 +13,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   (local $0 i32)
   block $break|0
    loop $continue|0
@@ -180,6 +180,6 @@
    unreachable
   end
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
  )
 )

--- a/tests/compiler/empty.optimized.wat
+++ b/tests/compiler/empty.optimized.wat
@@ -1,11 +1,11 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $null (; 0 ;) (type $v)
+ (func $null (; 0 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/empty.untouched.wat
+++ b/tests/compiler/empty.untouched.wat
@@ -1,11 +1,11 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (global $HEAP_BASE i32 (i32.const 8))
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $null (; 0 ;) (type $v)
+ (func $null (; 0 ;) (type $_)
  )
 )

--- a/tests/compiler/enum.optimized.wat
+++ b/tests/compiler/enum.optimized.wat
@@ -1,5 +1,5 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -36,13 +36,13 @@
  (export "SelfReference.ZERO" (global $enum/SelfReference.ZERO))
  (export "SelfReference.ONE" (global $enum/SelfReference.ONE))
  (start $start)
- (func $start (; 0 ;) (type $v)
+ (func $start (; 0 ;) (type $_)
   i32.const 0
   global.set $enum/NonConstant.ZERO
   i32.const 1
   global.set $enum/NonConstant.ONE
  )
- (func $null (; 1 ;) (type $v)
+ (func $null (; 1 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/enum.untouched.wat
+++ b/tests/compiler/enum.untouched.wat
@@ -1,6 +1,6 @@
 (module
  (type $i (func (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -42,7 +42,7 @@
  (func $enum/getZero (; 0 ;) (type $i) (result i32)
   i32.const 0
  )
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   call $enum/getZero
   global.set $enum/NonConstant.ZERO
   call $enum/getZero
@@ -54,6 +54,6 @@
   global.get $enum/NonConstant.ONE
   drop
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
  )
 )

--- a/tests/compiler/export.optimized.wat
+++ b/tests/compiler/export.optimized.wat
@@ -1,6 +1,6 @@
 (module
  (type $iii (func (param i32 i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $export/ns.two)
@@ -31,7 +31,7 @@
   local.get $1
   i32.mul
  )
- (func $export/ns.two (; 3 ;) (type $v)
+ (func $export/ns.two (; 3 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/export.untouched.wat
+++ b/tests/compiler/export.untouched.wat
@@ -1,6 +1,6 @@
 (module
  (type $iii (func (param i32 i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -32,9 +32,9 @@
   local.get $1
   i32.mul
  )
- (func $export/ns.two (; 3 ;) (type $v)
+ (func $export/ns.two (; 3 ;) (type $_)
   nop
  )
- (func $null (; 4 ;) (type $v)
+ (func $null (; 4 ;) (type $_)
  )
 )

--- a/tests/compiler/exports.optimized.wat
+++ b/tests/compiler/exports.optimized.wat
@@ -2,9 +2,9 @@
  (type $iii (func (param i32 i32) (result i32)))
  (type $i (func (result i32)))
  (type $ii (func (param i32) (result i32)))
- (type $iiv (func (param i32 i32)))
- (type $iv (func (param i32)))
- (type $v (func))
+ (type $ii_ (func (param i32 i32)))
+ (type $i_ (func (param i32)))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -125,21 +125,21 @@
   local.get $0
   i32.load
  )
- (func $exports/Car#set:numDoors (; 5 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $exports/Car#set:numDoors (; 5 ;) (type $ii_) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
  )
- (func $exports/Car#openDoors (; 6 ;) (type $iv) (param $0 i32)
+ (func $exports/Car#openDoors (; 6 ;) (type $i_) (param $0 i32)
   nop
  )
- (func $start (; 7 ;) (type $v)
+ (func $start (; 7 ;) (type $_)
   i32.const 8
   global.set $~lib/allocator/arena/startOffset
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $null (; 8 ;) (type $v)
+ (func $null (; 8 ;) (type $_)
   nop
  )
  (func $exports/subOpt|trampoline (; 9 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
@@ -160,7 +160,7 @@
   local.get $1
   i32.sub
  )
- (func $~setargc (; 10 ;) (type $iv) (param $0 i32)
+ (func $~setargc (; 10 ;) (type $i_) (param $0 i32)
   local.get $0
   global.set $~argc
  )

--- a/tests/compiler/exports.untouched.wat
+++ b/tests/compiler/exports.untouched.wat
@@ -2,9 +2,9 @@
  (type $iii (func (param i32 i32) (result i32)))
  (type $i (func (result i32)))
  (type $ii (func (param i32) (result i32)))
- (type $iiv (func (param i32 i32)))
- (type $iv (func (param i32)))
- (type $v (func))
+ (type $ii_ (func (param i32 i32)))
+ (type $i_ (func (param i32)))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -175,12 +175,12 @@
   local.get $0
   i32.load
  )
- (func $exports/Car#set:numDoors (; 8 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $exports/Car#set:numDoors (; 8 ;) (type $ii_) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
  )
- (func $exports/Car#openDoors (; 9 ;) (type $iv) (param $0 i32)
+ (func $exports/Car#openDoors (; 9 ;) (type $i_) (param $0 i32)
   nop
  )
  (func $exports/vehicles.Car.getNumTires (; 10 ;) (type $i) (result i32)
@@ -208,15 +208,15 @@
   local.get $0
   i32.load
  )
- (func $exports/vehicles.Car#set:numDoors (; 13 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $exports/vehicles.Car#set:numDoors (; 13 ;) (type $ii_) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
  )
- (func $exports/vehicles.Car#openDoors (; 14 ;) (type $iv) (param $0 i32)
+ (func $exports/vehicles.Car#openDoors (; 14 ;) (type $i_) (param $0 i32)
   nop
  )
- (func $start (; 15 ;) (type $v)
+ (func $start (; 15 ;) (type $_)
   global.get $HEAP_BASE
   global.get $~lib/internal/allocator/AL_MASK
   i32.add
@@ -228,7 +228,7 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $null (; 16 ;) (type $v)
+ (func $null (; 16 ;) (type $_)
  )
  (func $exports/subOpt|trampoline (; 17 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
@@ -248,7 +248,7 @@
   local.get $1
   call $exports/subOpt
  )
- (func $~setargc (; 18 ;) (type $iv) (param $0 i32)
+ (func $~setargc (; 18 ;) (type $i_) (param $0 i32)
   local.get $0
   global.set $~argc
  )
@@ -272,7 +272,7 @@
   local.get $0
   i32.load
  )
- (func $Car#set:doors (; 21 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $Car#set:doors (; 21 ;) (type $ii_) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -297,7 +297,7 @@
   local.get $0
   i32.load
  )
- (func $vehicles.Car#set:doors (; 24 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $vehicles.Car#set:doors (; 24 ;) (type $ii_) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store

--- a/tests/compiler/external.optimized.wat
+++ b/tests/compiler/external.optimized.wat
@@ -1,5 +1,5 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (import "foo" "var" (global $external/var_ i32))
  (import "external" "foo" (func $external/foo))
  (import "external" "foo.bar" (func $external/foo.bar))
@@ -15,7 +15,7 @@
  (export "two" (func $external/two))
  (export "three" (func $external/three))
  (export "var_" (global $external/var_))
- (func $null (; 4 ;) (type $v)
+ (func $null (; 4 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/external.untouched.wat
+++ b/tests/compiler/external.untouched.wat
@@ -1,5 +1,5 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (import "foo" "var" (global $external/var_ i32))
  (import "external" "foo" (func $external/foo))
  (import "external" "foo.bar" (func $external/foo.bar))
@@ -16,6 +16,6 @@
  (export "two" (func $external/two))
  (export "three" (func $external/three))
  (export "var_" (global $external/var_))
- (func $null (; 4 ;) (type $v)
+ (func $null (; 4 ;) (type $_)
  )
 )

--- a/tests/compiler/for.optimized.wat
+++ b/tests/compiler/for.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\06\00\00\00f\00o\00r\00.\00t\00s")
@@ -10,7 +10,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -158,7 +158,7 @@
    end
   end
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/for.untouched.wat
+++ b/tests/compiler/for.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\06\00\00\00f\00o\00r\00.\00t\00s\00")
@@ -11,7 +11,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -215,6 +215,6 @@
    unreachable
   end
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
  )
 )

--- a/tests/compiler/function-expression.optimized.wat
+++ b/tests/compiler/function-expression.optimized.wat
@@ -1,7 +1,7 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (type $i (func (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -19,13 +19,13 @@
  (func $start~anonymous|1 (; 1 ;) (type $ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $start~someName|3 (; 2 ;) (type $v)
+ (func $start~someName|3 (; 2 ;) (type $_)
   nop
  )
  (func $start~anonymous|4 (; 3 ;) (type $i) (result i32)
   i32.const 1
  )
- (func $start (; 4 ;) (type $v)
+ (func $start (; 4 ;) (type $_)
   i32.const 1
   global.set $~argc
   i32.const 1
@@ -59,7 +59,7 @@
   i32.const 0
   global.set $~argc
   global.get $function-expression/f3
-  call_indirect (type $v)
+  call_indirect (type $_)
   i32.const 0
   global.set $~argc
   global.get $function-expression/f4

--- a/tests/compiler/function-expression.untouched.wat
+++ b/tests/compiler/function-expression.untouched.wat
@@ -1,7 +1,7 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (type $i (func (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -23,13 +23,13 @@
  (func $start~anonymous|2 (; 2 ;) (type $ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $start~someName|3 (; 3 ;) (type $v)
+ (func $start~someName|3 (; 3 ;) (type $_)
   nop
  )
  (func $start~anonymous|4 (; 4 ;) (type $i) (result i32)
   i32.const 1
  )
- (func $start (; 5 ;) (type $v)
+ (func $start (; 5 ;) (type $_)
   block (result i32)
    i32.const 1
    global.set $~argc
@@ -70,7 +70,7 @@
    i32.const 0
    global.set $~argc
    global.get $function-expression/f3
-   call_indirect (type $v)
+   call_indirect (type $_)
   end
   block (result i32)
    i32.const 0
@@ -90,6 +90,6 @@
    unreachable
   end
  )
- (func $null (; 6 ;) (type $v)
+ (func $null (; 6 ;) (type $_)
  )
 )

--- a/tests/compiler/function-types.optimized.wat
+++ b/tests/compiler/function-types.optimized.wat
@@ -1,9 +1,9 @@
 (module
  (type $iii (func (param i32 i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $III (func (param i64 i64) (result i64)))
  (type $FFF (func (param f64 f64) (result f64)))
- (type $v (func))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\11\00\00\00f\00u\00n\00c\00t\00i\00o\00n\00-\00t\00y\00p\00e\00s\00.\00t\00s")
@@ -30,7 +30,7 @@
   local.get $1
   f64.add
  )
- (func $start (; 4 ;) (type $v)
+ (func $start (; 4 ;) (type $_)
   (local $0 i32)
   i32.const 1
   global.set $function-types/i32Adder
@@ -180,7 +180,7 @@
    unreachable
   end
  )
- (func $null (; 5 ;) (type $v)
+ (func $null (; 5 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/function-types.untouched.wat
+++ b/tests/compiler/function-types.untouched.wat
@@ -1,11 +1,11 @@
 (module
  (type $i (func (result i32)))
  (type $iii (func (param i32 i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $III (func (param i64 i64) (result i64)))
  (type $FFF (func (param f64 f64) (result f64)))
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\11\00\00\00f\00u\00n\00c\00t\00i\00o\00n\00-\00t\00y\00p\00e\00s\00.\00t\00s\00")
@@ -90,7 +90,7 @@
   local.get $2
   call $function-types/makeAndAdd<i32>
  )
- (func $start (; 12 ;) (type $v)
+ (func $start (; 12 ;) (type $_)
   nop
   call $function-types/makeAdder<i32>
   global.set $function-types/i32Adder
@@ -232,6 +232,6 @@
    unreachable
   end
  )
- (func $null (; 13 ;) (type $v)
+ (func $null (; 13 ;) (type $_)
  )
 )

--- a/tests/compiler/function.optimized.wat
+++ b/tests/compiler/function.optimized.wat
@@ -1,11 +1,11 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $start (; 0 ;) (type $v)
+ (func $start (; 0 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/function.untouched.wat
+++ b/tests/compiler/function.untouched.wat
@@ -1,15 +1,15 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (type $i (func (result i32)))
  (type $I (func (result i64)))
  (type $f (func (result f32)))
  (type $F (func (result f64)))
- (type $iv (func (param i32)))
+ (type $i_ (func (param i32)))
  (type $ii (func (param i32) (result i32)))
  (type $II (func (param i64) (result i64)))
  (type $ff (func (param f32) (result f32)))
  (type $FF (func (param f64) (result f64)))
- (type $iiv (func (param i32 i32)))
+ (type $ii_ (func (param i32 i32)))
  (type $iii (func (param i32 i32) (result i32)))
  (type $IiI (func (param i64 i32) (result i64)))
  (type $fff (func (param f32 f32) (result f32)))
@@ -21,7 +21,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $function/v (; 0 ;) (type $v)
+ (func $function/v (; 0 ;) (type $_)
   nop
  )
  (func $function/i (; 1 ;) (type $i) (result i32)
@@ -36,7 +36,7 @@
  (func $function/F (; 4 ;) (type $F) (result f64)
   f64.const 0
  )
- (func $function/iv (; 5 ;) (type $iv) (param $0 i32)
+ (func $function/iv (; 5 ;) (type $i_) (param $0 i32)
   nop
  )
  (func $function/ii (; 6 ;) (type $ii) (param $0 i32) (result i32)
@@ -51,7 +51,7 @@
  (func $function/FF (; 9 ;) (type $FF) (param $0 f64) (result f64)
   local.get $0
  )
- (func $function/iiv (; 10 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $function/iiv (; 10 ;) (type $ii_) (param $0 i32) (param $1 i32)
   nop
  )
  (func $function/iii (; 11 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
@@ -75,7 +75,7 @@
   local.get $1
   f64.add
  )
- (func $start (; 15 ;) (type $v)
+ (func $start (; 15 ;) (type $_)
   call $function/v
   call $function/i
   drop
@@ -119,6 +119,6 @@
   call $function/FFF
   drop
  )
- (func $null (; 16 ;) (type $v)
+ (func $null (; 16 ;) (type $_)
  )
 )

--- a/tests/compiler/getter-call.optimized.wat
+++ b/tests/compiler/getter-call.optimized.wat
@@ -1,7 +1,7 @@
 (module
  (type $i (func (result i32)))
  (type $ii (func (param i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 2 funcref)
  (elem (i32.const 0) $null $getter-call/C#get:x~anonymous|1)
@@ -86,13 +86,13 @@
   i32.const 1
   call_indirect (type $i)
  )
- (func $start (; 3 ;) (type $v)
+ (func $start (; 3 ;) (type $_)
   i32.const 8
   global.set $~lib/allocator/arena/startOffset
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $null (; 4 ;) (type $v)
+ (func $null (; 4 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/getter-call.untouched.wat
+++ b/tests/compiler/getter-call.untouched.wat
@@ -1,7 +1,7 @@
 (module
  (type $i (func (result i32)))
  (type $ii (func (param i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 2 funcref)
  (elem (i32.const 0) $null $getter-call/C#get:x~anonymous|1)
@@ -128,7 +128,7 @@
   call $getter-call/C#get:x
   call_indirect (type $i)
  )
- (func $start (; 6 ;) (type $v)
+ (func $start (; 6 ;) (type $_)
   global.get $HEAP_BASE
   global.get $~lib/internal/allocator/AL_MASK
   i32.add
@@ -140,6 +140,6 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $null (; 7 ;) (type $v)
+ (func $null (; 7 ;) (type $_)
  )
 )

--- a/tests/compiler/getter-setter.optimized.wat
+++ b/tests/compiler/getter-setter.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\10\00\00\00g\00e\00t\00t\00e\00r\00-\00s\00e\00t\00t\00e\00r\00.\00t\00s")
@@ -10,7 +10,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   global.get $getter-setter/Foo._bar
   if
    i32.const 0
@@ -47,7 +47,7 @@
    unreachable
   end
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/getter-setter.untouched.wat
+++ b/tests/compiler/getter-setter.untouched.wat
@@ -1,8 +1,8 @@
 (module
  (type $i (func (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $iv (func (param i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $i_ (func (param i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\10\00\00\00g\00e\00t\00t\00e\00r\00-\00s\00e\00t\00t\00e\00r\00.\00t\00s\00")
@@ -16,11 +16,11 @@
  (func $getter-setter/Foo.get:bar (; 1 ;) (type $i) (result i32)
   global.get $getter-setter/Foo._bar
  )
- (func $getter-setter/Foo.set:bar (; 2 ;) (type $iv) (param $0 i32)
+ (func $getter-setter/Foo.set:bar (; 2 ;) (type $i_) (param $0 i32)
   local.get $0
   global.set $getter-setter/Foo._bar
  )
- (func $start (; 3 ;) (type $v)
+ (func $start (; 3 ;) (type $_)
   call $getter-setter/Foo.get:bar
   i32.const 0
   i32.eq
@@ -64,6 +64,6 @@
    unreachable
   end
  )
- (func $null (; 4 ;) (type $v)
+ (func $null (; 4 ;) (type $_)
  )
 )

--- a/tests/compiler/i64-polyfill.optimized.wat
+++ b/tests/compiler/i64-polyfill.optimized.wat
@@ -1,8 +1,8 @@
 (module
  (type $i (func (result i32)))
- (type $iiv (func (param i32 i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $ii_ (func (param i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -47,7 +47,7 @@
  (func $../../examples/i64-polyfill/assembly/i64/getLo (; 1 ;) (type $i) (result i32)
   global.get $../../examples/i64-polyfill/assembly/i64/lo
  )
- (func $../../examples/i64-polyfill/assembly/i64/clz (; 2 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/clz (; 2 ;) (type $ii_) (param $0 i32) (param $1 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -61,7 +61,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/ctz (; 3 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/ctz (; 3 ;) (type $ii_) (param $0 i32) (param $1 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -75,7 +75,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/popcnt (; 4 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/popcnt (; 4 ;) (type $ii_) (param $0 i32) (param $1 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -89,7 +89,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/eqz (; 5 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/eqz (; 5 ;) (type $ii_) (param $0 i32) (param $1 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -102,7 +102,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/add (; 6 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/add (; 6 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -128,7 +128,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/sub (; 7 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/sub (; 7 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -154,7 +154,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/mul (; 8 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/mul (; 8 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -180,7 +180,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/div_s (; 9 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/div_s (; 9 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -206,7 +206,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/div_u (; 10 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/div_u (; 10 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -232,7 +232,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/rem_s (; 11 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/rem_s (; 11 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -258,7 +258,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/rem_u (; 12 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/rem_u (; 12 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -284,7 +284,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/and (; 13 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/and (; 13 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -310,7 +310,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/or (; 14 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/or (; 14 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -336,7 +336,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/xor (; 15 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/xor (; 15 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -362,7 +362,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/shl (; 16 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/shl (; 16 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -388,7 +388,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/shr_s (; 17 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/shr_s (; 17 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -414,7 +414,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/shr_u (; 18 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/shr_u (; 18 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -440,7 +440,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/rotl (; 19 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/rotl (; 19 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -466,7 +466,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/rotr (; 20 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/rotr (; 20 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -492,7 +492,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/eq (; 21 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/eq (; 21 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -512,7 +512,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/ne (; 22 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/ne (; 22 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -532,7 +532,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/lt_s (; 23 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/lt_s (; 23 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -552,7 +552,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/lt_u (; 24 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/lt_u (; 24 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -572,7 +572,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/le_s (; 25 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/le_s (; 25 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -592,7 +592,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/le_u (; 26 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/le_u (; 26 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -612,7 +612,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/gt_s (; 27 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/gt_s (; 27 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -632,7 +632,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/gt_u (; 28 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/gt_u (; 28 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -652,7 +652,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/ge_s (; 29 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/ge_s (; 29 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -672,7 +672,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/ge_u (; 30 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/ge_u (; 30 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -692,7 +692,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $null (; 31 ;) (type $v)
+ (func $null (; 31 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/i64-polyfill.untouched.wat
+++ b/tests/compiler/i64-polyfill.untouched.wat
@@ -1,8 +1,8 @@
 (module
  (type $i (func (result i32)))
- (type $iiv (func (param i32 i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $ii_ (func (param i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -50,7 +50,7 @@
  (func $../../examples/i64-polyfill/assembly/i64/getLo (; 1 ;) (type $i) (result i32)
   global.get $../../examples/i64-polyfill/assembly/i64/lo
  )
- (func $../../examples/i64-polyfill/assembly/i64/clz (; 2 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/clz (; 2 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i64)
   local.get $0
   i64.extend_i32_u
@@ -67,7 +67,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/ctz (; 3 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/ctz (; 3 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i64)
   local.get $0
   i64.extend_i32_u
@@ -84,7 +84,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/popcnt (; 4 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/popcnt (; 4 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i64)
   local.get $0
   i64.extend_i32_u
@@ -101,7 +101,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/eqz (; 5 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/eqz (; 5 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i64.extend_i32_u
@@ -117,7 +117,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/add (; 6 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/add (; 6 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -144,7 +144,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/sub (; 7 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/sub (; 7 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -171,7 +171,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/mul (; 8 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/mul (; 8 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -198,7 +198,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/div_s (; 9 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/div_s (; 9 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -225,7 +225,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/div_u (; 10 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/div_u (; 10 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -252,7 +252,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/rem_s (; 11 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/rem_s (; 11 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -279,7 +279,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/rem_u (; 12 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/rem_u (; 12 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -306,7 +306,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/and (; 13 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/and (; 13 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -333,7 +333,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/or (; 14 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/or (; 14 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -360,7 +360,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/xor (; 15 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/xor (; 15 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -387,7 +387,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/shl (; 16 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/shl (; 16 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -414,7 +414,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/shr_s (; 17 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/shr_s (; 17 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -441,7 +441,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/shr_u (; 18 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/shr_u (; 18 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -468,7 +468,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/rotl (; 19 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/rotl (; 19 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -495,7 +495,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/rotr (; 20 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/rotr (; 20 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -522,7 +522,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/eq (; 21 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/eq (; 21 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -545,7 +545,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/ne (; 22 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/ne (; 22 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -568,7 +568,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/lt_s (; 23 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/lt_s (; 23 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -591,7 +591,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/lt_u (; 24 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/lt_u (; 24 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -614,7 +614,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/le_s (; 25 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/le_s (; 25 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -637,7 +637,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/le_u (; 26 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/le_u (; 26 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -660,7 +660,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/gt_s (; 27 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/gt_s (; 27 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -683,7 +683,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/gt_u (; 28 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/gt_u (; 28 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -706,7 +706,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/ge_s (; 29 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/ge_s (; 29 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -729,7 +729,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/ge_u (; 30 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/ge_u (; 30 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -752,6 +752,6 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $null (; 31 ;) (type $v)
+ (func $null (; 31 ;) (type $_)
  )
 )

--- a/tests/compiler/if.optimized.wat
+++ b/tests/compiler/if.optimized.wat
@@ -1,7 +1,7 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\05\00\00\00i\00f\00.\00t\00s")
@@ -40,7 +40,7 @@
    unreachable
   end
  )
- (func $start (; 4 ;) (type $v)
+ (func $start (; 4 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/if.untouched.wat
+++ b/tests/compiler/if.untouched.wat
@@ -1,7 +1,7 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\05\00\00\00i\00f\00.\00t\00s\00")
@@ -63,7 +63,7 @@
   unreachable
   unreachable
  )
- (func $start (; 5 ;) (type $v)
+ (func $start (; 5 ;) (type $_)
   i32.const 0
   call $if/ifThenElse
   i32.const 0
@@ -143,6 +143,6 @@
    unreachable
   end
  )
- (func $null (; 6 ;) (type $v)
+ (func $null (; 6 ;) (type $_)
  )
 )

--- a/tests/compiler/import.optimized.wat
+++ b/tests/compiler/import.optimized.wat
@@ -1,11 +1,11 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $start (; 0 ;) (type $v)
+ (func $start (; 0 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/import.untouched.wat
+++ b/tests/compiler/import.untouched.wat
@@ -1,6 +1,6 @@
 (module
  (type $iii (func (param i32 i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -26,10 +26,10 @@
   local.get $1
   i32.mul
  )
- (func $export/ns.two (; 3 ;) (type $v)
+ (func $export/ns.two (; 3 ;) (type $_)
   nop
  )
- (func $start (; 4 ;) (type $v)
+ (func $start (; 4 ;) (type $_)
   global.get $export/a
   global.get $export/b
   call $export/add
@@ -57,6 +57,6 @@
   drop
   call $export/ns.two
  )
- (func $null (; 5 ;) (type $v)
+ (func $null (; 5 ;) (type $_)
  )
 )

--- a/tests/compiler/infer-type.optimized.wat
+++ b/tests/compiler/infer-type.optimized.wat
@@ -1,5 +1,5 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 1)
  (data (i32.const 8) "\0d\00\00\00i\00n\00f\00e\00r\00-\00t\00y\00p\00e\00.\00t\00s")
  (table $0 1 funcref)
@@ -11,7 +11,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 0 ;) (type $v)
+ (func $start (; 0 ;) (type $_)
   (local $0 i32)
   i32.const 0
   global.set $infer-type/ri
@@ -34,7 +34,7 @@
    end
   end
  )
- (func $null (; 1 ;) (type $v)
+ (func $null (; 1 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/infer-type.untouched.wat
+++ b/tests/compiler/infer-type.untouched.wat
@@ -1,10 +1,10 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (type $i (func (result i32)))
  (type $I (func (result i64)))
  (type $f (func (result f32)))
  (type $F (func (result f64)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0d\00\00\00i\00n\00f\00e\00r\00-\00t\00y\00p\00e\00.\00t\00s\00")
@@ -23,7 +23,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $infer-type/locals (; 1 ;) (type $v)
+ (func $infer-type/locals (; 1 ;) (type $_)
   (local $0 i32)
   (local $1 i64)
   (local $2 f64)
@@ -55,7 +55,7 @@
  (func $infer-type/refF (; 5 ;) (type $F) (result f64)
   f64.const 0
  )
- (func $start (; 6 ;) (type $v)
+ (func $start (; 6 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   global.get $infer-type/i
@@ -126,6 +126,6 @@
    unreachable
   end
  )
- (func $null (; 7 ;) (type $v)
+ (func $null (; 7 ;) (type $_)
  )
 )

--- a/tests/compiler/inlining-recursive.optimized.wat
+++ b/tests/compiler/inlining-recursive.optimized.wat
@@ -1,5 +1,5 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -8,13 +8,13 @@
  (export "foo" (func $inlining-recursive/foo))
  (export "bar" (func $inlining-recursive/baz))
  (export "baz" (func $inlining-recursive/baz))
- (func $inlining-recursive/foo (; 0 ;) (type $v)
+ (func $inlining-recursive/foo (; 0 ;) (type $_)
   call $inlining-recursive/foo
  )
- (func $inlining-recursive/baz (; 1 ;) (type $v)
+ (func $inlining-recursive/baz (; 1 ;) (type $_)
   call $inlining-recursive/baz
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/inlining-recursive.untouched.wat
+++ b/tests/compiler/inlining-recursive.untouched.wat
@@ -1,5 +1,5 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -9,17 +9,17 @@
  (export "foo" (func $inlining-recursive/foo))
  (export "bar" (func $inlining-recursive/bar))
  (export "baz" (func $inlining-recursive/baz))
- (func $inlining-recursive/foo (; 0 ;) (type $v)
+ (func $inlining-recursive/foo (; 0 ;) (type $_)
   call $inlining-recursive/foo
  )
- (func $inlining-recursive/baz (; 1 ;) (type $v)
+ (func $inlining-recursive/baz (; 1 ;) (type $_)
   call $inlining-recursive/bar
  )
- (func $inlining-recursive/bar (; 2 ;) (type $v)
+ (func $inlining-recursive/bar (; 2 ;) (type $_)
   block $inlining-recursive/bar|inlined.0
    call $inlining-recursive/baz
   end
  )
- (func $null (; 3 ;) (type $v)
+ (func $null (; 3 ;) (type $_)
  )
 )

--- a/tests/compiler/inlining.optimized.wat
+++ b/tests/compiler/inlining.optimized.wat
@@ -1,7 +1,7 @@
 (module
  (type $i (func (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (type $ii (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -21,7 +21,7 @@
  (func $inlining/func_fe~anonymous|1 (; 2 ;) (type $ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $inlining/test_funcs (; 3 ;) (type $v)
+ (func $inlining/test_funcs (; 3 ;) (type $_)
   i32.const 1
   global.set $~argc
   i32.const 2
@@ -100,7 +100,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $inlining/test_ctor (; 5 ;) (type $v)
+ (func $inlining/test_ctor (; 5 ;) (type $_)
   (local $0 i32)
   i32.const 16
   call $~lib/allocator/arena/__memory_allocate
@@ -178,7 +178,7 @@
    unreachable
   end
  )
- (func $start (; 6 ;) (type $v)
+ (func $start (; 6 ;) (type $_)
   call $inlining/test_funcs
   i32.const 40
   global.set $~lib/allocator/arena/startOffset
@@ -186,7 +186,7 @@
   global.set $~lib/allocator/arena/offset
   call $inlining/test_ctor
  )
- (func $null (; 7 ;) (type $v)
+ (func $null (; 7 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/inlining.untouched.wat
+++ b/tests/compiler/inlining.untouched.wat
@@ -1,7 +1,7 @@
 (module
  (type $i (func (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (type $ii (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -29,7 +29,7 @@
  (func $inlining/func_fe~anonymous|1 (; 2 ;) (type $ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $inlining/test_funcs (; 3 ;) (type $v)
+ (func $inlining/test_funcs (; 3 ;) (type $_)
   (local $0 f32)
   (local $1 f64)
   (local $2 i32)
@@ -367,7 +367,7 @@
   call $~lib/allocator/arena/__memory_allocate
   return
  )
- (func $inlining/test_ctor (; 6 ;) (type $v)
+ (func $inlining/test_ctor (; 6 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -475,7 +475,7 @@
    unreachable
   end
  )
- (func $start (; 7 ;) (type $v)
+ (func $start (; 7 ;) (type $_)
   call $inlining/test
   i32.const 3
   i32.eq
@@ -501,6 +501,6 @@
   global.set $~lib/allocator/arena/offset
   call $inlining/test_ctor
  )
- (func $null (; 8 ;) (type $v)
+ (func $null (; 8 ;) (type $_)
  )
 )

--- a/tests/compiler/instanceof.optimized.wat
+++ b/tests/compiler/instanceof.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0d\00\00\00i\00n\00s\00t\00a\00n\00c\00e\00o\00f\00.\00t\00s")
@@ -10,7 +10,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   global.get $instanceof/an
   if
    i32.const 0
@@ -33,7 +33,7 @@
    unreachable
   end
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/instanceof.untouched.wat
+++ b/tests/compiler/instanceof.untouched.wat
@@ -1,8 +1,8 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $ii (func (param i32) (result i32)))
  (type $Fi (func (param f64) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0d\00\00\00i\00n\00s\00t\00a\00n\00c\00e\00o\00f\00.\00t\00s\00")
@@ -29,7 +29,7 @@
   i32.const 0
   return
  )
- (func $start (; 4 ;) (type $v)
+ (func $start (; 4 ;) (type $_)
   i32.const 1
   i32.eqz
   if
@@ -284,6 +284,6 @@
    unreachable
   end
  )
- (func $null (; 5 ;) (type $v)
+ (func $null (; 5 ;) (type $_)
  )
 )

--- a/tests/compiler/limits.optimized.wat
+++ b/tests/compiler/limits.optimized.wat
@@ -1,11 +1,11 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $start (; 0 ;) (type $v)
+ (func $start (; 0 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/limits.untouched.wat
+++ b/tests/compiler/limits.untouched.wat
@@ -1,5 +1,5 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -33,7 +33,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 0 ;) (type $v)
+ (func $start (; 0 ;) (type $_)
   global.get $~lib/builtins/i8.MIN_VALUE
   drop
   global.get $~lib/builtins/i8.MAX_VALUE
@@ -87,6 +87,6 @@
   global.get $~lib/builtins/f64.MAX_SAFE_INTEGER
   drop
  )
- (func $null (; 1 ;) (type $v)
+ (func $null (; 1 ;) (type $_)
  )
 )

--- a/tests/compiler/literals.optimized.wat
+++ b/tests/compiler/literals.optimized.wat
@@ -1,11 +1,11 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $start (; 0 ;) (type $v)
+ (func $start (; 0 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/literals.untouched.wat
+++ b/tests/compiler/literals.untouched.wat
@@ -1,5 +1,5 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -7,7 +7,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 0 ;) (type $v)
+ (func $start (; 0 ;) (type $_)
   i32.const 0
   drop
   i32.const 1
@@ -97,6 +97,6 @@
   i32.const 0
   drop
  )
- (func $null (; 1 ;) (type $v)
+ (func $null (; 1 ;) (type $_)
  )
 )

--- a/tests/compiler/logical.optimized.wat
+++ b/tests/compiler/logical.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\n\00\00\00l\00o\00g\00i\00c\00a\00l\00.\00t\00s")
@@ -13,7 +13,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   i32.const 2
   global.set $logical/i
   global.get $logical/i
@@ -119,7 +119,7 @@
    unreachable
   end
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/logical.untouched.wat
+++ b/tests/compiler/logical.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\n\00\00\00l\00o\00g\00i\00c\00a\00l\00.\00t\00s\00")
@@ -14,7 +14,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   (local $0 i32)
   (local $1 f64)
   i32.const 0
@@ -244,6 +244,6 @@
    unreachable
   end
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
  )
 )

--- a/tests/compiler/main.optimized.wat
+++ b/tests/compiler/main.optimized.wat
@@ -1,6 +1,6 @@
 (module
  (type $iii (func (param i32 i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -20,7 +20,7 @@
   end
   global.get $main/code
  )
- (func $null (; 1 ;) (type $v)
+ (func $null (; 1 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/main.untouched.wat
+++ b/tests/compiler/main.untouched.wat
@@ -1,6 +1,6 @@
 (module
  (type $iii (func (param i32 i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -20,10 +20,10 @@
   end
   global.get $main/code
  )
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   i32.const 1
   global.set $main/code
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
  )
 )

--- a/tests/compiler/mandelbrot.optimized.wat
+++ b/tests/compiler/mandelbrot.optimized.wat
@@ -1,7 +1,7 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $FF (func (param f64) (result f64)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -392,7 +392,7 @@
   local.get $0
   f64.add
  )
- (func $../../examples/mandelbrot/assembly/index/computeLine (; 2 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/mandelbrot/assembly/index/computeLine (; 2 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 f64)
   (local $5 f64)
   (local $6 f64)
@@ -587,7 +587,7 @@
    end
   end
  )
- (func $null (; 3 ;) (type $v)
+ (func $null (; 3 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/mandelbrot.untouched.wat
+++ b/tests/compiler/mandelbrot.untouched.wat
@@ -1,8 +1,8 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $FF (func (param f64) (result f64)))
  (type $FFFF (func (param f64 f64 f64) (result f64)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -487,7 +487,7 @@
   local.get $2
   f64.min
  )
- (func $../../examples/mandelbrot/assembly/index/computeLine (; 3 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/mandelbrot/assembly/index/computeLine (; 3 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 f64)
   (local $5 f64)
   (local $6 f64)
@@ -722,6 +722,6 @@
    unreachable
   end
  )
- (func $null (; 4 ;) (type $v)
+ (func $null (; 4 ;) (type $_)
  )
 )

--- a/tests/compiler/many-locals.optimized.wat
+++ b/tests/compiler/many-locals.optimized.wat
@@ -1,6 +1,6 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 1)
  (data (i32.const 8) "\0e\00\00\00m\00a\00n\00y\00-\00l\00o\00c\00a\00l\00s\00.\00t\00s")
  (table $0 1 funcref)
@@ -19,7 +19,7 @@
   i32.const 24
   i32.shr_s
  )
- (func $start (; 2 ;) (type $v)
+ (func $start (; 2 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/many-locals.untouched.wat
+++ b/tests/compiler/many-locals.untouched.wat
@@ -1,7 +1,7 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0e\00\00\00m\00a\00n\00y\00-\00l\00o\00c\00a\00l\00s\00.\00t\00s\00")
@@ -791,7 +791,7 @@
   i32.const 24
   i32.shr_s
  )
- (func $start (; 3 ;) (type $v)
+ (func $start (; 3 ;) (type $_)
   i32.const 42
   call $many-locals/testI32
   i32.const 42
@@ -819,6 +819,6 @@
    unreachable
   end
  )
- (func $null (; 4 ;) (type $v)
+ (func $null (; 4 ;) (type $_)
  )
 )

--- a/tests/compiler/memcpy.optimized.wat
+++ b/tests/compiler/memcpy.optimized.wat
@@ -1,7 +1,7 @@
 (module
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\t\00\00\00m\00e\00m\00c\00p\00y\00.\00t\00s")
@@ -914,7 +914,7 @@
   end
   local.get $6
  )
- (func $start (; 2 ;) (type $v)
+ (func $start (; 2 ;) (type $_)
   i32.const 8
   i64.const 1229782938247303441
   i64.store
@@ -1090,7 +1090,7 @@
    unreachable
   end
  )
- (func $null (; 3 ;) (type $v)
+ (func $null (; 3 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/memcpy.untouched.wat
+++ b/tests/compiler/memcpy.untouched.wat
@@ -1,7 +1,7 @@
 (module
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\t\00\00\00m\00e\00m\00c\00p\00y\00.\00t\00s\00")
@@ -1208,7 +1208,7 @@
   end
   local.get $3
  )
- (func $start (; 2 ;) (type $v)
+ (func $start (; 2 ;) (type $_)
   global.get $memcpy/base
   i64.const 1229782938247303441
   i64.store
@@ -1428,6 +1428,6 @@
    unreachable
   end
  )
- (func $null (; 3 ;) (type $v)
+ (func $null (; 3 ;) (type $_)
  )
 )

--- a/tests/compiler/memmove.optimized.wat
+++ b/tests/compiler/memmove.optimized.wat
@@ -1,7 +1,7 @@
 (module
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\n\00\00\00m\00e\00m\00m\00o\00v\00e\00.\00t\00s")
@@ -193,7 +193,7 @@
   end
   local.get $3
  )
- (func $start (; 2 ;) (type $v)
+ (func $start (; 2 ;) (type $_)
   i32.const 8
   i64.const 1229782938247303441
   i64.store
@@ -369,7 +369,7 @@
    unreachable
   end
  )
- (func $null (; 3 ;) (type $v)
+ (func $null (; 3 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/memmove.untouched.wat
+++ b/tests/compiler/memmove.untouched.wat
@@ -1,7 +1,7 @@
 (module
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\n\00\00\00m\00e\00m\00m\00o\00v\00e\00.\00t\00s\00")
@@ -225,7 +225,7 @@
   end
   local.get $3
  )
- (func $start (; 2 ;) (type $v)
+ (func $start (; 2 ;) (type $_)
   global.get $memmove/base
   i64.const 1229782938247303441
   i64.store
@@ -445,6 +445,6 @@
    unreachable
   end
  )
- (func $null (; 3 ;) (type $v)
+ (func $null (; 3 ;) (type $_)
  )
 )

--- a/tests/compiler/memset.optimized.wat
+++ b/tests/compiler/memset.optimized.wat
@@ -1,7 +1,7 @@
 (module
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\t\00\00\00m\00e\00m\00s\00e\00t\00.\00t\00s")
@@ -242,7 +242,7 @@
   end
   local.get $3
  )
- (func $start (; 2 ;) (type $v)
+ (func $start (; 2 ;) (type $_)
   i32.const 32
   global.set $memset/dest
   global.get $memset/dest
@@ -338,7 +338,7 @@
    unreachable
   end
  )
- (func $null (; 3 ;) (type $v)
+ (func $null (; 3 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/memset.untouched.wat
+++ b/tests/compiler/memset.untouched.wat
@@ -1,7 +1,7 @@
 (module
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\t\00\00\00m\00e\00m\00s\00e\00t\00.\00t\00s\00")
@@ -276,7 +276,7 @@
   end
   local.get $3
  )
- (func $start (; 2 ;) (type $v)
+ (func $start (; 2 ;) (type $_)
   global.get $HEAP_BASE
   global.set $memset/dest
   global.get $memset/dest
@@ -378,6 +378,6 @@
    unreachable
   end
  )
- (func $null (; 3 ;) (type $v)
+ (func $null (; 3 ;) (type $_)
  )
 )

--- a/tests/compiler/named-export-default.optimized.wat
+++ b/tests/compiler/named-export-default.optimized.wat
@@ -1,6 +1,6 @@
 (module
  (type $i (func (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -10,7 +10,7 @@
  (func $named-export-default/get3 (; 0 ;) (type $i) (result i32)
   i32.const 3
  )
- (func $null (; 1 ;) (type $v)
+ (func $null (; 1 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/named-export-default.untouched.wat
+++ b/tests/compiler/named-export-default.untouched.wat
@@ -1,6 +1,6 @@
 (module
  (type $i (func (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -11,6 +11,6 @@
  (func $named-export-default/get3 (; 0 ;) (type $i) (result i32)
   i32.const 3
  )
- (func $null (; 1 ;) (type $v)
+ (func $null (; 1 ;) (type $_)
  )
 )

--- a/tests/compiler/named-import-default.optimized.wat
+++ b/tests/compiler/named-import-default.optimized.wat
@@ -1,6 +1,6 @@
 (module
  (type $i (func (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -10,7 +10,7 @@
  (func $named-import-default/getValue (; 0 ;) (type $i) (result i32)
   i32.const 3
  )
- (func $null (; 1 ;) (type $v)
+ (func $null (; 1 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/named-import-default.untouched.wat
+++ b/tests/compiler/named-import-default.untouched.wat
@@ -1,6 +1,6 @@
 (module
  (type $i (func (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -14,6 +14,6 @@
  (func $named-import-default/getValue (; 1 ;) (type $i) (result i32)
   call $named-export-default/get3
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
  )
 )

--- a/tests/compiler/namespace.optimized.wat
+++ b/tests/compiler/namespace.optimized.wat
@@ -1,11 +1,11 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $start (; 0 ;) (type $v)
+ (func $start (; 0 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/namespace.untouched.wat
+++ b/tests/compiler/namespace.untouched.wat
@@ -1,6 +1,6 @@
 (module
  (type $i (func (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -18,7 +18,7 @@
  (func $namespace/Joined.anotherFunc (; 1 ;) (type $i) (result i32)
   global.get $namespace/Joined.THREE
  )
- (func $start (; 2 ;) (type $v)
+ (func $start (; 2 ;) (type $_)
   global.get $namespace/Outer.Inner.aVar
   drop
   call $namespace/Outer.Inner.aFunc
@@ -28,6 +28,6 @@
   call $namespace/Joined.anotherFunc
   drop
  )
- (func $null (; 3 ;) (type $v)
+ (func $null (; 3 ;) (type $_)
  )
 )

--- a/tests/compiler/new-without-allocator.optimized.wat
+++ b/tests/compiler/new-without-allocator.optimized.wat
@@ -1,6 +1,6 @@
 (module
  (type $i (func (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -10,7 +10,7 @@
  (func $new-without-allocator/test (; 0 ;) (type $i) (result i32)
   unreachable
  )
- (func $null (; 1 ;) (type $v)
+ (func $null (; 1 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/new-without-allocator.untouched.wat
+++ b/tests/compiler/new-without-allocator.untouched.wat
@@ -1,7 +1,7 @@
 (module
  (type $i (func (result i32)))
  (type $ii (func (param i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -29,6 +29,6 @@
   local.set $0
   i32.const 3
  )
- (func $null (; 3 ;) (type $v)
+ (func $null (; 3 ;) (type $_)
  )
 )

--- a/tests/compiler/nonNullAssertion.optimized.wat
+++ b/tests/compiler/nonNullAssertion.optimized.wat
@@ -1,7 +1,7 @@
 (module
  (type $ii (func (param i32) (result i32)))
  (type $i (func (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -76,13 +76,13 @@
   i32.load offset=4
   call_indirect (type $i)
  )
- (func $start (; 6 ;) (type $v)
+ (func $start (; 6 ;) (type $_)
   i32.const 8
   global.set $~lib/allocator/arena/startOffset
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $null (; 7 ;) (type $v)
+ (func $null (; 7 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/nonNullAssertion.untouched.wat
+++ b/tests/compiler/nonNullAssertion.untouched.wat
@@ -2,7 +2,7 @@
  (type $ii (func (param i32) (result i32)))
  (type $iii (func (param i32 i32) (result i32)))
  (type $i (func (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -164,7 +164,7 @@
   i32.load offset=4
   call_indirect (type $i)
  )
- (func $start (; 14 ;) (type $v)
+ (func $start (; 14 ;) (type $_)
   global.get $HEAP_BASE
   global.get $~lib/internal/allocator/AL_MASK
   i32.add
@@ -176,6 +176,6 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $null (; 15 ;) (type $v)
+ (func $null (; 15 ;) (type $_)
  )
 )

--- a/tests/compiler/number.optimized.wat
+++ b/tests/compiler/number.optimized.wat
@@ -1,13 +1,13 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $iiiv (func (param i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $iii_ (func (param i32 i32 i32)))
  (type $iii (func (param i32 i32) (result i32)))
  (type $Fi (func (param f64) (result i32)))
  (type $iFi (func (param i32 f64) (result i32)))
  (type $iIiIiIii (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
@@ -199,7 +199,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/number/utoa32_lut (; 4 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/number/utoa32_lut (; 4 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   i32.const 584
@@ -833,7 +833,7 @@
    local.get $10
   end
  )
- (func $~lib/internal/memory/memcpy (; 9 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 9 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1730,7 +1730,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 10 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 10 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -2661,7 +2661,7 @@
   end
   local.get $1
  )
- (func $start (; 15 ;) (type $v)
+ (func $start (; 15 ;) (type $_)
   (local $0 i32)
   i32.const 2192
   global.set $~lib/allocator/arena/startOffset
@@ -2827,7 +2827,7 @@
    unreachable
   end
  )
- (func $null (; 16 ;) (type $v)
+ (func $null (; 16 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/number.untouched.wat
+++ b/tests/compiler/number.untouched.wat
@@ -1,17 +1,17 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $iiiv (func (param i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $iii_ (func (param i32 i32 i32)))
  (type $iii (func (param i32 i32) (result i32)))
  (type $iiiiii (func (param i32 i32 i32 i32 i32) (result i32)))
  (type $Fi (func (param f64) (result i32)))
  (type $iFi (func (param i32 f64) (result i32)))
  (type $iIiIiIii (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiiiiv (func (param i32 i32 i32 i32 i32)))
- (type $iv (func (param i32)))
+ (type $iiiii_ (func (param i32 i32 i32 i32 i32)))
+ (type $i_ (func (param i32)))
  (type $fi (func (param f32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\01\00\00\000\00")
@@ -288,7 +288,7 @@
   i32.store
   local.get $2
  )
- (func $~lib/internal/number/utoa32_lut (; 4 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/number/utoa32_lut (; 4 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1239,7 +1239,7 @@
   end
   local.get $15
  )
- (func $~lib/internal/memory/memcpy (; 13 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 13 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2440,7 +2440,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 14 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 14 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -3513,7 +3513,7 @@
   local.get $2
   i32.add
  )
- (func $~lib/internal/string/copyUnsafe (; 17 ;) (type $iiiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
+ (func $~lib/internal/string/copyUnsafe (; 17 ;) (type $iiiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -3652,7 +3652,7 @@
   call $~lib/internal/string/copyUnsafe
   local.get $10
  )
- (func $~lib/allocator/arena/__memory_free (; 19 ;) (type $iv) (param $0 i32)
+ (func $~lib/allocator/arena/__memory_free (; 19 ;) (type $i_) (param $0 i32)
   nop
  )
  (func $~lib/internal/number/dtoa (; 20 ;) (type $Fi) (param $0 f64) (result i32)
@@ -3815,7 +3815,7 @@
    local.get $2
   end
  )
- (func $start (; 27 ;) (type $v)
+ (func $start (; 27 ;) (type $_)
   (local $0 i32)
   (local $1 f32)
   (local $2 f64)
@@ -4609,6 +4609,6 @@
    unreachable
   end
  )
- (func $null (; 28 ;) (type $v)
+ (func $null (; 28 ;) (type $_)
  )
 )

--- a/tests/compiler/object-literal.optimized.wat
+++ b/tests/compiler/object-literal.optimized.wat
@@ -1,8 +1,8 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $iv (func (param i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $i_ (func (param i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
@@ -148,7 +148,7 @@
   call $~lib/internal/string/compareUnsafe
   i32.eqz
  )
- (func $object-literal/bar (; 4 ;) (type $iv) (param $0 i32)
+ (func $object-literal/bar (; 4 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.load
   i32.const 1
@@ -174,7 +174,7 @@
    unreachable
   end
  )
- (func $start (; 5 ;) (type $v)
+ (func $start (; 5 ;) (type $_)
   (local $0 i32)
   i32.const 80
   global.set $~lib/allocator/arena/startOffset
@@ -225,7 +225,7 @@
    unreachable
   end
  )
- (func $null (; 6 ;) (type $v)
+ (func $null (; 6 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/object-literal.untouched.wat
+++ b/tests/compiler/object-literal.untouched.wat
@@ -1,10 +1,10 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $iv (func (param i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $i_ (func (param i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $iii (func (param i32 i32) (result i32)))
  (type $iiiiii (func (param i32 i32 i32 i32 i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0b\00\00\00h\00e\00l\00l\00o\00 \00w\00o\00r\00l\00d\00")
@@ -203,7 +203,7 @@
   call $~lib/internal/string/compareUnsafe
   i32.eqz
  )
- (func $object-literal/bar (; 5 ;) (type $iv) (param $0 i32)
+ (func $object-literal/bar (; 5 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.load
   i32.const 1
@@ -231,7 +231,7 @@
    unreachable
   end
  )
- (func $object-literal/bar2 (; 6 ;) (type $iv) (param $0 i32)
+ (func $object-literal/bar2 (; 6 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.load
   i32.const 2
@@ -246,7 +246,7 @@
    unreachable
   end
  )
- (func $object-literal/Foo2#test (; 7 ;) (type $iv) (param $0 i32)
+ (func $object-literal/Foo2#test (; 7 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.load
   i32.const 3
@@ -261,7 +261,7 @@
    unreachable
   end
  )
- (func $start (; 8 ;) (type $v)
+ (func $start (; 8 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -309,6 +309,6 @@
   end
   call $object-literal/Foo2#test
  )
- (func $null (; 9 ;) (type $v)
+ (func $null (; 9 ;) (type $_)
  )
 )

--- a/tests/compiler/optional-typeparameters.optimized.wat
+++ b/tests/compiler/optional-typeparameters.optimized.wat
@@ -1,6 +1,6 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -73,7 +73,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   i32.const 8
   global.set $~lib/allocator/arena/startOffset
   global.get $~lib/allocator/arena/startOffset
@@ -85,7 +85,7 @@
   call $~lib/allocator/arena/__memory_allocate
   global.set $optional-typeparameters/tDerived
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/optional-typeparameters.untouched.wat
+++ b/tests/compiler/optional-typeparameters.untouched.wat
@@ -2,7 +2,7 @@
  (type $ii (func (param i32) (result i32)))
  (type $iiii (func (param i32 i32 i32) (result i32)))
  (type $iFFF (func (param i32 f64 f64) (result f64)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -138,7 +138,7 @@
   local.get $2
   f64.add
  )
- (func $start (; 8 ;) (type $v)
+ (func $start (; 8 ;) (type $_)
   i32.const 1
   call $optional-typeparameters/testConcrete<i32,i32>
   drop
@@ -172,6 +172,6 @@
   call $optional-typeparameters/TestDerived<f64,f64>#test<f64>
   drop
  )
- (func $null (; 9 ;) (type $v)
+ (func $null (; 9 ;) (type $_)
  )
 )

--- a/tests/compiler/overflow.optimized.wat
+++ b/tests/compiler/overflow.optimized.wat
@@ -1,12 +1,12 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 1)
  (data (i32.const 8) "\0b\00\00\00o\00v\00e\00r\00f\00l\00o\00w\00.\00t\00s")
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $start (; 0 ;) (type $v)
+ (func $start (; 0 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/overflow.untouched.wat
+++ b/tests/compiler/overflow.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0b\00\00\00o\00v\00e\00r\00f\00l\00o\00w\00.\00t\00s\00")
@@ -10,7 +10,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -755,6 +755,6 @@
    end
   end
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
  )
 )

--- a/tests/compiler/portable-conversions.optimized.wat
+++ b/tests/compiler/portable-conversions.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\17\00\00\00p\00o\00r\00t\00a\00b\00l\00e\00-\00c\00o\00n\00v\00e\00r\00s\00i\00o\00n\00s\00.\00t\00s")
@@ -13,7 +13,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   global.get $portable-conversions/i
   i32.const 255
   i32.and
@@ -614,7 +614,7 @@
    unreachable
   end
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/portable-conversions.untouched.wat
+++ b/tests/compiler/portable-conversions.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\17\00\00\00p\00o\00r\00t\00a\00b\00l\00e\00-\00c\00o\00n\00v\00e\00r\00s\00i\00o\00n\00s\00.\00t\00s\00")
@@ -14,7 +14,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   global.get $portable-conversions/i
   i32.const 24
   i32.shl
@@ -636,6 +636,6 @@
    unreachable
   end
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
  )
 )

--- a/tests/compiler/recursive.optimized.wat
+++ b/tests/compiler/recursive.optimized.wat
@@ -1,6 +1,6 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -25,7 +25,7 @@
   call $recursive/fib
   i32.add
  )
- (func $null (; 1 ;) (type $v)
+ (func $null (; 1 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/recursive.untouched.wat
+++ b/tests/compiler/recursive.untouched.wat
@@ -1,6 +1,6 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -26,6 +26,6 @@
   call $recursive/fib
   i32.add
  )
- (func $null (; 1 ;) (type $v)
+ (func $null (; 1 ;) (type $_)
  )
 )

--- a/tests/compiler/reexport.optimized.wat
+++ b/tests/compiler/reexport.optimized.wat
@@ -1,6 +1,6 @@
 (module
  (type $iii (func (param i32 i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $export/ns.two)
@@ -35,7 +35,7 @@
   local.get $1
   i32.mul
  )
- (func $export/ns.two (; 3 ;) (type $v)
+ (func $export/ns.two (; 3 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/reexport.untouched.wat
+++ b/tests/compiler/reexport.untouched.wat
@@ -1,6 +1,6 @@
 (module
  (type $iii (func (param i32 i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -37,10 +37,10 @@
   local.get $1
   i32.mul
  )
- (func $export/ns.two (; 3 ;) (type $v)
+ (func $export/ns.two (; 3 ;) (type $_)
   nop
  )
- (func $start (; 4 ;) (type $v)
+ (func $start (; 4 ;) (type $_)
   i32.const 1
   i32.const 2
   call $export/add
@@ -50,6 +50,6 @@
   i32.add
   drop
  )
- (func $null (; 5 ;) (type $v)
+ (func $null (; 5 ;) (type $_)
  )
 )

--- a/tests/compiler/rereexport.optimized.wat
+++ b/tests/compiler/rereexport.optimized.wat
@@ -1,5 +1,5 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
@@ -11,7 +11,7 @@
  (export "renamed_a" (global $export/a))
  (export "renamed_b" (global $export/b))
  (export "renamed_renamed_b" (global $export/b))
- (func $start (; 0 ;) (type $v)
+ (func $start (; 0 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/rereexport.untouched.wat
+++ b/tests/compiler/rereexport.untouched.wat
@@ -1,6 +1,6 @@
 (module
  (type $iii (func (param i32 i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -25,7 +25,7 @@
   local.get $1
   i32.mul
  )
- (func $start (; 2 ;) (type $v)
+ (func $start (; 2 ;) (type $_)
   i32.const 1
   i32.const 2
   call $export/add
@@ -35,6 +35,6 @@
   i32.add
   drop
  )
- (func $null (; 3 ;) (type $v)
+ (func $null (; 3 ;) (type $_)
  )
 )

--- a/tests/compiler/retain-i32.optimized.wat
+++ b/tests/compiler/retain-i32.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0d\00\00\00r\00e\00t\00a\00i\00n\00-\00i\003\002\00.\00t\00s")
@@ -11,7 +11,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   (local $0 i32)
   i32.const -128
   local.set $0
@@ -258,7 +258,7 @@
    unreachable
   end
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/retain-i32.untouched.wat
+++ b/tests/compiler/retain-i32.untouched.wat
@@ -1,7 +1,7 @@
 (module
- (type $iiv (func (param i32 i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $ii_ (func (param i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0d\00\00\00r\00e\00t\00a\00i\00n\00-\00i\003\002\00.\00t\00s\00")
@@ -22,7 +22,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $retain-i32/test (; 1 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $retain-i32/test (; 1 ;) (type $ii_) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.add
@@ -332,7 +332,7 @@
    unreachable
   end
  )
- (func $start (; 2 ;) (type $v)
+ (func $start (; 2 ;) (type $_)
   (local $0 i32)
   i32.const 0
   global.get $~lib/builtins/i8.MAX_VALUE
@@ -792,6 +792,6 @@
    unreachable
   end
  )
- (func $null (; 3 ;) (type $v)
+ (func $null (; 3 ;) (type $_)
  )
 )

--- a/tests/compiler/scoped.optimized.wat
+++ b/tests/compiler/scoped.optimized.wat
@@ -1,12 +1,12 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 0 ;) (type $v)
+ (func $start (; 0 ;) (type $_)
   (local $0 i32)
   loop $repeat|0
    local.get $0
@@ -35,7 +35,7 @@
    end
   end
  )
- (func $null (; 1 ;) (type $v)
+ (func $null (; 1 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/scoped.untouched.wat
+++ b/tests/compiler/scoped.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iv (func (param i32)))
- (type $v (func))
+ (type $i_ (func (param i32)))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -11,14 +11,14 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $scoped/fn (; 0 ;) (type $iv) (param $0 i32)
+ (func $scoped/fn (; 0 ;) (type $i_) (param $0 i32)
   (local $1 i32)
   i32.const 0
   local.set $1
   local.get $0
   local.set $1
  )
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i64)
@@ -71,6 +71,6 @@
   i32.const 42
   call $scoped/fn
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
  )
 )

--- a/tests/compiler/static-this.optimized.wat
+++ b/tests/compiler/static-this.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0e\00\00\00s\00t\00a\00t\00i\00c\00-\00t\00h\00i\00s\00.\00t\00s")
@@ -10,7 +10,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   global.get $static-this/Foo.bar
   i32.const 42
   i32.ne
@@ -23,7 +23,7 @@
    unreachable
   end
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/static-this.untouched.wat
+++ b/tests/compiler/static-this.untouched.wat
@@ -1,7 +1,7 @@
 (module
  (type $i (func (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0e\00\00\00s\00t\00a\00t\00i\00c\00-\00t\00h\00i\00s\00.\00t\00s\00")
@@ -15,7 +15,7 @@
  (func $static-this/Foo.getBar (; 1 ;) (type $i) (result i32)
   global.get $static-this/Foo.bar
  )
- (func $start (; 2 ;) (type $v)
+ (func $start (; 2 ;) (type $_)
   call $static-this/Foo.getBar
   i32.const 42
   i32.eq
@@ -29,6 +29,6 @@
    unreachable
   end
  )
- (func $null (; 3 ;) (type $v)
+ (func $null (; 3 ;) (type $_)
  )
 )

--- a/tests/compiler/std/allocator_arena.optimized.wat
+++ b/tests/compiler/std/allocator_arena.optimized.wat
@@ -1,7 +1,7 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $iiiv (func (param i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $iii_ (func (param i32 i32 i32)))
+ (type $_ (func))
  (type $FUNCSIG$i (func (result i32)))
  (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$vii (func (param i32 i32)))
@@ -262,7 +262,7 @@
    end
   end
  )
- (func $~lib/internal/memory/memcpy (; 3 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 3 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1412,7 +1412,7 @@
    i32.const 0
   end
  )
- (func $start (; 6 ;) (type $v)
+ (func $start (; 6 ;) (type $_)
   i32.const 56
   global.set $~lib/allocator/arena/startOffset
   global.get $~lib/allocator/arena/startOffset
@@ -1524,7 +1524,7 @@
    unreachable
   end
  )
- (func $null (; 7 ;) (type $v)
+ (func $null (; 7 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/allocator_arena.untouched.wat
+++ b/tests/compiler/std/allocator_arena.untouched.wat
@@ -1,10 +1,10 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $iiiv (func (param i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $iii_ (func (param i32 i32 i32)))
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iv (func (param i32)))
- (type $v (func))
+ (type $i_ (func (param i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\16\00\00\00s\00t\00d\00/\00a\00l\00l\00o\00c\00a\00t\00o\00r\00_\00a\00r\00e\00n\00a\00.\00t\00s\00")
@@ -103,7 +103,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/internal/memory/memset (; 2 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 2 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -357,7 +357,7 @@
    end
   end
  )
- (func $~lib/internal/memory/memcpy (; 3 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 3 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1558,7 +1558,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 4 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 4 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -1839,14 +1839,14 @@
    i32.const 0
   end
  )
- (func $~lib/allocator/arena/__memory_free (; 6 ;) (type $iv) (param $0 i32)
+ (func $~lib/allocator/arena/__memory_free (; 6 ;) (type $i_) (param $0 i32)
   nop
  )
- (func $~lib/allocator/arena/__memory_reset (; 7 ;) (type $v)
+ (func $~lib/allocator/arena/__memory_reset (; 7 ;) (type $_)
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $start (; 8 ;) (type $v)
+ (func $start (; 8 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2046,6 +2046,6 @@
    unreachable
   end
  )
- (func $null (; 9 ;) (type $v)
+ (func $null (; 9 ;) (type $_)
  )
 )

--- a/tests/compiler/std/array-access.optimized.wat
+++ b/tests/compiler/std/array-access.optimized.wat
@@ -1,7 +1,7 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (type $FUNCSIG$iiiii (func (param i32 i32 i32 i32) (result i32)))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
@@ -225,7 +225,7 @@
   end
   call $~lib/string/String#startsWith
  )
- (func $null (; 8 ;) (type $v)
+ (func $null (; 8 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/array-access.untouched.wat
+++ b/tests/compiler/std/array-access.untouched.wat
@@ -2,9 +2,9 @@
  (type $ii (func (param i32) (result i32)))
  (type $iii (func (param i32 i32) (result i32)))
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $iiiiii (func (param i32 i32 i32 i32 i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\00\00\00\00")
@@ -316,6 +316,6 @@
   i32.const 0
   call $~lib/string/String#startsWith
  )
- (func $null (; 12 ;) (type $v)
+ (func $null (; 12 ;) (type $_)
  )
 )

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -1,7 +1,7 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $ii (func (param i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (type $FUNCSIG$vii (func (param i32 i32)))
  (type $FUNCSIG$i (func (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
@@ -391,7 +391,7 @@
   call $~lib/internal/memory/memset
   local.get $0
  )
- (func $start (; 6 ;) (type $v)
+ (func $start (; 6 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 232
@@ -895,7 +895,7 @@
    unreachable
   end
  )
- (func $null (; 7 ;) (type $v)
+ (func $null (; 7 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -1,9 +1,9 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $iii (func (param i32 i32) (result i32)))
  (type $ii (func (param i32) (result i32)))
- (type $iiiv (func (param i32 i32 i32)))
- (type $v (func))
+ (type $iii_ (func (param i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\03\00\00\00\00\00\00\00\00\01\02\00\00\00\00\00")
@@ -228,7 +228,7 @@
   call $~lib/allocator/arena/__memory_allocate
   return
  )
- (func $~lib/internal/memory/memset (; 7 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 7 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -543,7 +543,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<i8>#__unchecked_set (; 9 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i8>#__unchecked_set (; 9 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -628,7 +628,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<i32>#__unchecked_set (; 11 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__unchecked_set (; 11 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -723,7 +723,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<Ref>#__unchecked_set (; 14 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<Ref>#__unchecked_set (; 14 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -818,7 +818,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<RefWithCtor>#__unchecked_set (; 17 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<RefWithCtor>#__unchecked_set (; 17 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -842,7 +842,7 @@
   local.get $5
   i32.store offset=8
  )
- (func $start (; 18 ;) (type $v)
+ (func $start (; 18 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1282,6 +1282,6 @@
    unreachable
   end
  )
- (func $null (; 19 ;) (type $v)
+ (func $null (; 19 ;) (type $_)
  )
 )

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -1,26 +1,26 @@
 (module
  (type $iii (func (param i32 i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $ii (func (param i32) (result i32)))
- (type $iiiv (func (param i32 i32 i32)))
+ (type $iii_ (func (param i32 i32 i32)))
  (type $iiiii (func (param i32 i32 i32 i32) (result i32)))
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iv (func (param i32)))
- (type $iiv (func (param i32 i32)))
+ (type $i_ (func (param i32)))
+ (type $ii_ (func (param i32 i32)))
  (type $iiif (func (param i32 i32 i32) (result f32)))
  (type $F (func (result f64)))
- (type $Iv (func (param i64)))
+ (type $I_ (func (param i64)))
  (type $ffi (func (param f32 f32) (result i32)))
  (type $FFi (func (param f64 f64) (result i32)))
  (type $Fi (func (param f64) (result i32)))
- (type $iiiiiv (func (param i32 i32 i32 i32 i32)))
+ (type $iiiii_ (func (param i32 i32 i32 i32 i32)))
  (type $iFi (func (param i32 f64) (result i32)))
  (type $iIiIiIii (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
  (type $iiFi (func (param i32 i32 f64) (result i32)))
  (type $Ii (func (param i64) (result i32)))
- (type $iIiv (func (param i32 i64 i32)))
+ (type $iIi_ (func (param i32 i64 i32)))
  (type $iiIi (func (param i32 i32 i64) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
@@ -487,7 +487,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memset (; 4 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 4 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i64)
   local.get $2
@@ -1163,7 +1163,7 @@
   local.get $3
   call $~lib/array/Array<u32>#fill
  )
- (func $~lib/internal/memory/memcpy (; 13 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 13 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2060,7 +2060,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 14 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 14 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -3024,7 +3024,7 @@
   local.get $2
   call $~lib/array/Array<i32>#splice
  )
- (func $~lib/array/Array<i32>#__set (; 27 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__set (; 27 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -3312,13 +3312,13 @@
   i32.const 3
   i32.gt_s
  )
- (func $start~anonymous|17 (; 46 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start~anonymous|17 (; 46 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   global.get $std/array/i
   local.get $0
   i32.add
   global.set $std/array/i
  )
- (func $~lib/array/Array<i32>#forEach (; 47 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#forEach (; 47 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3351,7 +3351,7 @@
     local.get $2
     local.get $0
     local.get $1
-    call_indirect (type $iiiv)
+    call_indirect (type $iii_)
     local.get $2
     i32.const 1
     i32.add
@@ -3362,7 +3362,7 @@
    unreachable
   end
  )
- (func $start~anonymous|18 (; 48 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start~anonymous|18 (; 48 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3372,7 +3372,7 @@
   i32.add
   global.set $std/array/i
  )
- (func $start~anonymous|20 (; 49 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start~anonymous|20 (; 49 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -3381,7 +3381,7 @@
   i32.add
   global.set $std/array/i
  )
- (func $start~anonymous|21 (; 50 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start~anonymous|21 (; 50 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
   i32.eqz
@@ -3869,7 +3869,7 @@
   i32.shr_u
   i32.xor
  )
- (func $~lib/math/NativeMath.seedRandom (; 70 ;) (type $Iv) (param $0 i64)
+ (func $~lib/math/NativeMath.seedRandom (; 70 ;) (type $I_) (param $0 i64)
   (local $1 i64)
   local.get $0
   i64.eqz
@@ -5696,7 +5696,7 @@
   end
   i32.const 1
  )
- (func $std/array/assertSorted<i32> (; 90 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<i32> (; 90 ;) (type $ii_) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   call $~lib/array/Array<i32>#sort
@@ -5712,7 +5712,7 @@
    unreachable
   end
  )
- (func $std/array/assertSortedDefault<i32> (; 91 ;) (type $iv) (param $0 i32)
+ (func $std/array/assertSortedDefault<i32> (; 91 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 48
   call $std/array/assertSorted<i32>
@@ -5871,7 +5871,7 @@
   call $~lib/internal/sort/insertionSort<i32>
   local.get $0
  )
- (func $std/array/assertSorted<Array<i32>> (; 96 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<Array<i32>> (; 96 ;) (type $ii_) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   call $~lib/array/Array<Array<i32>>#sort
@@ -6224,7 +6224,7 @@
   i32.store16 offset=4
   local.get $1
  )
- (func $~lib/internal/string/copyUnsafe (; 106 ;) (type $iiiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
+ (func $~lib/internal/string/copyUnsafe (; 106 ;) (type $iiiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
   local.get $1
   i32.const 1
   i32.shl
@@ -6641,7 +6641,7 @@
    end
   end
  )
- (func $~lib/internal/number/utoa32_lut (; 114 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/number/utoa32_lut (; 114 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   i32.const 4832
@@ -8991,7 +8991,7 @@
    end
   end
  )
- (func $~lib/internal/number/utoa64_lut (; 134 ;) (type $iIiv) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/internal/number/utoa64_lut (; 134 ;) (type $iIi_) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -10043,7 +10043,7 @@
   end
   local.get $1
  )
- (func $start (; 147 ;) (type $v)
+ (func $start (; 147 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 8432
@@ -14498,7 +14498,7 @@
    unreachable
   end
  )
- (func $null (; 148 ;) (type $v)
+ (func $null (; 148 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -1,16 +1,16 @@
 (module
  (type $iii (func (param i32 i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $ii (func (param i32) (result i32)))
- (type $iiiv (func (param i32 i32 i32)))
+ (type $iii_ (func (param i32 i32 i32)))
  (type $iiiii (func (param i32 i32 i32 i32) (result i32)))
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iv (func (param i32)))
- (type $iiv (func (param i32 i32)))
+ (type $i_ (func (param i32)))
+ (type $ii_ (func (param i32 i32)))
  (type $iiif (func (param i32 i32 i32) (result f32)))
  (type $iif (func (param i32 i32) (result f32)))
  (type $F (func (result f64)))
- (type $Iv (func (param i64)))
+ (type $I_ (func (param i64)))
  (type $II (func (param i64) (result i64)))
  (type $ffi (func (param f32 f32) (result i32)))
  (type $fi (func (param f32) (result i32)))
@@ -18,14 +18,14 @@
  (type $iiF (func (param i32 i32) (result f64)))
  (type $Fi (func (param f64) (result i32)))
  (type $iiiiii (func (param i32 i32 i32 i32 i32) (result i32)))
- (type $iiiiiv (func (param i32 i32 i32 i32 i32)))
+ (type $iiiii_ (func (param i32 i32 i32 i32 i32)))
  (type $iFi (func (param i32 f64) (result i32)))
  (type $iIiIiIii (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
  (type $iiFi (func (param i32 i32 f64) (result i32)))
  (type $Ii (func (param i64) (result i32)))
- (type $iIiv (func (param i32 i64 i32)))
+ (type $iIi_ (func (param i32 i64 i32)))
  (type $iiIi (func (param i32 i32 i64) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (import "Math" "random" (func $~lib/bindings/Math/random (result f64)))
  (memory $0 1)
@@ -566,7 +566,7 @@
   call $~lib/allocator/arena/__memory_allocate
   return
  )
- (func $~lib/internal/memory/memset (; 6 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 6 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -1471,7 +1471,7 @@
   i32.const 2
   i32.shr_s
  )
- (func $~lib/internal/memory/memcpy (; 26 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 26 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2672,7 +2672,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 27 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 27 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -2899,7 +2899,7 @@
    end
   end
  )
- (func $~lib/allocator/arena/__memory_free (; 28 ;) (type $iv) (param $0 i32)
+ (func $~lib/allocator/arena/__memory_free (; 28 ;) (type $i_) (param $0 i32)
   nop
  )
  (func $~lib/internal/arraybuffer/reallocateUnsafe (; 29 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
@@ -4078,7 +4078,7 @@
   local.get $2
   call $~lib/array/Array<i32>#splice
  )
- (func $~lib/array/Array<i32>#__set (; 43 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__set (; 43 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4457,13 +4457,13 @@
   i32.const 3
   i32.gt_s
  )
- (func $start~anonymous|17 (; 63 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start~anonymous|17 (; 63 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   global.get $std/array/i
   local.get $0
   i32.add
   global.set $std/array/i
  )
- (func $~lib/array/Array<i32>#forEach (; 64 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#forEach (; 64 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4514,7 +4514,7 @@
      local.get $2
      local.get $0
      local.get $1
-     call_indirect (type $iiiv)
+     call_indirect (type $iii_)
     end
     local.get $2
     i32.const 1
@@ -4526,7 +4526,7 @@
    unreachable
   end
  )
- (func $start~anonymous|18 (; 65 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start~anonymous|18 (; 65 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -4536,13 +4536,13 @@
   i32.add
   global.set $std/array/i
  )
- (func $start~anonymous|19 (; 66 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start~anonymous|19 (; 66 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   global.get $std/array/i
   local.get $0
   i32.add
   global.set $std/array/i
  )
- (func $start~anonymous|20 (; 67 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start~anonymous|20 (; 67 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -4551,7 +4551,7 @@
   i32.add
   global.set $std/array/i
  )
- (func $start~anonymous|21 (; 68 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start~anonymous|21 (; 68 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
   i32.const 0
@@ -5525,7 +5525,7 @@
   i32.shr_u
   i32.xor
  )
- (func $~lib/math/NativeMath.seedRandom (; 102 ;) (type $Iv) (param $0 i64)
+ (func $~lib/math/NativeMath.seedRandom (; 102 ;) (type $I_) (param $0 i64)
   local.get $0
   i64.eqz
   if
@@ -5554,7 +5554,7 @@
   call $~lib/math/splitMix32
   global.set $~lib/math/random_state1_32
  )
- (func $~lib/internal/sort/insertionSort<f32> (; 103 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<f32> (; 103 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -5695,7 +5695,7 @@
    unreachable
   end
  )
- (func $~lib/internal/sort/weakHeapSort<f32> (; 104 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/weakHeapSort<f32> (; 104 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -6513,7 +6513,7 @@
   end
   i32.const 1
  )
- (func $~lib/internal/sort/insertionSort<f64> (; 110 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<f64> (; 110 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -6654,7 +6654,7 @@
    unreachable
   end
  )
- (func $~lib/internal/sort/weakHeapSort<f64> (; 111 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/weakHeapSort<f64> (; 111 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -7505,7 +7505,7 @@
   end
   i32.const 1
  )
- (func $~lib/internal/sort/insertionSort<i32> (; 118 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<i32> (; 118 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -7646,7 +7646,7 @@
    unreachable
   end
  )
- (func $~lib/internal/sort/weakHeapSort<i32> (; 119 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/weakHeapSort<i32> (; 119 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -8351,7 +8351,7 @@
   local.get $1
   call $~lib/array/Array<i32>#sort
  )
- (func $~lib/internal/sort/insertionSort<u32> (; 123 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<u32> (; 123 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -8492,7 +8492,7 @@
    unreachable
   end
  )
- (func $~lib/internal/sort/weakHeapSort<u32> (; 124 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/weakHeapSort<u32> (; 124 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -9407,7 +9407,7 @@
   end
   i32.const 1
  )
- (func $std/array/assertSorted<i32> (; 133 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<i32> (; 133 ;) (type $ii_) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   call $~lib/array/Array<i32>#sort
@@ -9423,7 +9423,7 @@
    unreachable
   end
  )
- (func $std/array/assertSortedDefault<i32> (; 134 ;) (type $iv) (param $0 i32)
+ (func $std/array/assertSortedDefault<i32> (; 134 ;) (type $i_) (param $0 i32)
   local.get $0
   block $~lib/internal/sort/COMPARATOR<i32>|inlined.1 (result i32)
    i32.const 48
@@ -9512,7 +9512,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<Array<i32>>#__set (; 140 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<Array<i32>>#__set (; 140 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9677,7 +9677,7 @@
   call $~lib/array/Array<i32>#__get
   i32.sub
  )
- (func $~lib/internal/sort/insertionSort<Array<i32>> (; 144 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<Array<i32>> (; 144 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -10010,7 +10010,7 @@
   end
   i32.const 1
  )
- (func $std/array/assertSorted<Array<i32>> (; 147 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<Array<i32>> (; 147 ;) (type $ii_) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   call $~lib/array/Array<Array<i32>>#sort
@@ -10100,7 +10100,7 @@
   i32.store
   local.get $0
  )
- (func $~lib/array/Array<Proxy<i32>>#__set (; 150 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<Proxy<i32>>#__set (; 150 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -10222,7 +10222,7 @@
   i32.load
   i32.sub
  )
- (func $~lib/internal/sort/insertionSort<Proxy<i32>> (; 153 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<Proxy<i32>> (; 153 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -10588,7 +10588,7 @@
   end
   i32.const 1
  )
- (func $std/array/assertSorted<Proxy<i32>> (; 157 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<Proxy<i32>> (; 157 ;) (type $ii_) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   call $~lib/array/Array<Proxy<i32>>#sort
@@ -10604,7 +10604,7 @@
    unreachable
   end
  )
- (func $~lib/internal/sort/insertionSort<String> (; 158 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<String> (; 158 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -10970,7 +10970,7 @@
   end
   i32.const 1
  )
- (func $std/array/assertSorted<String> (; 162 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<String> (; 162 ;) (type $ii_) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   call $~lib/array/Array<String>#sort
@@ -11112,7 +11112,7 @@
   select
   call $~lib/internal/string/compareUnsafe
  )
- (func $std/array/assertSorted<String>|trampoline (; 165 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<String>|trampoline (; 165 ;) (type $ii_) (param $0 i32) (param $1 i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -11382,7 +11382,7 @@
   i32.store16 offset=4
   local.get $2
  )
- (func $~lib/internal/string/copyUnsafe (; 172 ;) (type $iiiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
+ (func $~lib/internal/string/copyUnsafe (; 172 ;) (type $iiiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -11522,7 +11522,7 @@
   end
   local.get $1
  )
- (func $~lib/array/Array<String>#__set (; 176 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<String>#__set (; 176 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12036,7 +12036,7 @@
   unreachable
   unreachable
  )
- (func $~lib/internal/number/utoa32_lut (; 181 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/number/utoa32_lut (; 181 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -14870,7 +14870,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<Ref>#__unchecked_set (; 200 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<Ref>#__unchecked_set (; 200 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15663,7 +15663,7 @@
   unreachable
   unreachable
  )
- (func $~lib/internal/number/utoa64_lut (; 209 ;) (type $iIiv) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/internal/number/utoa64_lut (; 209 ;) (type $iIi_) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -17356,7 +17356,7 @@
   local.get $3
   return
  )
- (func $start (; 225 ;) (type $v)
+ (func $start (; 225 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -21857,6 +21857,6 @@
    unreachable
   end
  )
- (func $null (; 226 ;) (type $v)
+ (func $null (; 226 ;) (type $_)
  )
 )

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -1,11 +1,11 @@
 (module
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $ii (func (param i32) (result i32)))
- (type $iiiv (func (param i32 i32 i32)))
+ (type $iii_ (func (param i32 i32 i32)))
  (type $iii (func (param i32 i32) (result i32)))
  (type $iiiii (func (param i32 i32 i32 i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (type $FUNCSIG$vii (func (param i32 i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
@@ -337,7 +337,7 @@
    end
   end
  )
- (func $~lib/internal/memory/memcpy (; 4 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 4 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1234,7 +1234,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 5 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 5 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -1710,7 +1710,7 @@
   local.get $1
   call $~lib/dataview/DataView#constructor
  )
- (func $start (; 12 ;) (type $v)
+ (func $start (; 12 ;) (type $_)
   (local $0 i32)
   i32.const 288
   global.set $~lib/allocator/arena/startOffset
@@ -1967,7 +1967,7 @@
    unreachable
   end
  )
- (func $null (; 13 ;) (type $v)
+ (func $null (; 13 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/arraybuffer.untouched.wat
+++ b/tests/compiler/std/arraybuffer.untouched.wat
@@ -1,11 +1,11 @@
 (module
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $ii (func (param i32) (result i32)))
- (type $iiiv (func (param i32 i32 i32)))
+ (type $iii_ (func (param i32 i32 i32)))
  (type $iii (func (param i32 i32) (result i32)))
  (type $iiiii (func (param i32 i32 i32 i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\13\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
@@ -154,7 +154,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memset (; 4 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 4 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -447,7 +447,7 @@
   end
   local.get $3
  )
- (func $~lib/internal/memory/memcpy (; 6 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 6 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1648,7 +1648,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 7 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 7 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -2301,7 +2301,7 @@
   local.get $3
   call $~lib/dataview/DataView#constructor
  )
- (func $start (; 22 ;) (type $v)
+ (func $start (; 22 ;) (type $_)
   (local $0 i32)
   global.get $HEAP_BASE
   global.get $~lib/internal/allocator/AL_MASK
@@ -2660,6 +2660,6 @@
    unreachable
   end
  )
- (func $null (; 23 ;) (type $v)
+ (func $null (; 23 ;) (type $_)
  )
 )

--- a/tests/compiler/std/constructor.optimized.wat
+++ b/tests/compiler/std/constructor.optimized.wat
@@ -1,6 +1,6 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (type $FUNCSIG$i (func (result i32)))
  (memory $0 0)
  (table $0 1 funcref)
@@ -101,7 +101,7 @@
   i32.store
   local.get $0
  )
- (func $start (; 3 ;) (type $v)
+ (func $start (; 3 ;) (type $_)
   (local $0 i32)
   i32.const 8
   global.set $~lib/allocator/arena/startOffset
@@ -156,7 +156,7 @@
   local.get $0
   global.set $std/constructor/ctorConditionallyAllocates
  )
- (func $null (; 4 ;) (type $v)
+ (func $null (; 4 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/constructor.untouched.wat
+++ b/tests/compiler/std/constructor.untouched.wat
@@ -1,6 +1,6 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -251,7 +251,7 @@
   end
   local.get $0
  )
- (func $start (; 12 ;) (type $v)
+ (func $start (; 12 ;) (type $_)
   global.get $HEAP_BASE
   global.get $~lib/internal/allocator/AL_MASK
   i32.add
@@ -293,6 +293,6 @@
   call $std/constructor/CtorConditionallyAllocates#constructor
   global.set $std/constructor/ctorConditionallyAllocates
  )
- (func $null (; 13 ;) (type $v)
+ (func $null (; 13 ;) (type $_)
  )
 )

--- a/tests/compiler/std/dataview.optimized.wat
+++ b/tests/compiler/std/dataview.optimized.wat
@@ -1,12 +1,12 @@
 (module
  (type $iii (func (param i32 i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $ii (func (param i32) (result i32)))
- (type $iiiv (func (param i32 i32 i32)))
+ (type $iii_ (func (param i32 i32 i32)))
  (type $iiif (func (param i32 i32 i32) (result f32)))
  (type $II (func (param i64) (result i64)))
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (type $FUNCSIG$vii (func (param i32 i32)))
  (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
  (type $FUNCSIG$dii (func (param i32 i32) (result f64)))
@@ -385,7 +385,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/internal/typedarray/TypedArray<u8>#__set (; 5 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<u8>#__set (; 5 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1096,7 +1096,7 @@
   local.get $1
   i32.store16 offset=8
  )
- (func $start (; 23 ;) (type $v)
+ (func $start (; 23 ;) (type $_)
   (local $0 i32)
   i32.const 216
   global.set $~lib/allocator/arena/startOffset
@@ -2625,7 +2625,7 @@
    unreachable
   end
  )
- (func $null (; 24 ;) (type $v)
+ (func $null (; 24 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/dataview.untouched.wat
+++ b/tests/compiler/std/dataview.untouched.wat
@@ -1,18 +1,18 @@
 (module
  (type $iii (func (param i32 i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $ii (func (param i32) (result i32)))
- (type $iiiv (func (param i32 i32 i32)))
+ (type $iii_ (func (param i32 i32 i32)))
  (type $iiiii (func (param i32 i32 i32 i32) (result i32)))
  (type $iiif (func (param i32 i32 i32) (result f32)))
  (type $iiiF (func (param i32 i32 i32) (result f64)))
  (type $II (func (param i64) (result i64)))
  (type $iiii (func (param i32 i32 i32) (result i32)))
  (type $iiiI (func (param i32 i32 i32) (result i64)))
- (type $iifiv (func (param i32 i32 f32 i32)))
- (type $iiFiv (func (param i32 i32 f64 i32)))
- (type $iiIiv (func (param i32 i32 i64 i32)))
- (type $v (func))
+ (type $iifi_ (func (param i32 i32 f32 i32)))
+ (type $iiFi_ (func (param i32 i32 f64 i32)))
+ (type $iiIi_ (func (param i32 i32 i64 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\1b\00\00\00~\00l\00i\00b\00/\00i\00n\00t\00e\00r\00n\00a\00l\00/\00t\00y\00p\00e\00d\00a\00r\00r\00a\00y\00.\00t\00s\00")
@@ -156,7 +156,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memset (; 4 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 4 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -496,7 +496,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/internal/typedarray/TypedArray<u8>#__set (; 8 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<u8>#__set (; 8 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1276,7 +1276,7 @@
    call $~lib/polyfills/bswap<u64>
   end
  )
- (func $~lib/dataview/DataView#setFloat32 (; 26 ;) (type $iifiv) (param $0 i32) (param $1 i32) (param $2 f32) (param $3 i32)
+ (func $~lib/dataview/DataView#setFloat32 (; 26 ;) (type $iifi_) (param $0 i32) (param $1 i32) (param $2 f32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1338,7 +1338,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/dataview/DataView#setFloat64 (; 27 ;) (type $iiFiv) (param $0 i32) (param $1 i32) (param $2 f64) (param $3 i32)
+ (func $~lib/dataview/DataView#setFloat64 (; 27 ;) (type $iiFi_) (param $0 i32) (param $1 i32) (param $2 f64) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1400,7 +1400,7 @@
    i64.store offset=8
   end
  )
- (func $~lib/dataview/DataView#setInt8 (; 28 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/dataview/DataView#setInt8 (; 28 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1445,7 +1445,7 @@
   local.get $2
   i32.store8 offset=8
  )
- (func $~lib/dataview/DataView#setInt16 (; 29 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/dataview/DataView#setInt16 (; 29 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1498,7 +1498,7 @@
   end
   i32.store16 offset=8
  )
- (func $~lib/dataview/DataView#setInt32 (; 30 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/dataview/DataView#setInt32 (; 30 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1551,7 +1551,7 @@
   end
   i32.store offset=8
  )
- (func $~lib/dataview/DataView#setInt64 (; 31 ;) (type $iiIiv) (param $0 i32) (param $1 i32) (param $2 i64) (param $3 i32)
+ (func $~lib/dataview/DataView#setInt64 (; 31 ;) (type $iiIi_) (param $0 i32) (param $1 i32) (param $2 i64) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1604,7 +1604,7 @@
   end
   i64.store offset=8
  )
- (func $~lib/dataview/DataView#setUint8 (; 32 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/dataview/DataView#setUint8 (; 32 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1649,7 +1649,7 @@
   local.get $2
   i32.store8 offset=8
  )
- (func $~lib/dataview/DataView#setUint16 (; 33 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/dataview/DataView#setUint16 (; 33 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1702,7 +1702,7 @@
   end
   i32.store16 offset=8
  )
- (func $~lib/dataview/DataView#setUint32 (; 34 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/dataview/DataView#setUint32 (; 34 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1755,7 +1755,7 @@
   end
   i32.store offset=8
  )
- (func $~lib/dataview/DataView#setUint64 (; 35 ;) (type $iiIiv) (param $0 i32) (param $1 i32) (param $2 i64) (param $3 i32)
+ (func $~lib/dataview/DataView#setUint64 (; 35 ;) (type $iiIi_) (param $0 i32) (param $1 i32) (param $2 i64) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1808,7 +1808,7 @@
   end
   i64.store offset=8
  )
- (func $start (; 36 ;) (type $v)
+ (func $start (; 36 ;) (type $_)
   global.get $HEAP_BASE
   global.get $~lib/internal/allocator/AL_MASK
   i32.add
@@ -3501,6 +3501,6 @@
    unreachable
   end
  )
- (func $null (; 37 ;) (type $v)
+ (func $null (; 37 ;) (type $_)
  )
 )

--- a/tests/compiler/std/date.optimized.wat
+++ b/tests/compiler/std/date.optimized.wat
@@ -1,9 +1,9 @@
 (module
  (type $iiiiiiFF (func (param i32 i32 i32 i32 i32 i32 f64) (result f64)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $F (func (result f64)))
  (type $ii (func (param i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (import "Date" "UTC" (func $~lib/bindings/Date/UTC (param i32 i32 i32 i32 i32 i32 f64) (result f64)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (import "Date" "now" (func $~lib/bindings/Date/now (result f64)))
@@ -80,7 +80,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $start (; 4 ;) (type $v)
+ (func $start (; 4 ;) (type $_)
   (local $0 i32)
   (local $1 i64)
   i32.const 40
@@ -202,7 +202,7 @@
    unreachable
   end
  )
- (func $null (; 5 ;) (type $v)
+ (func $null (; 5 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -1,12 +1,12 @@
 (module
  (type $iiiiiiFF (func (param i32 i32 i32 i32 i32 i32 f64) (result f64)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $F (func (result f64)))
  (type $iIi (func (param i32 i64) (result i32)))
  (type $ii (func (param i32) (result i32)))
  (type $iI (func (param i32) (result i64)))
  (type $iII (func (param i32 i64) (result i64)))
- (type $v (func))
+ (type $_ (func))
  (import "Date" "UTC" (func $~lib/bindings/Date/UTC (param i32 i32 i32 i32 i32 i32 f64) (result f64)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (import "Date" "now" (func $~lib/bindings/Date/now (result f64)))
@@ -138,7 +138,7 @@
   i64.store
   local.get $1
  )
- (func $start (; 8 ;) (type $v)
+ (func $start (; 8 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -323,6 +323,6 @@
    unreachable
   end
  )
- (func $null (; 9 ;) (type $v)
+ (func $null (; 9 ;) (type $_)
  )
 )

--- a/tests/compiler/std/gc-array.optimized.wat
+++ b/tests/compiler/std/gc-array.optimized.wat
@@ -1,11 +1,11 @@
 (module
- (type $iv (func (param i32)))
+ (type $i_ (func (param i32)))
  (type $ii (func (param i32) (result i32)))
- (type $iiv (func (param i32 i32)))
- (type $v (func))
+ (type $ii_ (func (param i32 i32)))
+ (type $_ (func))
  (type $iii (func (param i32 i32) (result i32)))
- (type $iiiv (func (param i32 i32 i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iii_ (func (param i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $i (func (result i32)))
  (type $FUNCSIG$vii (func (param i32 i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
@@ -29,7 +29,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "main" (func $std/gc-array/main))
- (func $~lib/arraybuffer/ArrayBuffer~gc (; 1 ;) (type $iv) (param $0 i32)
+ (func $~lib/arraybuffer/ArrayBuffer~gc (; 1 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.eqz
   if
@@ -38,7 +38,7 @@
   local.get $0
   call $~lib/collector/itcm/__gc_mark
  )
- (func $~lib/collector/itcm/ManagedObjectList#push (; 2 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/ManagedObjectList#push (; 2 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=4
@@ -66,7 +66,7 @@
   local.get $1
   i32.store offset=4
  )
- (func $~lib/collector/itcm/ManagedObject#makeGray (; 3 ;) (type $iv) (param $0 i32)
+ (func $~lib/collector/itcm/ManagedObject#makeGray (; 3 ;) (type $i_) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   global.get $~lib/collector/itcm/iter
@@ -106,7 +106,7 @@
   i32.or
   i32.store
  )
- (func $~lib/collector/itcm/__gc_mark (; 4 ;) (type $iv) (param $0 i32)
+ (func $~lib/collector/itcm/__gc_mark (; 4 ;) (type $i_) (param $0 i32)
   (local $1 i32)
   local.get $0
   if
@@ -125,7 +125,7 @@
    end
   end
  )
- (func $~lib/array/Array<Foo>~gc (; 5 ;) (type $iv) (param $0 i32)
+ (func $~lib/array/Array<Foo>~gc (; 5 ;) (type $i_) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -217,10 +217,10 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/allocator/arena/__memory_free (; 7 ;) (type $iv) (param $0 i32)
+ (func $~lib/allocator/arena/__memory_free (; 7 ;) (type $i_) (param $0 i32)
   nop
  )
- (func $~lib/collector/itcm/step (; 8 ;) (type $v)
+ (func $~lib/collector/itcm/step (; 8 ;) (type $_)
   (local $0 i32)
   block $break|0
    block $case3|0
@@ -267,7 +267,7 @@
      end
      global.get $std/gc-array/arr
      i32.const 3
-     call_indirect (type $iv)
+     call_indirect (type $i_)
      i32.const 2
      global.set $~lib/collector/itcm/state
      br $break|0
@@ -298,11 +298,11 @@
      i32.add
      local.get $0
      i32.load offset=8
-     call_indirect (type $iv)
+     call_indirect (type $i_)
     else     
      global.get $std/gc-array/arr
      i32.const 3
-     call_indirect (type $iv)
+     call_indirect (type $i_)
      global.get $~lib/collector/itcm/toSpace
      global.get $~lib/collector/itcm/iter
      i32.load
@@ -353,7 +353,7 @@
    end
   end
  )
- (func $~lib/collector/itcm/__gc_collect (; 9 ;) (type $v)
+ (func $~lib/collector/itcm/__gc_collect (; 9 ;) (type $_)
   (local $0 i32)
   block $break|0
    block $case1|0
@@ -438,7 +438,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memcpy (; 12 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 12 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1335,7 +1335,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 13 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 13 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -1834,7 +1834,7 @@
   end
   local.get $0
  )
- (func $~lib/collector/itcm/__gc_link (; 16 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/__gc_link (; 16 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   global.get $~lib/collector/itcm/white
   i32.eqz
@@ -1864,7 +1864,7 @@
    call $~lib/collector/itcm/ManagedObject#makeGray
   end
  )
- (func $~lib/array/Array<Foo>#__set (; 17 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<Foo>#__set (; 17 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -1923,7 +1923,7 @@
   end
   i32.const 0
  )
- (func $start (; 19 ;) (type $v)
+ (func $start (; 19 ;) (type $_)
   i32.const 184
   global.set $~lib/allocator/arena/startOffset
   global.get $~lib/allocator/arena/startOffset
@@ -1953,7 +1953,7 @@
   call $~lib/array/Array<Foo>#__set
   call $~lib/collector/itcm/__gc_collect
  )
- (func $null (; 20 ;) (type $v)
+ (func $null (; 20 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/gc-array.untouched.wat
+++ b/tests/compiler/std/gc-array.untouched.wat
@@ -1,11 +1,11 @@
 (module
- (type $iv (func (param i32)))
+ (type $i_ (func (param i32)))
  (type $ii (func (param i32) (result i32)))
- (type $iiv (func (param i32 i32)))
- (type $v (func))
+ (type $ii_ (func (param i32 i32)))
+ (type $_ (func))
  (type $iii (func (param i32 i32) (result i32)))
- (type $iiiv (func (param i32 i32 i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iii_ (func (param i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $i (func (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -41,7 +41,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "main" (func $std/gc-array/main))
- (func $~lib/arraybuffer/ArrayBuffer~gc (; 1 ;) (type $iv) (param $0 i32)
+ (func $~lib/arraybuffer/ArrayBuffer~gc (; 1 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.eqz
   if
@@ -64,7 +64,7 @@
   i32.xor
   i32.and
  )
- (func $~lib/collector/itcm/ManagedObject#set:next (; 4 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/ManagedObject#set:next (; 4 ;) (type $ii_) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   local.get $0
@@ -74,7 +74,7 @@
   i32.or
   i32.store
  )
- (func $~lib/collector/itcm/ManagedObject#unlink (; 5 ;) (type $iv) (param $0 i32)
+ (func $~lib/collector/itcm/ManagedObject#unlink (; 5 ;) (type $i_) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -90,7 +90,7 @@
   local.get $1
   call $~lib/collector/itcm/ManagedObject#set:next
  )
- (func $~lib/collector/itcm/ManagedObjectList#push (; 6 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/ManagedObjectList#push (; 6 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=4
@@ -108,7 +108,7 @@
   local.get $1
   i32.store offset=4
  )
- (func $~lib/collector/itcm/ManagedObject#makeGray (; 7 ;) (type $iv) (param $0 i32)
+ (func $~lib/collector/itcm/ManagedObject#makeGray (; 7 ;) (type $i_) (param $0 i32)
   local.get $0
   global.get $~lib/collector/itcm/iter
   i32.eq
@@ -133,7 +133,7 @@
   i32.or
   i32.store
  )
- (func $~lib/collector/itcm/__gc_mark (; 8 ;) (type $iv) (param $0 i32)
+ (func $~lib/collector/itcm/__gc_mark (; 8 ;) (type $i_) (param $0 i32)
   (local $1 i32)
   local.get $0
   if
@@ -155,7 +155,7 @@
    end
   end
  )
- (func $~lib/array/Array<Foo>~gc (; 9 ;) (type $iv) (param $0 i32)
+ (func $~lib/array/Array<Foo>~gc (; 9 ;) (type $i_) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -272,7 +272,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/collector/itcm/ManagedObjectList#clear (; 11 ;) (type $iv) (param $0 i32)
+ (func $~lib/collector/itcm/ManagedObjectList#clear (; 11 ;) (type $i_) (param $0 i32)
   local.get $0
   local.get $0
   i32.store
@@ -280,7 +280,7 @@
   local.get $0
   i32.store offset=4
  )
- (func $~lib/collector/itcm/ManagedObject#set:color (; 12 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/ManagedObject#set:color (; 12 ;) (type $ii_) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $0
   i32.load
@@ -292,10 +292,10 @@
   i32.or
   i32.store
  )
- (func $~lib/allocator/arena/__memory_free (; 13 ;) (type $iv) (param $0 i32)
+ (func $~lib/allocator/arena/__memory_free (; 13 ;) (type $i_) (param $0 i32)
   nop
  )
- (func $~lib/collector/itcm/step (; 14 ;) (type $v)
+ (func $~lib/collector/itcm/step (; 14 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   block $break|0
@@ -391,7 +391,7 @@
       end
       local.get $0
       i32.load offset=8
-      call_indirect (type $iv)
+      call_indirect (type $i_)
      else      
       i32.const 3
       call $~iterateRoots
@@ -457,7 +457,7 @@
    unreachable
   end
  )
- (func $~lib/collector/itcm/__gc_collect (; 15 ;) (type $v)
+ (func $~lib/collector/itcm/__gc_collect (; 15 ;) (type $_)
   (local $0 i32)
   block $break|0
    block $case1|0
@@ -489,7 +489,7 @@
    end
   end
  )
- (func $~lib/gc/gc.collect (; 16 ;) (type $v)
+ (func $~lib/gc/gc.collect (; 16 ;) (type $_)
   call $~lib/collector/itcm/__gc_collect
   return
  )
@@ -532,7 +532,7 @@
    i32.add
   end
  )
- (func $std/gc-array/Foo~gc (; 18 ;) (type $iv) (param $0 i32)
+ (func $std/gc-array/Foo~gc (; 18 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.eqz
   if
@@ -541,7 +541,7 @@
   local.get $0
   call $~lib/collector/itcm/__gc_mark
  )
- (func $~lib/string/String~gc (; 19 ;) (type $iv) (param $0 i32)
+ (func $~lib/string/String~gc (; 19 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.eqz
   if
@@ -562,7 +562,7 @@
   i32.sub
   i32.shl
  )
- (func $~lib/internal/arraybuffer/__gc (; 21 ;) (type $iv) (param $0 i32)
+ (func $~lib/internal/arraybuffer/__gc (; 21 ;) (type $i_) (param $0 i32)
   nop
  )
  (func $~lib/internal/arraybuffer/allocateUnsafe (; 22 ;) (type $ii) (param $0 i32) (result i32)
@@ -589,7 +589,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memcpy (; 23 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 23 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1790,7 +1790,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 24 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 24 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -2017,7 +2017,7 @@
    end
   end
  )
- (func $~lib/internal/memory/memset (; 25 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 25 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -2371,7 +2371,7 @@
   end
   local.get $0
  )
- (func $~lib/collector/itcm/__gc_link (; 27 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/__gc_link (; 27 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   block $~lib/collector/itcm/refToObj|inlined.1 (result i32)
@@ -2407,7 +2407,7 @@
    call $~lib/collector/itcm/ManagedObject#makeGray
   end
  )
- (func $~lib/array/Array<Foo>#__set (; 28 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<Foo>#__set (; 28 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2487,7 +2487,7 @@
   end
   i32.const 0
  )
- (func $start (; 30 ;) (type $v)
+ (func $start (; 30 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2538,11 +2538,11 @@
   call $~lib/array/Array<Foo>#__set
   call $~lib/gc/gc.collect
  )
- (func $null (; 31 ;) (type $v)
+ (func $null (; 31 ;) (type $_)
  )
- (func $~iterateRoots (; 32 ;) (type $iv) (param $0 i32)
+ (func $~iterateRoots (; 32 ;) (type $i_) (param $0 i32)
   global.get $std/gc-array/arr
   local.get $0
-  call_indirect (type $iv)
+  call_indirect (type $i_)
  )
 )

--- a/tests/compiler/std/gc-basics.optimized.wat
+++ b/tests/compiler/std/gc-basics.optimized.wat
@@ -1,9 +1,9 @@
 (module
- (type $iv (func (param i32)))
- (type $v (func))
+ (type $i_ (func (param i32)))
+ (type $_ (func))
  (type $ii (func (param i32) (result i32)))
- (type $iiv (func (param i32 i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $ii_ (func (param i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $i (func (result i32)))
  (type $FUNCSIG$i (func (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
@@ -25,7 +25,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "main" (func $std/gc-basics/main))
- (func $std/gc-basics/MyObject_visit (; 1 ;) (type $iv) (param $0 i32)
+ (func $std/gc-basics/MyObject_visit (; 1 ;) (type $i_) (param $0 i32)
   nop
  )
  (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $ii) (param $0 i32) (result i32)
@@ -90,7 +90,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/collector/itcm/ManagedObjectList#push (; 3 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/ManagedObjectList#push (; 3 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=4
@@ -118,7 +118,7 @@
   local.get $1
   i32.store offset=4
  )
- (func $~lib/collector/itcm/ManagedObject#makeGray (; 4 ;) (type $iv) (param $0 i32)
+ (func $~lib/collector/itcm/ManagedObject#makeGray (; 4 ;) (type $i_) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   global.get $~lib/collector/itcm/iter
@@ -158,7 +158,7 @@
   i32.or
   i32.store
  )
- (func $~lib/collector/itcm/__gc_mark (; 5 ;) (type $iv) (param $0 i32)
+ (func $~lib/collector/itcm/__gc_mark (; 5 ;) (type $i_) (param $0 i32)
   (local $1 i32)
   local.get $0
   if
@@ -177,7 +177,7 @@
    end
   end
  )
- (func $~lib/collector/itcm/step (; 6 ;) (type $v)
+ (func $~lib/collector/itcm/step (; 6 ;) (type $_)
   (local $0 i32)
   block $break|0
    block $case3|0
@@ -224,10 +224,10 @@
      end
      global.get $std/gc-basics/obj
      i32.const 2
-     call_indirect (type $iv)
+     call_indirect (type $i_)
      global.get $std/gc-basics/obj2
      i32.const 2
-     call_indirect (type $iv)
+     call_indirect (type $i_)
      i32.const 2
      global.set $~lib/collector/itcm/state
      br $break|0
@@ -258,14 +258,14 @@
      i32.add
      local.get $0
      i32.load offset=8
-     call_indirect (type $iv)
+     call_indirect (type $i_)
     else     
      global.get $std/gc-basics/obj
      i32.const 2
-     call_indirect (type $iv)
+     call_indirect (type $i_)
      global.get $std/gc-basics/obj2
      i32.const 2
-     call_indirect (type $iv)
+     call_indirect (type $i_)
      global.get $~lib/collector/itcm/toSpace
      global.get $~lib/collector/itcm/iter
      i32.load
@@ -339,7 +339,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/string/String~gc (; 8 ;) (type $iv) (param $0 i32)
+ (func $~lib/string/String~gc (; 8 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.eqz
   if
@@ -348,7 +348,7 @@
   local.get $0
   call $~lib/collector/itcm/__gc_mark
  )
- (func $~lib/collector/itcm/__gc_collect (; 9 ;) (type $v)
+ (func $~lib/collector/itcm/__gc_collect (; 9 ;) (type $_)
   (local $0 i32)
   block $break|0
    block $case1|0
@@ -384,7 +384,7 @@
   end
   i32.const 0
  )
- (func $start (; 11 ;) (type $v)
+ (func $start (; 11 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -479,7 +479,7 @@
   global.set $std/gc-basics/obj
   call $~lib/collector/itcm/__gc_collect
  )
- (func $null (; 12 ;) (type $v)
+ (func $null (; 12 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/gc-basics.untouched.wat
+++ b/tests/compiler/std/gc-basics.untouched.wat
@@ -1,10 +1,10 @@
 (module
- (type $iv (func (param i32)))
+ (type $i_ (func (param i32)))
  (type $iii (func (param i32 i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (type $ii (func (param i32) (result i32)))
- (type $iiv (func (param i32 i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $ii_ (func (param i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $i (func (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -36,7 +36,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "main" (func $std/gc-basics/main))
- (func $std/gc-basics/MyObject_visit (; 1 ;) (type $iv) (param $0 i32)
+ (func $std/gc-basics/MyObject_visit (; 1 ;) (type $i_) (param $0 i32)
   nop
  )
  (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $ii) (param $0 i32) (result i32)
@@ -118,7 +118,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/collector/itcm/ManagedObjectList#clear (; 3 ;) (type $iv) (param $0 i32)
+ (func $~lib/collector/itcm/ManagedObjectList#clear (; 3 ;) (type $i_) (param $0 i32)
   local.get $0
   local.get $0
   i32.store
@@ -140,7 +140,7 @@
   i32.xor
   i32.and
  )
- (func $~lib/collector/itcm/ManagedObject#set:next (; 6 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/ManagedObject#set:next (; 6 ;) (type $ii_) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   local.get $0
@@ -150,7 +150,7 @@
   i32.or
   i32.store
  )
- (func $~lib/collector/itcm/ManagedObject#unlink (; 7 ;) (type $iv) (param $0 i32)
+ (func $~lib/collector/itcm/ManagedObject#unlink (; 7 ;) (type $i_) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -166,7 +166,7 @@
   local.get $1
   call $~lib/collector/itcm/ManagedObject#set:next
  )
- (func $~lib/collector/itcm/ManagedObjectList#push (; 8 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/ManagedObjectList#push (; 8 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=4
@@ -184,7 +184,7 @@
   local.get $1
   i32.store offset=4
  )
- (func $~lib/collector/itcm/ManagedObject#makeGray (; 9 ;) (type $iv) (param $0 i32)
+ (func $~lib/collector/itcm/ManagedObject#makeGray (; 9 ;) (type $i_) (param $0 i32)
   local.get $0
   global.get $~lib/collector/itcm/iter
   i32.eq
@@ -209,7 +209,7 @@
   i32.or
   i32.store
  )
- (func $~lib/collector/itcm/__gc_mark (; 10 ;) (type $iv) (param $0 i32)
+ (func $~lib/collector/itcm/__gc_mark (; 10 ;) (type $i_) (param $0 i32)
   (local $1 i32)
   local.get $0
   if
@@ -231,7 +231,7 @@
    end
   end
  )
- (func $~lib/collector/itcm/ManagedObject#set:color (; 11 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/ManagedObject#set:color (; 11 ;) (type $ii_) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $0
   i32.load
@@ -243,10 +243,10 @@
   i32.or
   i32.store
  )
- (func $~lib/allocator/arena/__memory_free (; 12 ;) (type $iv) (param $0 i32)
+ (func $~lib/allocator/arena/__memory_free (; 12 ;) (type $i_) (param $0 i32)
   nop
  )
- (func $~lib/collector/itcm/step (; 13 ;) (type $v)
+ (func $~lib/collector/itcm/step (; 13 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   block $break|0
@@ -342,7 +342,7 @@
       end
       local.get $0
       i32.load offset=8
-      call_indirect (type $iv)
+      call_indirect (type $i_)
      else      
       i32.const 2
       call $~iterateRoots
@@ -447,7 +447,7 @@
    i32.add
   end
  )
- (func $~lib/string/String~gc (; 15 ;) (type $iv) (param $0 i32)
+ (func $~lib/string/String~gc (; 15 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.eqz
   if
@@ -456,7 +456,7 @@
   local.get $0
   call $~lib/collector/itcm/__gc_mark
  )
- (func $~lib/collector/itcm/__gc_collect (; 16 ;) (type $v)
+ (func $~lib/collector/itcm/__gc_collect (; 16 ;) (type $_)
   (local $0 i32)
   block $break|0
    block $case1|0
@@ -488,7 +488,7 @@
    end
   end
  )
- (func $~lib/gc/gc.collect (; 17 ;) (type $v)
+ (func $~lib/gc/gc.collect (; 17 ;) (type $_)
   call $~lib/collector/itcm/__gc_collect
   return
  )
@@ -502,7 +502,7 @@
   end
   i32.const 0
  )
- (func $start (; 19 ;) (type $v)
+ (func $start (; 19 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -622,14 +622,14 @@
   global.set $std/gc-basics/obj
   call $~lib/gc/gc.collect
  )
- (func $null (; 20 ;) (type $v)
+ (func $null (; 20 ;) (type $_)
  )
- (func $~iterateRoots (; 21 ;) (type $iv) (param $0 i32)
+ (func $~iterateRoots (; 21 ;) (type $i_) (param $0 i32)
   global.get $std/gc-basics/obj
   local.get $0
-  call_indirect (type $iv)
+  call_indirect (type $i_)
   global.get $std/gc-basics/obj2
   local.get $0
-  call_indirect (type $iv)
+  call_indirect (type $i_)
  )
 )

--- a/tests/compiler/std/gc-integration.optimized.wat
+++ b/tests/compiler/std/gc-integration.optimized.wat
@@ -1,7 +1,7 @@
 (module
- (type $iv (func (param i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $i_ (func (param i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\15\00\00\00s\00t\00d\00/\00g\00c\00-\00i\00n\00t\00e\00g\00r\00a\00t\00i\00o\00n\00.\00t\00s")
@@ -14,7 +14,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start~anonymous|1 (; 1 ;) (type $iv) (param $0 i32)
+ (func $start~anonymous|1 (; 1 ;) (type $i_) (param $0 i32)
   global.get $std/gc-integration/i
   i32.const 1
   i32.add
@@ -33,19 +33,19 @@
    unreachable
   end
  )
- (func $start (; 2 ;) (type $v)
+ (func $start (; 2 ;) (type $_)
   i32.const 8
   i32.const 1
-  call_indirect (type $iv)
+  call_indirect (type $i_)
   global.get $std/gc-integration/B.d
   i32.const 1
-  call_indirect (type $iv)
+  call_indirect (type $i_)
   global.get $std/gc-integration/a_ref
   i32.const 1
-  call_indirect (type $iv)
+  call_indirect (type $i_)
   global.get $std/gc-integration/b_ref
   i32.const 1
-  call_indirect (type $iv)
+  call_indirect (type $i_)
   global.get $std/gc-integration/i
   i32.const 4
   i32.ne
@@ -58,7 +58,7 @@
    unreachable
   end
  )
- (func $null (; 3 ;) (type $v)
+ (func $null (; 3 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/gc-integration.untouched.wat
+++ b/tests/compiler/std/gc-integration.untouched.wat
@@ -1,7 +1,7 @@
 (module
- (type $iv (func (param i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $i_ (func (param i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\15\00\00\00s\00t\00d\00/\00g\00c\00-\00i\00n\00t\00e\00g\00r\00a\00t\00i\00o\00n\00.\00t\00s\00")
@@ -17,7 +17,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start~anonymous|1 (; 1 ;) (type $iv) (param $0 i32)
+ (func $start~anonymous|1 (; 1 ;) (type $i_) (param $0 i32)
   local.get $0
   block (result i32)
    global.get $std/gc-integration/i
@@ -39,7 +39,7 @@
    unreachable
   end
  )
- (func $start (; 2 ;) (type $v)
+ (func $start (; 2 ;) (type $_)
   global.get $std/gc-integration/B.c
   drop
   global.get $std/gc-integration/B.d
@@ -59,20 +59,20 @@
    unreachable
   end
  )
- (func $null (; 3 ;) (type $v)
+ (func $null (; 3 ;) (type $_)
  )
- (func $~iterateRoots (; 4 ;) (type $iv) (param $0 i32)
+ (func $~iterateRoots (; 4 ;) (type $i_) (param $0 i32)
   global.get $std/gc-integration/B.c
   local.get $0
-  call_indirect (type $iv)
+  call_indirect (type $i_)
   global.get $std/gc-integration/B.d
   local.get $0
-  call_indirect (type $iv)
+  call_indirect (type $i_)
   global.get $std/gc-integration/a_ref
   local.get $0
-  call_indirect (type $iv)
+  call_indirect (type $i_)
   global.get $std/gc-integration/b_ref
   local.get $0
-  call_indirect (type $iv)
+  call_indirect (type $i_)
  )
 )

--- a/tests/compiler/std/gc-object.optimized.wat
+++ b/tests/compiler/std/gc-object.optimized.wat
@@ -1,9 +1,9 @@
 (module
  (type $iii (func (param i32 i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (type $ii (func (param i32) (result i32)))
- (type $iv (func (param i32)))
- (type $iiv (func (param i32 i32)))
+ (type $i_ (func (param i32)))
+ (type $ii_ (func (param i32 i32)))
  (type $FUNCSIG$i (func (result i32)))
  (memory $0 0)
  (table $0 4 funcref)
@@ -83,7 +83,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/collector/itcm/ManagedObjectList#push (; 1 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/ManagedObjectList#push (; 1 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=4
@@ -111,7 +111,7 @@
   local.get $1
   i32.store offset=4
  )
- (func $~lib/collector/itcm/ManagedObject#makeGray (; 2 ;) (type $iv) (param $0 i32)
+ (func $~lib/collector/itcm/ManagedObject#makeGray (; 2 ;) (type $i_) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   global.get $~lib/collector/itcm/iter
@@ -151,7 +151,7 @@
   i32.or
   i32.store
  )
- (func $~lib/collector/itcm/__gc_mark (; 3 ;) (type $iv) (param $0 i32)
+ (func $~lib/collector/itcm/__gc_mark (; 3 ;) (type $i_) (param $0 i32)
   (local $1 i32)
   local.get $0
   if
@@ -170,7 +170,7 @@
    end
   end
  )
- (func $~lib/collector/itcm/step (; 4 ;) (type $v)
+ (func $~lib/collector/itcm/step (; 4 ;) (type $_)
   (local $0 i32)
   block $break|0
    block $case3|0
@@ -217,7 +217,7 @@
      end
      global.get $std/gc-object/obj
      i32.const 1
-     call_indirect (type $iv)
+     call_indirect (type $i_)
      i32.const 2
      global.set $~lib/collector/itcm/state
      br $break|0
@@ -248,11 +248,11 @@
      i32.add
      local.get $0
      i32.load offset=8
-     call_indirect (type $iv)
+     call_indirect (type $i_)
     else     
      global.get $std/gc-object/obj
      i32.const 1
-     call_indirect (type $iv)
+     call_indirect (type $i_)
      global.get $~lib/collector/itcm/toSpace
      global.get $~lib/collector/itcm/iter
      i32.load
@@ -334,7 +334,7 @@
   i32.const 16
   i32.add
  )
- (func $std/gc-object/Base~gc (; 6 ;) (type $iv) (param $0 i32)
+ (func $std/gc-object/Base~gc (; 6 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.eqz
   if
@@ -343,7 +343,7 @@
   local.get $0
   call $~lib/collector/itcm/__gc_mark
  )
- (func $std/gc-object/Custom~gc (; 7 ;) (type $iv) (param $0 i32)
+ (func $std/gc-object/Custom~gc (; 7 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.eqz
   if
@@ -351,7 +351,7 @@
   end
   local.get $0
   i32.const 2
-  call_indirect (type $iv)
+  call_indirect (type $i_)
   local.get $0
   i32.load
   call $~lib/collector/itcm/__gc_mark
@@ -380,7 +380,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $~lib/collector/itcm/__gc_collect (; 9 ;) (type $v)
+ (func $~lib/collector/itcm/__gc_collect (; 9 ;) (type $_)
   (local $0 i32)
   block $break|0
    block $case1|0
@@ -406,7 +406,7 @@
    end
   end
  )
- (func $std/gc-object/main (; 10 ;) (type $v)
+ (func $std/gc-object/main (; 10 ;) (type $_)
   global.get $~started
   i32.eqz
   if
@@ -415,7 +415,7 @@
    global.set $~started
   end
  )
- (func $start (; 11 ;) (type $v)
+ (func $start (; 11 ;) (type $_)
   (local $0 i32)
   i32.const 8
   global.set $~lib/allocator/arena/startOffset
@@ -435,7 +435,7 @@
   global.set $std/gc-object/obj
   call $~lib/collector/itcm/__gc_collect
  )
- (func $null (; 12 ;) (type $v)
+ (func $null (; 12 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/gc-object.untouched.wat
+++ b/tests/compiler/std/gc-object.untouched.wat
@@ -1,9 +1,9 @@
 (module
  (type $iii (func (param i32 i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (type $ii (func (param i32) (result i32)))
- (type $iv (func (param i32)))
- (type $iiv (func (param i32 i32)))
+ (type $i_ (func (param i32)))
+ (type $ii_ (func (param i32 i32)))
  (memory $0 0)
  (table $0 4 funcref)
  (elem (i32.const 0) $null $~lib/collector/itcm/__gc_mark $std/gc-object/Base~gc $std/gc-object/Custom~gc)
@@ -110,7 +110,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/collector/itcm/ManagedObjectList#clear (; 1 ;) (type $iv) (param $0 i32)
+ (func $~lib/collector/itcm/ManagedObjectList#clear (; 1 ;) (type $i_) (param $0 i32)
   local.get $0
   local.get $0
   i32.store
@@ -132,7 +132,7 @@
   i32.xor
   i32.and
  )
- (func $~lib/collector/itcm/ManagedObject#set:next (; 4 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/ManagedObject#set:next (; 4 ;) (type $ii_) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   local.get $0
@@ -142,7 +142,7 @@
   i32.or
   i32.store
  )
- (func $~lib/collector/itcm/ManagedObject#unlink (; 5 ;) (type $iv) (param $0 i32)
+ (func $~lib/collector/itcm/ManagedObject#unlink (; 5 ;) (type $i_) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -158,7 +158,7 @@
   local.get $1
   call $~lib/collector/itcm/ManagedObject#set:next
  )
- (func $~lib/collector/itcm/ManagedObjectList#push (; 6 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/ManagedObjectList#push (; 6 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=4
@@ -176,7 +176,7 @@
   local.get $1
   i32.store offset=4
  )
- (func $~lib/collector/itcm/ManagedObject#makeGray (; 7 ;) (type $iv) (param $0 i32)
+ (func $~lib/collector/itcm/ManagedObject#makeGray (; 7 ;) (type $i_) (param $0 i32)
   local.get $0
   global.get $~lib/collector/itcm/iter
   i32.eq
@@ -201,7 +201,7 @@
   i32.or
   i32.store
  )
- (func $~lib/collector/itcm/__gc_mark (; 8 ;) (type $iv) (param $0 i32)
+ (func $~lib/collector/itcm/__gc_mark (; 8 ;) (type $i_) (param $0 i32)
   (local $1 i32)
   local.get $0
   if
@@ -223,7 +223,7 @@
    end
   end
  )
- (func $~lib/collector/itcm/ManagedObject#set:color (; 9 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/ManagedObject#set:color (; 9 ;) (type $ii_) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $0
   i32.load
@@ -235,10 +235,10 @@
   i32.or
   i32.store
  )
- (func $~lib/allocator/arena/__memory_free (; 10 ;) (type $iv) (param $0 i32)
+ (func $~lib/allocator/arena/__memory_free (; 10 ;) (type $i_) (param $0 i32)
   nop
  )
- (func $~lib/collector/itcm/step (; 11 ;) (type $v)
+ (func $~lib/collector/itcm/step (; 11 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   block $break|0
@@ -334,7 +334,7 @@
       end
       local.get $0
       i32.load offset=8
-      call_indirect (type $iv)
+      call_indirect (type $i_)
      else      
       i32.const 1
       call $~iterateRoots
@@ -439,7 +439,7 @@
    i32.add
   end
  )
- (func $std/gc-object/Base~gc (; 13 ;) (type $iv) (param $0 i32)
+ (func $std/gc-object/Base~gc (; 13 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.eqz
   if
@@ -459,7 +459,7 @@
   end
   local.get $0
  )
- (func $std/gc-object/Custom~gc (; 15 ;) (type $iv) (param $0 i32)
+ (func $std/gc-object/Custom~gc (; 15 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.eqz
   if
@@ -467,7 +467,7 @@
   end
   local.get $0
   i32.const 2
-  call_indirect (type $iv)
+  call_indirect (type $i_)
   local.get $0
   i32.load
   call $~lib/collector/itcm/__gc_mark
@@ -495,7 +495,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $~lib/collector/itcm/__gc_collect (; 17 ;) (type $v)
+ (func $~lib/collector/itcm/__gc_collect (; 17 ;) (type $_)
   (local $0 i32)
   block $break|0
    block $case1|0
@@ -527,11 +527,11 @@
    end
   end
  )
- (func $~lib/gc/gc.collect (; 18 ;) (type $v)
+ (func $~lib/gc/gc.collect (; 18 ;) (type $_)
   call $~lib/collector/itcm/__gc_collect
   return
  )
- (func $std/gc-object/main (; 19 ;) (type $v)
+ (func $std/gc-object/main (; 19 ;) (type $_)
   global.get $~started
   i32.eqz
   if
@@ -540,7 +540,7 @@
    global.set $~started
   end
  )
- (func $start (; 20 ;) (type $v)
+ (func $start (; 20 ;) (type $_)
   global.get $HEAP_BASE
   global.get $~lib/internal/allocator/AL_MASK
   i32.add
@@ -565,11 +565,11 @@
   global.set $std/gc-object/obj
   call $~lib/gc/gc.collect
  )
- (func $null (; 21 ;) (type $v)
+ (func $null (; 21 ;) (type $_)
  )
- (func $~iterateRoots (; 22 ;) (type $iv) (param $0 i32)
+ (func $~iterateRoots (; 22 ;) (type $i_) (param $0 i32)
   global.get $std/gc-object/obj
   local.get $0
-  call_indirect (type $iv)
+  call_indirect (type $i_)
  )
 )

--- a/tests/compiler/std/hash.optimized.wat
+++ b/tests/compiler/std/hash.optimized.wat
@@ -1,7 +1,7 @@
 (module
  (type $ii (func (param i32) (result i32)))
  (type $Ii (func (param i64) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 1)
  (data (i32.const 16) "\01\00\00\00a")
  (data (i32.const 24) "\02\00\00\00a\00b")
@@ -143,7 +143,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $start (; 3 ;) (type $v)
+ (func $start (; 3 ;) (type $_)
   i32.const 0
   call $~lib/internal/hash/hashStr
   drop
@@ -196,7 +196,7 @@
   call $~lib/internal/hash/hash64
   drop
  )
- (func $null (; 4 ;) (type $v)
+ (func $null (; 4 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/hash.untouched.wat
+++ b/tests/compiler/std/hash.untouched.wat
@@ -1,7 +1,7 @@
 (module
  (type $ii (func (param i32) (result i32)))
  (type $Ii (func (param i64) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 1)
  (data (i32.const 8) "\00\00\00\00")
  (data (i32.const 16) "\01\00\00\00a\00")
@@ -200,7 +200,7 @@
   local.set $3
   local.get $3
  )
- (func $start (; 4 ;) (type $v)
+ (func $start (; 4 ;) (type $_)
   (local $0 i32)
   (local $1 f32)
   (local $2 f64)
@@ -370,6 +370,6 @@
   call $std/hash/check
   drop
  )
- (func $null (; 5 ;) (type $v)
+ (func $null (; 5 ;) (type $_)
  )
 )

--- a/tests/compiler/std/libm.optimized.wat
+++ b/tests/compiler/std/libm.optimized.wat
@@ -3,7 +3,7 @@
  (type $FFF (func (param f64 f64) (result f64)))
  (type $FiF (func (param f64 i32) (result f64)))
  (type $Ff (func (param f64) (result f32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -3985,7 +3985,7 @@
   local.get $0
   f64.trunc
  )
- (func $null (; 54 ;) (type $v)
+ (func $null (; 54 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/libm.untouched.wat
+++ b/tests/compiler/std/libm.untouched.wat
@@ -4,7 +4,7 @@
  (type $FFF (func (param f64 f64) (result f64)))
  (type $FiF (func (param f64 i32) (result f64)))
  (type $Ff (func (param f64) (result f32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -4801,6 +4801,6 @@
   local.get $1
   f64.trunc
  )
- (func $null (; 61 ;) (type $v)
+ (func $null (; 61 ;) (type $_)
  )
 )

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -1,22 +1,22 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (type $ii (func (param i32) (result i32)))
- (type $iv (func (param i32)))
+ (type $i_ (func (param i32)))
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $iiiv (func (param i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $iii_ (func (param i32 i32 i32)))
  (type $iii (func (param i32 i32) (result i32)))
- (type $iiv (func (param i32 i32)))
+ (type $ii_ (func (param i32 i32)))
  (type $iIi (func (param i32 i64) (result i32)))
  (type $Ii (func (param i64) (result i32)))
  (type $iIii (func (param i32 i64 i32) (result i32)))
- (type $iIiv (func (param i32 i64 i32)))
+ (type $iIi_ (func (param i32 i64 i32)))
  (type $ifi (func (param i32 f32) (result i32)))
  (type $ifii (func (param i32 f32 i32) (result i32)))
- (type $ifiv (func (param i32 f32 i32)))
+ (type $ifi_ (func (param i32 f32 i32)))
  (type $iFi (func (param i32 f64) (result i32)))
  (type $iFii (func (param i32 f64 i32) (result i32)))
- (type $iFiv (func (param i32 f64 i32)))
+ (type $iFi_ (func (param i32 f64 i32)))
  (type $FUNCSIG$vii (func (param i32 i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (type $FUNCSIG$i (func (result i32)))
@@ -367,7 +367,7 @@
   end
   local.get $2
  )
- (func $~lib/map/Map<i8,i32>#clear (; 5 ;) (type $iv) (param $0 i32)
+ (func $~lib/map/Map<i8,i32>#clear (; 5 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 16
   i32.const 0
@@ -478,7 +478,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i8,i32>#rehash (; 9 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i8,i32>#rehash (; 9 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -588,7 +588,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<i8,i32>#set (; 10 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<i8,i32>#set (; 10 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -779,7 +779,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<i8,i32> (; 13 ;) (type $v)
+ (func $std/map/test<i8,i32> (; 13 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   call $~lib/map/Map<i8,i32>#constructor
@@ -1139,7 +1139,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u8,i32>#rehash (; 15 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,i32>#rehash (; 15 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1249,7 +1249,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<u8,i32>#set (; 16 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<u8,i32>#set (; 16 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1434,7 +1434,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<u8,i32> (; 19 ;) (type $v)
+ (func $std/map/test<u8,i32> (; 19 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   call $~lib/map/Map<i8,i32>#constructor
@@ -1837,7 +1837,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i16,i32>#rehash (; 22 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i16,i32>#rehash (; 22 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1956,7 +1956,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<i16,i32>#set (; 23 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<i16,i32>#set (; 23 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2174,7 +2174,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<i16,i32> (; 26 ;) (type $v)
+ (func $std/map/test<i16,i32> (; 26 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   call $~lib/map/Map<i8,i32>#constructor
@@ -2544,7 +2544,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u16,i32>#rehash (; 28 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,i32>#rehash (; 28 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2663,7 +2663,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<u16,i32>#set (; 29 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<u16,i32>#set (; 29 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2875,7 +2875,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<u16,i32> (; 32 ;) (type $v)
+ (func $std/map/test<u16,i32> (; 32 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   call $~lib/map/Map<i8,i32>#constructor
@@ -3290,7 +3290,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i32,i32>#rehash (; 36 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i32,i32>#rehash (; 36 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3397,7 +3397,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<i32,i32>#set (; 37 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<i32,i32>#set (; 37 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3565,7 +3565,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<i32,i32> (; 40 ;) (type $v)
+ (func $std/map/test<i32,i32> (; 40 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   call $~lib/map/Map<i8,i32>#constructor
@@ -3883,7 +3883,7 @@
    unreachable
   end
  )
- (func $std/map/test<u32,i32> (; 41 ;) (type $v)
+ (func $std/map/test<u32,i32> (; 41 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   call $~lib/map/Map<i8,i32>#constructor
@@ -4201,7 +4201,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<i64,i32>#clear (; 42 ;) (type $iv) (param $0 i32)
+ (func $~lib/map/Map<i64,i32>#clear (; 42 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 16
   i32.const 0
@@ -4369,7 +4369,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i64,i32>#rehash (; 47 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i64,i32>#rehash (; 47 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4476,7 +4476,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<i64,i32>#set (; 48 ;) (type $iIiv) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/map/Map<i64,i32>#set (; 48 ;) (type $iIi_) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4645,7 +4645,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<i64,i32> (; 51 ;) (type $v)
+ (func $std/map/test<i64,i32> (; 51 ;) (type $_)
   (local $0 i64)
   (local $1 i32)
   call $~lib/map/Map<i64,i32>#constructor
@@ -4970,7 +4970,7 @@
    unreachable
   end
  )
- (func $std/map/test<u64,i32> (; 52 ;) (type $v)
+ (func $std/map/test<u64,i32> (; 52 ;) (type $_)
   (local $0 i64)
   (local $1 i32)
   call $~lib/map/Map<i64,i32>#constructor
@@ -5348,7 +5348,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<f32,i32>#rehash (; 55 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f32,i32>#rehash (; 55 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5456,7 +5456,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<f32,i32>#set (; 56 ;) (type $ifiv) (param $0 i32) (param $1 f32) (param $2 i32)
+ (func $~lib/map/Map<f32,i32>#set (; 56 ;) (type $ifi_) (param $0 i32) (param $1 f32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5628,7 +5628,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<f32,i32> (; 59 ;) (type $v)
+ (func $std/map/test<f32,i32> (; 59 ;) (type $_)
   (local $0 f32)
   (local $1 i32)
   call $~lib/map/Map<i8,i32>#constructor
@@ -6006,7 +6006,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<f64,i32>#rehash (; 62 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f64,i32>#rehash (; 62 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6114,7 +6114,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<f64,i32>#set (; 63 ;) (type $iFiv) (param $0 i32) (param $1 f64) (param $2 i32)
+ (func $~lib/map/Map<f64,i32>#set (; 63 ;) (type $iFi_) (param $0 i32) (param $1 f64) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6286,7 +6286,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<f64,i32> (; 66 ;) (type $v)
+ (func $std/map/test<f64,i32> (; 66 ;) (type $_)
   (local $0 f64)
   (local $1 i32)
   call $~lib/map/Map<i64,i32>#constructor
@@ -6611,7 +6611,7 @@
    unreachable
   end
  )
- (func $start (; 67 ;) (type $v)
+ (func $start (; 67 ;) (type $_)
   i32.const 144
   global.set $~lib/allocator/arena/startOffset
   global.get $~lib/allocator/arena/startOffset
@@ -6627,7 +6627,7 @@
   call $std/map/test<f32,i32>
   call $std/map/test<f64,i32>
  )
- (func $null (; 68 ;) (type $v)
+ (func $null (; 68 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -1,22 +1,22 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (type $ii (func (param i32) (result i32)))
- (type $iv (func (param i32)))
+ (type $i_ (func (param i32)))
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $iiiv (func (param i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $iii_ (func (param i32 i32 i32)))
  (type $iii (func (param i32 i32) (result i32)))
- (type $iiv (func (param i32 i32)))
+ (type $ii_ (func (param i32 i32)))
  (type $iIi (func (param i32 i64) (result i32)))
  (type $Ii (func (param i64) (result i32)))
  (type $iIii (func (param i32 i64 i32) (result i32)))
- (type $iIiv (func (param i32 i64 i32)))
+ (type $iIi_ (func (param i32 i64 i32)))
  (type $ifi (func (param i32 f32) (result i32)))
  (type $ifii (func (param i32 f32 i32) (result i32)))
- (type $ifiv (func (param i32 f32 i32)))
+ (type $ifi_ (func (param i32 f32 i32)))
  (type $iFi (func (param i32 f64) (result i32)))
  (type $iFii (func (param i32 f64 i32) (result i32)))
- (type $iFiv (func (param i32 f64 i32)))
+ (type $iFi_ (func (param i32 f64 i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\13\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
@@ -168,7 +168,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memset (; 5 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 5 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -461,7 +461,7 @@
   end
   local.get $3
  )
- (func $~lib/map/Map<i8,i32>#clear (; 7 ;) (type $iv) (param $0 i32)
+ (func $~lib/map/Map<i8,i32>#clear (; 7 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -602,7 +602,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i8,i32>#rehash (; 12 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i8,i32>#rehash (; 12 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -742,7 +742,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<i8,i32>#set (; 13 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<i8,i32>#set (; 13 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -959,7 +959,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<i8,i32> (; 17 ;) (type $v)
+ (func $std/map/test<i8,i32> (; 17 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -1343,7 +1343,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<u8,i32>#clear (; 18 ;) (type $iv) (param $0 i32)
+ (func $~lib/map/Map<u8,i32>#clear (; 18 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -1473,7 +1473,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u8,i32>#rehash (; 22 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,i32>#rehash (; 22 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1613,7 +1613,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<u8,i32>#set (; 23 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<u8,i32>#set (; 23 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1824,7 +1824,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<u8,i32> (; 27 ;) (type $v)
+ (func $std/map/test<u8,i32> (; 27 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -2194,7 +2194,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<i16,i32>#clear (; 28 ;) (type $iv) (param $0 i32)
+ (func $~lib/map/Map<i16,i32>#clear (; 28 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -2350,7 +2350,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i16,i32>#rehash (; 33 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i16,i32>#rehash (; 33 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2490,7 +2490,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<i16,i32>#set (; 34 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<i16,i32>#set (; 34 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2707,7 +2707,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<i16,i32> (; 38 ;) (type $v)
+ (func $std/map/test<i16,i32> (; 38 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -3091,7 +3091,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<u16,i32>#clear (; 39 ;) (type $iv) (param $0 i32)
+ (func $~lib/map/Map<u16,i32>#clear (; 39 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -3221,7 +3221,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u16,i32>#rehash (; 43 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,i32>#rehash (; 43 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3361,7 +3361,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<u16,i32>#set (; 44 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<u16,i32>#set (; 44 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3572,7 +3572,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<u16,i32> (; 48 ;) (type $v)
+ (func $std/map/test<u16,i32> (; 48 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -3942,7 +3942,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<i32,i32>#clear (; 49 ;) (type $iv) (param $0 i32)
+ (func $~lib/map/Map<i32,i32>#clear (; 49 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -4110,7 +4110,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i32,i32>#rehash (; 54 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i32,i32>#rehash (; 54 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4250,7 +4250,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<i32,i32>#set (; 55 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<i32,i32>#set (; 55 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4455,7 +4455,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<i32,i32> (; 59 ;) (type $v)
+ (func $std/map/test<i32,i32> (; 59 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4811,7 +4811,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<u32,i32>#clear (; 60 ;) (type $iv) (param $0 i32)
+ (func $~lib/map/Map<u32,i32>#clear (; 60 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -4937,7 +4937,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u32,i32>#rehash (; 64 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u32,i32>#rehash (; 64 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5077,7 +5077,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<u32,i32>#set (; 65 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<u32,i32>#set (; 65 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5282,7 +5282,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<u32,i32> (; 69 ;) (type $v)
+ (func $std/map/test<u32,i32> (; 69 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -5638,7 +5638,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<i64,i32>#clear (; 70 ;) (type $iv) (param $0 i32)
+ (func $~lib/map/Map<i64,i32>#clear (; 70 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -5852,7 +5852,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i64,i32>#rehash (; 75 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i64,i32>#rehash (; 75 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5993,7 +5993,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<i64,i32>#set (; 76 ;) (type $iIiv) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/map/Map<i64,i32>#set (; 76 ;) (type $iIi_) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -6200,7 +6200,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<i64,i32> (; 80 ;) (type $v)
+ (func $std/map/test<i64,i32> (; 80 ;) (type $_)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -6563,7 +6563,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<u64,i32>#clear (; 81 ;) (type $iv) (param $0 i32)
+ (func $~lib/map/Map<u64,i32>#clear (; 81 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -6689,7 +6689,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u64,i32>#rehash (; 85 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u64,i32>#rehash (; 85 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6830,7 +6830,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<u64,i32>#set (; 86 ;) (type $iIiv) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/map/Map<u64,i32>#set (; 86 ;) (type $iIi_) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -7037,7 +7037,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<u64,i32> (; 90 ;) (type $v)
+ (func $std/map/test<u64,i32> (; 90 ;) (type $_)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -7400,7 +7400,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<f32,i32>#clear (; 91 ;) (type $iv) (param $0 i32)
+ (func $~lib/map/Map<f32,i32>#clear (; 91 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -7527,7 +7527,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<f32,i32>#rehash (; 95 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f32,i32>#rehash (; 95 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7669,7 +7669,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<f32,i32>#set (; 96 ;) (type $ifiv) (param $0 i32) (param $1 f32) (param $2 i32)
+ (func $~lib/map/Map<f32,i32>#set (; 96 ;) (type $ifi_) (param $0 i32) (param $1 f32) (param $2 i32)
   (local $3 f32)
   (local $4 i32)
   (local $5 i32)
@@ -7879,7 +7879,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<f32,i32> (; 100 ;) (type $v)
+ (func $std/map/test<f32,i32> (; 100 ;) (type $_)
   (local $0 i32)
   (local $1 f32)
   i32.const 0
@@ -8242,7 +8242,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<f64,i32>#clear (; 101 ;) (type $iv) (param $0 i32)
+ (func $~lib/map/Map<f64,i32>#clear (; 101 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -8369,7 +8369,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<f64,i32>#rehash (; 105 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f64,i32>#rehash (; 105 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8511,7 +8511,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<f64,i32>#set (; 106 ;) (type $iFiv) (param $0 i32) (param $1 f64) (param $2 i32)
+ (func $~lib/map/Map<f64,i32>#set (; 106 ;) (type $iFi_) (param $0 i32) (param $1 f64) (param $2 i32)
   (local $3 f64)
   (local $4 i32)
   (local $5 i32)
@@ -8721,7 +8721,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<f64,i32> (; 110 ;) (type $v)
+ (func $std/map/test<f64,i32> (; 110 ;) (type $_)
   (local $0 i32)
   (local $1 f64)
   i32.const 0
@@ -9084,7 +9084,7 @@
    unreachable
   end
  )
- (func $start (; 111 ;) (type $v)
+ (func $start (; 111 ;) (type $_)
   global.get $HEAP_BASE
   global.get $~lib/internal/allocator/AL_MASK
   i32.add
@@ -9106,6 +9106,6 @@
   call $std/map/test<f32,i32>
   call $std/map/test<f64,i32>
  )
- (func $null (; 112 ;) (type $v)
+ (func $null (; 112 ;) (type $_)
  )
 )

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -1,5 +1,5 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $FFFii (func (param f64 f64 f64 i32) (result i32)))
  (type $FFFF (func (param f64 f64 f64) (result f64)))
  (type $FiF (func (param f64 i32) (result f64)))
@@ -13,11 +13,11 @@
  (type $ffffii (func (param f32 f32 f32 f32 i32) (result i32)))
  (type $fff (func (param f32 f32) (result f32)))
  (type $F (func (result f64)))
- (type $Iv (func (param i64)))
+ (type $I_ (func (param i64)))
  (type $ii (func (param i32) (result i32)))
  (type $f (func (result f32)))
  (type $IiI (func (param i64 i32) (result i64)))
- (type $v (func))
+ (type $_ (func))
  (type $FUNCSIG$iddd (func (param f64 f64 f64) (result i32)))
  (type $FUNCSIG$ifff (func (param f32 f32 f32) (result i32)))
  (type $FUNCSIG$ididi (func (param f64 i32 f64 i32) (result i32)))
@@ -7994,7 +7994,7 @@
   i32.shr_u
   i32.xor
  )
- (func $~lib/math/NativeMath.seedRandom (; 122 ;) (type $Iv) (param $0 i64)
+ (func $~lib/math/NativeMath.seedRandom (; 122 ;) (type $I_) (param $0 i64)
   (local $1 i64)
   local.get $0
   i64.eqz
@@ -9510,7 +9510,7 @@
   end
   local.get $2
  )
- (func $start (; 149 ;) (type $v)
+ (func $start (; 149 ;) (type $_)
   (local $0 f64)
   (local $1 f32)
   (local $2 i32)
@@ -38637,7 +38637,7 @@
    unreachable
   end
  )
- (func $null (; 150 ;) (type $v)
+ (func $null (; 150 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -1,5 +1,5 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $FFFii (func (param f64 f64 f64 i32) (result i32)))
  (type $Fi (func (param f64) (result i32)))
  (type $FFFF (func (param f64 f64 f64) (result f64)))
@@ -17,12 +17,12 @@
  (type $ffffii (func (param f32 f32 f32 f32 i32) (result i32)))
  (type $fff (func (param f32 f32) (result f32)))
  (type $F (func (result f64)))
- (type $Iv (func (param i64)))
+ (type $I_ (func (param i64)))
  (type $II (func (param i64) (result i64)))
  (type $ii (func (param i32) (result i32)))
  (type $f (func (result f32)))
  (type $IiI (func (param i64 i32) (result i64)))
- (type $v (func))
+ (type $_ (func))
  (import "Math" "E" (global $~lib/bindings/Math/E f64))
  (import "Math" "LN2" (global $~lib/bindings/Math/LN2 f64))
  (import "Math" "LN10" (global $~lib/bindings/Math/LN10 f64))
@@ -9768,7 +9768,7 @@
   i32.shr_u
   i32.xor
  )
- (func $~lib/math/NativeMath.seedRandom (; 130 ;) (type $Iv) (param $0 i64)
+ (func $~lib/math/NativeMath.seedRandom (; 130 ;) (type $I_) (param $0 i64)
   local.get $0
   i64.eqz
   if
@@ -11581,7 +11581,7 @@
    local.get $3
   end
  )
- (func $start (; 157 ;) (type $v)
+ (func $start (; 157 ;) (type $_)
   (local $0 i32)
   (local $1 f64)
   (local $2 i32)
@@ -42988,6 +42988,6 @@
    unreachable
   end
  )
- (func $null (; 158 ;) (type $v)
+ (func $null (; 158 ;) (type $_)
  )
 )

--- a/tests/compiler/std/mod.optimized.wat
+++ b/tests/compiler/std/mod.optimized.wat
@@ -2,11 +2,11 @@
  (type $FFF (func (param f64 f64) (result f64)))
  (type $FFFi (func (param f64 f64 f64) (result i32)))
  (type $FFi (func (param f64 f64) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $fffi (func (param f32 f32 f32) (result i32)))
  (type $fff (func (param f32 f32) (result f32)))
  (type $ffi (func (param f32 f32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (import "math" "mod" (func $std/mod/mod (param f64 f64) (result f64)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -500,7 +500,7 @@
   local.get $2
   call $std/mod/check<f32>
  )
- (func $start (; 8 ;) (type $v)
+ (func $start (; 8 ;) (type $_)
   f64.const 3
   f64.const 2
   f64.const 1
@@ -2257,7 +2257,7 @@
    unreachable
   end
  )
- (func $null (; 9 ;) (type $v)
+ (func $null (; 9 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/mod.untouched.wat
+++ b/tests/compiler/std/mod.untouched.wat
@@ -3,12 +3,12 @@
  (type $FFFi (func (param f64 f64 f64) (result i32)))
  (type $FFi (func (param f64 f64) (result i32)))
  (type $Fi (func (param f64) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $fffi (func (param f32 f32 f32) (result i32)))
  (type $fff (func (param f32 f32) (result f32)))
  (type $ffi (func (param f32 f32) (result i32)))
  (type $fi (func (param f32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (import "math" "mod" (func $std/mod/mod (param f64 f64) (result f64)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -631,7 +631,7 @@
   local.get $2
   call $std/mod/check<f32>
  )
- (func $start (; 10 ;) (type $v)
+ (func $start (; 10 ;) (type $_)
   f64.const 3
   f64.const 2
   f64.const 1
@@ -2416,6 +2416,6 @@
    unreachable
   end
  )
- (func $null (; 11 ;) (type $v)
+ (func $null (; 11 ;) (type $_)
  )
 )

--- a/tests/compiler/std/new.optimized.wat
+++ b/tests/compiler/std/new.optimized.wat
@@ -1,6 +1,6 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (type $FUNCSIG$i (func (result i32)))
  (memory $0 0)
  (table $0 1 funcref)
@@ -94,7 +94,7 @@
   f32.store offset=4
   local.get $0
  )
- (func $start (; 2 ;) (type $v)
+ (func $start (; 2 ;) (type $_)
   i32.const 8
   global.set $~lib/allocator/arena/startOffset
   global.get $~lib/allocator/arena/startOffset
@@ -102,7 +102,7 @@
   call $std/new/AClass#constructor
   global.set $std/new/aClass
  )
- (func $null (; 3 ;) (type $v)
+ (func $null (; 3 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/new.untouched.wat
+++ b/tests/compiler/std/new.untouched.wat
@@ -1,7 +1,7 @@
 (module
  (type $ifi (func (param i32 f32) (result i32)))
  (type $ii (func (param i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -127,7 +127,7 @@
   f32.store offset=4
   local.get $0
  )
- (func $start (; 3 ;) (type $v)
+ (func $start (; 3 ;) (type $_)
   global.get $HEAP_BASE
   global.get $~lib/internal/allocator/AL_MASK
   i32.add
@@ -143,6 +143,6 @@
   call $std/new/AClass#constructor
   global.set $std/new/aClass
  )
- (func $null (; 4 ;) (type $v)
+ (func $null (; 4 ;) (type $_)
  )
 )

--- a/tests/compiler/std/operator-overloading.optimized.wat
+++ b/tests/compiler/std/operator-overloading.optimized.wat
@@ -1,10 +1,10 @@
 (module
  (type $ii (func (param i32) (result i32)))
  (type $iii (func (param i32 i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $FFF (func (param f64 f64) (result f64)))
  (type $FiF (func (param f64 i32) (result f64)))
- (type $v (func))
+ (type $_ (func))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -1202,7 +1202,7 @@
   i32.trunc_f64_s
   call $std/operator-overloading/Tester#constructor
  )
- (func $start (; 6 ;) (type $v)
+ (func $start (; 6 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2457,7 +2457,7 @@
    unreachable
   end
  )
- (func $null (; 7 ;) (type $v)
+ (func $null (; 7 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/operator-overloading.untouched.wat
+++ b/tests/compiler/std/operator-overloading.untouched.wat
@@ -2,10 +2,10 @@
  (type $iiii (func (param i32 i32 i32) (result i32)))
  (type $ii (func (param i32) (result i32)))
  (type $iii (func (param i32 i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $FFF (func (param f64 f64) (result f64)))
  (type $FiF (func (param f64 i32) (result f64)))
- (type $v (func))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\1b\00\00\00s\00t\00d\00/\00o\00p\00e\00r\00a\00t\00o\00r\00-\00o\00v\00e\00r\00l\00o\00a\00d\00i\00n\00g\00.\00t\00s\00")
@@ -1776,7 +1776,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $start (; 34 ;) (type $v)
+ (func $start (; 34 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   global.get $HEAP_BASE
@@ -2837,6 +2837,6 @@
    unreachable
   end
  )
- (func $null (; 35 ;) (type $v)
+ (func $null (; 35 ;) (type $_)
  )
 )

--- a/tests/compiler/std/pointer.optimized.wat
+++ b/tests/compiler/std/pointer.optimized.wat
@@ -1,7 +1,7 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $iiiv (func (param i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $iii_ (func (param i32 i32 i32)))
+ (type $_ (func))
  (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$vii (func (param i32 i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
@@ -62,7 +62,7 @@
   i32.const 0
   i32.store8
  )
- (func $~lib/internal/memory/memcpy (; 2 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 2 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1159,7 +1159,7 @@
    end
   end
  )
- (func $start (; 4 ;) (type $v)
+ (func $start (; 4 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 8
@@ -1548,7 +1548,7 @@
    unreachable
   end
  )
- (func $null (; 5 ;) (type $v)
+ (func $null (; 5 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/pointer.untouched.wat
+++ b/tests/compiler/std/pointer.untouched.wat
@@ -1,10 +1,10 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $iiv (func (param i32 i32)))
- (type $iiiv (func (param i32 i32 i32)))
- (type $iifv (func (param i32 i32 f32)))
- (type $ifv (func (param i32 f32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $ii_ (func (param i32 i32)))
+ (type $iii_ (func (param i32 i32 i32)))
+ (type $iif_ (func (param i32 i32 f32)))
+ (type $if_ (func (param i32 f32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0e\00\00\00s\00t\00d\00/\00p\00o\00i\00n\00t\00e\00r\00.\00t\00s\00")
@@ -20,7 +20,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $~lib/internal/memory/memset (; 1 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 1 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -274,7 +274,7 @@
    end
   end
  )
- (func $~lib/internal/memory/memcpy (; 2 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 2 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1475,7 +1475,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 3 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 3 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -1702,7 +1702,7 @@
    end
   end
  )
- (func $std/pointer/Pointer<Entry>#set:value (; 4 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $std/pointer/Pointer<Entry>#set:value (; 4 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1733,7 +1733,7 @@
    call $~lib/internal/memory/memmove
   end
  )
- (func $std/pointer/Pointer<f32>#set (; 5 ;) (type $iifv) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $std/pointer/Pointer<f32>#set (; 5 ;) (type $iif_) (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $0
   local.get $1
   i32.const 4
@@ -1742,12 +1742,12 @@
   local.get $2
   f32.store
  )
- (func $std/pointer/Pointer<f32>#set:value (; 6 ;) (type $ifv) (param $0 i32) (param $1 f32)
+ (func $std/pointer/Pointer<f32>#set:value (; 6 ;) (type $if_) (param $0 i32) (param $1 f32)
   local.get $0
   local.get $1
   f32.store
  )
- (func $start (; 7 ;) (type $v)
+ (func $start (; 7 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 f32)
@@ -2350,6 +2350,6 @@
    unreachable
   end
  )
- (func $null (; 8 ;) (type $v)
+ (func $null (; 8 ;) (type $_)
  )
 )

--- a/tests/compiler/std/polyfills.optimized.wat
+++ b/tests/compiler/std/polyfills.optimized.wat
@@ -1,12 +1,12 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 1)
  (data (i32.const 8) "\10\00\00\00s\00t\00d\00/\00p\00o\00l\00y\00f\00i\00l\00l\00s\00.\00t\00s")
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $start (; 0 ;) (type $v)
+ (func $start (; 0 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/polyfills.untouched.wat
+++ b/tests/compiler/std/polyfills.untouched.wat
@@ -1,8 +1,8 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $II (func (param i64) (result i64)))
- (type $v (func))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\10\00\00\00s\00t\00d\00/\00p\00o\00l\00y\00f\00i\00l\00l\00s\00.\00t\00s\00")
@@ -184,7 +184,7 @@
   i32.or
   return
  )
- (func $start (; 11 ;) (type $v)
+ (func $start (; 11 ;) (type $_)
   (local $0 i32)
   i32.const 170
   call $~lib/polyfills/bswap<u8>
@@ -507,6 +507,6 @@
    unreachable
   end
  )
- (func $null (; 12 ;) (type $v)
+ (func $null (; 12 ;) (type $_)
  )
 )

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -1,23 +1,23 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (type $ii (func (param i32) (result i32)))
- (type $iv (func (param i32)))
+ (type $i_ (func (param i32)))
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $iii (func (param i32 i32) (result i32)))
- (type $iiv (func (param i32 i32)))
+ (type $ii_ (func (param i32 i32)))
  (type $iIi (func (param i32 i64) (result i32)))
  (type $Ii (func (param i64) (result i32)))
  (type $iIii (func (param i32 i64 i32) (result i32)))
- (type $iIv (func (param i32 i64)))
+ (type $iI_ (func (param i32 i64)))
  (type $ifi (func (param i32 f32) (result i32)))
  (type $fi (func (param f32) (result i32)))
  (type $ifii (func (param i32 f32 i32) (result i32)))
- (type $ifv (func (param i32 f32)))
+ (type $if_ (func (param i32 f32)))
  (type $iFi (func (param i32 f64) (result i32)))
  (type $Fi (func (param f64) (result i32)))
  (type $iFii (func (param i32 f64 i32) (result i32)))
- (type $iFv (func (param i32 f64)))
+ (type $iF_ (func (param i32 f64)))
  (type $FUNCSIG$vii (func (param i32 i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (type $FUNCSIG$i (func (result i32)))
@@ -368,7 +368,7 @@
   end
   local.get $2
  )
- (func $~lib/set/Set<i8>#clear (; 5 ;) (type $iv) (param $0 i32)
+ (func $~lib/set/Set<i8>#clear (; 5 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 16
   i32.const 0
@@ -479,7 +479,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i8>#rehash (; 9 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i8>#rehash (; 9 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -585,7 +585,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<i8>#add (; 10 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i8>#add (; 10 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -748,7 +748,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<i8> (; 12 ;) (type $v)
+ (func $std/set/test<i8> (; 12 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   call $~lib/set/Set<i8>#constructor
@@ -1009,7 +1009,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u8>#rehash (; 14 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u8>#rehash (; 14 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1115,7 +1115,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<u8>#add (; 15 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u8>#add (; 15 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1274,7 +1274,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<u8> (; 17 ;) (type $v)
+ (func $std/set/test<u8> (; 17 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   call $~lib/set/Set<i8>#constructor
@@ -1592,7 +1592,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i16>#rehash (; 20 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i16>#rehash (; 20 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1707,7 +1707,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<i16>#add (; 21 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i16>#add (; 21 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1888,7 +1888,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<i16> (; 23 ;) (type $v)
+ (func $std/set/test<i16> (; 23 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   call $~lib/set/Set<i8>#constructor
@@ -2159,7 +2159,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u16>#rehash (; 25 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u16>#rehash (; 25 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2274,7 +2274,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<u16>#add (; 26 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u16>#add (; 26 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2451,7 +2451,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<u16> (; 28 ;) (type $v)
+ (func $std/set/test<u16> (; 28 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   call $~lib/set/Set<i8>#constructor
@@ -2781,7 +2781,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i32>#rehash (; 32 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i32>#rehash (; 32 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2884,7 +2884,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<i32>#add (; 33 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i32>#add (; 33 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3033,7 +3033,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<i32> (; 35 ;) (type $v)
+ (func $std/set/test<i32> (; 35 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   call $~lib/set/Set<i8>#constructor
@@ -3280,7 +3280,7 @@
    unreachable
   end
  )
- (func $std/set/test<u32> (; 36 ;) (type $v)
+ (func $std/set/test<u32> (; 36 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   call $~lib/set/Set<i8>#constructor
@@ -3527,7 +3527,7 @@
    unreachable
   end
  )
- (func $~lib/set/Set<i64>#clear (; 37 ;) (type $iv) (param $0 i32)
+ (func $~lib/set/Set<i64>#clear (; 37 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 16
   i32.const 0
@@ -3695,7 +3695,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i64>#rehash (; 42 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i64>#rehash (; 42 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3798,7 +3798,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<i64>#add (; 43 ;) (type $iIv) (param $0 i32) (param $1 i64)
+ (func $~lib/set/Set<i64>#add (; 43 ;) (type $iI_) (param $0 i32) (param $1 i64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3948,7 +3948,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<i64> (; 45 ;) (type $v)
+ (func $std/set/test<i64> (; 45 ;) (type $_)
   (local $0 i64)
   (local $1 i32)
   call $~lib/set/Set<i64>#constructor
@@ -4195,7 +4195,7 @@
    unreachable
   end
  )
- (func $std/set/test<u64> (; 46 ;) (type $v)
+ (func $std/set/test<u64> (; 46 ;) (type $_)
   (local $0 i64)
   (local $1 i32)
   call $~lib/set/Set<i64>#constructor
@@ -4499,7 +4499,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<f32>#rehash (; 50 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<f32>#rehash (; 50 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4603,7 +4603,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<f32>#add (; 51 ;) (type $ifv) (param $0 i32) (param $1 f32)
+ (func $~lib/set/Set<f32>#add (; 51 ;) (type $if_) (param $0 i32) (param $1 f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4752,7 +4752,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<f32> (; 53 ;) (type $v)
+ (func $std/set/test<f32> (; 53 ;) (type $_)
   (local $0 f32)
   (local $1 i32)
   call $~lib/set/Set<i8>#constructor
@@ -5056,7 +5056,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<f64>#rehash (; 57 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<f64>#rehash (; 57 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5160,7 +5160,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<f64>#add (; 58 ;) (type $iFv) (param $0 i32) (param $1 f64)
+ (func $~lib/set/Set<f64>#add (; 58 ;) (type $iF_) (param $0 i32) (param $1 f64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5309,7 +5309,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<f64> (; 60 ;) (type $v)
+ (func $std/set/test<f64> (; 60 ;) (type $_)
   (local $0 f64)
   (local $1 i32)
   call $~lib/set/Set<i64>#constructor
@@ -5556,7 +5556,7 @@
    unreachable
   end
  )
- (func $start (; 61 ;) (type $v)
+ (func $start (; 61 ;) (type $_)
   i32.const 144
   global.set $~lib/allocator/arena/startOffset
   global.get $~lib/allocator/arena/startOffset
@@ -5572,7 +5572,7 @@
   call $std/set/test<f32>
   call $std/set/test<f64>
  )
- (func $null (; 62 ;) (type $v)
+ (func $null (; 62 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -1,24 +1,24 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (type $ii (func (param i32) (result i32)))
- (type $iv (func (param i32)))
+ (type $i_ (func (param i32)))
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $iiiv (func (param i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $iii_ (func (param i32 i32 i32)))
  (type $iii (func (param i32 i32) (result i32)))
- (type $iiv (func (param i32 i32)))
+ (type $ii_ (func (param i32 i32)))
  (type $iIi (func (param i32 i64) (result i32)))
  (type $Ii (func (param i64) (result i32)))
  (type $iIii (func (param i32 i64 i32) (result i32)))
- (type $iIv (func (param i32 i64)))
+ (type $iI_ (func (param i32 i64)))
  (type $ifi (func (param i32 f32) (result i32)))
  (type $fi (func (param f32) (result i32)))
  (type $ifii (func (param i32 f32 i32) (result i32)))
- (type $ifv (func (param i32 f32)))
+ (type $if_ (func (param i32 f32)))
  (type $iFi (func (param i32 f64) (result i32)))
  (type $Fi (func (param f64) (result i32)))
  (type $iFii (func (param i32 f64 i32) (result i32)))
- (type $iFv (func (param i32 f64)))
+ (type $iF_ (func (param i32 f64)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\13\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
@@ -170,7 +170,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memset (; 5 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 5 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -463,7 +463,7 @@
   end
   local.get $3
  )
- (func $~lib/set/Set<i8>#clear (; 7 ;) (type $iv) (param $0 i32)
+ (func $~lib/set/Set<i8>#clear (; 7 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -603,7 +603,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i8>#rehash (; 13 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i8>#rehash (; 13 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -739,7 +739,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<i8>#add (; 14 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i8>#add (; 14 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -915,7 +915,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<i8> (; 17 ;) (type $v)
+ (func $std/set/test<i8> (; 17 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -1198,7 +1198,7 @@
    unreachable
   end
  )
- (func $~lib/set/Set<u8>#clear (; 18 ;) (type $iv) (param $0 i32)
+ (func $~lib/set/Set<u8>#clear (; 18 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -1327,7 +1327,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u8>#rehash (; 23 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u8>#rehash (; 23 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1463,7 +1463,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<u8>#add (; 24 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u8>#add (; 24 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1637,7 +1637,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<u8> (; 27 ;) (type $v)
+ (func $std/set/test<u8> (; 27 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -1920,7 +1920,7 @@
    unreachable
   end
  )
- (func $~lib/set/Set<i16>#clear (; 28 ;) (type $iv) (param $0 i32)
+ (func $~lib/set/Set<i16>#clear (; 28 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -2075,7 +2075,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i16>#rehash (; 34 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i16>#rehash (; 34 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2211,7 +2211,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<i16>#add (; 35 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i16>#add (; 35 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2387,7 +2387,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<i16> (; 38 ;) (type $v)
+ (func $std/set/test<i16> (; 38 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -2670,7 +2670,7 @@
    unreachable
   end
  )
- (func $~lib/set/Set<u16>#clear (; 39 ;) (type $iv) (param $0 i32)
+ (func $~lib/set/Set<u16>#clear (; 39 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -2799,7 +2799,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u16>#rehash (; 44 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u16>#rehash (; 44 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2935,7 +2935,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<u16>#add (; 45 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u16>#add (; 45 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3109,7 +3109,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<u16> (; 48 ;) (type $v)
+ (func $std/set/test<u16> (; 48 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -3392,7 +3392,7 @@
    unreachable
   end
  )
- (func $~lib/set/Set<i32>#clear (; 49 ;) (type $iv) (param $0 i32)
+ (func $~lib/set/Set<i32>#clear (; 49 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -3559,7 +3559,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i32>#rehash (; 55 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i32>#rehash (; 55 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3695,7 +3695,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<i32>#add (; 56 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i32>#add (; 56 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3867,7 +3867,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<i32> (; 59 ;) (type $v)
+ (func $std/set/test<i32> (; 59 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4150,7 +4150,7 @@
    unreachable
   end
  )
- (func $~lib/set/Set<u32>#clear (; 60 ;) (type $iv) (param $0 i32)
+ (func $~lib/set/Set<u32>#clear (; 60 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -4275,7 +4275,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u32>#rehash (; 65 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u32>#rehash (; 65 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4411,7 +4411,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<u32>#add (; 66 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u32>#add (; 66 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4583,7 +4583,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<u32> (; 69 ;) (type $v)
+ (func $std/set/test<u32> (; 69 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4866,7 +4866,7 @@
    unreachable
   end
  )
- (func $~lib/set/Set<i64>#clear (; 70 ;) (type $iv) (param $0 i32)
+ (func $~lib/set/Set<i64>#clear (; 70 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -5079,7 +5079,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i64>#rehash (; 76 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i64>#rehash (; 76 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5216,7 +5216,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<i64>#add (; 77 ;) (type $iIv) (param $0 i32) (param $1 i64)
+ (func $~lib/set/Set<i64>#add (; 77 ;) (type $iI_) (param $0 i32) (param $1 i64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5389,7 +5389,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<i64> (; 80 ;) (type $v)
+ (func $std/set/test<i64> (; 80 ;) (type $_)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -5672,7 +5672,7 @@
    unreachable
   end
  )
- (func $~lib/set/Set<u64>#clear (; 81 ;) (type $iv) (param $0 i32)
+ (func $~lib/set/Set<u64>#clear (; 81 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -5797,7 +5797,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u64>#rehash (; 86 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u64>#rehash (; 86 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5934,7 +5934,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<u64>#add (; 87 ;) (type $iIv) (param $0 i32) (param $1 i64)
+ (func $~lib/set/Set<u64>#add (; 87 ;) (type $iI_) (param $0 i32) (param $1 i64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6107,7 +6107,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<u64> (; 90 ;) (type $v)
+ (func $std/set/test<u64> (; 90 ;) (type $_)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -6390,7 +6390,7 @@
    unreachable
   end
  )
- (func $~lib/set/Set<f32>#clear (; 91 ;) (type $iv) (param $0 i32)
+ (func $~lib/set/Set<f32>#clear (; 91 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -6516,7 +6516,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<f32>#rehash (; 96 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<f32>#rehash (; 96 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6654,7 +6654,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<f32>#add (; 97 ;) (type $ifv) (param $0 i32) (param $1 f32)
+ (func $~lib/set/Set<f32>#add (; 97 ;) (type $if_) (param $0 i32) (param $1 f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6828,7 +6828,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<f32> (; 100 ;) (type $v)
+ (func $std/set/test<f32> (; 100 ;) (type $_)
   (local $0 i32)
   (local $1 f32)
   i32.const 0
@@ -7111,7 +7111,7 @@
    unreachable
   end
  )
- (func $~lib/set/Set<f64>#clear (; 101 ;) (type $iv) (param $0 i32)
+ (func $~lib/set/Set<f64>#clear (; 101 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -7237,7 +7237,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<f64>#rehash (; 106 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<f64>#rehash (; 106 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7375,7 +7375,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<f64>#add (; 107 ;) (type $iFv) (param $0 i32) (param $1 f64)
+ (func $~lib/set/Set<f64>#add (; 107 ;) (type $iF_) (param $0 i32) (param $1 f64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7549,7 +7549,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<f64> (; 110 ;) (type $v)
+ (func $std/set/test<f64> (; 110 ;) (type $_)
   (local $0 i32)
   (local $1 f64)
   i32.const 0
@@ -7832,7 +7832,7 @@
    unreachable
   end
  )
- (func $start (; 111 ;) (type $v)
+ (func $start (; 111 ;) (type $_)
   global.get $HEAP_BASE
   global.get $~lib/internal/allocator/AL_MASK
   i32.add
@@ -7854,6 +7854,6 @@
   call $std/set/test<f32>
   call $std/set/test<f64>
  )
- (func $null (; 112 ;) (type $v)
+ (func $null (; 112 ;) (type $_)
  )
 )

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -1,9 +1,9 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $iii (func (param i32 i32) (result i32)))
- (type $iiiv (func (param i32 i32 i32)))
+ (type $iii_ (func (param i32 i32 i32)))
  (type $ii (func (param i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (type $FUNCSIG$vii (func (param i32 i32)))
  (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
@@ -117,7 +117,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memcpy (; 3 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 3 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1014,7 +1014,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 4 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 4 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -1613,7 +1613,7 @@
   f64.const 2.25
   f64.store offset=8
  )
- (func $start (; 11 ;) (type $v)
+ (func $start (; 11 ;) (type $_)
   (local $0 i32)
   i32.const 280
   global.set $~lib/allocator/arena/startOffset
@@ -1968,7 +1968,7 @@
    unreachable
   end
  )
- (func $null (; 12 ;) (type $v)
+ (func $null (; 12 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -1,16 +1,16 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $iii (func (param i32 i32) (result i32)))
- (type $iiiv (func (param i32 i32 i32)))
+ (type $iii_ (func (param i32 i32 i32)))
  (type $ii (func (param i32) (result i32)))
- (type $iv (func (param i32)))
+ (type $i_ (func (param i32)))
  (type $iiI (func (param i32 i32) (result i64)))
- (type $iiIv (func (param i32 i32 i64)))
+ (type $iiI_ (func (param i32 i32 i64)))
  (type $iif (func (param i32 i32) (result f32)))
- (type $iifv (func (param i32 i32 f32)))
+ (type $iif_ (func (param i32 i32 f32)))
  (type $iiF (func (param i32 i32) (result f64)))
- (type $iiFv (func (param i32 i32 f64)))
- (type $v (func))
+ (type $iiF_ (func (param i32 i32 f64)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\08\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00")
@@ -195,7 +195,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memcpy (; 5 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 5 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1396,7 +1396,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 6 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 6 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -1623,10 +1623,10 @@
    end
   end
  )
- (func $~lib/allocator/arena/__memory_free (; 7 ;) (type $iv) (param $0 i32)
+ (func $~lib/allocator/arena/__memory_free (; 7 ;) (type $i_) (param $0 i32)
   nop
  )
- (func $~lib/internal/memory/memset (; 8 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 8 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -1987,7 +1987,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<i32>#__set (; 10 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__set (; 10 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2087,7 +2087,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<i64>#__set (; 12 ;) (type $iiIv) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<i64>#__set (; 12 ;) (type $iiI_) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2187,7 +2187,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<f32>#__set (; 14 ;) (type $iifv) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/array/Array<f32>#__set (; 14 ;) (type $iif_) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2287,7 +2287,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<f64>#__set (; 16 ;) (type $iiFv) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/array/Array<f64>#__set (; 16 ;) (type $iiF_) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2354,7 +2354,7 @@
    f64.store offset=8
   end
  )
- (func $start (; 17 ;) (type $v)
+ (func $start (; 17 ;) (type $_)
   (local $0 i32)
   global.get $HEAP_BASE
   global.get $~lib/internal/allocator/AL_MASK
@@ -2619,6 +2619,6 @@
    unreachable
   end
  )
- (func $null (; 18 ;) (type $v)
+ (func $null (; 18 ;) (type $_)
  )
 )

--- a/tests/compiler/std/string-utf8.optimized.wat
+++ b/tests/compiler/std/string-utf8.optimized.wat
@@ -1,9 +1,9 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $iii (func (param i32 i32) (result i32)))
- (type $iiiv (func (param i32 i32 i32)))
- (type $v (func))
+ (type $iii_ (func (param i32 i32 i32)))
+ (type $_ (func))
  (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -418,7 +418,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memcpy (; 5 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 5 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1315,7 +1315,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 6 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 6 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -1837,7 +1837,7 @@
   call $~lib/internal/string/compareUnsafe
   i32.eqz
  )
- (func $start (; 10 ;) (type $v)
+ (func $start (; 10 ;) (type $_)
   i32.const 192
   global.set $~lib/allocator/arena/startOffset
   global.get $~lib/allocator/arena/startOffset
@@ -2082,7 +2082,7 @@
    unreachable
   end
  )
- (func $null (; 11 ;) (type $v)
+ (func $null (; 11 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/string-utf8.untouched.wat
+++ b/tests/compiler/std/string-utf8.untouched.wat
@@ -1,11 +1,11 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $iii (func (param i32 i32) (result i32)))
- (type $iiiv (func (param i32 i32 i32)))
- (type $iv (func (param i32)))
+ (type $iii_ (func (param i32 i32 i32)))
+ (type $i_ (func (param i32)))
  (type $iiiiii (func (param i32 i32 i32 i32 i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\06\00\00\00\01\d87\dch\00i\00R\d8b\df")
@@ -488,7 +488,7 @@
   i32.store
   local.get $2
  )
- (func $~lib/internal/memory/memcpy (; 5 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 5 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1689,7 +1689,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 6 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 6 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -1916,7 +1916,7 @@
    end
   end
  )
- (func $~lib/allocator/arena/__memory_free (; 7 ;) (type $iv) (param $0 i32)
+ (func $~lib/allocator/arena/__memory_free (; 7 ;) (type $i_) (param $0 i32)
   nop
  )
  (func $~lib/string/String.fromUTF8 (; 8 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
@@ -2344,7 +2344,7 @@
   call $~lib/internal/string/compareUnsafe
   i32.eqz
  )
- (func $start (; 11 ;) (type $v)
+ (func $start (; 11 ;) (type $_)
   (local $0 i32)
   global.get $HEAP_BASE
   global.get $~lib/internal/allocator/AL_MASK
@@ -2617,6 +2617,6 @@
    br $~lib/memory/memory.free|inlined.1
   end
  )
- (func $null (; 12 ;) (type $v)
+ (func $null (; 12 ;) (type $_)
  )
 )

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -1,19 +1,19 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $iii (func (param i32 i32) (result i32)))
  (type $ii (func (param i32) (result i32)))
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiiv (func (param i32 i32 i32)))
- (type $iiiiiv (func (param i32 i32 i32 i32 i32)))
+ (type $iii_ (func (param i32 i32 i32)))
+ (type $iiiii_ (func (param i32 i32 i32 i32 i32)))
  (type $i (func (result i32)))
  (type $iiF (func (param i32 i32) (result f64)))
  (type $iF (func (param i32) (result f64)))
  (type $Ii (func (param i64) (result i32)))
- (type $iIiv (func (param i32 i64 i32)))
+ (type $iIi_ (func (param i32 i64 i32)))
  (type $Fi (func (param f64) (result i32)))
  (type $iFi (func (param i32 f64) (result i32)))
  (type $iIiIiIii (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$iiiii (func (param i32 i32 i32 i32) (result i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
@@ -621,7 +621,7 @@
   end
   i32.const -1
  )
- (func $~lib/internal/memory/memcpy (; 11 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 11 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1518,7 +1518,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 12 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 12 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -1716,7 +1716,7 @@
    end
   end
  )
- (func $~lib/internal/string/repeatUnsafe (; 13 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/string/repeatUnsafe (; 13 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1921,7 +1921,7 @@
    end
   end
  )
- (func $~lib/internal/string/copyUnsafe (; 14 ;) (type $iiiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
+ (func $~lib/internal/string/copyUnsafe (; 14 ;) (type $iiiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
   local.get $1
   i32.const 1
   i32.shl
@@ -3834,7 +3834,7 @@
    end
   end
  )
- (func $~lib/internal/number/utoa32_lut (; 43 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/number/utoa32_lut (; 43 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   i32.const 1816
@@ -4055,7 +4055,7 @@
    end
   end
  )
- (func $~lib/internal/number/utoa64_lut (; 47 ;) (type $iIiv) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/internal/number/utoa64_lut (; 47 ;) (type $iIi_) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5386,7 +5386,7 @@
   end
   local.get $1
  )
- (func $start (; 55 ;) (type $v)
+ (func $start (; 55 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 5880
@@ -9163,7 +9163,7 @@
    unreachable
   end
  )
- (func $null (; 56 ;) (type $v)
+ (func $null (; 56 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -1,21 +1,21 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
  (type $iii (func (param i32 i32) (result i32)))
  (type $ii (func (param i32) (result i32)))
  (type $iiiiii (func (param i32 i32 i32 i32 i32) (result i32)))
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiiv (func (param i32 i32 i32)))
- (type $iiiiiv (func (param i32 i32 i32 i32 i32)))
+ (type $iii_ (func (param i32 i32 i32)))
+ (type $iiiii_ (func (param i32 i32 i32 i32 i32)))
  (type $i (func (result i32)))
  (type $iiF (func (param i32 i32) (result f64)))
  (type $iF (func (param i32) (result f64)))
- (type $iv (func (param i32)))
+ (type $i_ (func (param i32)))
  (type $Ii (func (param i64) (result i32)))
- (type $iIiv (func (param i32 i64 i32)))
+ (type $iIi_ (func (param i32 i64 i32)))
  (type $Fi (func (param f64) (result i32)))
  (type $iFi (func (param i32 f64) (result i32)))
  (type $iIiIiIii (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\10\00\00\00h\00i\00,\00 \00I\00\'\00m\00 \00a\00 \00s\00t\00r\00i\00n\00g\00")
@@ -802,7 +802,7 @@
   end
   i32.const -1
  )
- (func $~lib/internal/memory/memcpy (; 12 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 12 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2003,7 +2003,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 13 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 13 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -2230,7 +2230,7 @@
    end
   end
  )
- (func $~lib/internal/string/repeatUnsafe (; 14 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/string/repeatUnsafe (; 14 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -2510,7 +2510,7 @@
    unreachable
   end
  )
- (func $~lib/internal/string/copyUnsafe (; 15 ;) (type $iiiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
+ (func $~lib/internal/string/copyUnsafe (; 15 ;) (type $iiiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -3950,7 +3950,7 @@
   call $~lib/allocator/arena/__memory_allocate
   return
  )
- (func $~lib/internal/memory/memset (; 39 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 39 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -4265,7 +4265,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<String>#__unchecked_set (; 41 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<String>#__unchecked_set (; 41 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4309,7 +4309,7 @@
   i32.add
   i32.load offset=8
  )
- (func $~lib/allocator/arena/__memory_free (; 43 ;) (type $iv) (param $0 i32)
+ (func $~lib/allocator/arena/__memory_free (; 43 ;) (type $i_) (param $0 i32)
   nop
  )
  (func $~lib/internal/arraybuffer/reallocateUnsafe (; 44 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
@@ -4902,7 +4902,7 @@
   unreachable
   unreachable
  )
- (func $~lib/internal/number/utoa32_lut (; 50 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/number/utoa32_lut (; 50 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5243,7 +5243,7 @@
   unreachable
   unreachable
  )
- (func $~lib/internal/number/utoa64_lut (; 54 ;) (type $iIiv) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/internal/number/utoa64_lut (; 54 ;) (type $iIi_) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -7189,7 +7189,7 @@
   end
   local.get $3
  )
- (func $start (; 64 ;) (type $v)
+ (func $start (; 64 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10757,6 +10757,6 @@
    unreachable
   end
  )
- (func $null (; 65 ;) (type $v)
+ (func $null (; 65 ;) (type $_)
  )
 )

--- a/tests/compiler/std/symbol.optimized.wat
+++ b/tests/compiler/std/symbol.optimized.wat
@@ -1,12 +1,12 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $iv (func (param i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $i_ (func (param i32)))
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiiv (func (param i32 i32 i32)))
+ (type $iii_ (func (param i32 i32 i32)))
  (type $iii (func (param i32 i32) (result i32)))
- (type $iiv (func (param i32 i32)))
- (type $v (func))
+ (type $ii_ (func (param i32 i32)))
+ (type $_ (func))
  (type $FUNCSIG$vii (func (param i32 i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (type $FUNCSIG$i (func (result i32)))
@@ -393,7 +393,7 @@
   end
   local.get $2
  )
- (func $~lib/map/Map<String,usize>#clear (; 5 ;) (type $iv) (param $0 i32)
+ (func $~lib/map/Map<String,usize>#clear (; 5 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 16
   i32.const 0
@@ -593,7 +593,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<String,usize>#rehash (; 11 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<String,usize>#rehash (; 11 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -700,7 +700,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<String,usize>#set (; 12 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<String,usize>#set (; 12 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -866,7 +866,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<usize,String>#rehash (; 15 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<usize,String>#rehash (; 15 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -973,7 +973,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<usize,String>#set (; 16 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<usize,String>#set (; 16 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1192,7 +1192,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memcpy (; 22 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 22 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2089,7 +2089,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 23 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 23 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -2440,7 +2440,7 @@
   i32.const 592
   call $~lib/string/String.__concat
  )
- (func $start (; 28 ;) (type $v)
+ (func $start (; 28 ;) (type $_)
   (local $0 i32)
   i32.const 760
   global.set $~lib/allocator/arena/startOffset
@@ -2617,7 +2617,7 @@
    unreachable
   end
  )
- (func $null (; 29 ;) (type $v)
+ (func $null (; 29 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/symbol.untouched.wat
+++ b/tests/compiler/std/symbol.untouched.wat
@@ -1,14 +1,14 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $iv (func (param i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $i_ (func (param i32)))
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiiv (func (param i32 i32 i32)))
+ (type $iii_ (func (param i32 i32 i32)))
  (type $iii (func (param i32 i32) (result i32)))
  (type $iiiiii (func (param i32 i32 i32 i32 i32) (result i32)))
- (type $iiv (func (param i32 i32)))
- (type $iiiiiv (func (param i32 i32 i32 i32 i32)))
- (type $v (func))
+ (type $ii_ (func (param i32 i32)))
+ (type $iiiii_ (func (param i32 i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\03\00\00\001\002\003\00")
@@ -218,7 +218,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memset (; 6 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 6 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -511,7 +511,7 @@
   end
   local.get $3
  )
- (func $~lib/map/Map<String,usize>#clear (; 8 ;) (type $iv) (param $0 i32)
+ (func $~lib/map/Map<String,usize>#clear (; 8 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -571,7 +571,7 @@
   call $~lib/map/Map<String,usize>#clear
   local.get $0
  )
- (func $~lib/map/Map<usize,String>#clear (; 10 ;) (type $iv) (param $0 i32)
+ (func $~lib/map/Map<usize,String>#clear (; 10 ;) (type $i_) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -858,7 +858,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<String,usize>#rehash (; 18 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<String,usize>#rehash (; 18 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -998,7 +998,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<String,usize>#set (; 19 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<String,usize>#set (; 19 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1197,7 +1197,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<usize,String>#rehash (; 22 ;) (type $iiv) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<usize,String>#rehash (; 22 ;) (type $ii_) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1337,7 +1337,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<usize,String>#set (; 23 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<usize,String>#set (; 23 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1588,7 +1588,7 @@
   i32.store
   local.get $2
  )
- (func $~lib/internal/memory/memcpy (; 29 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 29 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2789,7 +2789,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 30 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 30 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -3016,7 +3016,7 @@
    end
   end
  )
- (func $~lib/internal/string/copyUnsafe (; 31 ;) (type $iiiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
+ (func $~lib/internal/string/copyUnsafe (; 31 ;) (type $iiiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -3300,7 +3300,7 @@
   i32.const 592
   call $~lib/string/String.__concat
  )
- (func $start (; 35 ;) (type $v)
+ (func $start (; 35 ;) (type $_)
   global.get $HEAP_BASE
   global.get $~lib/internal/allocator/AL_MASK
   i32.add
@@ -3469,6 +3469,6 @@
   global.get $~lib/symbol/Symbol.isConcatSpreadable
   drop
  )
- (func $null (; 36 ;) (type $v)
+ (func $null (; 36 ;) (type $_)
  )
 )

--- a/tests/compiler/std/trace.optimized.wat
+++ b/tests/compiler/std/trace.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiFFFFFv (func (param i32 i32 f64 f64 f64 f64 f64)))
- (type $v (func))
+ (type $iiFFFFF_ (func (param i32 i32 f64 f64 f64 f64 f64)))
+ (type $_ (func))
  (import "env" "trace" (func $~lib/env/trace (param i32 i32 f64 f64 f64 f64 f64)))
  (memory $0 1)
  (data (i32.const 8) "\0d\00\00\00z\00e\00r\00o\00_\00i\00m\00p\00l\00i\00c\00i\00t")
@@ -17,7 +17,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "main" (func $std/trace/main))
- (func $std/trace/main (; 1 ;) (type $v)
+ (func $std/trace/main (; 1 ;) (type $_)
   global.get $~started
   i32.eqz
   if
@@ -26,7 +26,7 @@
    global.set $~started
   end
  )
- (func $start (; 2 ;) (type $v)
+ (func $start (; 2 ;) (type $_)
   i32.const 8
   i32.const 0
   f64.const 0
@@ -92,7 +92,7 @@
   f64.const 5.5
   call $~lib/env/trace
  )
- (func $null (; 3 ;) (type $v)
+ (func $null (; 3 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/trace.untouched.wat
+++ b/tests/compiler/std/trace.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiFFFFFv (func (param i32 i32 f64 f64 f64 f64 f64)))
- (type $v (func))
+ (type $iiFFFFF_ (func (param i32 i32 f64 f64 f64 f64 f64)))
+ (type $_ (func))
  (import "env" "trace" (func $~lib/env/trace (param i32 i32 f64 f64 f64 f64 f64)))
  (memory $0 1)
  (data (i32.const 8) "\0d\00\00\00z\00e\00r\00o\00_\00i\00m\00p\00l\00i\00c\00i\00t\00")
@@ -18,7 +18,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "main" (func $std/trace/main))
- (func $std/trace/main (; 1 ;) (type $v)
+ (func $std/trace/main (; 1 ;) (type $_)
   global.get $~started
   i32.eqz
   if
@@ -27,7 +27,7 @@
    global.set $~started
   end
  )
- (func $start (; 2 ;) (type $v)
+ (func $start (; 2 ;) (type $_)
   i32.const 8
   i32.const 0
   f64.const 0
@@ -93,6 +93,6 @@
   f64.const 5.5
   call $~lib/env/trace
  )
- (func $null (; 3 ;) (type $v)
+ (func $null (; 3 ;) (type $_)
  )
 )

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -1,18 +1,18 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $iv (func (param i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $i_ (func (param i32)))
  (type $iii (func (param i32 i32) (result i32)))
  (type $ii (func (param i32) (result i32)))
- (type $iiiv (func (param i32 i32 i32)))
+ (type $iii_ (func (param i32 i32 i32)))
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiFv (func (param i32 i32 f64)))
+ (type $iiF_ (func (param i32 i32 f64)))
  (type $FFi (func (param f64 f64) (result i32)))
  (type $iiF (func (param i32 i32) (result f64)))
  (type $iiiii (func (param i32 i32 i32 i32) (result i32)))
- (type $v (func))
- (type $iiIv (func (param i32 i32 i64)))
+ (type $_ (func))
+ (type $iiI_ (func (param i32 i32 i64)))
  (type $IIiiI (func (param i64 i64 i32 i32) (result i64)))
- (type $iifv (func (param i32 i32 f32)))
+ (type $iif_ (func (param i32 i32 f32)))
  (type $ffiif (func (param f32 f32 i32 i32) (result f32)))
  (type $FFiiF (func (param f64 f64 i32 i32) (result f64)))
  (type $IiiI (func (param i64 i32 i32) (result i64)))
@@ -173,7 +173,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memset (; 3 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 3 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i64)
   local.get $2
@@ -644,7 +644,7 @@
   local.get $0
   call $~lib/internal/typedarray/TypedArray<i64>#constructor
  )
- (func $std/typedarray/testInstantiate (; 13 ;) (type $iv) (param $0 i32)
+ (func $std/typedarray/testInstantiate (; 13 ;) (type $i_) (param $0 i32)
   (local $1 i32)
   i32.const 0
   local.get $0
@@ -1077,7 +1077,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i32>#__set (; 14 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<i32>#__set (; 14 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1195,7 +1195,7 @@
   i32.store offset=8
   local.get $2
  )
- (func $~lib/internal/typedarray/TypedArray<f64>#__set (; 17 ;) (type $iiFv) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/internal/typedarray/TypedArray<f64>#__set (; 17 ;) (type $iiF_) (param $0 i32) (param $1 i32) (param $2 f64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1273,7 +1273,7 @@
   i32.store offset=8
   local.get $2
  )
- (func $~lib/internal/sort/insertionSort<f64> (; 19 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<f64> (; 19 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 f64)
@@ -1363,7 +1363,7 @@
    unreachable
   end
  )
- (func $~lib/internal/sort/weakHeapSort<f64> (; 20 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/weakHeapSort<f64> (; 20 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 f64)
@@ -1790,7 +1790,7 @@
   i32.add
   f64.load offset=8
  )
- (func $~lib/internal/typedarray/TypedArray<u8>#__set (; 24 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<u8>#__set (; 24 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1813,7 +1813,7 @@
   local.get $2
   i32.store8 offset=8
  )
- (func $~lib/typedarray/Uint8ClampedArray#__set (; 25 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#__set (; 25 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -2319,7 +2319,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduce<Int8Array,i8> (; 37 ;) (type $v)
+ (func $std/typedarray/testReduce<Int8Array,i8> (; 37 ;) (type $_)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -2394,7 +2394,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testReduce<Uint8Array,u8> (; 39 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint8Array,u8> (; 39 ;) (type $_)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -2427,7 +2427,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Uint8ClampedArray,u8> (; 40 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint8ClampedArray,u8> (; 40 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
@@ -2459,7 +2459,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i16>#__set (; 41 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<i16>#__set (; 41 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2533,7 +2533,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduce<Int16Array,i16> (; 43 ;) (type $v)
+ (func $std/typedarray/testReduce<Int16Array,i16> (; 43 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -2611,7 +2611,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduce<Uint16Array,u16> (; 45 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint16Array,u16> (; 45 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -2689,7 +2689,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testReduce<Int32Array,i32> (; 47 ;) (type $v)
+ (func $std/typedarray/testReduce<Int32Array,i32> (; 47 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -2719,7 +2719,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Uint32Array,u32> (; 48 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint32Array,u32> (; 48 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -2749,7 +2749,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i64>#__set (; 49 ;) (type $iiIv) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/internal/typedarray/TypedArray<i64>#__set (; 49 ;) (type $iiI_) (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2828,7 +2828,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testReduce<Int64Array,i64> (; 52 ;) (type $v)
+ (func $std/typedarray/testReduce<Int64Array,i64> (; 52 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -2858,7 +2858,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Uint64Array,u64> (; 53 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint64Array,u64> (; 53 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -2888,7 +2888,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<f32>#__set (; 54 ;) (type $iifv) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/internal/typedarray/TypedArray<f32>#__set (; 54 ;) (type $iif_) (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2967,7 +2967,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduce<Float32Array,f32> (; 57 ;) (type $v)
+ (func $std/typedarray/testReduce<Float32Array,f32> (; 57 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -3048,7 +3048,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduce<Float64Array,f64> (; 60 ;) (type $v)
+ (func $std/typedarray/testReduce<Float64Array,f64> (; 60 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -3121,7 +3121,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduceRight<Int8Array,i8> (; 62 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int8Array,i8> (; 62 ;) (type $_)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -3197,7 +3197,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testReduceRight<Uint8Array,u8> (; 64 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint8Array,u8> (; 64 ;) (type $_)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -3230,7 +3230,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8> (; 65 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8> (; 65 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
@@ -3310,7 +3310,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduceRight<Int16Array,i16> (; 67 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int16Array,i16> (; 67 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -3389,7 +3389,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduceRight<Uint16Array,u16> (; 69 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint16Array,u16> (; 69 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -3468,7 +3468,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testReduceRight<Int32Array,i32> (; 71 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int32Array,i32> (; 71 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -3498,7 +3498,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint32Array,u32> (; 72 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint32Array,u32> (; 72 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -3576,7 +3576,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testReduceRight<Int64Array,i64> (; 74 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int64Array,i64> (; 74 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -3606,7 +3606,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint64Array,u64> (; 75 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint64Array,u64> (; 75 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -3684,7 +3684,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduceRight<Float32Array,f32> (; 77 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Float32Array,f32> (; 77 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -3761,7 +3761,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduceRight<Float64Array,f64> (; 79 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Float64Array,f64> (; 79 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -3846,7 +3846,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArrayMap<Int8Array,i8> (; 82 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int8Array,i8> (; 82 ;) (type $_)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -3962,7 +3962,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArrayMap<Uint8Array,u8> (; 84 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint8Array,u8> (; 84 ;) (type $_)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -4077,7 +4077,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8> (; 86 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8> (; 86 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
@@ -4223,7 +4223,7 @@
   i32.add
   i32.load16_s offset=8
  )
- (func $std/typedarray/testArrayMap<Int16Array,i16> (; 89 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int16Array,i16> (; 89 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -4369,7 +4369,7 @@
   i32.add
   i32.load16_u offset=8
  )
- (func $std/typedarray/testArrayMap<Uint16Array,u16> (; 92 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint16Array,u16> (; 92 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -4490,7 +4490,7 @@
   end
   local.get $6
  )
- (func $std/typedarray/testArrayMap<Int32Array,i32> (; 94 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int32Array,i32> (; 94 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -4549,7 +4549,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint32Array,u32> (; 95 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint32Array,u32> (; 95 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -4696,7 +4696,7 @@
   i32.add
   i64.load offset=8
  )
- (func $std/typedarray/testArrayMap<Int64Array,i64> (; 99 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int64Array,i64> (; 99 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -4755,7 +4755,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint64Array,u64> (; 100 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint64Array,u64> (; 100 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -4901,7 +4901,7 @@
   i32.add
   f32.load offset=8
  )
- (func $std/typedarray/testArrayMap<Float32Array,f32> (; 104 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Float32Array,f32> (; 104 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -5020,7 +5020,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArrayMap<Float64Array,f64> (; 107 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Float64Array,f64> (; 107 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -5137,7 +5137,7 @@
   i32.and
   i32.eqz
  )
- (func $std/typedarray/testArraySome<Int8Array,i8> (; 111 ;) (type $v)
+ (func $std/typedarray/testArraySome<Int8Array,i8> (; 111 ;) (type $_)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -5224,7 +5224,7 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Uint8Array,u8> (; 113 ;) (type $v)
+ (func $std/typedarray/testArraySome<Uint8Array,u8> (; 113 ;) (type $_)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -5265,7 +5265,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint8ClampedArray,u8> (; 114 ;) (type $v)
+ (func $std/typedarray/testArraySome<Uint8ClampedArray,u8> (; 114 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
@@ -5368,7 +5368,7 @@
   i32.and
   i32.eqz
  )
- (func $std/typedarray/testArraySome<Int16Array,i16> (; 118 ;) (type $v)
+ (func $std/typedarray/testArraySome<Int16Array,i16> (; 118 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -5458,7 +5458,7 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Uint16Array,u16> (; 120 ;) (type $v)
+ (func $std/typedarray/testArraySome<Uint16Array,u16> (; 120 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -5557,7 +5557,7 @@
   local.get $0
   i32.eqz
  )
- (func $std/typedarray/testArraySome<Int32Array,i32> (; 124 ;) (type $v)
+ (func $std/typedarray/testArraySome<Int32Array,i32> (; 124 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -5597,7 +5597,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint32Array,u32> (; 125 ;) (type $v)
+ (func $std/typedarray/testArraySome<Uint32Array,u32> (; 125 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -5697,7 +5697,7 @@
   i64.const 0
   i64.eq
  )
- (func $std/typedarray/testArraySome<Int64Array,i64> (; 129 ;) (type $v)
+ (func $std/typedarray/testArraySome<Int64Array,i64> (; 129 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -5737,7 +5737,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint64Array,u64> (; 130 ;) (type $v)
+ (func $std/typedarray/testArraySome<Uint64Array,u64> (; 130 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -5837,7 +5837,7 @@
   f32.const 0
   f32.eq
  )
- (func $std/typedarray/testArraySome<Float32Array,f32> (; 134 ;) (type $v)
+ (func $std/typedarray/testArraySome<Float32Array,f32> (; 134 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -5937,7 +5937,7 @@
   f64.const 0
   f64.eq
  )
- (func $std/typedarray/testArraySome<Float64Array,f64> (; 138 ;) (type $v)
+ (func $std/typedarray/testArraySome<Float64Array,f64> (; 138 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -6033,7 +6033,7 @@
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int8Array,i8> (; 141 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Int8Array,i8> (; 141 ;) (type $_)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -6126,7 +6126,7 @@
   end
   local.get $0
  )
- (func $std/typedarray/testArrayFindIndex<Uint8Array,u8> (; 143 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Uint8Array,u8> (; 143 ;) (type $_)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -6170,7 +6170,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8> (; 144 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8> (; 144 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
@@ -6273,7 +6273,7 @@
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int16Array,i16> (; 147 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Int16Array,i16> (; 147 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -6369,7 +6369,7 @@
   end
   local.get $0
  )
- (func $std/typedarray/testArrayFindIndex<Uint16Array,u16> (; 149 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Uint16Array,u16> (; 149 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -6470,7 +6470,7 @@
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int32Array,i32> (; 152 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Int32Array,i32> (; 152 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -6513,7 +6513,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint32Array,u32> (; 153 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Uint32Array,u32> (; 153 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -6614,7 +6614,7 @@
   i64.const 4
   i64.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int64Array,i64> (; 156 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Int64Array,i64> (; 156 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -6657,7 +6657,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint64Array,u64> (; 157 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Uint64Array,u64> (; 157 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -6758,7 +6758,7 @@
   f32.const 4
   f32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Float32Array,f32> (; 160 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Float32Array,f32> (; 160 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -6859,7 +6859,7 @@
   f64.const 4
   f64.eq
  )
- (func $std/typedarray/testArrayFindIndex<Float64Array,f64> (; 163 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Float64Array,f64> (; 163 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -6960,7 +6960,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int8Array,i8> (; 166 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Int8Array,i8> (; 166 ;) (type $_)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -7055,7 +7055,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Uint8Array,u8> (; 169 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Uint8Array,u8> (; 169 ;) (type $_)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -7096,7 +7096,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8> (; 170 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8> (; 170 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
@@ -7198,7 +7198,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int16Array,i16> (; 173 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Int16Array,i16> (; 173 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -7290,7 +7290,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Uint16Array,u16> (; 175 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Uint16Array,u16> (; 175 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -7388,7 +7388,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int32Array,i32> (; 178 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Int32Array,i32> (; 178 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -7428,7 +7428,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint32Array,u32> (; 179 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Uint32Array,u32> (; 179 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -7527,7 +7527,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int64Array,i64> (; 182 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Int64Array,i64> (; 182 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -7574,7 +7574,7 @@
   i64.const 0
   i64.eq
  )
- (func $std/typedarray/testArrayEvery<Uint64Array,u64> (; 184 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Uint64Array,u64> (; 184 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -7823,7 +7823,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Float32Array,f32> (; 188 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Float32Array,f32> (; 188 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -8080,7 +8080,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Float64Array,f64> (; 192 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Float64Array,f64> (; 192 ;) (type $_)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -8120,7 +8120,7 @@
    unreachable
   end
  )
- (func $start (; 193 ;) (type $v)
+ (func $start (; 193 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 624
@@ -9113,7 +9113,7 @@
   call $std/typedarray/testArrayEvery<Float32Array,f32>
   call $std/typedarray/testArrayEvery<Float64Array,f64>
  )
- (func $null (; 194 ;) (type $v)
+ (func $null (; 194 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -1,19 +1,19 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $iv (func (param i32)))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $i_ (func (param i32)))
  (type $iii (func (param i32 i32) (result i32)))
  (type $ii (func (param i32) (result i32)))
- (type $iiiv (func (param i32 i32 i32)))
+ (type $iii_ (func (param i32 i32 i32)))
  (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiFv (func (param i32 i32 f64)))
+ (type $iiF_ (func (param i32 i32 f64)))
  (type $FFi (func (param f64 f64) (result i32)))
  (type $iiF (func (param i32 i32) (result f64)))
  (type $iiiii (func (param i32 i32 i32 i32) (result i32)))
- (type $v (func))
- (type $iiIv (func (param i32 i32 i64)))
+ (type $_ (func))
+ (type $iiI_ (func (param i32 i32 i64)))
  (type $IIiiI (func (param i64 i64 i32 i32) (result i64)))
  (type $iiII (func (param i32 i32 i64) (result i64)))
- (type $iifv (func (param i32 i32 f32)))
+ (type $iif_ (func (param i32 i32 f32)))
  (type $ffiif (func (param f32 f32 i32 i32) (result f32)))
  (type $iiff (func (param i32 i32 f32) (result f32)))
  (type $FFiiF (func (param f64 f64 i32 i32) (result f64)))
@@ -220,7 +220,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memset (; 4 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 4 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -1303,7 +1303,7 @@
   local.set $0
   local.get $0
  )
- (func $std/typedarray/testInstantiate (; 27 ;) (type $iv) (param $0 i32)
+ (func $std/typedarray/testInstantiate (; 27 ;) (type $i_) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1878,7 +1878,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i32>#__set (; 28 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<i32>#__set (; 28 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2066,7 +2066,7 @@
   i32.store offset=8
   local.get $7
  )
- (func $~lib/internal/typedarray/TypedArray<f64>#__set (; 31 ;) (type $iiFv) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/internal/typedarray/TypedArray<f64>#__set (; 31 ;) (type $iiF_) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (local $4 i32)
   (local $5 f64)
@@ -2217,7 +2217,7 @@
   i32.store offset=8
   local.get $7
  )
- (func $~lib/internal/sort/insertionSort<f64> (; 33 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<f64> (; 33 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -2358,10 +2358,10 @@
    unreachable
   end
  )
- (func $~lib/allocator/arena/__memory_free (; 34 ;) (type $iv) (param $0 i32)
+ (func $~lib/allocator/arena/__memory_free (; 34 ;) (type $i_) (param $0 i32)
   nop
  )
- (func $~lib/internal/sort/weakHeapSort<f64> (; 35 ;) (type $iiiiv) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/weakHeapSort<f64> (; 35 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3140,7 +3140,7 @@
    f64.load offset=8
   end
  )
- (func $~lib/internal/typedarray/TypedArray<u8>#__set (; 40 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<u8>#__set (; 40 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3181,7 +3181,7 @@
    i32.store8 offset=8
   end
  )
- (func $~lib/typedarray/Uint8ClampedArray#__set (; 41 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#__set (; 41 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -3240,7 +3240,7 @@
    i32.load8_u offset=8
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i8>#__set (; 43 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<i8>#__set (; 43 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3992,7 +3992,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Int8Array,i8> (; 56 ;) (type $v)
+ (func $std/typedarray/testReduce<Int8Array,i8> (; 56 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4116,7 +4116,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Uint8Array,u8> (; 59 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint8Array,u8> (; 59 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4160,7 +4160,7 @@
   local.get $1
   i32.add
  )
- (func $std/typedarray/testReduce<Uint8ClampedArray,u8> (; 61 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint8ClampedArray,u8> (; 61 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4199,7 +4199,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i16>#__set (; 62 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<i16>#__set (; 62 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4323,7 +4323,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Int16Array,i16> (; 65 ;) (type $v)
+ (func $std/typedarray/testReduce<Int16Array,i16> (; 65 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4364,7 +4364,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<u16>#__set (; 66 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<u16>#__set (; 66 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4488,7 +4488,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Uint16Array,u16> (; 69 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint16Array,u16> (; 69 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4610,7 +4610,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Int32Array,i32> (; 72 ;) (type $v)
+ (func $std/typedarray/testReduce<Int32Array,i32> (; 72 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4647,7 +4647,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<u32>#__set (; 73 ;) (type $iiiv) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<u32>#__set (; 73 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4771,7 +4771,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Uint32Array,u32> (; 76 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint32Array,u32> (; 76 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4808,7 +4808,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i64>#__set (; 77 ;) (type $iiIv) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/internal/typedarray/TypedArray<i64>#__set (; 77 ;) (type $iiI_) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -4932,7 +4932,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Int64Array,i64> (; 80 ;) (type $v)
+ (func $std/typedarray/testReduce<Int64Array,i64> (; 80 ;) (type $_)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -4969,7 +4969,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<u64>#__set (; 81 ;) (type $iiIv) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/internal/typedarray/TypedArray<u64>#__set (; 81 ;) (type $iiI_) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -5093,7 +5093,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Uint64Array,u64> (; 84 ;) (type $v)
+ (func $std/typedarray/testReduce<Uint64Array,u64> (; 84 ;) (type $_)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -5130,7 +5130,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<f32>#__set (; 85 ;) (type $iifv) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/internal/typedarray/TypedArray<f32>#__set (; 85 ;) (type $iif_) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (local $4 i32)
   (local $5 f32)
@@ -5254,7 +5254,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Float32Array,f32> (; 88 ;) (type $v)
+ (func $std/typedarray/testReduce<Float32Array,f32> (; 88 ;) (type $_)
   (local $0 i32)
   (local $1 f32)
   i32.const 0
@@ -5374,7 +5374,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Float64Array,f64> (; 91 ;) (type $v)
+ (func $std/typedarray/testReduce<Float64Array,f64> (; 91 ;) (type $_)
   (local $0 i32)
   (local $1 f64)
   i32.const 0
@@ -5493,7 +5493,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Int8Array,i8> (; 94 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int8Array,i8> (; 94 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -5616,7 +5616,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Uint8Array,u8> (; 97 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint8Array,u8> (; 97 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -5660,7 +5660,7 @@
   local.get $1
   i32.add
  )
- (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8> (; 99 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8> (; 99 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -5781,7 +5781,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Int16Array,i16> (; 102 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int16Array,i16> (; 102 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -5904,7 +5904,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Uint16Array,u16> (; 105 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint16Array,u16> (; 105 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -6025,7 +6025,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Int32Array,i32> (; 108 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int32Array,i32> (; 108 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -6144,7 +6144,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Uint32Array,u32> (; 111 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint32Array,u32> (; 111 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -6263,7 +6263,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Int64Array,i64> (; 114 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Int64Array,i64> (; 114 ;) (type $_)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -6382,7 +6382,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Uint64Array,u64> (; 117 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Uint64Array,u64> (; 117 ;) (type $_)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -6501,7 +6501,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Float32Array,f32> (; 120 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Float32Array,f32> (; 120 ;) (type $_)
   (local $0 i32)
   (local $1 f32)
   i32.const 0
@@ -6620,7 +6620,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Float64Array,f64> (; 123 ;) (type $v)
+ (func $std/typedarray/testReduceRight<Float64Array,f64> (; 123 ;) (type $_)
   (local $0 i32)
   (local $1 f64)
   i32.const 0
@@ -6768,7 +6768,7 @@
   end
   local.get $7
  )
- (func $std/typedarray/testArrayMap<Int8Array,i8> (; 126 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int8Array,i8> (; 126 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -6955,7 +6955,7 @@
   end
   local.get $7
  )
- (func $std/typedarray/testArrayMap<Uint8Array,u8> (; 129 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint8Array,u8> (; 129 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -7136,7 +7136,7 @@
   end
   local.get $7
  )
- (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8> (; 132 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8> (; 132 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -7356,7 +7356,7 @@
    i32.load16_s offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Int16Array,i16> (; 136 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int16Array,i16> (; 136 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -7580,7 +7580,7 @@
    i32.load16_u offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Uint16Array,u16> (; 140 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint16Array,u16> (; 140 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -7759,7 +7759,7 @@
   end
   local.get $7
  )
- (func $std/typedarray/testArrayMap<Int32Array,i32> (; 143 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int32Array,i32> (; 143 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -7969,7 +7969,7 @@
    i32.load offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Uint32Array,u32> (; 147 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint32Array,u32> (; 147 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -8180,7 +8180,7 @@
    i64.load offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Int64Array,i64> (; 151 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Int64Array,i64> (; 151 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -8391,7 +8391,7 @@
    i64.load offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Uint64Array,u64> (; 155 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Uint64Array,u64> (; 155 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -8602,7 +8602,7 @@
    f32.load offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Float32Array,f32> (; 159 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Float32Array,f32> (; 159 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -8776,7 +8776,7 @@
   end
   local.get $7
  )
- (func $std/typedarray/testArrayMap<Float64Array,f64> (; 162 ;) (type $v)
+ (func $std/typedarray/testArrayMap<Float64Array,f64> (; 162 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -8941,7 +8941,7 @@
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Int8Array,i8> (; 166 ;) (type $v)
+ (func $std/typedarray/testArraySome<Int8Array,i8> (; 166 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9090,7 +9090,7 @@
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Uint8Array,u8> (; 170 ;) (type $v)
+ (func $std/typedarray/testArraySome<Uint8Array,u8> (; 170 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9239,7 +9239,7 @@
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Uint8ClampedArray,u8> (; 174 ;) (type $v)
+ (func $std/typedarray/testArraySome<Uint8ClampedArray,u8> (; 174 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9392,7 +9392,7 @@
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Int16Array,i16> (; 178 ;) (type $v)
+ (func $std/typedarray/testArraySome<Int16Array,i16> (; 178 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9541,7 +9541,7 @@
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Uint16Array,u16> (; 182 ;) (type $v)
+ (func $std/typedarray/testArraySome<Uint16Array,u16> (; 182 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9686,7 +9686,7 @@
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Int32Array,i32> (; 186 ;) (type $v)
+ (func $std/typedarray/testArraySome<Int32Array,i32> (; 186 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9831,7 +9831,7 @@
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Uint32Array,u32> (; 190 ;) (type $v)
+ (func $std/typedarray/testArraySome<Uint32Array,u32> (; 190 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9976,7 +9976,7 @@
   i64.const 0
   i64.eq
  )
- (func $std/typedarray/testArraySome<Int64Array,i64> (; 194 ;) (type $v)
+ (func $std/typedarray/testArraySome<Int64Array,i64> (; 194 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10121,7 +10121,7 @@
   i64.const 0
   i64.eq
  )
- (func $std/typedarray/testArraySome<Uint64Array,u64> (; 198 ;) (type $v)
+ (func $std/typedarray/testArraySome<Uint64Array,u64> (; 198 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10266,7 +10266,7 @@
   f32.const 0
   f32.eq
  )
- (func $std/typedarray/testArraySome<Float32Array,f32> (; 202 ;) (type $v)
+ (func $std/typedarray/testArraySome<Float32Array,f32> (; 202 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10411,7 +10411,7 @@
   f64.const 0
   f64.eq
  )
- (func $std/typedarray/testArraySome<Float64Array,f64> (; 206 ;) (type $v)
+ (func $std/typedarray/testArraySome<Float64Array,f64> (; 206 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10564,7 +10564,7 @@
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int8Array,i8> (; 210 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Int8Array,i8> (; 210 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10712,7 +10712,7 @@
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Uint8Array,u8> (; 214 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Uint8Array,u8> (; 214 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10860,7 +10860,7 @@
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8> (; 218 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8> (; 218 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11012,7 +11012,7 @@
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int16Array,i16> (; 222 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Int16Array,i16> (; 222 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11160,7 +11160,7 @@
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Uint16Array,u16> (; 226 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Uint16Array,u16> (; 226 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11304,7 +11304,7 @@
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int32Array,i32> (; 230 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Int32Array,i32> (; 230 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11448,7 +11448,7 @@
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Uint32Array,u32> (; 234 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Uint32Array,u32> (; 234 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11592,7 +11592,7 @@
   i64.const 4
   i64.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int64Array,i64> (; 238 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Int64Array,i64> (; 238 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11736,7 +11736,7 @@
   i64.const 4
   i64.eq
  )
- (func $std/typedarray/testArrayFindIndex<Uint64Array,u64> (; 242 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Uint64Array,u64> (; 242 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11880,7 +11880,7 @@
   f32.const 4
   f32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Float32Array,f32> (; 246 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Float32Array,f32> (; 246 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12024,7 +12024,7 @@
   f64.const 4
   f64.eq
  )
- (func $std/typedarray/testArrayFindIndex<Float64Array,f64> (; 250 ;) (type $v)
+ (func $std/typedarray/testArrayFindIndex<Float64Array,f64> (; 250 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12185,7 +12185,7 @@
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Int8Array,i8> (; 254 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Int8Array,i8> (; 254 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12343,7 +12343,7 @@
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Uint8Array,u8> (; 258 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Uint8Array,u8> (; 258 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12501,7 +12501,7 @@
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8> (; 262 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8> (; 262 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12663,7 +12663,7 @@
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Int16Array,i16> (; 266 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Int16Array,i16> (; 266 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12821,7 +12821,7 @@
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Uint16Array,u16> (; 270 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Uint16Array,u16> (; 270 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12975,7 +12975,7 @@
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Int32Array,i32> (; 274 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Int32Array,i32> (; 274 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13129,7 +13129,7 @@
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Uint32Array,u32> (; 278 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Uint32Array,u32> (; 278 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13283,7 +13283,7 @@
   i64.const 2
   i64.eq
  )
- (func $std/typedarray/testArrayEvery<Int64Array,i64> (; 282 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Int64Array,i64> (; 282 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13437,7 +13437,7 @@
   i64.const 2
   i64.eq
  )
- (func $std/typedarray/testArrayEvery<Uint64Array,u64> (; 286 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Uint64Array,u64> (; 286 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13847,7 +13847,7 @@
   f32.const 2
   f32.eq
  )
- (func $std/typedarray/testArrayEvery<Float32Array,f32> (; 291 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Float32Array,f32> (; 291 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14259,7 +14259,7 @@
   f64.const 2
   f64.eq
  )
- (func $std/typedarray/testArrayEvery<Float64Array,f64> (; 296 ;) (type $v)
+ (func $std/typedarray/testArrayEvery<Float64Array,f64> (; 296 ;) (type $_)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14313,7 +14313,7 @@
    unreachable
   end
  )
- (func $start (; 297 ;) (type $v)
+ (func $start (; 297 ;) (type $_)
   (local $0 i32)
   global.get $~lib/typedarray/Int8Array.BYTES_PER_ELEMENT
   i32.const 1
@@ -15559,6 +15559,6 @@
   call $std/typedarray/testArrayEvery<Float32Array,f32>
   call $std/typedarray/testArrayEvery<Float64Array,f64>
  )
- (func $null (; 298 ;) (type $v)
+ (func $null (; 298 ;) (type $_)
  )
 )

--- a/tests/compiler/switch.optimized.wat
+++ b/tests/compiler/switch.optimized.wat
@@ -1,7 +1,7 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\t\00\00\00s\00w\00i\00t\00c\00h\00.\00t\00s")
@@ -67,7 +67,7 @@
   end
   i32.const 0
  )
- (func $start (; 3 ;) (type $v)
+ (func $start (; 3 ;) (type $_)
   i32.const 0
   call $switch/doSwitch
   if
@@ -237,7 +237,7 @@
    unreachable
   end
  )
- (func $null (; 4 ;) (type $v)
+ (func $null (; 4 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/switch.untouched.wat
+++ b/tests/compiler/switch.untouched.wat
@@ -1,7 +1,7 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\t\00\00\00s\00w\00i\00t\00c\00h\00.\00t\00s\00")
@@ -168,7 +168,7 @@
   drop
   i32.const 2
  )
- (func $start (; 8 ;) (type $v)
+ (func $start (; 8 ;) (type $_)
   i32.const 0
   call $switch/doSwitch
   i32.const 0
@@ -560,6 +560,6 @@
    unreachable
   end
  )
- (func $null (; 9 ;) (type $v)
+ (func $null (; 9 ;) (type $_)
  )
 )

--- a/tests/compiler/ternary.optimized.wat
+++ b/tests/compiler/ternary.optimized.wat
@@ -1,5 +1,5 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -7,7 +7,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 0 ;) (type $v)
+ (func $start (; 0 ;) (type $_)
   i32.const 1
   global.set $ternary/a
   i32.const 1
@@ -15,7 +15,7 @@
   i32.const 1
   global.set $ternary/a
  )
- (func $null (; 1 ;) (type $v)
+ (func $null (; 1 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/ternary.untouched.wat
+++ b/tests/compiler/ternary.untouched.wat
@@ -1,5 +1,5 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -8,7 +8,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 0 ;) (type $v)
+ (func $start (; 0 ;) (type $_)
   i32.const 1
   drop
   i32.const 1
@@ -22,6 +22,6 @@
   i32.const 1
   global.set $ternary/a
  )
- (func $null (; 1 ;) (type $v)
+ (func $null (; 1 ;) (type $_)
  )
 )

--- a/tests/compiler/typealias.optimized.wat
+++ b/tests/compiler/typealias.optimized.wat
@@ -1,6 +1,6 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
@@ -10,7 +10,7 @@
  (func $typealias/alias (; 0 ;) (type $ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/typealias.untouched.wat
+++ b/tests/compiler/typealias.untouched.wat
@@ -1,6 +1,6 @@
 (module
  (type $ii (func (param i32) (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -12,9 +12,9 @@
  (func $typealias/alias (; 0 ;) (type $ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   nop
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
  )
 )

--- a/tests/compiler/unary.optimized.wat
+++ b/tests/compiler/unary.optimized.wat
@@ -1,5 +1,5 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -10,7 +10,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 0 ;) (type $v)
+ (func $start (; 0 ;) (type $_)
   (local $0 f32)
   (local $1 f64)
   (local $2 i32)
@@ -236,7 +236,7 @@
   local.get $1
   global.set $unary/F
  )
- (func $null (; 1 ;) (type $v)
+ (func $null (; 1 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/unary.untouched.wat
+++ b/tests/compiler/unary.untouched.wat
@@ -1,5 +1,5 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -11,7 +11,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 0 ;) (type $v)
+ (func $start (; 0 ;) (type $_)
   (local $0 i32)
   (local $1 i64)
   (local $2 f32)
@@ -366,6 +366,6 @@
   end
   global.set $unary/F
  )
- (func $null (; 1 ;) (type $v)
+ (func $null (; 1 ;) (type $_)
  )
 )

--- a/tests/compiler/void.optimized.wat
+++ b/tests/compiler/void.optimized.wat
@@ -1,11 +1,11 @@
 (module
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $start (; 0 ;) (type $v)
+ (func $start (; 0 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/void.untouched.wat
+++ b/tests/compiler/void.untouched.wat
@@ -1,6 +1,6 @@
 (module
  (type $i (func (result i32)))
- (type $v (func))
+ (type $_ (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -13,7 +13,7 @@
  (func $void/anInt (; 0 ;) (type $i) (result i32)
   i32.const 2
  )
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   i32.const 1
   drop
   call $void/anInt
@@ -23,6 +23,6 @@
   i32.add
   drop
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
  )
 )

--- a/tests/compiler/while.optimized.wat
+++ b/tests/compiler/while.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\08\00\00\00w\00h\00i\00l\00e\00.\00t\00s")
@@ -12,7 +12,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   (local $0 i32)
   loop $continue|0
    global.get $while/n
@@ -176,7 +176,7 @@
    unreachable
   end
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
   nop
  )
 )

--- a/tests/compiler/while.untouched.wat
+++ b/tests/compiler/while.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiiiv (func (param i32 i32 i32 i32)))
- (type $v (func))
+ (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $_ (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\08\00\00\00w\00h\00i\00l\00e\00.\00t\00s\00")
@@ -13,7 +13,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 1 ;) (type $v)
+ (func $start (; 1 ;) (type $_)
   (local $0 i32)
   block $break|0
    loop $continue|0
@@ -212,6 +212,6 @@
    unreachable
   end
  )
- (func $null (; 2 ;) (type $v)
+ (func $null (; 2 ;) (type $_)
  )
 )


### PR DESCRIPTION
This PR adds a few internals to help get started with SIMD, like the `v128` type. It doesn't implement any actual operations but leaves this to future PRs.

Essentially, if you'd want to play around with / implement SIMD, you'd `--enable simd` and go from there. When enabled, the only thing that works currently is

```ts
var v: v128;
```

yielding a `(mut v128)` global.