### PR TITLE
Put atomics behind a feature flag

### DIFF
--- a/cli/asc.json
+++ b/cli/asc.json
@@ -163,6 +163,7 @@
       " mutable-global  Enables mutable global imports and exports",
       " bulk-memory     Enables bulk memory operations",
       " simd            Enables SIMD types and operations.",
+      " threads         Enables threading and atomic operations.",
       ""
     ],
     "type": "s"

--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -1679,7 +1679,7 @@ export function compileCall(
       compiler.currentType = Type.void;
       return module.createStore(typeArguments[0].byteSize, arg0, arg1, type.toNativeType(), offset);
     }
-    case "atomic.load": { // Atomic.load<T!>(offset: usize, constantOffset?: usize) -> *
+    case "atomic.load": { // load<T!>(offset: usize, constantOffset?: usize) -> *
       if (!compiler.options.hasFeature(Feature.THREADS)) break;
       if (operands.length < 1 || operands.length > 2) {
         if (!(typeArguments && typeArguments.length == 1)) {
@@ -1731,7 +1731,7 @@ export function compileCall(
         offset
       );
     }
-    case "atomic.store": { // Atomic.store<T!>(offset: usize, value: *, constantOffset?: usize) -> void
+    case "atomic.store": { // store<T!>(offset: usize, value: *, constantOffset?: usize) -> void
       if (!compiler.options.hasFeature(Feature.THREADS)) break;
       compiler.currentType = Type.void;
       if (operands.length < 2 || operands.length > 3) {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -237,7 +237,9 @@ export const enum Feature {
   /** Bulk memory operations. */
   BULK_MEMORY = 1 << 2, // see: https://github.com/WebAssembly/bulk-memory-operations
   /** SIMD types and operations. */
-  SIMD = 1 << 3 // see: https://github.com/WebAssembly/simd
+  SIMD = 1 << 3, // see: https://github.com/WebAssembly/simd
+  /** Threading and atomic operations. */
+  THREADS = 1 << 4 // see: https://github.com/WebAssembly/threads
 }
 
 /** Indicates the desired kind of a conversion. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,8 @@ export const FEATURE_MUTABLE_GLOBAL = Feature.MUTABLE_GLOBAL;
 export const FEATURE_BULK_MEMORY = Feature.BULK_MEMORY;
 /** SIMD types and operations. */
 export const FEATURE_SIMD = Feature.SIMD;
+/** Threading and atomic operations. */
+export const FEATURE_THREADS = Feature.THREADS;
 
 /** Enables a specific feature. */
 export function enableFeature(options: Options, feature: Feature): void {

--- a/std/assembly/builtins.ts
+++ b/std/assembly/builtins.ts
@@ -43,7 +43,7 @@
 @builtin export declare function call_indirect<T>(target: void, ...args: void[]): T;
 @builtin export declare function instantiate<T>(...args: void[]): T;
 
-export namespace Atomic {
+export namespace atomic {
   @builtin export declare function load<T>(offset: usize, constantOffset?: usize): T;
   @builtin export declare function store<T>(offset: usize, value: void, constantOffset?: usize): void;
   @builtin export declare function add<T>(ptr: usize, value: T, constantOffset?: usize): T;
@@ -88,7 +88,7 @@ export namespace i32 {
   @builtin export declare function store16(offset: usize, value: i32, constantOffset?: usize): void;
   @builtin export declare function store(offset: usize, value: i32, constantOffset?: usize): void;
   
-  namespace atomic {
+  export namespace atomic {
     @builtin export declare function load8_s(offset: usize, constantOffset?: usize): i32;
     @builtin export declare function load8_u(offset: usize, constantOffset?: usize): i32;
     @builtin export declare function load16_s(offset: usize, constantOffset?: usize): i32;
@@ -100,33 +100,33 @@ export namespace i32 {
     @builtin export declare function wait(ptr: usize, expected:i32, timeout:i64): i32;
     @builtin export declare function notify(ptr: usize, count:u32): u32;
 
-    namespace rmw8_u {
-      @builtin export declare function add(offset: usize, value: i32, constantOffset?: usize): i32
-      @builtin export declare function sub(offset: usize, value: i32, constantOffset?: usize): i32
-      @builtin export declare function and(offset: usize, value: i32, constantOffset?: usize): i32
-      @builtin export declare function or(offset: usize, value: i32, constantOffset?: usize): i32
-      @builtin export declare function xor(offset: usize, value: i32, constantOffset?: usize): i32
-      @builtin export declare function xchg(offset: usize, value: i32, constantOffset?: usize): i32
+    export namespace rmw8_u {
+      @builtin export declare function add(offset: usize, value: i32, constantOffset?: usize): i32;
+      @builtin export declare function sub(offset: usize, value: i32, constantOffset?: usize): i32;
+      @builtin export declare function and(offset: usize, value: i32, constantOffset?: usize): i32;
+      @builtin export declare function or(offset: usize, value: i32, constantOffset?: usize): i32;
+      @builtin export declare function xor(offset: usize, value: i32, constantOffset?: usize): i32;
+      @builtin export declare function xchg(offset: usize, value: i32, constantOffset?: usize): i32;
       @builtin export declare function cmpxchg(offset: usize, expected:i32, replacement: i32, constantOffset?: usize): i32;
     }
 
-    namespace rmw16_u {
-      @builtin export declare function add(offset: usize, value: i32, constantOffset?: usize): i32
-      @builtin export declare function sub(offset: usize, value: i32, constantOffset?: usize): i32
-      @builtin export declare function and(offset: usize, value: i32, constantOffset?: usize): i32
-      @builtin export declare function or(offset: usize, value: i32, constantOffset?: usize): i32
-      @builtin export declare function xor(offset: usize, value: i32, constantOffset?: usize): i32
-      @builtin export declare function xchg(offset: usize, value: i32, constantOffset?: usize): i32
+    export namespace rmw16_u {
+      @builtin export declare function add(offset: usize, value: i32, constantOffset?: usize): i32;
+      @builtin export declare function sub(offset: usize, value: i32, constantOffset?: usize): i32;
+      @builtin export declare function and(offset: usize, value: i32, constantOffset?: usize): i32;
+      @builtin export declare function or(offset: usize, value: i32, constantOffset?: usize): i32;
+      @builtin export declare function xor(offset: usize, value: i32, constantOffset?: usize): i32;
+      @builtin export declare function xchg(offset: usize, value: i32, constantOffset?: usize): i32;
       @builtin export declare function cmpxchg(offset: usize, expected:i32, replacement: i32, constantOffset?: usize): i32;
     }
 
-    namespace rmw {
-      @builtin export declare function add(offset: usize, value: i32, constantOffset?: usize): i32
-      @builtin export declare function sub(offset: usize, value: i32, constantOffset?: usize): i32
-      @builtin export declare function and(offset: usize, value: i32, constantOffset?: usize): i32
-      @builtin export declare function or(offset: usize, value: i32, constantOffset?: usize): i32
-      @builtin export declare function xor(offset: usize, value: i32, constantOffset?: usize): i32
-      @builtin export declare function xchg(offset: usize, value: i32, constantOffset?: usize): i32
+    export namespace rmw {
+      @builtin export declare function add(offset: usize, value: i32, constantOffset?: usize): i32;
+      @builtin export declare function sub(offset: usize, value: i32, constantOffset?: usize): i32;
+      @builtin export declare function and(offset: usize, value: i32, constantOffset?: usize): i32;
+      @builtin export declare function or(offset: usize, value: i32, constantOffset?: usize): i32;
+      @builtin export declare function xor(offset: usize, value: i32, constantOffset?: usize): i32;
+      @builtin export declare function xchg(offset: usize, value: i32, constantOffset?: usize): i32;
       @builtin export declare function cmpxchg(offset: usize, expected:i32, replacement: i32, constantOffset?: usize): i32;
     }
   }
@@ -166,43 +166,43 @@ export namespace i64 {
     @builtin export declare function wait(ptr: usize, expected:i64, timeout:i64): i32;
     @builtin export declare function notify(ptr: usize, count:u32): u32;
 
-    namespace rmw8_u {
-      @builtin export declare function add(offset: usize, value: i64, constantOffset?: usize): i64
-      @builtin export declare function sub(offset: usize, value: i64, constantOffset?: usize): i64
-      @builtin export declare function and(offset: usize, value: i64, constantOffset?: usize): i64
-      @builtin export declare function or(offset: usize, value: i64, constantOffset?: usize): i64
-      @builtin export declare function xor(offset: usize, value: i64, constantOffset?: usize): i64
-      @builtin export declare function xchg(offset: usize, value: i64, constantOffset?: usize): i64
+    export namespace rmw8_u {
+      @builtin export declare function add(offset: usize, value: i64, constantOffset?: usize): i64;
+      @builtin export declare function sub(offset: usize, value: i64, constantOffset?: usize): i64;
+      @builtin export declare function and(offset: usize, value: i64, constantOffset?: usize): i64;
+      @builtin export declare function or(offset: usize, value: i64, constantOffset?: usize): i64;
+      @builtin export declare function xor(offset: usize, value: i64, constantOffset?: usize): i64;
+      @builtin export declare function xchg(offset: usize, value: i64, constantOffset?: usize): i64;
       @builtin export declare function cmpxchg(offset: usize, expected:i64, replacement: i64, constantOffset?: usize): i64;
     }
 
-    namespace rmw16_u {
-      @builtin export declare function add(offset: usize, value: i64, constantOffset?: usize): i64
-      @builtin export declare function sub(offset: usize, value: i64, constantOffset?: usize): i64
-      @builtin export declare function and(offset: usize, value: i64, constantOffset?: usize): i64
-      @builtin export declare function or(offset: usize, value: i64, constantOffset?: usize): i64
-      @builtin export declare function xor(offset: usize, value: i64, constantOffset?: usize): i64
-      @builtin export declare function xchg(offset: usize, value: i64, constantOffset?: usize): i64
+    export namespace rmw16_u {
+      @builtin export declare function add(offset: usize, value: i64, constantOffset?: usize): i64;
+      @builtin export declare function sub(offset: usize, value: i64, constantOffset?: usize): i64;
+      @builtin export declare function and(offset: usize, value: i64, constantOffset?: usize): i64;
+      @builtin export declare function or(offset: usize, value: i64, constantOffset?: usize): i64;
+      @builtin export declare function xor(offset: usize, value: i64, constantOffset?: usize): i64;
+      @builtin export declare function xchg(offset: usize, value: i64, constantOffset?: usize): i64;
       @builtin export declare function cmpxchg(offset: usize, expected:i64, replacement: i64, constantOffset?: usize): i64;
     }
 
-    namespace rmw32_u {
-      @builtin export declare function add(offset: usize, value: i64, constantOffset?: usize): i64
-      @builtin export declare function sub(offset: usize, value: i64, constantOffset?: usize): i64
-      @builtin export declare function and(offset: usize, value: i64, constantOffset?: usize): i64
-      @builtin export declare function or(offset: usize, value: i64, constantOffset?: usize): i64
-      @builtin export declare function xor(offset: usize, value: i64, constantOffset?: usize): i64
-      @builtin export declare function xchg(offset: usize, value: i64, constantOffset?: usize): i64
+    export namespace rmw32_u {
+      @builtin export declare function add(offset: usize, value: i64, constantOffset?: usize): i64;
+      @builtin export declare function sub(offset: usize, value: i64, constantOffset?: usize): i64;
+      @builtin export declare function and(offset: usize, value: i64, constantOffset?: usize): i64;
+      @builtin export declare function or(offset: usize, value: i64, constantOffset?: usize): i64;
+      @builtin export declare function xor(offset: usize, value: i64, constantOffset?: usize): i64;
+      @builtin export declare function xchg(offset: usize, value: i64, constantOffset?: usize): i64;
       @builtin export declare function cmpxchg(offset: usize, expected:i64, replacement: i64, constantOffset?: usize): i64;
     }
 
-    namespace rmw {
-      @builtin export declare function add(offset: usize, value: i64, constantOffset?: usize): i64
-      @builtin export declare function sub(offset: usize, value: i64, constantOffset?: usize): i64
-      @builtin export declare function and(offset: usize, value: i64, constantOffset?: usize): i64
-      @builtin export declare function or(offset: usize, value: i64, constantOffset?: usize): i64
-      @builtin export declare function xor(offset: usize, value: i64, constantOffset?: usize): i64
-      @builtin export declare function xchg(offset: usize, value: i64, constantOffset?: usize): i64
+    export namespace rmw {
+      @builtin export declare function add(offset: usize, value: i64, constantOffset?: usize): i64;
+      @builtin export declare function sub(offset: usize, value: i64, constantOffset?: usize): i64;
+      @builtin export declare function and(offset: usize, value: i64, constantOffset?: usize): i64;
+      @builtin export declare function or(offset: usize, value: i64, constantOffset?: usize): i64;
+      @builtin export declare function xor(offset: usize, value: i64, constantOffset?: usize): i64;
+      @builtin export declare function xchg(offset: usize, value: i64, constantOffset?: usize): i64;
       @builtin export declare function cmpxchg(offset: usize, expected:i64, replacement: i64, constantOffset?: usize): i64;
     }
   } 

--- a/std/portable/index.js
+++ b/std/portable/index.js
@@ -12,6 +12,7 @@ globalScope.ASC_FEATURE_MUTABLE_GLOBAL = false;
 globalScope.ASC_FEATURE_SIGN_EXTENSION = false;
 globalScope.ASC_FEATURE_BULK_MEMORY = false;
 globalScope.ASC_FEATURE_SIMD = false;
+globalScope.ASC_FEATURE_THREADS = false;
 
 var F64 = new Float64Array(1);
 var U64 = new Uint32Array(F64.buffer);


### PR DESCRIPTION
This PR puts atomic operations behind `--enable threads`. Also renames the `Atomic.*` namespace to lower case so it blends in well with other intrinsics (even though `atomic.*` are actually deferred).