### PR TITLE
Added a test for wildcard exports

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -12,6 +12,7 @@ under the licensing terms detailed in LICENSE:
 * Linus Unnebäck <linus@folkdatorn.se>
 * Joshua Tenner <tenner.joshua@gmail.com>
 * Nidin Vinayakan <01@01alchemist.com>
+* Aaron Turner <aaron@aaronthedev.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/tests/compiler/wildcard-export.optimized.wat
+++ b/tests/compiler/wildcard-export.optimized.wat
@@ -1,0 +1,17 @@
+(module
+ (type $_ (func))
+ (memory $0 0)
+ (table $0 1 funcref)
+ (elem (i32.const 0) $start)
+ (global $export/a i32 (i32.const 1))
+ (global $export/b i32 (i32.const 2))
+ (export "memory" (memory $0))
+ (export "table" (table $0))
+ (export "a" (global $export/a))
+ (export "renamed_a" (global $export/a))
+ (export "renamed_b" (global $export/b))
+ (export "renamed_renamed_b" (global $export/b))
+ (func $start (; 0 ;) (type $_)
+  nop
+ )
+)

--- a/tests/compiler/wildcard-export.ts
+++ b/tests/compiler/wildcard-export.ts
@@ -1,0 +1,1 @@
+export * from './rereexport';

--- a/tests/compiler/wildcard-export.untouched.wat
+++ b/tests/compiler/wildcard-export.untouched.wat
@@ -1,0 +1,49 @@
+(module
+ (type $iii (func (param i32 i32) (result i32)))
+ (type $_ (func))
+ (memory $0 0)
+ (table $0 1 funcref)
+ (elem (i32.const 0) $null)
+ (global $export/a i32 (i32.const 1))
+ (global $export/b i32 (i32.const 2))
+ (global $export/c i32 (i32.const 3))
+ (global $~lib/memory/HEAP_BASE i32 (i32.const 8))
+ (export "memory" (memory $0))
+ (export "table" (table $0))
+ (export "a" (global $export/a))
+ (export "renamed_a" (global $export/a))
+ (export "renamed_b" (global $export/b))
+ (export "renamed_renamed_b" (global $export/b))
+ (start $start)
+ (func $export/add (; 0 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  local.get $1
+  i32.add
+ )
+ (func $export/mul (; 1 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  local.get $1
+  i32.mul
+ )
+ (func $start:reexport (; 2 ;) (type $_)
+  i32.const 1
+  i32.const 2
+  call $export/add
+  i32.const 3
+  i32.const 4
+  call $export/mul
+  i32.add
+  drop
+ )
+ (func $start:rereexport (; 3 ;) (type $_)
+  call $start:reexport
+ )
+ (func $start:wildcard-export (; 4 ;) (type $_)
+  call $start:rereexport
+ )
+ (func $start (; 5 ;) (type $_)
+  call $start:wildcard-export
+ )
+ (func $null (; 6 ;) (type $_)
+ )
+)


### PR DESCRIPTION
relates to #27
relates to #249
relates to #489
opens #498

As the title states! This creates a new test for the new `export *` support 😄 

<img width="511" alt="screen shot 2019-02-20 at 9 48 33 pm" src="https://user-images.githubusercontent.com/1448289/53146652-dc8b7800-3559-11e9-8d07-9027639879f4.png">
