### PR TITLE
Shared memory support added to compiler

### DIFF
--- a/cli/asc.js
+++ b/cli/asc.js
@@ -422,6 +422,7 @@ exports.main = function main(argv, options, callback) {
   assemblyscript.setNoTreeShaking(compilerOptions, args.noTreeShaking);
   assemblyscript.setNoAssert(compilerOptions, args.noAssert);
   assemblyscript.setImportMemory(compilerOptions, args.importMemory);
+  assemblyscript.setSharedMemory(compilerOptions, args.sharedMemory);
   assemblyscript.setImportTable(compilerOptions, args.importTable);
   assemblyscript.setMemoryBase(compilerOptions, args.memoryBase >>> 0);
   assemblyscript.setSourceMap(compilerOptions, args.sourceMap != null);

--- a/cli/asc.json
+++ b/cli/asc.json
@@ -106,6 +106,11 @@
     "type": "b",
     "default": false
   },
+  "sharedMemory": {
+    "description": "Declare memory as shared by settings the max shared memory.",
+    "type": "i",
+    "default": 0
+  },
   "memoryBase": {
     "description": "Sets the start offset of compiler-generated static memory.",
     "type": "i",

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -184,6 +184,8 @@ export class Options {
   noAssert: bool = false;
   /** If true, imports the memory provided by the embedder. */
   importMemory: bool = false;
+  /** If greater than zero, declare memory as shared by setting max memory to sharedMemory. */
+  sharedMemory: i32 = 0;
   /** If true, imports the function table provided by the embedder. */
   importTable: bool = false;
   /** If true, generates information necessary for source maps. */
@@ -396,18 +398,19 @@ export class Compiler extends DiagnosticEmitter {
     }
 
     // set up memory
+    var isSharedMemory = options.hasFeature(Feature.THREADS) && options.sharedMemory > 0;
     module.setMemory(
       this.options.memoryBase /* is specified */ || this.memorySegments.length
         ? i64_low(i64_shr_u(i64_align(memoryOffset, 0x10000), i64_new(16, 0)))
         : 0,
-      Module.UNLIMITED_MEMORY,
+      isSharedMemory ? options.sharedMemory : Module.UNLIMITED_MEMORY,
       this.memorySegments,
       options.target,
       "memory"
     );
 
     // import memory if requested (default memory is named '0' by Binaryen)
-    if (options.importMemory) module.addMemoryImport("0", "env", "memory");
+    if (options.importMemory) module.addMemoryImport("0", "env", "memory", isSharedMemory);
 
     // set up function table
     var functionTable = this.functionTable;

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,11 @@ export function setImportMemory(options: Options, importMemory: bool): void {
   options.importMemory = importMemory;
 }
 
+/** Sets the `sharedMemory` option. */
+export function setSharedMemory(options: Options, sharedMemory: i32): void {
+  options.sharedMemory = sharedMemory;
+}
+
 /** Sets the `importTable` option. */
 export function setImportTable(options: Options, importTable: bool): void {
   options.importTable = importTable;


### PR DESCRIPTION
**CHANGES**

- `sharedMemory` option added to the compiler
Since shared memory needs mandatory max memory size, `sharedMemory` option accept a positive integer. 

| value  | meaning |
| ------------- | ------------- |
|`0` (default)| non shared memory|
|`+ve integer > 0` | enable shared memory and set max shared memory size|

- Feature is behind the flag `--enable threads`