### PR TITLE
Use Binaryen's function signature naming scheme

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -368,16 +368,25 @@ export class Type {
   /** Converts this type to its signature string. */
   toSignatureString(): string {
     switch (this.kind) {
-      default: return "i";
+      // same naming scheme as Binaryen
+      case TypeKind.I8:
+      case TypeKind.U8:
+      case TypeKind.I16:
+      case TypeKind.U16:
+      case TypeKind.I32:
+      case TypeKind.U32:
+      case TypeKind.BOOL: return "i";
       case TypeKind.I64:
-      case TypeKind.U64: return "I";
+      case TypeKind.U64: return "j";
       case TypeKind.ISIZE:
-      case TypeKind.USIZE: return this.size == 64 ? "I" : "i";
+      case TypeKind.USIZE: return this.size == 64 ? "j" : "i";
       case TypeKind.F32: return "f";
-      case TypeKind.F64: return "F";
-      case TypeKind.V128: return "v";
-      case TypeKind.VOID: return "_";
+      case TypeKind.F64: return "d";
+      case TypeKind.V128: return "V";
+      case TypeKind.VOID: return "v";
+      default: assert(false);
     }
+    return "i";
   }
 
   // Types
@@ -614,12 +623,12 @@ export class Signature {
   /** Converts a signature to a function type string. */
   static makeSignatureString(parameterTypes: Type[] | null, returnType: Type, thisType: Type | null = null): string {
     var sb = [];
+    sb.push(returnType.toSignatureString());
     if (thisType) sb.push(thisType.toSignatureString());
     if (parameterTypes) {
       for (let i = 0, k = parameterTypes.length; i < k; ++i) sb.push(parameterTypes[i].toSignatureString());
     }
-    sb.push(returnType.toSignatureString());
-    return sb.join("");
+    return "FUNCSIG$" + sb.join("");
   }
 
   /** Converts this signature to a function type string. */

--- a/tests/compiler/abi.optimized.wat
+++ b/tests/compiler/abi.optimized.wat
@@ -1,7 +1,7 @@
 (module
- (type $i (func (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\06\00\00\00a\00b\00i\00.\00t\00s")
@@ -15,10 +15,10 @@
  (export "exportedExported" (func $abi/exported))
  (export "exportedInternal" (func $abi/exported))
  (start $start)
- (func $abi/exported (; 1 ;) (type $i) (result i32)
+ (func $abi/exported (; 1 ;) (type $FUNCSIG$i) (result i32)
   i32.const -128
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   i32.const 1
   global.set $abi/condition
   i32.const 0
@@ -33,7 +33,7 @@
    unreachable
   end
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/abi.untouched.wat
+++ b/tests/compiler/abi.untouched.wat
@@ -1,7 +1,7 @@
 (module
- (type $i (func (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\06\00\00\00a\00b\00i\00.\00t\00s\00")
@@ -16,10 +16,10 @@
  (export "exportedExported" (func $abi/exportedExported))
  (export "exportedInternal" (func $abi/exportedInternal))
  (start $start)
- (func $abi/internal (; 1 ;) (type $i) (result i32)
+ (func $abi/internal (; 1 ;) (type $FUNCSIG$i) (result i32)
   i32.const 128
  )
- (func $start:abi (; 2 ;) (type $_)
+ (func $start:abi (; 2 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   call $abi/internal
@@ -194,26 +194,26 @@
    end
   end
  )
- (func $abi/exported (; 3 ;) (type $i) (result i32)
+ (func $abi/exported (; 3 ;) (type $FUNCSIG$i) (result i32)
   i32.const 128
   i32.const 24
   i32.shl
   i32.const 24
   i32.shr_s
  )
- (func $abi/exportedExported (; 4 ;) (type $i) (result i32)
+ (func $abi/exportedExported (; 4 ;) (type $FUNCSIG$i) (result i32)
   call $abi/exported
  )
- (func $abi/exportedInternal (; 5 ;) (type $i) (result i32)
+ (func $abi/exportedInternal (; 5 ;) (type $FUNCSIG$i) (result i32)
   call $abi/internal
   i32.const 24
   i32.shl
   i32.const 24
   i32.shr_s
  )
- (func $start (; 6 ;) (type $_)
+ (func $start (; 6 ;) (type $FUNCSIG$v)
   call $start:abi
  )
- (func $null (; 7 ;) (type $_)
+ (func $null (; 7 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/asc-constants.optimized.wat
+++ b/tests/compiler/asc-constants.optimized.wat
@@ -1,11 +1,11 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $start (; 0 ;) (type $_)
+ (func $start (; 0 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/asc-constants.untouched.wat
+++ b/tests/compiler/asc-constants.untouched.wat
@@ -1,5 +1,5 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -17,7 +17,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:asc-constants (; 0 ;) (type $_)
+ (func $start:asc-constants (; 0 ;) (type $FUNCSIG$v)
   i32.const 1
   drop
   i32.const 0
@@ -39,9 +39,9 @@
   i32.const 0
   drop
  )
- (func $start (; 1 ;) (type $_)
+ (func $start (; 1 ;) (type $FUNCSIG$v)
   call $start:asc-constants
  )
- (func $null (; 2 ;) (type $_)
+ (func $null (; 2 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/assert.optimized.wat
+++ b/tests/compiler/assert.optimized.wat
@@ -1,5 +1,5 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 1)
  (data (i32.const 8) "\t\00\00\00a\00s\00s\00e\00r\00t\00.\00t\00s")
  (data (i32.const 32) "\0c\00\00\00m\00u\00s\00t\00 \00b\00e\00 \00t\00r\00u\00e")
@@ -7,7 +7,7 @@
  (elem (i32.const 0) $start)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $start (; 0 ;) (type $_)
+ (func $start (; 0 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/assert.untouched.wat
+++ b/tests/compiler/assert.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\t\00\00\00a\00s\00s\00e\00r\00t\00.\00t\00s\00")
@@ -11,7 +11,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:assert (; 1 ;) (type $_)
+ (func $start:assert (; 1 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 1
   i32.eqz
@@ -107,9 +107,9 @@
    unreachable
   end
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   call $start:assert
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/binary.optimized.wat
+++ b/tests/compiler/binary.optimized.wat
@@ -1,5 +1,5 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (type $FUNCSIG$dd (func (param f64) (result f64)))
  (type $FUNCSIG$ff (func (param f32) (result f32)))
  (memory $0 0)
@@ -406,7 +406,7 @@
   local.get $0
   f64.mul
  )
- (func $start:binary (; 4 ;) (type $_)
+ (func $start:binary (; 4 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i64)
   (local $2 f32)
@@ -749,10 +749,10 @@
   call $~lib/math/NativeMath.pow
   global.set $binary/F
  )
- (func $start (; 5 ;) (type $_)
+ (func $start (; 5 ;) (type $FUNCSIG$v)
   call $start:binary
  )
- (func $null (; 6 ;) (type $_)
+ (func $null (; 6 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/binary.untouched.wat
+++ b/tests/compiler/binary.untouched.wat
@@ -1,9 +1,9 @@
 (module
- (type $FFF (func (param f64 f64) (result f64)))
- (type $FiF (func (param f64 i32) (result f64)))
- (type $fff (func (param f32 f32) (result f32)))
- (type $fif (func (param f32 i32) (result f32)))
- (type $_ (func))
+ (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))
+ (type $FUNCSIG$ddi (func (param f64 i32) (result f64)))
+ (type $FUNCSIG$fff (func (param f32 f32) (result f32)))
+ (type $FUNCSIG$ffi (func (param f32 i32) (result f32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -16,7 +16,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $~lib/math/NativeMath.scalbn (; 0 ;) (type $FiF) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/NativeMath.scalbn (; 0 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
@@ -107,7 +107,7 @@
   f64.reinterpret_i64
   f64.mul
  )
- (func $~lib/math/NativeMath.pow (; 1 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.pow (; 1 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -1195,7 +1195,7 @@
   local.get $16
   f64.mul
  )
- (func $~lib/math/NativeMathf.mod (; 2 ;) (type $fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (; 2 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1451,7 +1451,7 @@
   local.get $2
   f32.reinterpret_i32
  )
- (func $~lib/math/NativeMathf.scalbn (; 3 ;) (type $fif) (param $0 f32) (param $1 i32) (result f32)
+ (func $~lib/math/NativeMathf.scalbn (; 3 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
   (local $2 f32)
   (local $3 i32)
   (local $4 i32)
@@ -1541,7 +1541,7 @@
   f32.reinterpret_i32
   f32.mul
  )
- (func $~lib/math/NativeMathf.pow (; 4 ;) (type $fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.pow (; 4 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2479,7 +2479,7 @@
   local.get $11
   f32.mul
  )
- (func $~lib/math/NativeMath.mod (; 5 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (; 5 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -2737,7 +2737,7 @@
   local.get $2
   f64.reinterpret_i64
  )
- (func $start:binary (; 6 ;) (type $_)
+ (func $start:binary (; 6 ;) (type $FUNCSIG$v)
   global.get $binary/i
   i32.const 1
   i32.lt_s
@@ -3345,9 +3345,9 @@
   call $~lib/math/NativeMath.pow
   global.set $binary/F
  )
- (func $start (; 7 ;) (type $_)
+ (func $start (; 7 ;) (type $FUNCSIG$v)
   call $start:binary
  )
- (func $null (; 8 ;) (type $_)
+ (func $null (; 8 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/bool.optimized.wat
+++ b/tests/compiler/bool.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\07\00\00\00b\00o\00o\00l\00.\00t\00s")
@@ -16,7 +16,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:bool (; 1 ;) (type $_)
+ (func $start:bool (; 1 ;) (type $FUNCSIG$v)
   global.get $bool/i
   i32.const 0
   i32.ne
@@ -109,10 +109,10 @@
    unreachable
   end
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   call $start:bool
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/bool.untouched.wat
+++ b/tests/compiler/bool.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\07\00\00\00b\00o\00o\00l\00.\00t\00s\00")
@@ -17,7 +17,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:bool (; 1 ;) (type $_)
+ (func $start:bool (; 1 ;) (type $FUNCSIG$v)
   global.get $bool/i
   i32.const 0
   i32.ne
@@ -117,9 +117,9 @@
    unreachable
   end
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   call $start:bool
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/builtins.optimized.wat
+++ b/tests/compiler/builtins.optimized.wat
@@ -1,7 +1,7 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $ii_ (func (param i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0b\00\00\00b\00u\00i\00l\00t\00i\00n\00s\00.\00t\00s")
@@ -21,10 +21,10 @@
  (export "table" (table $0))
  (export "test" (func $builtins/test))
  (start $start)
- (func $start:builtins~anonymous|0 (; 1 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $start:builtins~anonymous|0 (; 1 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $start:builtins (; 2 ;) (type $_)
+ (func $start:builtins (; 2 ;) (type $FUNCSIG$v)
   i32.const 31
   global.set $builtins/i
   i32.const 0
@@ -373,7 +373,7 @@
   i32.const 1
   i32.const 2
   global.get $builtins/fn
-  call_indirect (type $ii_)
+  call_indirect (type $FUNCSIG$vii)
   i32.const 8
   i32.load8_s
   drop
@@ -444,10 +444,10 @@
   f64.const 1
   f64.store
  )
- (func $builtins/test (; 3 ;) (type $_)
+ (func $builtins/test (; 3 ;) (type $FUNCSIG$v)
   nop
  )
- (func $start (; 4 ;) (type $_)
+ (func $start (; 4 ;) (type $FUNCSIG$v)
   call $start:builtins
  )
 )

--- a/tests/compiler/builtins.untouched.wat
+++ b/tests/compiler/builtins.untouched.wat
@@ -1,7 +1,7 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $ii_ (func (param i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0b\00\00\00b\00u\00i\00l\00t\00i\00n\00s\00.\00t\00s\00")
@@ -53,10 +53,10 @@
  (export "table" (table $0))
  (export "test" (func $builtins/test))
  (start $start)
- (func $start:builtins~anonymous|0 (; 1 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $start:builtins~anonymous|0 (; 1 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $start:builtins (; 2 ;) (type $_)
+ (func $start:builtins (; 2 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i64)
@@ -1372,7 +1372,7 @@
   i32.const 1
   i32.const 2
   global.get $builtins/fn
-  call_indirect (type $ii_)
+  call_indirect (type $FUNCSIG$vii)
   i32.const 1
   i32.const 1
   i32.eq
@@ -2329,12 +2329,12 @@
   end
   drop
  )
- (func $builtins/test (; 3 ;) (type $_)
+ (func $builtins/test (; 3 ;) (type $FUNCSIG$v)
   nop
  )
- (func $start (; 4 ;) (type $_)
+ (func $start (; 4 ;) (type $FUNCSIG$v)
   call $start:builtins
  )
- (func $null (; 5 ;) (type $_)
+ (func $null (; 5 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/call-inferred.optimized.wat
+++ b/tests/compiler/call-inferred.optimized.wat
@@ -1,12 +1,12 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 1)
  (data (i32.const 8) "\10\00\00\00c\00a\00l\00l\00-\00i\00n\00f\00e\00r\00r\00e\00d\00.\00t\00s")
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $start (; 0 ;) (type $_)
+ (func $start (; 0 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/call-inferred.untouched.wat
+++ b/tests/compiler/call-inferred.untouched.wat
@@ -1,9 +1,9 @@
 (module
- (type $ii (func (param i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $FF (func (param f64) (result f64)))
- (type $ff (func (param f32) (result f32)))
- (type $_ (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$dd (func (param f64) (result f64)))
+ (type $FUNCSIG$ff (func (param f32) (result f32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\10\00\00\00c\00a\00l\00l\00-\00i\00n\00f\00e\00r\00r\00e\00d\00.\00t\00s\00")
@@ -13,19 +13,19 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $call-inferred/foo<i32> (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $call-inferred/foo<i32> (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $call-inferred/foo<f64> (; 2 ;) (type $FF) (param $0 f64) (result f64)
+ (func $call-inferred/foo<f64> (; 2 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
  )
- (func $call-inferred/foo<f32> (; 3 ;) (type $ff) (param $0 f32) (result f32)
+ (func $call-inferred/foo<f32> (; 3 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
  )
- (func $call-inferred/bar<f32> (; 4 ;) (type $ff) (param $0 f32) (result f32)
+ (func $call-inferred/bar<f32> (; 4 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
  )
- (func $start:call-inferred (; 5 ;) (type $_)
+ (func $start:call-inferred (; 5 ;) (type $FUNCSIG$v)
   i32.const 42
   call $call-inferred/foo<i32>
   i32.const 42
@@ -79,9 +79,9 @@
    unreachable
   end
  )
- (func $start (; 6 ;) (type $_)
+ (func $start (; 6 ;) (type $FUNCSIG$v)
   call $start:call-inferred
  )
- (func $null (; 7 ;) (type $_)
+ (func $null (; 7 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/call-optional.optimized.wat
+++ b/tests/compiler/call-optional.optimized.wat
@@ -1,7 +1,7 @@
 (module
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\10\00\00\00c\00a\00l\00l\00-\00o\00p\00t\00i\00o\00n\00a\00l\00.\00t\00s")
@@ -12,7 +12,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $call-optional/opt|trampoline (; 1 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $call-optional/opt|trampoline (; 1 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -36,7 +36,7 @@
   local.get $2
   i32.add
  )
- (func $start:call-optional (; 2 ;) (type $_)
+ (func $start:call-optional (; 2 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 1
@@ -115,7 +115,7 @@
   i32.const 0
   i32.const 0
   global.get $call-optional/optIndirect
-  call_indirect (type $iiii)
+  call_indirect (type $FUNCSIG$iiii)
   if
    i32.const 0
    i32.const 8
@@ -130,7 +130,7 @@
   i32.const 4
   i32.const 0
   global.get $call-optional/optIndirect
-  call_indirect (type $iiii)
+  call_indirect (type $FUNCSIG$iiii)
   i32.const 5
   i32.ne
   if
@@ -147,7 +147,7 @@
   i32.const 4
   i32.const 5
   global.get $call-optional/optIndirect
-  call_indirect (type $iiii)
+  call_indirect (type $FUNCSIG$iiii)
   i32.const 12
   i32.ne
   if
@@ -159,10 +159,10 @@
    unreachable
   end
  )
- (func $start (; 3 ;) (type $_)
+ (func $start (; 3 ;) (type $FUNCSIG$v)
   call $start:call-optional
  )
- (func $null (; 4 ;) (type $_)
+ (func $null (; 4 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/call-optional.untouched.wat
+++ b/tests/compiler/call-optional.untouched.wat
@@ -1,7 +1,7 @@
 (module
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\10\00\00\00c\00a\00l\00l\00-\00o\00p\00t\00i\00o\00n\00a\00l\00.\00t\00s\00")
@@ -13,14 +13,14 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $call-optional/opt (; 1 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $call-optional/opt (; 1 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
   local.get $2
   i32.add
  )
- (func $call-optional/opt|trampoline (; 2 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $call-optional/opt|trampoline (; 2 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -43,7 +43,7 @@
   local.get $2
   call $call-optional/opt
  )
- (func $start:call-optional (; 3 ;) (type $_)
+ (func $start:call-optional (; 3 ;) (type $FUNCSIG$v)
   block (result i32)
    i32.const 1
    global.set $~lib/argc
@@ -104,7 +104,7 @@
    i32.const 0
    i32.const 0
    global.get $call-optional/optIndirect
-   call_indirect (type $iiii)
+   call_indirect (type $FUNCSIG$iiii)
   end
   i32.const 0
   i32.eq
@@ -124,7 +124,7 @@
    i32.const 4
    i32.const 0
    global.get $call-optional/optIndirect
-   call_indirect (type $iiii)
+   call_indirect (type $FUNCSIG$iiii)
   end
   i32.const 5
   i32.eq
@@ -144,7 +144,7 @@
    i32.const 4
    i32.const 5
    global.get $call-optional/optIndirect
-   call_indirect (type $iiii)
+   call_indirect (type $FUNCSIG$iiii)
   end
   i32.const 12
   i32.eq
@@ -158,9 +158,9 @@
    unreachable
   end
  )
- (func $start (; 4 ;) (type $_)
+ (func $start (; 4 ;) (type $FUNCSIG$v)
   call $start:call-optional
  )
- (func $null (; 5 ;) (type $_)
+ (func $null (; 5 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/call-super.optimized.wat
+++ b/tests/compiler/call-super.optimized.wat
@@ -1,7 +1,7 @@
 (module
- (type $_ (func))
- (type $ii (func (param i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$i (func (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -13,7 +13,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -75,7 +75,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $call-super/A#constructor (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $call-super/A#constructor (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -134,7 +134,7 @@
   end
   local.get $0
  )
- (func $call-super/test1 (; 4 ;) (type $_)
+ (func $call-super/test1 (; 4 ;) (type $FUNCSIG$v)
   (local $0 i32)
   call $call-super/B#constructor
   local.tee $0
@@ -162,7 +162,7 @@
    unreachable
   end
  )
- (func $call-super/C#constructor (; 5 ;) (type $ii) (param $0 i32) (result i32)
+ (func $call-super/C#constructor (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -209,7 +209,7 @@
   end
   local.get $0
  )
- (func $call-super/test2 (; 7 ;) (type $_)
+ (func $call-super/test2 (; 7 ;) (type $FUNCSIG$v)
   (local $0 i32)
   call $call-super/D#constructor
   local.tee $0
@@ -237,7 +237,7 @@
    unreachable
   end
  )
- (func $call-super/E#constructor (; 8 ;) (type $ii) (param $0 i32) (result i32)
+ (func $call-super/E#constructor (; 8 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -262,7 +262,7 @@
   end
   local.get $0
  )
- (func $call-super/test3 (; 9 ;) (type $_)
+ (func $call-super/test3 (; 9 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 8
   call $~lib/allocator/arena/__memory_allocate
@@ -305,7 +305,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $call-super/test4 (; 11 ;) (type $_)
+ (func $call-super/test4 (; 11 ;) (type $FUNCSIG$v)
   (local $0 i32)
   call $call-super/H#constructor
   local.tee $0
@@ -333,7 +333,7 @@
    unreachable
   end
  )
- (func $call-super/test5 (; 12 ;) (type $_)
+ (func $call-super/test5 (; 12 ;) (type $FUNCSIG$v)
   (local $0 i32)
   call $call-super/H#constructor
   local.tee $0
@@ -361,7 +361,7 @@
    unreachable
   end
  )
- (func $start (; 13 ;) (type $_)
+ (func $start (; 13 ;) (type $FUNCSIG$v)
   i32.const 40
   global.set $~lib/allocator/arena/startOffset
   global.get $~lib/allocator/arena/startOffset
@@ -372,7 +372,7 @@
   call $call-super/test4
   call $call-super/test5
  )
- (func $null (; 14 ;) (type $_)
+ (func $null (; 14 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/call-super.untouched.wat
+++ b/tests/compiler/call-super.untouched.wat
@@ -1,7 +1,7 @@
 (module
- (type $_ (func))
- (type $ii (func (param i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0d\00\00\00c\00a\00l\00l\00-\00s\00u\00p\00e\00r\00.\00t\00s\00")
@@ -13,7 +13,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:~lib/allocator/arena (; 1 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 1 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -25,7 +25,7 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -104,12 +104,12 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/memory/memory.allocate (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/memory/memory.allocate (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/allocator/arena/__memory_allocate
   return
  )
- (func $call-super/A#constructor (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $call-super/A#constructor (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -137,7 +137,7 @@
   end
   local.get $0
  )
- (func $call-super/B#constructor (; 5 ;) (type $ii) (param $0 i32) (result i32)
+ (func $call-super/B#constructor (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -178,7 +178,7 @@
   end
   local.get $0
  )
- (func $call-super/test1 (; 6 ;) (type $_)
+ (func $call-super/test1 (; 6 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   call $call-super/B#constructor
@@ -210,7 +210,7 @@
    unreachable
   end
  )
- (func $call-super/C#constructor (; 7 ;) (type $ii) (param $0 i32) (result i32)
+ (func $call-super/C#constructor (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -223,7 +223,7 @@
   i32.store
   local.get $0
  )
- (func $call-super/D#constructor (; 8 ;) (type $ii) (param $0 i32) (result i32)
+ (func $call-super/D#constructor (; 8 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -264,7 +264,7 @@
   end
   local.get $0
  )
- (func $call-super/test2 (; 9 ;) (type $_)
+ (func $call-super/test2 (; 9 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   call $call-super/D#constructor
@@ -296,7 +296,7 @@
    unreachable
   end
  )
- (func $call-super/E#constructor (; 10 ;) (type $ii) (param $0 i32) (result i32)
+ (func $call-super/E#constructor (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -324,7 +324,7 @@
   end
   local.get $0
  )
- (func $call-super/F#constructor (; 11 ;) (type $ii) (param $0 i32) (result i32)
+ (func $call-super/F#constructor (; 11 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -340,7 +340,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $call-super/test3 (; 12 ;) (type $_)
+ (func $call-super/test3 (; 12 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   call $call-super/F#constructor
@@ -372,7 +372,7 @@
    unreachable
   end
  )
- (func $call-super/G#constructor (; 13 ;) (type $ii) (param $0 i32) (result i32)
+ (func $call-super/G#constructor (; 13 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -385,7 +385,7 @@
   i32.store
   local.get $0
  )
- (func $call-super/H#constructor (; 14 ;) (type $ii) (param $0 i32) (result i32)
+ (func $call-super/H#constructor (; 14 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -401,7 +401,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $call-super/test4 (; 15 ;) (type $_)
+ (func $call-super/test4 (; 15 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   call $call-super/H#constructor
@@ -433,7 +433,7 @@
    unreachable
   end
  )
- (func $call-super/I#constructor (; 16 ;) (type $ii) (param $0 i32) (result i32)
+ (func $call-super/I#constructor (; 16 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -446,7 +446,7 @@
   i32.store
   local.get $0
  )
- (func $call-super/J#constructor (; 17 ;) (type $ii) (param $0 i32) (result i32)
+ (func $call-super/J#constructor (; 17 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -462,7 +462,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $call-super/test5 (; 18 ;) (type $_)
+ (func $call-super/test5 (; 18 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   call $call-super/J#constructor
@@ -494,7 +494,7 @@
    unreachable
   end
  )
- (func $start:call-super (; 19 ;) (type $_)
+ (func $start:call-super (; 19 ;) (type $FUNCSIG$v)
   call $start:~lib/allocator/arena
   call $call-super/test1
   call $call-super/test2
@@ -502,9 +502,9 @@
   call $call-super/test4
   call $call-super/test5
  )
- (func $start (; 20 ;) (type $_)
+ (func $start (; 20 ;) (type $FUNCSIG$v)
   call $start:call-super
  )
- (func $null (; 21 ;) (type $_)
+ (func $null (; 21 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/class-extends.optimized.wat
+++ b/tests/compiler/class-extends.optimized.wat
@@ -1,13 +1,13 @@
 (module
- (type $i_ (func (param i32)))
- (type $_ (func))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "test" (func $class-extends/test))
- (func $class-extends/test (; 0 ;) (type $i_) (param $0 i32)
+ (func $class-extends/test (; 0 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.load
   drop
@@ -21,7 +21,7 @@
   i32.const 3
   i32.store16 offset=4
  )
- (func $null (; 1 ;) (type $_)
+ (func $null (; 1 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/class-extends.untouched.wat
+++ b/tests/compiler/class-extends.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $i_ (func (param i32)))
- (type $_ (func))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -8,7 +8,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "test" (func $class-extends/test))
- (func $class-extends/test (; 0 ;) (type $i_) (param $0 i32)
+ (func $class-extends/test (; 0 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.load
   drop
@@ -22,6 +22,6 @@
   i32.const 3
   i32.store16 offset=4
  )
- (func $null (; 1 ;) (type $_)
+ (func $null (; 1 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/class-overloading.optimized.wat
+++ b/tests/compiler/class-overloading.optimized.wat
@@ -1,16 +1,16 @@
 (module
- (type $i_ (func (param i32)))
- (type $_ (func))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "test" (func $class-overloading/test))
- (func $class-overloading/test (; 0 ;) (type $i_) (param $0 i32)
+ (func $class-overloading/test (; 0 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $start (; 1 ;) (type $_)
+ (func $start (; 1 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/class-overloading.untouched.wat
+++ b/tests/compiler/class-overloading.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $i_ (func (param i32)))
- (type $_ (func))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -9,20 +9,20 @@
  (export "table" (table $0))
  (export "test" (func $class-overloading/test))
  (start $start)
- (func $class-overloading/Foo#baz (; 0 ;) (type $i_) (param $0 i32)
+ (func $class-overloading/Foo#baz (; 0 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $class-overloading/test (; 1 ;) (type $i_) (param $0 i32)
+ (func $class-overloading/test (; 1 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   call $class-overloading/Foo#baz
  )
- (func $start:class-overloading (; 2 ;) (type $_)
+ (func $start:class-overloading (; 2 ;) (type $FUNCSIG$v)
   i32.const 0
   call $class-overloading/test
  )
- (func $start (; 3 ;) (type $_)
+ (func $start (; 3 ;) (type $FUNCSIG$v)
   call $start:class-overloading
  )
- (func $null (; 4 ;) (type $_)
+ (func $null (; 4 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/class.optimized.wat
+++ b/tests/compiler/class.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $_ (func))
- (type $ii (func (param i32) (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
  (memory $0 1)
  (data (i32.const 8) "\08\00\00\00c\00l\00a\00s\00s\00.\00t\00s")
  (table $0 1 funcref)
@@ -8,7 +8,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "test" (func $class/test))
- (func $class/test (; 0 ;) (type $ii) (param $0 i32) (result i32)
+ (func $class/test (; 0 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load
   drop
@@ -29,7 +29,7 @@
   i32.store8 offset=6
   local.get $0
  )
- (func $start (; 1 ;) (type $_)
+ (func $start (; 1 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/class.untouched.wat
+++ b/tests/compiler/class.untouched.wat
@@ -1,11 +1,11 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $fff (func (param f32 f32) (result f32)))
- (type $_ (func))
- (type $ii (func (param i32) (result i32)))
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $ifff (func (param i32 f32 f32) (result f32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$fff (func (param f32 f32) (result f32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$fiff (func (param i32 f32 f32) (result f32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\08\00\00\00c\00l\00a\00s\00s\00.\00t\00s\00")
@@ -17,14 +17,14 @@
  (export "table" (table $0))
  (export "test" (func $class/test))
  (start $start)
- (func $class/Animal.add (; 1 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $class/Animal.add (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
   global.get $class/Animal.ONE
   i32.add
  )
- (func $class/Animal.sub<f32> (; 2 ;) (type $fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $class/Animal.sub<f32> (; 2 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   local.get $0
   local.get $1
   f32.sub
@@ -32,7 +32,7 @@
   f32.convert_i32_s
   f32.add
  )
- (func $start:class (; 3 ;) (type $_)
+ (func $start:class (; 3 ;) (type $FUNCSIG$v)
   i32.const 4
   i32.const 4
   i32.eq
@@ -56,14 +56,14 @@
   call $class/Animal.sub<f32>
   drop
  )
- (func $class/Animal<f64>#instanceAdd (; 4 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $class/Animal<f64>#instanceAdd (; 4 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   local.get $2
   i32.add
   global.get $class/Animal.ONE
   i32.add
  )
- (func $class/Animal<f64>#instanceSub<f32> (; 5 ;) (type $ifff) (param $0 i32) (param $1 f32) (param $2 f32) (result f32)
+ (func $class/Animal<f64>#instanceSub<f32> (; 5 ;) (type $FUNCSIG$fiff) (param $0 i32) (param $1 f32) (param $2 f32) (result f32)
   local.get $1
   local.get $2
   f32.sub
@@ -71,7 +71,7 @@
   f32.convert_i32_s
   f32.add
  )
- (func $class/test (; 6 ;) (type $ii) (param $0 i32) (result i32)
+ (func $class/test (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -116,9 +116,9 @@
   local.set $2
   local.get $2
  )
- (func $start (; 7 ;) (type $_)
+ (func $start (; 7 ;) (type $FUNCSIG$v)
   call $start:class
  )
- (func $null (; 8 ;) (type $_)
+ (func $null (; 8 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/closure.optimized.wat
+++ b/tests/compiler/closure.optimized.wat
@@ -1,11 +1,11 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $null (; 0 ;) (type $_)
+ (func $null (; 0 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/closure.untouched.wat
+++ b/tests/compiler/closure.untouched.wat
@@ -1,11 +1,11 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (global $~lib/memory/HEAP_BASE i32 (i32.const 8))
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $null (; 0 ;) (type $_)
+ (func $null (; 0 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/comma.optimized.wat
+++ b/tests/compiler/comma.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\08\00\00\00c\00o\00m\00m\00a\00.\00t\00s")
@@ -11,7 +11,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:comma (; 1 ;) (type $_)
+ (func $start:comma (; 1 ;) (type $FUNCSIG$v)
   (local $0 i32)
   global.get $comma/a
   local.tee $0
@@ -163,10 +163,10 @@
    unreachable
   end
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   call $start:comma
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/comma.untouched.wat
+++ b/tests/compiler/comma.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\08\00\00\00c\00o\00m\00m\00a\00.\00t\00s\00")
@@ -12,7 +12,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:comma (; 1 ;) (type $_)
+ (func $start:comma (; 1 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   block
@@ -204,9 +204,9 @@
    drop
   end
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   call $start:comma
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/constructor.optimized.wat
+++ b/tests/compiler/constructor.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $_ (func))
- (type $ii (func (param i32) (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$i (func (result i32)))
  (memory $0 0)
  (table $0 1 funcref)
@@ -21,7 +21,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $~lib/allocator/arena/__memory_allocate (; 0 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 0 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -101,7 +101,7 @@
   i32.store
   local.get $0
  )
- (func $start:constructor (; 3 ;) (type $_)
+ (func $start:constructor (; 3 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 8
   global.set $~lib/allocator/arena/startOffset
@@ -156,10 +156,10 @@
   local.get $0
   global.set $constructor/ctorConditionallyAllocates
  )
- (func $start (; 4 ;) (type $_)
+ (func $start (; 4 ;) (type $FUNCSIG$v)
   call $start:constructor
  )
- (func $null (; 5 ;) (type $_)
+ (func $null (; 5 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/constructor.untouched.wat
+++ b/tests/compiler/constructor.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $_ (func))
- (type $ii (func (param i32) (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -21,7 +21,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:~lib/allocator/arena (; 0 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 0 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -33,7 +33,7 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -112,12 +112,12 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/memory/memory.allocate (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/memory/memory.allocate (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/allocator/arena/__memory_allocate
   return
  )
- (func $constructor/EmptyCtor#constructor (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $constructor/EmptyCtor#constructor (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -127,7 +127,7 @@
   end
   local.get $0
  )
- (func $constructor/EmptyCtorWithFieldInit#constructor (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $constructor/EmptyCtorWithFieldInit#constructor (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -140,7 +140,7 @@
   i32.store
   local.get $0
  )
- (func $constructor/EmptyCtorWithFieldNoInit#constructor (; 5 ;) (type $ii) (param $0 i32) (result i32)
+ (func $constructor/EmptyCtorWithFieldNoInit#constructor (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -153,7 +153,7 @@
   i32.store
   local.get $0
  )
- (func $constructor/None#constructor (; 6 ;) (type $ii) (param $0 i32) (result i32)
+ (func $constructor/None#constructor (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -163,7 +163,7 @@
   end
   local.get $0
  )
- (func $constructor/JustFieldInit#constructor (; 7 ;) (type $ii) (param $0 i32) (result i32)
+ (func $constructor/JustFieldInit#constructor (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -176,7 +176,7 @@
   i32.store
   local.get $0
  )
- (func $constructor/JustFieldNoInit#constructor (; 8 ;) (type $ii) (param $0 i32) (result i32)
+ (func $constructor/JustFieldNoInit#constructor (; 8 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -189,7 +189,7 @@
   i32.store
   local.get $0
  )
- (func $constructor/CtorReturns#constructor (; 9 ;) (type $ii) (param $0 i32) (result i32)
+ (func $constructor/CtorReturns#constructor (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   block $~lib/memory/memory.allocate|inlined.0 (result i32)
    i32.const 0
@@ -199,7 +199,7 @@
    br $~lib/memory/memory.allocate|inlined.0
   end
  )
- (func $constructor/CtorConditionallyReturns#constructor (; 10 ;) (type $ii) (param $0 i32) (result i32)
+ (func $constructor/CtorConditionallyReturns#constructor (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   global.get $constructor/b
   if
@@ -221,7 +221,7 @@
   end
   local.get $0
  )
- (func $constructor/CtorAllocates#constructor (; 11 ;) (type $ii) (param $0 i32) (result i32)
+ (func $constructor/CtorAllocates#constructor (; 11 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -235,7 +235,7 @@
   drop
   local.get $0
  )
- (func $constructor/CtorConditionallyAllocates#constructor (; 12 ;) (type $ii) (param $0 i32) (result i32)
+ (func $constructor/CtorConditionallyAllocates#constructor (; 12 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   global.get $constructor/b
   if
    block (result i32)
@@ -259,7 +259,7 @@
   end
   local.get $0
  )
- (func $start:constructor (; 13 ;) (type $_)
+ (func $start:constructor (; 13 ;) (type $FUNCSIG$v)
   call $start:~lib/allocator/arena
   i32.const 0
   call $constructor/EmptyCtor#constructor
@@ -292,9 +292,9 @@
   call $constructor/CtorConditionallyAllocates#constructor
   global.set $constructor/ctorConditionallyAllocates
  )
- (func $start (; 14 ;) (type $_)
+ (func $start (; 14 ;) (type $FUNCSIG$v)
   call $start:constructor
  )
- (func $null (; 15 ;) (type $_)
+ (func $null (; 15 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/declare.optimized.wat
+++ b/tests/compiler/declare.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $_ (func))
- (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (import "declare" "externalConstant" (global $declare/externalConstant i32))
  (import "declare" "my.externalConstant" (global $declare/my.externalConstant i32))
  (import "declare" "externalFunction" (func $declare/externalFunction))
@@ -13,7 +13,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:declare (; 3 ;) (type $_)
+ (func $start:declare (; 3 ;) (type $FUNCSIG$v)
   call $declare/externalFunction
   global.get $declare/externalConstant
   i32.const 1
@@ -39,10 +39,10 @@
    unreachable
   end
  )
- (func $start (; 4 ;) (type $_)
+ (func $start (; 4 ;) (type $FUNCSIG$v)
   call $start:declare
  )
- (func $null (; 5 ;) (type $_)
+ (func $null (; 5 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/declare.untouched.wat
+++ b/tests/compiler/declare.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $_ (func))
- (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (import "declare" "externalConstant" (global $declare/externalConstant i32))
  (import "declare" "my.externalConstant" (global $declare/my.externalConstant i32))
  (import "declare" "externalFunction" (func $declare/externalFunction))
@@ -14,7 +14,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:declare (; 3 ;) (type $_)
+ (func $start:declare (; 3 ;) (type $FUNCSIG$v)
   call $declare/externalFunction
   global.get $declare/externalConstant
   i32.const 1
@@ -42,9 +42,9 @@
    unreachable
   end
  )
- (func $start (; 4 ;) (type $_)
+ (func $start (; 4 ;) (type $FUNCSIG$v)
   call $start:declare
  )
- (func $null (; 5 ;) (type $_)
+ (func $null (; 5 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/do.optimized.wat
+++ b/tests/compiler/do.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\05\00\00\00d\00o\00.\00t\00s")
@@ -12,7 +12,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:do (; 1 ;) (type $_)
+ (func $start:do (; 1 ;) (type $FUNCSIG$v)
   (local $0 i32)
   loop $continue|0
    global.get $do/n
@@ -148,10 +148,10 @@
    unreachable
   end
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   call $start:do
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/do.untouched.wat
+++ b/tests/compiler/do.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\05\00\00\00d\00o\00.\00t\00s\00")
@@ -13,7 +13,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:do (; 1 ;) (type $_)
+ (func $start:do (; 1 ;) (type $FUNCSIG$v)
   (local $0 i32)
   block $break|0
    loop $continue|0
@@ -180,9 +180,9 @@
    unreachable
   end
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   call $start:do
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/empty.optimized.wat
+++ b/tests/compiler/empty.optimized.wat
@@ -1,11 +1,11 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $null (; 0 ;) (type $_)
+ (func $null (; 0 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/empty.untouched.wat
+++ b/tests/compiler/empty.untouched.wat
@@ -1,11 +1,11 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (global $~lib/memory/HEAP_BASE i32 (i32.const 8))
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $null (; 0 ;) (type $_)
+ (func $null (; 0 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/enum.optimized.wat
+++ b/tests/compiler/enum.optimized.wat
@@ -1,5 +1,5 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -36,13 +36,13 @@
  (export "SelfReference.ZERO" (global $enum/SelfReference.ZERO))
  (export "SelfReference.ONE" (global $enum/SelfReference.ONE))
  (start $start)
- (func $start (; 0 ;) (type $_)
+ (func $start (; 0 ;) (type $FUNCSIG$v)
   i32.const 0
   global.set $enum/NonConstant.ZERO
   i32.const 1
   global.set $enum/NonConstant.ONE
  )
- (func $null (; 1 ;) (type $_)
+ (func $null (; 1 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/enum.untouched.wat
+++ b/tests/compiler/enum.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $i (func (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -39,10 +39,10 @@
  (export "SelfReference.ZERO" (global $enum/SelfReference.ZERO))
  (export "SelfReference.ONE" (global $enum/SelfReference.ONE))
  (start $start)
- (func $enum/getZero (; 0 ;) (type $i) (result i32)
+ (func $enum/getZero (; 0 ;) (type $FUNCSIG$i) (result i32)
   i32.const 0
  )
- (func $start:enum (; 1 ;) (type $_)
+ (func $start:enum (; 1 ;) (type $FUNCSIG$v)
   call $enum/getZero
   global.set $enum/NonConstant.ZERO
   call $enum/getZero
@@ -54,9 +54,9 @@
   global.get $enum/NonConstant.ONE
   drop
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   call $start:enum
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/export.optimized.wat
+++ b/tests/compiler/export.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iii (func (param i32 i32) (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $export/ns.one)
@@ -16,22 +16,22 @@
  (export "b" (global $export/b))
  (export "renamed_c" (global $export/c))
  (export "ns.two" (func $export/ns.one))
- (func $export/add (; 0 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/add (; 0 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $export/sub (; 1 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/sub (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $export/mul (; 2 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/mul (; 2 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.mul
  )
- (func $export/ns.one (; 3 ;) (type $_)
+ (func $export/ns.one (; 3 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/export.untouched.wat
+++ b/tests/compiler/export.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iii (func (param i32 i32) (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -17,27 +17,27 @@
  (export "b" (global $export/b))
  (export "renamed_c" (global $export/c))
  (export "ns.two" (func $export/ns.two))
- (func $export/add (; 0 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/add (; 0 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $export/sub (; 1 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/sub (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $export/mul (; 2 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/mul (; 2 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.mul
  )
- (func $export/ns.one (; 3 ;) (type $_)
+ (func $export/ns.one (; 3 ;) (type $FUNCSIG$v)
   nop
  )
- (func $export/ns.two (; 4 ;) (type $_)
+ (func $export/ns.two (; 4 ;) (type $FUNCSIG$v)
   nop
  )
- (func $null (; 5 ;) (type $_)
+ (func $null (; 5 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/exports.optimized.wat
+++ b/tests/compiler/exports.optimized.wat
@@ -1,11 +1,10 @@
 (module
- (type $_ (func))
- (type $iii (func (param i32 i32) (result i32)))
- (type $i (func (result i32)))
- (type $ii (func (param i32) (result i32)))
- (type $ii_ (func (param i32 i32)))
- (type $i_ (func (param i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$vi (func (param i32)))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -47,17 +46,17 @@
  (export "vehicles.Car.getNumTires" (func $exports/Car.getNumTires))
  (export "outer.inner.a" (global $exports/outer.inner.a))
  (start $start)
- (func $exports/add (; 0 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/add (; 0 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $exports/subOpt (; 1 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/subOpt (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $exports/Car.getNumTires (; 2 ;) (type $i) (result i32)
+ (func $exports/Car.getNumTires (; 2 ;) (type $FUNCSIG$i) (result i32)
   i32.const 4
  )
  (func $~lib/allocator/arena/__memory_allocate (; 3 ;) (type $FUNCSIG$i) (result i32)
@@ -110,28 +109,28 @@
   global.set $~lib/allocator/arena/offset
   local.get $0
  )
- (func $exports/Car#get:numDoors (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $exports/Car#get:numDoors (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load
  )
- (func $exports/Car#set:numDoors (; 5 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $exports/Car#set:numDoors (; 5 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
  )
- (func $exports/Car#openDoors (; 6 ;) (type $i_) (param $0 i32)
+ (func $exports/Car#openDoors (; 6 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $start (; 7 ;) (type $_)
+ (func $start (; 7 ;) (type $FUNCSIG$v)
   i32.const 8
   global.set $~lib/allocator/arena/startOffset
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $null (; 8 ;) (type $_)
+ (func $null (; 8 ;) (type $FUNCSIG$v)
   nop
  )
- (func $exports/subOpt|trampoline (; 9 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/subOpt|trampoline (; 9 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -149,11 +148,11 @@
   local.get $1
   i32.sub
  )
- (func $~lib/setargc (; 10 ;) (type $i_) (param $0 i32)
+ (func $~lib/setargc (; 10 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   global.set $~lib/argc
  )
- (func $exports/Car#constructor|trampoline (; 11 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/Car#constructor|trampoline (; 11 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange

--- a/tests/compiler/exports.untouched.wat
+++ b/tests/compiler/exports.untouched.wat
@@ -1,10 +1,10 @@
 (module
- (type $_ (func))
- (type $iii (func (param i32 i32) (result i32)))
- (type $i (func (result i32)))
- (type $ii (func (param i32) (result i32)))
- (type $ii_ (func (param i32 i32)))
- (type $i_ (func (param i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$vi (func (param i32)))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -47,7 +47,7 @@
  (export "vehicles.Car.getNumTires" (func $exports/vehicles.Car.getNumTires))
  (export "outer.inner.a" (global $exports/outer.inner.a))
  (start $start)
- (func $start:~lib/allocator/arena (; 0 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 0 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -59,28 +59,28 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $start:exports (; 1 ;) (type $_)
+ (func $start:exports (; 1 ;) (type $FUNCSIG$v)
   call $start:~lib/allocator/arena
  )
- (func $exports/add (; 2 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/add (; 2 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $exports/subOpt (; 3 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/subOpt (; 3 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $exports/math.sub (; 4 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/math.sub (; 4 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $exports/Car.getNumTires (; 5 ;) (type $i) (result i32)
+ (func $exports/Car.getNumTires (; 5 ;) (type $FUNCSIG$i) (result i32)
   global.get $exports/Car.TIRES
  )
- (func $~lib/allocator/arena/__memory_allocate (; 6 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -159,12 +159,12 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/memory/memory.allocate (; 7 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/memory/memory.allocate (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/allocator/arena/__memory_allocate
   return
  )
- (func $exports/Car#constructor (; 8 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/Car#constructor (; 8 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -182,22 +182,22 @@
   i32.store
   local.get $0
  )
- (func $exports/Car#get:numDoors (; 9 ;) (type $ii) (param $0 i32) (result i32)
+ (func $exports/Car#get:numDoors (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load
  )
- (func $exports/Car#set:numDoors (; 10 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $exports/Car#set:numDoors (; 10 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
  )
- (func $exports/Car#openDoors (; 11 ;) (type $i_) (param $0 i32)
+ (func $exports/Car#openDoors (; 11 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $exports/vehicles.Car.getNumTires (; 12 ;) (type $i) (result i32)
+ (func $exports/vehicles.Car.getNumTires (; 12 ;) (type $FUNCSIG$i) (result i32)
   global.get $exports/vehicles.Car.TIRES
  )
- (func $exports/vehicles.Car#constructor (; 13 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/vehicles.Car#constructor (; 13 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -215,24 +215,24 @@
   i32.store
   local.get $0
  )
- (func $exports/vehicles.Car#get:numDoors (; 14 ;) (type $ii) (param $0 i32) (result i32)
+ (func $exports/vehicles.Car#get:numDoors (; 14 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load
  )
- (func $exports/vehicles.Car#set:numDoors (; 15 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $exports/vehicles.Car#set:numDoors (; 15 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
  )
- (func $exports/vehicles.Car#openDoors (; 16 ;) (type $i_) (param $0 i32)
+ (func $exports/vehicles.Car#openDoors (; 16 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $start (; 17 ;) (type $_)
+ (func $start (; 17 ;) (type $FUNCSIG$v)
   call $start:exports
  )
- (func $null (; 18 ;) (type $_)
+ (func $null (; 18 ;) (type $FUNCSIG$v)
  )
- (func $exports/subOpt|trampoline (; 19 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/subOpt|trampoline (; 19 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -250,20 +250,20 @@
   local.get $1
   call $exports/subOpt
  )
- (func $~lib/setargc (; 20 ;) (type $i_) (param $0 i32)
+ (func $~lib/setargc (; 20 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   global.set $~lib/argc
  )
- (func $Car#get:doors (; 21 ;) (type $ii) (param $0 i32) (result i32)
+ (func $Car#get:doors (; 21 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load
  )
- (func $Car#set:doors (; 22 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $Car#set:doors (; 22 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
  )
- (func $exports/Car#constructor|trampoline (; 23 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/Car#constructor|trampoline (; 23 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -279,16 +279,16 @@
   local.get $1
   call $exports/Car#constructor
  )
- (func $vehicles.Car#get:doors (; 24 ;) (type $ii) (param $0 i32) (result i32)
+ (func $vehicles.Car#get:doors (; 24 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load
  )
- (func $vehicles.Car#set:doors (; 25 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $vehicles.Car#set:doors (; 25 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
  )
- (func $exports/vehicles.Car#constructor|trampoline (; 26 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/vehicles.Car#constructor|trampoline (; 26 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange

--- a/tests/compiler/external.optimized.wat
+++ b/tests/compiler/external.optimized.wat
@@ -1,5 +1,5 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (import "foo" "var" (global $external/var_ i32))
  (import "external" "foo" (func $external/foo))
  (import "external" "foo.bar" (func $external/foo.bar))
@@ -15,7 +15,7 @@
  (export "two" (func $external/two))
  (export "three" (func $external/three))
  (export "var_" (global $external/var_))
- (func $null (; 4 ;) (type $_)
+ (func $null (; 4 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/external.untouched.wat
+++ b/tests/compiler/external.untouched.wat
@@ -1,5 +1,5 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (import "foo" "var" (global $external/var_ i32))
  (import "external" "foo" (func $external/foo))
  (import "external" "foo.bar" (func $external/foo.bar))
@@ -16,6 +16,6 @@
  (export "two" (func $external/two))
  (export "three" (func $external/three))
  (export "var_" (global $external/var_))
- (func $null (; 4 ;) (type $_)
+ (func $null (; 4 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/for.optimized.wat
+++ b/tests/compiler/for.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\06\00\00\00f\00o\00r\00.\00t\00s")
@@ -10,7 +10,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:for (; 1 ;) (type $_)
+ (func $start:for (; 1 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -158,10 +158,10 @@
    end
   end
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   call $start:for
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/for.untouched.wat
+++ b/tests/compiler/for.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\06\00\00\00f\00o\00r\00.\00t\00s\00")
@@ -11,7 +11,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:for (; 1 ;) (type $_)
+ (func $start:for (; 1 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -215,9 +215,9 @@
    unreachable
   end
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   call $start:for
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/function-expression.optimized.wat
+++ b/tests/compiler/function-expression.optimized.wat
@@ -1,9 +1,9 @@
 (module
- (type $ii (func (param i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
- (type $i (func (result i32)))
- (type $iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\16\00\00\00f\00u\00n\00c\00t\00i\00o\00n\00-\00e\00x\00p\00r\00e\00s\00s\00i\00o\00n\00.\00t\00s")
@@ -17,32 +17,32 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:function-expression~anonymous|0 (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $start:function-expression~anonymous|0 (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $start:function-expression~someName (; 2 ;) (type $_)
+ (func $start:function-expression~someName (; 2 ;) (type $FUNCSIG$v)
   nop
  )
- (func $start:function-expression~anonymous|2 (; 3 ;) (type $i) (result i32)
+ (func $start:function-expression~anonymous|2 (; 3 ;) (type $FUNCSIG$i) (result i32)
   i32.const 1
  )
- (func $start:function-expression~anonymous|3 (; 4 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:function-expression~anonymous|3 (; 4 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $start:function-expression~anonymous|4 (; 5 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:function-expression~anonymous|4 (; 5 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
  )
- (func $start:function-expression~anonymous|5 (; 6 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:function-expression~anonymous|5 (; 6 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   i32.const 42
  )
- (func $start:function-expression (; 7 ;) (type $_)
+ (func $start:function-expression (; 7 ;) (type $FUNCSIG$v)
   i32.const 1
   global.set $~lib/argc
   i32.const 1
   global.get $function-expression/f1
-  call_indirect (type $ii)
+  call_indirect (type $FUNCSIG$ii)
   i32.const 1
   i32.ne
   if
@@ -57,7 +57,7 @@
   global.set $~lib/argc
   i32.const 2
   global.get $function-expression/f2
-  call_indirect (type $ii)
+  call_indirect (type $FUNCSIG$ii)
   i32.const 2
   i32.ne
   if
@@ -71,11 +71,11 @@
   i32.const 0
   global.set $~lib/argc
   global.get $function-expression/f3
-  call_indirect (type $_)
+  call_indirect (type $FUNCSIG$v)
   i32.const 0
   global.set $~lib/argc
   global.get $function-expression/f4
-  call_indirect (type $i)
+  call_indirect (type $FUNCSIG$i)
   i32.const 1
   i32.ne
   if
@@ -91,7 +91,7 @@
   i32.const 1
   i32.const 2
   i32.const 5
-  call_indirect (type $iii)
+  call_indirect (type $FUNCSIG$iii)
   i32.const 3
   i32.ne
   if
@@ -107,7 +107,7 @@
   i32.const 1
   i32.const 2
   i32.const 6
-  call_indirect (type $iii)
+  call_indirect (type $FUNCSIG$iii)
   i32.const 1
   i32.ne
   if
@@ -123,7 +123,7 @@
   i32.const 1
   i32.const 2
   i32.const 7
-  call_indirect (type $iii)
+  call_indirect (type $FUNCSIG$iii)
   i32.const 42
   i32.ne
   if
@@ -139,7 +139,7 @@
   i32.const 1
   i32.const 2
   i32.const 8
-  call_indirect (type $iii)
+  call_indirect (type $FUNCSIG$iii)
   i32.const 3
   i32.ne
   if
@@ -155,7 +155,7 @@
   i32.const 1
   i32.const 2
   i32.const 9
-  call_indirect (type $iii)
+  call_indirect (type $FUNCSIG$iii)
   i32.const 1
   i32.ne
   if
@@ -171,7 +171,7 @@
   i32.const 1
   i32.const 2
   i32.const 10
-  call_indirect (type $iii)
+  call_indirect (type $FUNCSIG$iii)
   i32.const 42
   i32.ne
   if
@@ -183,7 +183,7 @@
    unreachable
   end
  )
- (func $start (; 8 ;) (type $_)
+ (func $start (; 8 ;) (type $FUNCSIG$v)
   call $start:function-expression
  )
 )

--- a/tests/compiler/function-expression.untouched.wat
+++ b/tests/compiler/function-expression.untouched.wat
@@ -1,9 +1,9 @@
 (module
- (type $ii (func (param i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
- (type $i (func (result i32)))
- (type $iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\16\00\00\00f\00u\00n\00c\00t\00i\00o\00n\00-\00e\00x\00p\00r\00e\00s\00s\00i\00o\00n\00.\00t\00s\00")
@@ -18,64 +18,64 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:function-expression~anonymous|0 (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $start:function-expression~anonymous|0 (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $start:function-expression~anonymous|1 (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $start:function-expression~anonymous|1 (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $start:function-expression~someName (; 3 ;) (type $_)
+ (func $start:function-expression~someName (; 3 ;) (type $FUNCSIG$v)
   nop
  )
- (func $start:function-expression~anonymous|2 (; 4 ;) (type $i) (result i32)
+ (func $start:function-expression~anonymous|2 (; 4 ;) (type $FUNCSIG$i) (result i32)
   i32.const 1
  )
- (func $start:function-expression~anonymous|3 (; 5 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:function-expression~anonymous|3 (; 5 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $function-expression/testOmitted (; 6 ;) (type $ii) (param $0 i32) (result i32)
+ (func $function-expression/testOmitted (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 2
   global.set $~lib/argc
   i32.const 1
   i32.const 2
   local.get $0
-  call_indirect (type $iii)
+  call_indirect (type $FUNCSIG$iii)
  )
- (func $start:function-expression~anonymous|4 (; 7 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:function-expression~anonymous|4 (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
  )
- (func $start:function-expression~anonymous|5 (; 8 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:function-expression~anonymous|5 (; 8 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   i32.const 42
  )
- (func $function-expression/testOmittedReturn1~anonymous|0 (; 9 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $function-expression/testOmittedReturn1~anonymous|0 (; 9 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $function-expression/testOmittedReturn1 (; 10 ;) (type $i) (result i32)
+ (func $function-expression/testOmittedReturn1 (; 10 ;) (type $FUNCSIG$i) (result i32)
   i32.const 8
  )
- (func $function-expression/testOmittedReturn2~anonymous|0 (; 11 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $function-expression/testOmittedReturn2~anonymous|0 (; 11 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
  )
- (func $function-expression/testOmittedReturn2 (; 12 ;) (type $i) (result i32)
+ (func $function-expression/testOmittedReturn2 (; 12 ;) (type $FUNCSIG$i) (result i32)
   i32.const 9
  )
- (func $function-expression/testOmittedReturn3~anonymous|0 (; 13 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $function-expression/testOmittedReturn3~anonymous|0 (; 13 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   i32.const 42
  )
- (func $function-expression/testOmittedReturn3 (; 14 ;) (type $i) (result i32)
+ (func $function-expression/testOmittedReturn3 (; 14 ;) (type $FUNCSIG$i) (result i32)
   i32.const 10
  )
- (func $start:function-expression (; 15 ;) (type $_)
+ (func $start:function-expression (; 15 ;) (type $FUNCSIG$v)
   block (result i32)
    i32.const 1
    global.set $~lib/argc
    i32.const 1
    global.get $function-expression/f1
-   call_indirect (type $ii)
+   call_indirect (type $FUNCSIG$ii)
   end
   i32.const 1
   i32.eq
@@ -93,7 +93,7 @@
    global.set $~lib/argc
    i32.const 2
    global.get $function-expression/f2
-   call_indirect (type $ii)
+   call_indirect (type $FUNCSIG$ii)
   end
   i32.const 2
   i32.eq
@@ -110,13 +110,13 @@
    i32.const 0
    global.set $~lib/argc
    global.get $function-expression/f3
-   call_indirect (type $_)
+   call_indirect (type $FUNCSIG$v)
   end
   block (result i32)
    i32.const 0
    global.set $~lib/argc
    global.get $function-expression/f4
-   call_indirect (type $i)
+   call_indirect (type $FUNCSIG$i)
   end
   i32.const 1
   i32.eq
@@ -174,7 +174,7 @@
    i32.const 1
    i32.const 2
    call $function-expression/testOmittedReturn1
-   call_indirect (type $iii)
+   call_indirect (type $FUNCSIG$iii)
   end
   i32.const 3
   i32.eq
@@ -193,7 +193,7 @@
    i32.const 1
    i32.const 2
    call $function-expression/testOmittedReturn2
-   call_indirect (type $iii)
+   call_indirect (type $FUNCSIG$iii)
   end
   i32.const 1
   i32.eq
@@ -212,7 +212,7 @@
    i32.const 1
    i32.const 2
    call $function-expression/testOmittedReturn3
-   call_indirect (type $iii)
+   call_indirect (type $FUNCSIG$iii)
   end
   i32.const 42
   i32.eq
@@ -226,9 +226,9 @@
    unreachable
   end
  )
- (func $start (; 16 ;) (type $_)
+ (func $start (; 16 ;) (type $FUNCSIG$v)
   call $start:function-expression
  )
- (func $null (; 17 ;) (type $_)
+ (func $null (; 17 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/function-types.optimized.wat
+++ b/tests/compiler/function-types.optimized.wat
@@ -1,9 +1,9 @@
 (module
- (type $iii (func (param i32 i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $III (func (param i64 i64) (result i64)))
- (type $FFF (func (param f64 f64) (result f64)))
- (type $_ (func))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$jjj (func (param i64 i64) (result i64)))
+ (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\11\00\00\00f\00u\00n\00c\00t\00i\00o\00n\00-\00t\00y\00p\00e\00s\00.\00t\00s")
@@ -15,22 +15,22 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $function-types/makeAdder<i32>~anonymous|0 (; 1 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $function-types/makeAdder<i32>~anonymous|0 (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $function-types/makeAdder<i64>~anonymous|0 (; 2 ;) (type $III) (param $0 i64) (param $1 i64) (result i64)
+ (func $function-types/makeAdder<i64>~anonymous|0 (; 2 ;) (type $FUNCSIG$jjj) (param $0 i64) (param $1 i64) (result i64)
   local.get $0
   local.get $1
   i64.add
  )
- (func $function-types/makeAdder<f64>~anonymous|0 (; 3 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $function-types/makeAdder<f64>~anonymous|0 (; 3 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   f64.add
  )
- (func $start:function-types (; 4 ;) (type $_)
+ (func $start:function-types (; 4 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 1
   global.set $function-types/i32Adder
@@ -39,7 +39,7 @@
   i32.const 1
   i32.const 2
   global.get $function-types/i32Adder
-  call_indirect (type $iii)
+  call_indirect (type $FUNCSIG$iii)
   i32.const 3
   i32.ne
   if
@@ -57,7 +57,7 @@
   i64.const 10
   i64.const 20
   global.get $function-types/i64Adder
-  call_indirect (type $III)
+  call_indirect (type $FUNCSIG$jjj)
   i64.const 30
   i64.ne
   if
@@ -73,7 +73,7 @@
   f64.const 1.5
   f64.const 2.5
   i32.const 3
-  call_indirect (type $FFF)
+  call_indirect (type $FUNCSIG$ddd)
   f64.const 4
   f64.ne
   if
@@ -89,7 +89,7 @@
   i32.const 2
   i32.const 3
   global.get $function-types/i32Adder
-  call_indirect (type $iii)
+  call_indirect (type $FUNCSIG$iii)
   i32.const 5
   i32.ne
   if
@@ -105,7 +105,7 @@
   i32.const 3
   i32.const 4
   i32.const 1
-  call_indirect (type $iii)
+  call_indirect (type $FUNCSIG$iii)
   i32.const 7
   i32.ne
   if
@@ -121,7 +121,7 @@
   i32.const 4
   i32.const 5
   i32.const 4
-  call_indirect (type $iii)
+  call_indirect (type $FUNCSIG$iii)
   i32.const 9
   i32.ne
   if
@@ -152,7 +152,7 @@
   i32.const 1
   i32.const 2
   local.get $0
-  call_indirect (type $iii)
+  call_indirect (type $FUNCSIG$iii)
   i32.const 3
   i32.ne
   if
@@ -168,7 +168,7 @@
   i32.const 1
   i32.const 2
   i32.const 1
-  call_indirect (type $iii)
+  call_indirect (type $FUNCSIG$iii)
   i32.const 3
   i32.ne
   if
@@ -180,10 +180,10 @@
    unreachable
   end
  )
- (func $start (; 5 ;) (type $_)
+ (func $start (; 5 ;) (type $FUNCSIG$v)
   call $start:function-types
  )
- (func $null (; 6 ;) (type $_)
+ (func $null (; 6 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/function-types.untouched.wat
+++ b/tests/compiler/function-types.untouched.wat
@@ -1,11 +1,11 @@
 (module
- (type $i (func (result i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $III (func (param i64 i64) (result i64)))
- (type $FFF (func (param f64 f64) (result f64)))
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$jjj (func (param i64 i64) (result i64)))
+ (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\11\00\00\00f\00u\00n\00c\00t\00i\00o\00n\00-\00t\00y\00p\00e\00s\00.\00t\00s\00")
@@ -18,60 +18,60 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $function-types/makeAdder<i32>~anonymous|0 (; 1 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $function-types/makeAdder<i32>~anonymous|0 (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $function-types/makeAdder<i32> (; 2 ;) (type $i) (result i32)
+ (func $function-types/makeAdder<i32> (; 2 ;) (type $FUNCSIG$i) (result i32)
   i32.const 1
  )
- (func $function-types/makeAdder<i64>~anonymous|0 (; 3 ;) (type $III) (param $0 i64) (param $1 i64) (result i64)
+ (func $function-types/makeAdder<i64>~anonymous|0 (; 3 ;) (type $FUNCSIG$jjj) (param $0 i64) (param $1 i64) (result i64)
   local.get $0
   local.get $1
   i64.add
  )
- (func $function-types/makeAdder<i64> (; 4 ;) (type $i) (result i32)
+ (func $function-types/makeAdder<i64> (; 4 ;) (type $FUNCSIG$i) (result i32)
   i32.const 2
  )
- (func $function-types/makeAdder<f64>~anonymous|0 (; 5 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $function-types/makeAdder<f64>~anonymous|0 (; 5 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   f64.add
  )
- (func $function-types/makeAdder<f64> (; 6 ;) (type $i) (result i32)
+ (func $function-types/makeAdder<f64> (; 6 ;) (type $FUNCSIG$i) (result i32)
   i32.const 3
  )
- (func $function-types/doAddWithFn<i32> (; 7 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $function-types/doAddWithFn<i32> (; 7 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   i32.const 2
   global.set $~lib/argc
   local.get $0
   local.get $1
   local.get $2
-  call_indirect (type $iii)
+  call_indirect (type $FUNCSIG$iii)
  )
- (func $function-types/doAdd<i32> (; 8 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $function-types/doAdd<i32> (; 8 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   i32.const 2
   global.set $~lib/argc
   local.get $0
   local.get $1
   call $function-types/makeAdder<i32>
-  call_indirect (type $iii)
+  call_indirect (type $FUNCSIG$iii)
  )
- (func $function-types/addI32 (; 9 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $function-types/addI32 (; 9 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $function-types/makeAndAdd<i32> (; 10 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $function-types/makeAndAdd<i32> (; 10 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   i32.const 2
   global.set $~lib/argc
   local.get $0
   local.get $1
   local.get $2
-  call_indirect (type $iii)
+  call_indirect (type $FUNCSIG$iii)
  )
- (func $function-types/makeAndAdd<i32>|trampoline (; 11 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $function-types/makeAndAdd<i32>|trampoline (; 11 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -90,7 +90,7 @@
   local.get $2
   call $function-types/makeAndAdd<i32>
  )
- (func $start:function-types (; 12 ;) (type $_)
+ (func $start:function-types (; 12 ;) (type $FUNCSIG$v)
   call $function-types/makeAdder<i32>
   global.set $function-types/i32Adder
   block (result i32)
@@ -99,7 +99,7 @@
    i32.const 1
    i32.const 2
    global.get $function-types/i32Adder
-   call_indirect (type $iii)
+   call_indirect (type $FUNCSIG$iii)
   end
   i32.const 3
   i32.eq
@@ -120,7 +120,7 @@
    i64.const 10
    i64.const 20
    global.get $function-types/i64Adder
-   call_indirect (type $III)
+   call_indirect (type $FUNCSIG$jjj)
   end
   i64.const 30
   i64.eq
@@ -139,7 +139,7 @@
    f64.const 1.5
    f64.const 2.5
    call $function-types/makeAdder<f64>
-   call_indirect (type $FFF)
+   call_indirect (type $FUNCSIG$ddd)
   end
   f64.const 4
   f64.eq
@@ -231,9 +231,9 @@
    unreachable
   end
  )
- (func $start (; 13 ;) (type $_)
+ (func $start (; 13 ;) (type $FUNCSIG$v)
   call $start:function-types
  )
- (func $null (; 14 ;) (type $_)
+ (func $null (; 14 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/function.optimized.wat
+++ b/tests/compiler/function.optimized.wat
@@ -1,11 +1,11 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $start (; 0 ;) (type $_)
+ (func $start (; 0 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/function.untouched.wat
+++ b/tests/compiler/function.untouched.wat
@@ -1,19 +1,19 @@
 (module
- (type $_ (func))
- (type $i (func (result i32)))
- (type $I (func (result i64)))
- (type $f (func (result f32)))
- (type $F (func (result f64)))
- (type $i_ (func (param i32)))
- (type $ii (func (param i32) (result i32)))
- (type $II (func (param i64) (result i64)))
- (type $ff (func (param f32) (result f32)))
- (type $FF (func (param f64) (result f64)))
- (type $ii_ (func (param i32 i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $IiI (func (param i64 i32) (result i64)))
- (type $fff (func (param f32 f32) (result f32)))
- (type $FFF (func (param f64 f64) (result f64)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$j (func (result i64)))
+ (type $FUNCSIG$f (func (result f32)))
+ (type $FUNCSIG$d (func (result f64)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$jj (func (param i64) (result i64)))
+ (type $FUNCSIG$ff (func (param f32) (result f32)))
+ (type $FUNCSIG$dd (func (param f64) (result f64)))
+ (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$jji (func (param i64 i32) (result i64)))
+ (type $FUNCSIG$fff (func (param f32 f32) (result f32)))
+ (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -21,61 +21,61 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $function/v (; 0 ;) (type $_)
+ (func $function/v (; 0 ;) (type $FUNCSIG$v)
   nop
  )
- (func $function/i (; 1 ;) (type $i) (result i32)
+ (func $function/i (; 1 ;) (type $FUNCSIG$i) (result i32)
   i32.const 0
  )
- (func $function/I (; 2 ;) (type $I) (result i64)
+ (func $function/I (; 2 ;) (type $FUNCSIG$j) (result i64)
   i64.const 0
  )
- (func $function/f (; 3 ;) (type $f) (result f32)
+ (func $function/f (; 3 ;) (type $FUNCSIG$f) (result f32)
   f32.const 0
  )
- (func $function/F (; 4 ;) (type $F) (result f64)
+ (func $function/F (; 4 ;) (type $FUNCSIG$d) (result f64)
   f64.const 0
  )
- (func $function/iv (; 5 ;) (type $i_) (param $0 i32)
+ (func $function/iv (; 5 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $function/ii (; 6 ;) (type $ii) (param $0 i32) (result i32)
+ (func $function/ii (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $function/II (; 7 ;) (type $II) (param $0 i64) (result i64)
+ (func $function/II (; 7 ;) (type $FUNCSIG$jj) (param $0 i64) (result i64)
   local.get $0
  )
- (func $function/ff (; 8 ;) (type $ff) (param $0 f32) (result f32)
+ (func $function/ff (; 8 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
  )
- (func $function/FF (; 9 ;) (type $FF) (param $0 f64) (result f64)
+ (func $function/FF (; 9 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
  )
- (func $function/iiv (; 10 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $function/iiv (; 10 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $function/iii (; 11 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $function/iii (; 11 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $function/III (; 12 ;) (type $IiI) (param $0 i64) (param $1 i32) (result i64)
+ (func $function/III (; 12 ;) (type $FUNCSIG$jji) (param $0 i64) (param $1 i32) (result i64)
   local.get $0
   local.get $1
   i64.extend_i32_s
   i64.add
  )
- (func $function/fff (; 13 ;) (type $fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $function/fff (; 13 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   local.get $0
   local.get $1
   f32.add
  )
- (func $function/FFF (; 14 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $function/FFF (; 14 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   f64.add
  )
- (func $start:function (; 15 ;) (type $_)
+ (func $start:function (; 15 ;) (type $FUNCSIG$v)
   call $function/v
   call $function/i
   drop
@@ -119,9 +119,9 @@
   call $function/FFF
   drop
  )
- (func $start (; 16 ;) (type $_)
+ (func $start (; 16 ;) (type $FUNCSIG$v)
   call $start:function
  )
- (func $null (; 17 ;) (type $_)
+ (func $null (; 17 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/getter-call.optimized.wat
+++ b/tests/compiler/getter-call.optimized.wat
@@ -1,6 +1,5 @@
 (module
- (type $_ (func))
- (type $i (func (result i32)))
+ (type $FUNCSIG$v (func))
  (type $FUNCSIG$i (func (result i32)))
  (memory $0 0)
  (table $0 2 funcref)
@@ -62,24 +61,24 @@
   global.set $~lib/allocator/arena/offset
   local.get $0
  )
- (func $getter-call/C#get:x~anonymous|0 (; 1 ;) (type $i) (result i32)
+ (func $getter-call/C#get:x~anonymous|0 (; 1 ;) (type $FUNCSIG$i) (result i32)
   i32.const 42
  )
- (func $getter-call/test (; 2 ;) (type $i) (result i32)
+ (func $getter-call/test (; 2 ;) (type $FUNCSIG$i) (result i32)
   call $~lib/allocator/arena/__memory_allocate
   drop
   i32.const 0
   global.set $~lib/argc
   i32.const 1
-  call_indirect (type $i)
+  call_indirect (type $FUNCSIG$i)
  )
- (func $start (; 3 ;) (type $_)
+ (func $start (; 3 ;) (type $FUNCSIG$v)
   i32.const 8
   global.set $~lib/allocator/arena/startOffset
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $null (; 4 ;) (type $_)
+ (func $null (; 4 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/getter-call.untouched.wat
+++ b/tests/compiler/getter-call.untouched.wat
@@ -1,7 +1,7 @@
 (module
- (type $_ (func))
- (type $i (func (result i32)))
- (type $ii (func (param i32) (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
  (memory $0 0)
  (table $0 2 funcref)
  (elem (i32.const 0) $null $getter-call/C#get:x~anonymous|0)
@@ -13,7 +13,7 @@
  (export "table" (table $0))
  (export "test" (func $getter-call/test))
  (start $start)
- (func $start:~lib/allocator/arena (; 0 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 0 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -25,10 +25,10 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $start:getter-call (; 1 ;) (type $_)
+ (func $start:getter-call (; 1 ;) (type $FUNCSIG$v)
   call $start:~lib/allocator/arena
  )
- (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -107,12 +107,12 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/memory/memory.allocate (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/memory/memory.allocate (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/allocator/arena/__memory_allocate
   return
  )
- (func $getter-call/C#constructor (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $getter-call/C#constructor (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -122,13 +122,13 @@
   end
   local.get $0
  )
- (func $getter-call/C#get:x~anonymous|0 (; 5 ;) (type $i) (result i32)
+ (func $getter-call/C#get:x~anonymous|0 (; 5 ;) (type $FUNCSIG$i) (result i32)
   i32.const 42
  )
- (func $getter-call/C#get:x (; 6 ;) (type $ii) (param $0 i32) (result i32)
+ (func $getter-call/C#get:x (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
  )
- (func $getter-call/test (; 7 ;) (type $i) (result i32)
+ (func $getter-call/test (; 7 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   i32.const 0
   call $getter-call/C#constructor
@@ -137,11 +137,11 @@
   global.set $~lib/argc
   local.get $0
   call $getter-call/C#get:x
-  call_indirect (type $i)
+  call_indirect (type $FUNCSIG$i)
  )
- (func $start (; 8 ;) (type $_)
+ (func $start (; 8 ;) (type $FUNCSIG$v)
   call $start:getter-call
  )
- (func $null (; 9 ;) (type $_)
+ (func $null (; 9 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/getter-setter.optimized.wat
+++ b/tests/compiler/getter-setter.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\10\00\00\00g\00e\00t\00t\00e\00r\00-\00s\00e\00t\00t\00e\00r\00.\00t\00s")
@@ -10,7 +10,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:getter-setter (; 1 ;) (type $_)
+ (func $start:getter-setter (; 1 ;) (type $FUNCSIG$v)
   global.get $getter-setter/Foo._bar
   if
    i32.const 0
@@ -47,10 +47,10 @@
    unreachable
   end
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   call $start:getter-setter
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/getter-setter.untouched.wat
+++ b/tests/compiler/getter-setter.untouched.wat
@@ -1,8 +1,8 @@
 (module
- (type $i (func (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $i_ (func (param i32)))
- (type $_ (func))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\10\00\00\00g\00e\00t\00t\00e\00r\00-\00s\00e\00t\00t\00e\00r\00.\00t\00s\00")
@@ -13,14 +13,14 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $getter-setter/Foo.bar.get:bar (; 1 ;) (type $i) (result i32)
+ (func $getter-setter/Foo.bar.get:bar (; 1 ;) (type $FUNCSIG$i) (result i32)
   global.get $getter-setter/Foo._bar
  )
- (func $getter-setter/Foo.bar.set:bar (; 2 ;) (type $i_) (param $0 i32)
+ (func $getter-setter/Foo.bar.set:bar (; 2 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   global.set $getter-setter/Foo._bar
  )
- (func $start:getter-setter (; 3 ;) (type $_)
+ (func $start:getter-setter (; 3 ;) (type $FUNCSIG$v)
   call $getter-setter/Foo.bar.get:bar
   i32.const 0
   i32.eq
@@ -64,9 +64,9 @@
    unreachable
   end
  )
- (func $start (; 4 ;) (type $_)
+ (func $start (; 4 ;) (type $FUNCSIG$v)
   call $start:getter-setter
  )
- (func $null (; 5 ;) (type $_)
+ (func $null (; 5 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/i64-polyfill.optimized.wat
+++ b/tests/compiler/i64-polyfill.optimized.wat
@@ -1,8 +1,8 @@
 (module
- (type $i (func (result i32)))
- (type $ii_ (func (param i32 i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -41,13 +41,13 @@
  (export "gt_u" (func $../../examples/i64-polyfill/assembly/i64/gt_u))
  (export "ge_s" (func $../../examples/i64-polyfill/assembly/i64/ge_s))
  (export "ge_u" (func $../../examples/i64-polyfill/assembly/i64/ge_u))
- (func $../../examples/i64-polyfill/assembly/i64/getHi (; 0 ;) (type $i) (result i32)
+ (func $../../examples/i64-polyfill/assembly/i64/getHi (; 0 ;) (type $FUNCSIG$i) (result i32)
   global.get $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/getLo (; 1 ;) (type $i) (result i32)
+ (func $../../examples/i64-polyfill/assembly/i64/getLo (; 1 ;) (type $FUNCSIG$i) (result i32)
   global.get $../../examples/i64-polyfill/assembly/i64/lo
  )
- (func $../../examples/i64-polyfill/assembly/i64/clz (; 2 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/clz (; 2 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -61,7 +61,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/ctz (; 3 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/ctz (; 3 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -75,7 +75,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/popcnt (; 4 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/popcnt (; 4 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -89,7 +89,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/eqz (; 5 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/eqz (; 5 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -102,7 +102,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/add (; 6 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/add (; 6 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -128,7 +128,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/sub (; 7 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/sub (; 7 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -154,7 +154,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/mul (; 8 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/mul (; 8 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -180,7 +180,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/div_s (; 9 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/div_s (; 9 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -206,7 +206,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/div_u (; 10 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/div_u (; 10 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -232,7 +232,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/rem_s (; 11 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/rem_s (; 11 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -258,7 +258,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/rem_u (; 12 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/rem_u (; 12 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -284,7 +284,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/and (; 13 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/and (; 13 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -310,7 +310,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/or (; 14 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/or (; 14 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -336,7 +336,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/xor (; 15 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/xor (; 15 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -362,7 +362,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/shl (; 16 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/shl (; 16 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -388,7 +388,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/shr_s (; 17 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/shr_s (; 17 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -414,7 +414,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/shr_u (; 18 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/shr_u (; 18 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -440,7 +440,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/rotl (; 19 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/rotl (; 19 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -466,7 +466,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/rotr (; 20 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/rotr (; 20 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -492,7 +492,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/eq (; 21 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/eq (; 21 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -512,7 +512,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/ne (; 22 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/ne (; 22 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -532,7 +532,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/lt_s (; 23 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/lt_s (; 23 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -552,7 +552,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/lt_u (; 24 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/lt_u (; 24 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -572,7 +572,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/le_s (; 25 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/le_s (; 25 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -592,7 +592,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/le_u (; 26 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/le_u (; 26 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -612,7 +612,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/gt_s (; 27 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/gt_s (; 27 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -632,7 +632,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/gt_u (; 28 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/gt_u (; 28 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -652,7 +652,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/ge_s (; 29 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/ge_s (; 29 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -672,7 +672,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/ge_u (; 30 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/ge_u (; 30 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   local.get $0
   i64.extend_i32_u
   local.get $1
@@ -692,7 +692,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $null (; 31 ;) (type $_)
+ (func $null (; 31 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/i64-polyfill.untouched.wat
+++ b/tests/compiler/i64-polyfill.untouched.wat
@@ -1,8 +1,8 @@
 (module
- (type $i (func (result i32)))
- (type $ii_ (func (param i32 i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -42,13 +42,13 @@
  (export "gt_u" (func $../../examples/i64-polyfill/assembly/i64/gt_u))
  (export "ge_s" (func $../../examples/i64-polyfill/assembly/i64/ge_s))
  (export "ge_u" (func $../../examples/i64-polyfill/assembly/i64/ge_u))
- (func $../../examples/i64-polyfill/assembly/i64/getHi (; 0 ;) (type $i) (result i32)
+ (func $../../examples/i64-polyfill/assembly/i64/getHi (; 0 ;) (type $FUNCSIG$i) (result i32)
   global.get $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/getLo (; 1 ;) (type $i) (result i32)
+ (func $../../examples/i64-polyfill/assembly/i64/getLo (; 1 ;) (type $FUNCSIG$i) (result i32)
   global.get $../../examples/i64-polyfill/assembly/i64/lo
  )
- (func $../../examples/i64-polyfill/assembly/i64/clz (; 2 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/clz (; 2 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i64)
   local.get $0
   i64.extend_i32_u
@@ -65,7 +65,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/ctz (; 3 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/ctz (; 3 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i64)
   local.get $0
   i64.extend_i32_u
@@ -82,7 +82,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/popcnt (; 4 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/popcnt (; 4 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i64)
   local.get $0
   i64.extend_i32_u
@@ -99,7 +99,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/eqz (; 5 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/eqz (; 5 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i64.extend_i32_u
@@ -115,7 +115,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/add (; 6 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/add (; 6 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -142,7 +142,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/sub (; 7 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/sub (; 7 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -169,7 +169,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/mul (; 8 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/mul (; 8 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -196,7 +196,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/div_s (; 9 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/div_s (; 9 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -223,7 +223,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/div_u (; 10 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/div_u (; 10 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -250,7 +250,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/rem_s (; 11 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/rem_s (; 11 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -277,7 +277,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/rem_u (; 12 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/rem_u (; 12 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -304,7 +304,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/and (; 13 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/and (; 13 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -331,7 +331,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/or (; 14 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/or (; 14 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -358,7 +358,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/xor (; 15 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/xor (; 15 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -385,7 +385,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/shl (; 16 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/shl (; 16 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -412,7 +412,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/shr_s (; 17 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/shr_s (; 17 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -439,7 +439,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/shr_u (; 18 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/shr_u (; 18 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -466,7 +466,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/rotl (; 19 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/rotl (; 19 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -493,7 +493,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/rotr (; 20 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/rotr (; 20 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i64)
   local.get $0
   i64.extend_i32_u
@@ -520,7 +520,7 @@
   i32.wrap_i64
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/eq (; 21 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/eq (; 21 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -543,7 +543,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/ne (; 22 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/ne (; 22 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -566,7 +566,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/lt_s (; 23 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/lt_s (; 23 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -589,7 +589,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/lt_u (; 24 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/lt_u (; 24 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -612,7 +612,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/le_s (; 25 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/le_s (; 25 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -635,7 +635,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/le_u (; 26 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/le_u (; 26 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -658,7 +658,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/gt_s (; 27 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/gt_s (; 27 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -681,7 +681,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/gt_u (; 28 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/gt_u (; 28 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -704,7 +704,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/ge_s (; 29 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/ge_s (; 29 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -727,7 +727,7 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $../../examples/i64-polyfill/assembly/i64/ge_u (; 30 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/i64-polyfill/assembly/i64/ge_u (; 30 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   local.get $0
   i64.extend_i32_u
@@ -750,6 +750,6 @@
   i32.const 0
   global.set $../../examples/i64-polyfill/assembly/i64/hi
  )
- (func $null (; 31 ;) (type $_)
+ (func $null (; 31 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/if.optimized.wat
+++ b/tests/compiler/if.optimized.wat
@@ -1,7 +1,7 @@
 (module
- (type $ii (func (param i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\05\00\00\00i\00f\00.\00t\00s")
@@ -13,13 +13,13 @@
  (export "ifThen" (func $if/ifThen))
  (export "ifThenElseBlock" (func $if/ifThenElse))
  (export "ifAlwaysReturns" (func $if/ifAlwaysReturns))
- (func $if/ifThenElse (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $if/ifThenElse (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   i32.const 0
   local.get $0
   select
  )
- (func $if/ifThen (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $if/ifThen (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   if
    i32.const 1
@@ -27,7 +27,7 @@
   end
   i32.const 0
  )
- (func $if/ifAlwaysReturns (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $if/ifAlwaysReturns (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   if (result i32)
    i32.const 1
@@ -40,7 +40,7 @@
    unreachable
   end
  )
- (func $start (; 4 ;) (type $_)
+ (func $start (; 4 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/if.untouched.wat
+++ b/tests/compiler/if.untouched.wat
@@ -1,7 +1,7 @@
 (module
- (type $ii (func (param i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\05\00\00\00i\00f\00.\00t\00s\00")
@@ -15,7 +15,7 @@
  (export "ifThenElseBlock" (func $if/ifThenElseBlock))
  (export "ifAlwaysReturns" (func $if/ifAlwaysReturns))
  (start $start)
- (func $if/ifThenElse (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $if/ifThenElse (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   if
    i32.const 1
@@ -27,7 +27,7 @@
   unreachable
   unreachable
  )
- (func $if/ifThen (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $if/ifThen (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   if
    i32.const 1
@@ -35,7 +35,7 @@
   end
   i32.const 0
  )
- (func $if/ifThenElseBlock (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $if/ifThenElseBlock (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   if
    i32.const 1
@@ -47,7 +47,7 @@
   unreachable
   unreachable
  )
- (func $start:if (; 4 ;) (type $_)
+ (func $start:if (; 4 ;) (type $FUNCSIG$v)
   i32.const 0
   call $if/ifThenElse
   i32.const 0
@@ -127,7 +127,7 @@
    unreachable
   end
  )
- (func $if/ifAlwaysReturns (; 5 ;) (type $ii) (param $0 i32) (result i32)
+ (func $if/ifAlwaysReturns (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   if
    i32.const 1
@@ -143,9 +143,9 @@
   unreachable
   unreachable
  )
- (func $start (; 6 ;) (type $_)
+ (func $start (; 6 ;) (type $FUNCSIG$v)
   call $start:if
  )
- (func $null (; 7 ;) (type $_)
+ (func $null (; 7 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/import.optimized.wat
+++ b/tests/compiler/import.optimized.wat
@@ -1,11 +1,11 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $start (; 0 ;) (type $_)
+ (func $start (; 0 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/import.untouched.wat
+++ b/tests/compiler/import.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iii (func (param i32 i32) (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -11,25 +11,25 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $export/add (; 0 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/add (; 0 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $export/sub (; 1 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/sub (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $export/mul (; 2 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/mul (; 2 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.mul
  )
- (func $export/ns.two (; 3 ;) (type $_)
+ (func $export/ns.two (; 3 ;) (type $FUNCSIG$v)
   nop
  )
- (func $start:import (; 4 ;) (type $_)
+ (func $start:import (; 4 ;) (type $FUNCSIG$v)
   global.get $export/a
   global.get $export/b
   call $export/add
@@ -57,9 +57,9 @@
   drop
   call $export/ns.two
  )
- (func $start (; 5 ;) (type $_)
+ (func $start (; 5 ;) (type $FUNCSIG$v)
   call $start:import
  )
- (func $null (; 6 ;) (type $_)
+ (func $null (; 6 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/infer-type.optimized.wat
+++ b/tests/compiler/infer-type.optimized.wat
@@ -1,5 +1,5 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 1)
  (data (i32.const 8) "\0d\00\00\00i\00n\00f\00e\00r\00-\00t\00y\00p\00e\00.\00t\00s")
  (table $0 1 funcref)
@@ -11,7 +11,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:infer-type (; 0 ;) (type $_)
+ (func $start:infer-type (; 0 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   global.set $infer-type/ri
@@ -34,10 +34,10 @@
    end
   end
  )
- (func $start (; 1 ;) (type $_)
+ (func $start (; 1 ;) (type $FUNCSIG$v)
   call $start:infer-type
  )
- (func $null (; 2 ;) (type $_)
+ (func $null (; 2 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/infer-type.untouched.wat
+++ b/tests/compiler/infer-type.untouched.wat
@@ -1,10 +1,10 @@
 (module
- (type $_ (func))
- (type $i (func (result i32)))
- (type $I (func (result i64)))
- (type $f (func (result f32)))
- (type $F (func (result f64)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$j (func (result i64)))
+ (type $FUNCSIG$f (func (result f32)))
+ (type $FUNCSIG$d (func (result f64)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0d\00\00\00i\00n\00f\00e\00r\00-\00t\00y\00p\00e\00.\00t\00s\00")
@@ -23,7 +23,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $infer-type/locals (; 1 ;) (type $_)
+ (func $infer-type/locals (; 1 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i64)
   (local $2 f64)
@@ -43,19 +43,19 @@
   global.get $infer-type/F
   local.set $5
  )
- (func $infer-type/reti (; 2 ;) (type $i) (result i32)
+ (func $infer-type/reti (; 2 ;) (type $FUNCSIG$i) (result i32)
   i32.const 0
  )
- (func $infer-type/retI (; 3 ;) (type $I) (result i64)
+ (func $infer-type/retI (; 3 ;) (type $FUNCSIG$j) (result i64)
   i64.const 0
  )
- (func $infer-type/retf (; 4 ;) (type $f) (result f32)
+ (func $infer-type/retf (; 4 ;) (type $FUNCSIG$f) (result f32)
   f32.const 0
  )
- (func $infer-type/refF (; 5 ;) (type $F) (result f64)
+ (func $infer-type/refF (; 5 ;) (type $FUNCSIG$d) (result f64)
   f64.const 0
  )
- (func $start:infer-type (; 6 ;) (type $_)
+ (func $start:infer-type (; 6 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   global.get $infer-type/i
@@ -126,9 +126,9 @@
    unreachable
   end
  )
- (func $start (; 7 ;) (type $_)
+ (func $start (; 7 ;) (type $FUNCSIG$v)
   call $start:infer-type
  )
- (func $null (; 8 ;) (type $_)
+ (func $null (; 8 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/inlining-recursive.optimized.wat
+++ b/tests/compiler/inlining-recursive.optimized.wat
@@ -1,5 +1,5 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -8,13 +8,13 @@
  (export "foo" (func $inlining-recursive/foo))
  (export "bar" (func $inlining-recursive/baz))
  (export "baz" (func $inlining-recursive/baz))
- (func $inlining-recursive/foo (; 0 ;) (type $_)
+ (func $inlining-recursive/foo (; 0 ;) (type $FUNCSIG$v)
   call $inlining-recursive/foo
  )
- (func $inlining-recursive/baz (; 1 ;) (type $_)
+ (func $inlining-recursive/baz (; 1 ;) (type $FUNCSIG$v)
   call $inlining-recursive/baz
  )
- (func $null (; 2 ;) (type $_)
+ (func $null (; 2 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/inlining-recursive.untouched.wat
+++ b/tests/compiler/inlining-recursive.untouched.wat
@@ -1,5 +1,5 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -9,17 +9,17 @@
  (export "foo" (func $inlining-recursive/foo))
  (export "bar" (func $inlining-recursive/bar))
  (export "baz" (func $inlining-recursive/baz))
- (func $inlining-recursive/foo (; 0 ;) (type $_)
+ (func $inlining-recursive/foo (; 0 ;) (type $FUNCSIG$v)
   call $inlining-recursive/foo
  )
- (func $inlining-recursive/baz (; 1 ;) (type $_)
+ (func $inlining-recursive/baz (; 1 ;) (type $FUNCSIG$v)
   call $inlining-recursive/bar
  )
- (func $inlining-recursive/bar (; 2 ;) (type $_)
+ (func $inlining-recursive/bar (; 2 ;) (type $FUNCSIG$v)
   block $inlining-recursive/bar|inlined.0
    call $inlining-recursive/baz
   end
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/inlining.optimized.wat
+++ b/tests/compiler/inlining.optimized.wat
@@ -1,8 +1,8 @@
 (module
- (type $i (func (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
- (type $ii (func (param i32) (result i32)))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0b\00\00\00i\00n\00l\00i\00n\00i\00n\00g\00.\00t\00s")
@@ -15,18 +15,18 @@
  (export "table" (table $0))
  (export "test" (func $inlining/test))
  (start $start)
- (func $inlining/test (; 1 ;) (type $i) (result i32)
+ (func $inlining/test (; 1 ;) (type $FUNCSIG$i) (result i32)
   i32.const 3
  )
- (func $inlining/func_fe~anonymous|0 (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $inlining/func_fe~anonymous|0 (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $inlining/test_funcs (; 3 ;) (type $_)
+ (func $inlining/test_funcs (; 3 ;) (type $FUNCSIG$v)
   i32.const 1
   global.set $~lib/argc
   i32.const 2
   i32.const 1
-  call_indirect (type $ii)
+  call_indirect (type $FUNCSIG$ii)
   i32.const 2
   i32.ne
   if
@@ -38,7 +38,7 @@
    unreachable
   end
  )
- (func $~lib/allocator/arena/__memory_allocate (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -100,7 +100,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $inlining/test_ctor (; 5 ;) (type $_)
+ (func $inlining/test_ctor (; 5 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 16
   call $~lib/allocator/arena/__memory_allocate
@@ -178,7 +178,7 @@
    unreachable
   end
  )
- (func $start (; 6 ;) (type $_)
+ (func $start (; 6 ;) (type $FUNCSIG$v)
   call $inlining/test_funcs
   i32.const 40
   global.set $~lib/allocator/arena/startOffset
@@ -186,7 +186,7 @@
   global.set $~lib/allocator/arena/offset
   call $inlining/test_ctor
  )
- (func $null (; 7 ;) (type $_)
+ (func $null (; 7 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/inlining.untouched.wat
+++ b/tests/compiler/inlining.untouched.wat
@@ -1,8 +1,8 @@
 (module
- (type $i (func (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
- (type $ii (func (param i32) (result i32)))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0b\00\00\00i\00n\00l\00i\00n\00i\00n\00g\00.\00t\00s\00")
@@ -17,15 +17,15 @@
  (export "table" (table $0))
  (export "test" (func $inlining/test))
  (start $start)
- (func $inlining/test (; 1 ;) (type $i) (result i32)
+ (func $inlining/test (; 1 ;) (type $FUNCSIG$i) (result i32)
   global.get $inlining/constantGlobal
   i32.const 2
   i32.add
  )
- (func $inlining/func_fe~anonymous|0 (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $inlining/func_fe~anonymous|0 (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $inlining/test_funcs (; 3 ;) (type $_)
+ (func $inlining/test_funcs (; 3 ;) (type $FUNCSIG$v)
   (local $0 f32)
   (local $1 f64)
   (local $2 i32)
@@ -223,7 +223,7 @@
    block $inlining/func_fe|inlined.0 (result i32)
     i32.const 1
    end
-   call_indirect (type $ii)
+   call_indirect (type $FUNCSIG$ii)
   end
   i32.const 2
   i32.eq
@@ -279,7 +279,7 @@
    unreachable
   end
  )
- (func $start:~lib/allocator/arena (; 4 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 4 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -291,7 +291,7 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $~lib/allocator/arena/__memory_allocate (; 5 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -370,12 +370,12 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/memory/memory.allocate (; 6 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/memory/memory.allocate (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/allocator/arena/__memory_allocate
   return
  )
- (func $inlining/test_ctor (; 7 ;) (type $_)
+ (func $inlining/test_ctor (; 7 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -483,7 +483,7 @@
    unreachable
   end
  )
- (func $start:inlining (; 8 ;) (type $_)
+ (func $start:inlining (; 8 ;) (type $FUNCSIG$v)
   call $inlining/test
   i32.const 3
   i32.eq
@@ -500,9 +500,9 @@
   call $start:~lib/allocator/arena
   call $inlining/test_ctor
  )
- (func $start (; 9 ;) (type $_)
+ (func $start (; 9 ;) (type $FUNCSIG$v)
   call $start:inlining
  )
- (func $null (; 10 ;) (type $_)
+ (func $null (; 10 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/instanceof.optimized.wat
+++ b/tests/compiler/instanceof.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0d\00\00\00i\00n\00s\00t\00a\00n\00c\00e\00o\00f\00.\00t\00s")
@@ -10,7 +10,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:instanceof (; 1 ;) (type $_)
+ (func $start:instanceof (; 1 ;) (type $FUNCSIG$v)
   global.get $instanceof/an
   if
    i32.const 0
@@ -33,10 +33,10 @@
    unreachable
   end
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   call $start:instanceof
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/instanceof.untouched.wat
+++ b/tests/compiler/instanceof.untouched.wat
@@ -1,8 +1,8 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $ii (func (param i32) (result i32)))
- (type $Fi (func (param f64) (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$id (func (param f64) (result i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0d\00\00\00i\00n\00s\00t\00a\00n\00c\00e\00o\00f\00.\00t\00s\00")
@@ -19,23 +19,23 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $instanceof/isI32<i32> (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $instanceof/isI32<i32> (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   return
  )
- (func $instanceof/isI32<f64> (; 2 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $instanceof/isI32<f64> (; 2 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   i32.const 0
   return
  )
- (func $instanceof/isI32<u32> (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $instanceof/isI32<u32> (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   return
  )
- (func $instanceof/isI32<u16> (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $instanceof/isI32<u16> (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   return
  )
- (func $start:instanceof (; 5 ;) (type $_)
+ (func $start:instanceof (; 5 ;) (type $FUNCSIG$v)
   i32.const 1
   i32.eqz
   if
@@ -520,9 +520,9 @@
    unreachable
   end
  )
- (func $start (; 6 ;) (type $_)
+ (func $start (; 6 ;) (type $FUNCSIG$v)
   call $start:instanceof
  )
- (func $null (; 7 ;) (type $_)
+ (func $null (; 7 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/limits.optimized.wat
+++ b/tests/compiler/limits.optimized.wat
@@ -1,11 +1,11 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $start (; 0 ;) (type $_)
+ (func $start (; 0 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/limits.untouched.wat
+++ b/tests/compiler/limits.untouched.wat
@@ -1,5 +1,5 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -33,7 +33,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:limits (; 0 ;) (type $_)
+ (func $start:limits (; 0 ;) (type $FUNCSIG$v)
   global.get $~lib/builtins/i8.MIN_VALUE
   drop
   global.get $~lib/builtins/i8.MAX_VALUE
@@ -87,9 +87,9 @@
   global.get $~lib/builtins/f64.MAX_SAFE_INTEGER
   drop
  )
- (func $start (; 1 ;) (type $_)
+ (func $start (; 1 ;) (type $FUNCSIG$v)
   call $start:limits
  )
- (func $null (; 2 ;) (type $_)
+ (func $null (; 2 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/literals.optimized.wat
+++ b/tests/compiler/literals.optimized.wat
@@ -1,11 +1,11 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $start (; 0 ;) (type $_)
+ (func $start (; 0 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/literals.untouched.wat
+++ b/tests/compiler/literals.untouched.wat
@@ -1,5 +1,5 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -7,7 +7,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:literals (; 0 ;) (type $_)
+ (func $start:literals (; 0 ;) (type $FUNCSIG$v)
   i32.const 0
   drop
   i32.const 1
@@ -97,9 +97,9 @@
   i32.const 0
   drop
  )
- (func $start (; 1 ;) (type $_)
+ (func $start (; 1 ;) (type $FUNCSIG$v)
   call $start:literals
  )
- (func $null (; 2 ;) (type $_)
+ (func $null (; 2 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/logical.optimized.wat
+++ b/tests/compiler/logical.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\n\00\00\00l\00o\00g\00i\00c\00a\00l\00.\00t\00s")
@@ -13,7 +13,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:logical (; 1 ;) (type $_)
+ (func $start:logical (; 1 ;) (type $FUNCSIG$v)
   i32.const 2
   global.set $logical/i
   global.get $logical/i
@@ -119,10 +119,10 @@
    unreachable
   end
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   call $start:logical
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/logical.untouched.wat
+++ b/tests/compiler/logical.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\n\00\00\00l\00o\00g\00i\00c\00a\00l\00.\00t\00s\00")
@@ -14,7 +14,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:logical (; 1 ;) (type $_)
+ (func $start:logical (; 1 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f64)
   i32.const 0
@@ -244,9 +244,9 @@
    unreachable
   end
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   call $start:logical
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/main.optimized.wat
+++ b/tests/compiler/main.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $_ (func))
- (type $iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -9,7 +9,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "main" (func $main/main))
- (func $main/main (; 0 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $main/main (; 0 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   global.get $~lib/started
   i32.eqz
   if
@@ -20,7 +20,7 @@
   end
   global.get $main/code
  )
- (func $null (; 1 ;) (type $_)
+ (func $null (; 1 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/main.untouched.wat
+++ b/tests/compiler/main.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $_ (func))
- (type $iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -10,11 +10,11 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "main" (func $main/main))
- (func $start:main (; 0 ;) (type $_)
+ (func $start:main (; 0 ;) (type $FUNCSIG$v)
   i32.const 1
   global.set $main/code
  )
- (func $main/main (; 1 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $main/main (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   global.get $~lib/started
   i32.eqz
   if
@@ -24,9 +24,9 @@
   end
   global.get $main/code
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   call $start:main
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/mandelbrot.optimized.wat
+++ b/tests/compiler/mandelbrot.optimized.wat
@@ -1,14 +1,14 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $FF (func (param f64) (result f64)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$dd (func (param f64) (result f64)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "computeLine" (func $../../examples/mandelbrot/assembly/index/computeLine))
- (func $~lib/math/NativeMath.log (; 0 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log (; 0 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -186,7 +186,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.log2 (; 1 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log2 (; 1 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -392,7 +392,7 @@
   local.get $0
   f64.add
  )
- (func $../../examples/mandelbrot/assembly/index/computeLine (; 2 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/mandelbrot/assembly/index/computeLine (; 2 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 f64)
   (local $5 f64)
   (local $6 f64)
@@ -587,7 +587,7 @@
    end
   end
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/mandelbrot.untouched.wat
+++ b/tests/compiler/mandelbrot.untouched.wat
@@ -1,8 +1,8 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $FF (func (param f64) (result f64)))
- (type $FFFF (func (param f64 f64 f64) (result f64)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$dd (func (param f64) (result f64)))
+ (type $FUNCSIG$dddd (func (param f64 f64 f64) (result f64)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -11,7 +11,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "computeLine" (func $../../examples/mandelbrot/assembly/index/computeLine))
- (func $~lib/math/NativeMath.log (; 0 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log (; 0 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -224,7 +224,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.log2 (; 1 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log2 (; 1 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -480,14 +480,14 @@
   local.get $15
   f64.add
  )
- (func $../../examples/mandelbrot/assembly/index/clamp<f64> (; 2 ;) (type $FFFF) (param $0 f64) (param $1 f64) (param $2 f64) (result f64)
+ (func $../../examples/mandelbrot/assembly/index/clamp<f64> (; 2 ;) (type $FUNCSIG$dddd) (param $0 f64) (param $1 f64) (param $2 f64) (result f64)
   local.get $0
   local.get $1
   f64.max
   local.get $2
   f64.min
  )
- (func $../../examples/mandelbrot/assembly/index/computeLine (; 3 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $../../examples/mandelbrot/assembly/index/computeLine (; 3 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 f64)
   (local $5 f64)
   (local $6 f64)
@@ -722,6 +722,6 @@
    unreachable
   end
  )
- (func $null (; 4 ;) (type $_)
+ (func $null (; 4 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/many-locals.optimized.wat
+++ b/tests/compiler/many-locals.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $ii (func (param i32) (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 1)
  (data (i32.const 8) "\0e\00\00\00m\00a\00n\00y\00-\00l\00o\00c\00a\00l\00s\00.\00t\00s")
  (table $0 1 funcref)
@@ -9,17 +9,17 @@
  (export "table" (table $0))
  (export "testI32" (func $many-locals/testI32))
  (export "testI8" (func $many-locals/testI8))
- (func $many-locals/testI32 (; 0 ;) (type $ii) (param $0 i32) (result i32)
+ (func $many-locals/testI32 (; 0 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $many-locals/testI8 (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $many-locals/testI8 (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
   i32.const 24
   i32.shr_s
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/many-locals.untouched.wat
+++ b/tests/compiler/many-locals.untouched.wat
@@ -1,7 +1,7 @@
 (module
- (type $ii (func (param i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0e\00\00\00m\00a\00n\00y\00-\00l\00o\00c\00a\00l\00s\00.\00t\00s\00")
@@ -13,7 +13,7 @@
  (export "testI32" (func $many-locals/testI32))
  (export "testI8" (func $many-locals/testI8))
  (start $start)
- (func $many-locals/testI32 (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $many-locals/testI32 (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -400,7 +400,7 @@
   local.set $128
   local.get $128
  )
- (func $many-locals/testI8 (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $many-locals/testI8 (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -791,7 +791,7 @@
   i32.const 24
   i32.shr_s
  )
- (func $start:many-locals (; 3 ;) (type $_)
+ (func $start:many-locals (; 3 ;) (type $FUNCSIG$v)
   i32.const 42
   call $many-locals/testI32
   i32.const 42
@@ -819,9 +819,9 @@
    unreachable
   end
  )
- (func $start (; 4 ;) (type $_)
+ (func $start (; 4 ;) (type $FUNCSIG$v)
   call $start:many-locals
  )
- (func $null (; 5 ;) (type $_)
+ (func $null (; 5 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/memcpy.optimized.wat
+++ b/tests/compiler/memcpy.optimized.wat
@@ -1,7 +1,7 @@
 (module
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\t\00\00\00m\00e\00m\00c\00p\00y\00.\00t\00s")
@@ -12,7 +12,7 @@
  (export "table" (table $0))
  (export "memcpy" (func $memcpy/memcpy))
  (start $start)
- (func $memcpy/memcpy (; 1 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $memcpy/memcpy (; 1 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -914,7 +914,7 @@
   end
   local.get $6
  )
- (func $start:memcpy (; 2 ;) (type $_)
+ (func $start:memcpy (; 2 ;) (type $FUNCSIG$v)
   i32.const 8
   i64.const 1229782938247303441
   i64.store
@@ -1090,10 +1090,10 @@
    unreachable
   end
  )
- (func $start (; 3 ;) (type $_)
+ (func $start (; 3 ;) (type $FUNCSIG$v)
   call $start:memcpy
  )
- (func $null (; 4 ;) (type $_)
+ (func $null (; 4 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/memcpy.untouched.wat
+++ b/tests/compiler/memcpy.untouched.wat
@@ -1,7 +1,7 @@
 (module
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\t\00\00\00m\00e\00m\00c\00p\00y\00.\00t\00s\00")
@@ -14,7 +14,7 @@
  (export "table" (table $0))
  (export "memcpy" (func $memcpy/memcpy))
  (start $start)
- (func $memcpy/memcpy (; 1 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $memcpy/memcpy (; 1 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1208,7 +1208,7 @@
   end
   local.get $3
  )
- (func $start:memcpy (; 2 ;) (type $_)
+ (func $start:memcpy (; 2 ;) (type $FUNCSIG$v)
   global.get $memcpy/base
   i64.const 1229782938247303441
   i64.store
@@ -1428,9 +1428,9 @@
    unreachable
   end
  )
- (func $start (; 3 ;) (type $_)
+ (func $start (; 3 ;) (type $FUNCSIG$v)
   call $start:memcpy
  )
- (func $null (; 4 ;) (type $_)
+ (func $null (; 4 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/memmove.optimized.wat
+++ b/tests/compiler/memmove.optimized.wat
@@ -1,7 +1,7 @@
 (module
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\n\00\00\00m\00e\00m\00m\00o\00v\00e\00.\00t\00s")
@@ -11,7 +11,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $memmove/memmove (; 1 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $memmove/memmove (; 1 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -193,7 +193,7 @@
   end
   local.get $3
  )
- (func $start:memmove (; 2 ;) (type $_)
+ (func $start:memmove (; 2 ;) (type $FUNCSIG$v)
   i32.const 8
   i64.const 1229782938247303441
   i64.store
@@ -369,10 +369,10 @@
    unreachable
   end
  )
- (func $start (; 3 ;) (type $_)
+ (func $start (; 3 ;) (type $FUNCSIG$v)
   call $start:memmove
  )
- (func $null (; 4 ;) (type $_)
+ (func $null (; 4 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/memmove.untouched.wat
+++ b/tests/compiler/memmove.untouched.wat
@@ -1,7 +1,7 @@
 (module
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\n\00\00\00m\00e\00m\00m\00o\00v\00e\00.\00t\00s\00")
@@ -13,7 +13,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $memmove/memmove (; 1 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $memmove/memmove (; 1 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -225,7 +225,7 @@
   end
   local.get $3
  )
- (func $start:memmove (; 2 ;) (type $_)
+ (func $start:memmove (; 2 ;) (type $FUNCSIG$v)
   global.get $memmove/base
   i64.const 1229782938247303441
   i64.store
@@ -445,9 +445,9 @@
    unreachable
   end
  )
- (func $start (; 3 ;) (type $_)
+ (func $start (; 3 ;) (type $FUNCSIG$v)
   call $start:memmove
  )
- (func $null (; 4 ;) (type $_)
+ (func $null (; 4 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/memset.optimized.wat
+++ b/tests/compiler/memset.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (type $FUNCSIG$viii (func (param i32 i32 i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -239,7 +239,7 @@
    end
   end
  )
- (func $start:memset (; 2 ;) (type $_)
+ (func $start:memset (; 2 ;) (type $FUNCSIG$v)
   i32.const 32
   global.set $memset/dest
   global.get $memset/dest
@@ -333,10 +333,10 @@
    unreachable
   end
  )
- (func $start (; 3 ;) (type $_)
+ (func $start (; 3 ;) (type $FUNCSIG$v)
   call $start:memset
  )
- (func $null (; 4 ;) (type $_)
+ (func $null (; 4 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/memset.untouched.wat
+++ b/tests/compiler/memset.untouched.wat
@@ -1,7 +1,7 @@
 (module
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\t\00\00\00m\00e\00m\00s\00e\00t\00.\00t\00s\00")
@@ -12,7 +12,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $memset/memset (; 1 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $memset/memset (; 1 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -276,7 +276,7 @@
   end
   local.get $3
  )
- (func $start:memset (; 2 ;) (type $_)
+ (func $start:memset (; 2 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   global.set $memset/dest
   global.get $memset/dest
@@ -378,9 +378,9 @@
    unreachable
   end
  )
- (func $start (; 3 ;) (type $_)
+ (func $start (; 3 ;) (type $FUNCSIG$v)
   call $start:memset
  )
- (func $null (; 4 ;) (type $_)
+ (func $null (; 4 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/merge.optimized.wat
+++ b/tests/compiler/merge.optimized.wat
@@ -1,11 +1,11 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $start (; 0 ;) (type $_)
+ (func $start (; 0 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/merge.untouched.wat
+++ b/tests/compiler/merge.untouched.wat
@@ -1,5 +1,5 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -17,55 +17,55 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $merge/namespaceType.test (; 0 ;) (type $_)
+ (func $merge/namespaceType.test (; 0 ;) (type $FUNCSIG$v)
   nop
  )
- (func $merge/typeNamespace.test (; 1 ;) (type $_)
+ (func $merge/typeNamespace.test (; 1 ;) (type $FUNCSIG$v)
   nop
  )
- (func $merge/functionType (; 2 ;) (type $_)
+ (func $merge/functionType (; 2 ;) (type $FUNCSIG$v)
   nop
  )
- (func $merge/typeFunction (; 3 ;) (type $_)
+ (func $merge/typeFunction (; 3 ;) (type $FUNCSIG$v)
   nop
  )
- (func $merge/classNamespace.test1 (; 4 ;) (type $_)
+ (func $merge/classNamespace.test1 (; 4 ;) (type $FUNCSIG$v)
   nop
  )
- (func $merge/classNamespace.test2 (; 5 ;) (type $_)
+ (func $merge/classNamespace.test2 (; 5 ;) (type $FUNCSIG$v)
   nop
  )
- (func $merge/namespaceClass.test1 (; 6 ;) (type $_)
+ (func $merge/namespaceClass.test1 (; 6 ;) (type $FUNCSIG$v)
   nop
  )
- (func $merge/namespaceClass.test2 (; 7 ;) (type $_)
+ (func $merge/namespaceClass.test2 (; 7 ;) (type $FUNCSIG$v)
   nop
  )
- (func $merge/functionNamespace (; 8 ;) (type $_)
+ (func $merge/functionNamespace (; 8 ;) (type $FUNCSIG$v)
   nop
  )
- (func $merge/functionNamespace.test (; 9 ;) (type $_)
+ (func $merge/functionNamespace.test (; 9 ;) (type $FUNCSIG$v)
   nop
  )
- (func $merge/namespaceFunction.test (; 10 ;) (type $_)
+ (func $merge/namespaceFunction.test (; 10 ;) (type $FUNCSIG$v)
   nop
  )
- (func $merge/namespaceFunction (; 11 ;) (type $_)
+ (func $merge/namespaceFunction (; 11 ;) (type $FUNCSIG$v)
   nop
  )
- (func $merge/enumNamespace.test (; 12 ;) (type $_)
+ (func $merge/enumNamespace.test (; 12 ;) (type $FUNCSIG$v)
   nop
  )
- (func $merge/namespaceEnum.test (; 13 ;) (type $_)
+ (func $merge/namespaceEnum.test (; 13 ;) (type $FUNCSIG$v)
   nop
  )
- (func $merge/namespaceNamespace.test1 (; 14 ;) (type $_)
+ (func $merge/namespaceNamespace.test1 (; 14 ;) (type $FUNCSIG$v)
   nop
  )
- (func $merge/namespaceNamespace.test2 (; 15 ;) (type $_)
+ (func $merge/namespaceNamespace.test2 (; 15 ;) (type $FUNCSIG$v)
   nop
  )
- (func $start:merge (; 16 ;) (type $_)
+ (func $start:merge (; 16 ;) (type $FUNCSIG$v)
   global.get $merge/globalType
   drop
   global.get $merge/typeGlobal
@@ -91,9 +91,9 @@
   call $merge/namespaceNamespace.test1
   call $merge/namespaceNamespace.test2
  )
- (func $start (; 17 ;) (type $_)
+ (func $start (; 17 ;) (type $FUNCSIG$v)
   call $start:merge
  )
- (func $null (; 18 ;) (type $_)
+ (func $null (; 18 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/named-export-default.optimized.wat
+++ b/tests/compiler/named-export-default.optimized.wat
@@ -1,16 +1,16 @@
 (module
- (type $i (func (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "default" (func $named-export-default/get3))
- (func $named-export-default/get3 (; 0 ;) (type $i) (result i32)
+ (func $named-export-default/get3 (; 0 ;) (type $FUNCSIG$i) (result i32)
   i32.const 3
  )
- (func $null (; 1 ;) (type $_)
+ (func $null (; 1 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/named-export-default.untouched.wat
+++ b/tests/compiler/named-export-default.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $i (func (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -8,9 +8,9 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "default" (func $named-export-default/get3))
- (func $named-export-default/get3 (; 0 ;) (type $i) (result i32)
+ (func $named-export-default/get3 (; 0 ;) (type $FUNCSIG$i) (result i32)
   i32.const 3
  )
- (func $null (; 1 ;) (type $_)
+ (func $null (; 1 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/named-import-default.optimized.wat
+++ b/tests/compiler/named-import-default.optimized.wat
@@ -1,16 +1,16 @@
 (module
- (type $i (func (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "getValue" (func $named-import-default/getValue))
- (func $named-import-default/getValue (; 0 ;) (type $i) (result i32)
+ (func $named-import-default/getValue (; 0 ;) (type $FUNCSIG$i) (result i32)
   i32.const 3
  )
- (func $null (; 1 ;) (type $_)
+ (func $null (; 1 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/named-import-default.untouched.wat
+++ b/tests/compiler/named-import-default.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $i (func (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -8,12 +8,12 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "getValue" (func $named-import-default/getValue))
- (func $named-export-default/get3 (; 0 ;) (type $i) (result i32)
+ (func $named-export-default/get3 (; 0 ;) (type $FUNCSIG$i) (result i32)
   i32.const 3
  )
- (func $named-import-default/getValue (; 1 ;) (type $i) (result i32)
+ (func $named-import-default/getValue (; 1 ;) (type $FUNCSIG$i) (result i32)
   call $named-export-default/get3
  )
- (func $null (; 2 ;) (type $_)
+ (func $null (; 2 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/namespace.optimized.wat
+++ b/tests/compiler/namespace.optimized.wat
@@ -1,11 +1,11 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $start (; 0 ;) (type $_)
+ (func $start (; 0 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/namespace.untouched.wat
+++ b/tests/compiler/namespace.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $i (func (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -11,13 +11,13 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $namespace/Outer.Inner.aFunc (; 0 ;) (type $i) (result i32)
+ (func $namespace/Outer.Inner.aFunc (; 0 ;) (type $FUNCSIG$i) (result i32)
   global.get $namespace/Outer.Inner.aVar
  )
- (func $namespace/Joined.anotherFunc (; 1 ;) (type $i) (result i32)
+ (func $namespace/Joined.anotherFunc (; 1 ;) (type $FUNCSIG$i) (result i32)
   i32.const 3
  )
- (func $start:namespace (; 2 ;) (type $_)
+ (func $start:namespace (; 2 ;) (type $FUNCSIG$v)
   global.get $namespace/Outer.Inner.aVar
   drop
   call $namespace/Outer.Inner.aFunc
@@ -29,9 +29,9 @@
   call $namespace/Joined.anotherFunc
   drop
  )
- (func $start (; 3 ;) (type $_)
+ (func $start (; 3 ;) (type $FUNCSIG$v)
   call $start:namespace
  )
- (func $null (; 4 ;) (type $_)
+ (func $null (; 4 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/new-without-allocator.optimized.wat
+++ b/tests/compiler/new-without-allocator.optimized.wat
@@ -1,16 +1,16 @@
 (module
- (type $i (func (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "test" (func $new-without-allocator/test))
- (func $new-without-allocator/test (; 0 ;) (type $i) (result i32)
+ (func $new-without-allocator/test (; 0 ;) (type $FUNCSIG$i) (result i32)
   unreachable
  )
- (func $null (; 1 ;) (type $_)
+ (func $null (; 1 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/new-without-allocator.untouched.wat
+++ b/tests/compiler/new-without-allocator.untouched.wat
@@ -1,7 +1,7 @@
 (module
- (type $i (func (result i32)))
- (type $ii (func (param i32) (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -9,10 +9,10 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "test" (func $new-without-allocator/test))
- (func $~lib/memory/memory.allocate (; 0 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/memory/memory.allocate (; 0 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   unreachable
  )
- (func $new-without-allocator/A#constructor (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $new-without-allocator/A#constructor (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -22,13 +22,13 @@
   end
   local.get $0
  )
- (func $new-without-allocator/test (; 2 ;) (type $i) (result i32)
+ (func $new-without-allocator/test (; 2 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   i32.const 0
   call $new-without-allocator/A#constructor
   local.set $0
   i32.const 3
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/nonNullAssertion.optimized.wat
+++ b/tests/compiler/nonNullAssertion.optimized.wat
@@ -1,7 +1,7 @@
 (module
- (type $_ (func))
- (type $ii (func (param i32) (result i32)))
- (type $i (func (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$i (func (result i32)))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -23,14 +23,14 @@
  (export "testObjFn" (func $nonNullAssertion/testObjFn))
  (export "testObjRet" (func $nonNullAssertion/testObjFn))
  (start $start)
- (func $nonNullAssertion/testVar (; 0 ;) (type $ii) (param $0 i32) (result i32)
+ (func $nonNullAssertion/testVar (; 0 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $nonNullAssertion/testObj (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $nonNullAssertion/testObj (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load
  )
- (func $nonNullAssertion/testArr (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $nonNullAssertion/testArr (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load
@@ -46,7 +46,7 @@
    unreachable
   end
  )
- (func $nonNullAssertion/testAll (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $nonNullAssertion/testAll (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load
@@ -63,26 +63,26 @@
   end
   i32.load
  )
- (func $nonNullAssertion/testFn (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $nonNullAssertion/testFn (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   global.set $~lib/argc
   local.get $0
-  call_indirect (type $i)
+  call_indirect (type $FUNCSIG$i)
  )
- (func $nonNullAssertion/testObjFn (; 5 ;) (type $ii) (param $0 i32) (result i32)
+ (func $nonNullAssertion/testObjFn (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   global.set $~lib/argc
   local.get $0
   i32.load offset=4
-  call_indirect (type $i)
+  call_indirect (type $FUNCSIG$i)
  )
- (func $start (; 6 ;) (type $_)
+ (func $start (; 6 ;) (type $FUNCSIG$v)
   i32.const 8
   global.set $~lib/allocator/arena/startOffset
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $null (; 7 ;) (type $_)
+ (func $null (; 7 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/nonNullAssertion.untouched.wat
+++ b/tests/compiler/nonNullAssertion.untouched.wat
@@ -1,8 +1,8 @@
 (module
- (type $_ (func))
- (type $ii (func (param i32) (result i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $i (func (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$i (func (result i32)))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -25,7 +25,7 @@
  (export "testObjFn" (func $nonNullAssertion/testObjFn))
  (export "testObjRet" (func $nonNullAssertion/testObjRet))
  (start $start)
- (func $start:~lib/allocator/arena (; 0 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 0 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -37,21 +37,21 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $start:nonNullAssertion (; 1 ;) (type $_)
+ (func $start:nonNullAssertion (; 1 ;) (type $FUNCSIG$v)
   call $start:~lib/allocator/arena
  )
- (func $nonNullAssertion/testVar (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $nonNullAssertion/testVar (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $nonNullAssertion/testObj (; 3 ;) (type $ii) (param $0 i32) (result i32)
-  local.get $0
-  i32.load
- )
- (func $nonNullAssertion/testProp (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $nonNullAssertion/testObj (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load
  )
- (func $~lib/array/Array<Foo>#__get (; 5 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $nonNullAssertion/testProp (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load
+ )
+ (func $~lib/array/Array<Foo>#__get (; 5 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -84,12 +84,12 @@
    unreachable
   end
  )
- (func $nonNullAssertion/testArr (; 6 ;) (type $ii) (param $0 i32) (result i32)
+ (func $nonNullAssertion/testArr (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
   call $~lib/array/Array<Foo>#__get
  )
- (func $~lib/array/Array<Foo | null>#__get (; 7 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Foo | null>#__get (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -122,61 +122,61 @@
    unreachable
   end
  )
- (func $nonNullAssertion/testElem (; 8 ;) (type $ii) (param $0 i32) (result i32)
+ (func $nonNullAssertion/testElem (; 8 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
   call $~lib/array/Array<Foo | null>#__get
  )
- (func $nonNullAssertion/testAll (; 9 ;) (type $ii) (param $0 i32) (result i32)
-  local.get $0
-  i32.const 0
-  call $~lib/array/Array<Foo | null>#__get
-  i32.load
- )
- (func $nonNullAssertion/testAll2 (; 10 ;) (type $ii) (param $0 i32) (result i32)
+ (func $nonNullAssertion/testAll (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
   call $~lib/array/Array<Foo | null>#__get
   i32.load
  )
- (func $nonNullAssertion/testFn (; 11 ;) (type $ii) (param $0 i32) (result i32)
+ (func $nonNullAssertion/testAll2 (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.const 0
+  call $~lib/array/Array<Foo | null>#__get
+  i32.load
+ )
+ (func $nonNullAssertion/testFn (; 11 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   global.set $~lib/argc
   local.get $0
-  call_indirect (type $i)
+  call_indirect (type $FUNCSIG$i)
  )
- (func $nonNullAssertion/testFn2 (; 12 ;) (type $ii) (param $0 i32) (result i32)
+ (func $nonNullAssertion/testFn2 (; 12 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   local.set $1
   i32.const 0
   global.set $~lib/argc
   local.get $1
-  call_indirect (type $i)
+  call_indirect (type $FUNCSIG$i)
  )
- (func $nonNullAssertion/testRet (; 13 ;) (type $ii) (param $0 i32) (result i32)
+ (func $nonNullAssertion/testRet (; 13 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   global.set $~lib/argc
   local.get $0
-  call_indirect (type $i)
+  call_indirect (type $FUNCSIG$i)
  )
- (func $nonNullAssertion/testObjFn (; 14 ;) (type $ii) (param $0 i32) (result i32)
-  i32.const 0
-  global.set $~lib/argc
-  local.get $0
-  i32.load offset=4
-  call_indirect (type $i)
- )
- (func $nonNullAssertion/testObjRet (; 15 ;) (type $ii) (param $0 i32) (result i32)
+ (func $nonNullAssertion/testObjFn (; 14 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   global.set $~lib/argc
   local.get $0
   i32.load offset=4
-  call_indirect (type $i)
+  call_indirect (type $FUNCSIG$i)
  )
- (func $start (; 16 ;) (type $_)
+ (func $nonNullAssertion/testObjRet (; 15 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  i32.const 0
+  global.set $~lib/argc
+  local.get $0
+  i32.load offset=4
+  call_indirect (type $FUNCSIG$i)
+ )
+ (func $start (; 16 ;) (type $FUNCSIG$v)
   call $start:nonNullAssertion
  )
- (func $null (; 17 ;) (type $_)
+ (func $null (; 17 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/number.optimized.wat
+++ b/tests/compiler/number.optimized.wat
@@ -1,14 +1,11 @@
 (module
- (type $_ (func))
- (type $ii (func (param i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $iii_ (func (param i32 i32 i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
  (type $FUNCSIG$iijijij (func (param i32 i64 i32 i64 i32 i64) (result i32)))
- (type $FUNCSIG$ii (func (param i32) (result i32)))
- (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (type $FUNCSIG$i (func (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -50,7 +47,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $~lib/internal/number/decimalCount32 (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/decimalCount32 (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -104,7 +101,7 @@
    end
   end
  )
- (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -166,7 +163,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/internal/string/allocateUnsafe (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/string/allocateUnsafe (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 0
@@ -199,7 +196,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/number/utoa32_lut (; 4 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/number/utoa32_lut (; 4 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   i32.const 584
@@ -309,7 +306,7 @@
    i32.store16 offset=4
   end
  )
- (func $~lib/internal/number/itoa32 (; 5 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/itoa32 (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -380,7 +377,7 @@
   end
   local.get $3
  )
- (func $~lib/string/String.__eq (; 7 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -841,7 +838,7 @@
   i32.store16 offset=4
   local.get $10
  )
- (func $~lib/internal/memory/memcpy (; 9 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 9 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1738,7 +1735,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 10 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 10 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -1936,7 +1933,7 @@
    end
   end
  )
- (func $~lib/internal/number/prettify (; 11 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/internal/number/prettify (; 11 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2520,7 +2517,7 @@
   end
   local.get $0
  )
- (func $start:number (; 15 ;) (type $_)
+ (func $start:number (; 15 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 2192
   global.set $~lib/allocator/arena/startOffset
@@ -2685,10 +2682,10 @@
    unreachable
   end
  )
- (func $start (; 16 ;) (type $_)
+ (func $start (; 16 ;) (type $FUNCSIG$v)
   call $start:number
  )
- (func $null (; 17 ;) (type $_)
+ (func $null (; 17 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/number.untouched.wat
+++ b/tests/compiler/number.untouched.wat
@@ -1,17 +1,17 @@
 (module
- (type $_ (func))
- (type $ii (func (param i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $iii_ (func (param i32 i32 i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $iiiiii (func (param i32 i32 i32 i32 i32) (result i32)))
- (type $Fi (func (param f64) (result i32)))
- (type $iFi (func (param i32 f64) (result i32)))
- (type $iIiIiIii (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiiii_ (func (param i32 i32 i32 i32 i32)))
- (type $i_ (func (param i32)))
- (type $fi (func (param f32) (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$iiiiii (func (param i32 i32 i32 i32 i32) (result i32)))
+ (type $FUNCSIG$id (func (param f64) (result i32)))
+ (type $FUNCSIG$iid (func (param i32 f64) (result i32)))
+ (type $FUNCSIG$iijijiji (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viiiii (func (param i32 i32 i32 i32 i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$if (func (param f32) (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\01\00\00\000\00")
@@ -63,7 +63,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:~lib/allocator/arena (; 1 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 1 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -75,7 +75,7 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $~lib/internal/number/decimalCount32 (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/decimalCount32 (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 100000
@@ -144,7 +144,7 @@
   unreachable
   unreachable
  )
- (func $~lib/allocator/arena/__memory_allocate (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -223,7 +223,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/internal/string/allocateUnsafe (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/string/allocateUnsafe (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -263,7 +263,7 @@
   i32.store
   local.get $2
  )
- (func $~lib/internal/number/utoa32_lut (; 5 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/number/utoa32_lut (; 5 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -449,7 +449,7 @@
    i32.store16 offset=4
   end
  )
- (func $~lib/internal/number/itoa32 (; 6 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/itoa32 (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -501,16 +501,16 @@
   end
   local.get $3
  )
- (func $~lib/internal/number/itoa<i32> (; 7 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/itoa<i32> (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/internal/number/itoa32
   return
  )
- (func $~lib/number/I32#toString (; 8 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/number/I32#toString (; 8 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/internal/number/itoa<i32>
  )
- (func $~lib/internal/string/compareUnsafe (; 9 ;) (type $iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/internal/string/compareUnsafe (; 9 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -563,7 +563,7 @@
   end
   local.get $5
  )
- (func $~lib/string/String.__eq (; 10 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 10 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -607,19 +607,19 @@
   call $~lib/internal/string/compareUnsafe
   i32.eqz
  )
- (func $~lib/builtins/isFinite<f64> (; 11 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $~lib/builtins/isFinite<f64> (; 11 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   local.get $0
   f64.sub
   f64.const 0
   f64.eq
  )
- (func $~lib/builtins/isNaN<f64> (; 12 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $~lib/builtins/isNaN<f64> (; 12 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   local.get $0
   f64.ne
  )
- (func $~lib/internal/number/genDigits (; 13 ;) (type $iIiIiIii) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/internal/number/genDigits (; 13 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -1210,7 +1210,7 @@
   end
   local.get $15
  )
- (func $~lib/internal/memory/memcpy (; 14 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 14 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2411,7 +2411,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 15 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 15 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -2638,7 +2638,7 @@
    end
   end
  )
- (func $~lib/internal/number/prettify (; 16 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/internal/number/prettify (; 16 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3007,7 +3007,7 @@
   unreachable
   unreachable
  )
- (func $~lib/internal/number/dtoa_core (; 17 ;) (type $iFi) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/internal/number/dtoa_core (; 17 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 f64)
   (local $4 i32)
@@ -3480,7 +3480,7 @@
   local.get $2
   i32.add
  )
- (func $~lib/internal/string/copyUnsafe (; 18 ;) (type $iiiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
+ (func $~lib/internal/string/copyUnsafe (; 18 ;) (type $FUNCSIG$viiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -3509,7 +3509,7 @@
   local.get $7
   call $~lib/internal/memory/memmove
  )
- (func $~lib/string/String#substring (; 19 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substring (; 19 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3619,10 +3619,10 @@
   call $~lib/internal/string/copyUnsafe
   local.get $10
  )
- (func $~lib/allocator/arena/__memory_free (; 20 ;) (type $i_) (param $0 i32)
+ (func $~lib/allocator/arena/__memory_free (; 20 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $~lib/internal/number/dtoa (; 21 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $~lib/internal/number/dtoa (; 21 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3688,11 +3688,11 @@
   end
   local.get $3
  )
- (func $~lib/number/F64#toString (; 22 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $~lib/number/F64#toString (; 22 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   call $~lib/internal/number/dtoa
  )
- (func $~lib/number/Bool#toString (; 23 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/number/Bool#toString (; 23 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
   i32.ne
@@ -3702,7 +3702,7 @@
    i32.const 2176
   end
  )
- (func $~lib/number/F32.isSafeInteger (; 24 ;) (type $fi) (param $0 f32) (result i32)
+ (func $~lib/number/F32.isSafeInteger (; 24 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
   (local $1 i32)
   local.get $0
   f32.abs
@@ -3718,7 +3718,7 @@
    local.get $1
   end
  )
- (func $~lib/number/F32.isInteger (; 25 ;) (type $fi) (param $0 f32) (result i32)
+ (func $~lib/number/F32.isInteger (; 25 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
   (local $1 f32)
   (local $2 i32)
   block $~lib/builtins/isFinite<f32>|inlined.0 (result i32)
@@ -3742,7 +3742,7 @@
    local.get $2
   end
  )
- (func $~lib/number/F64.isSafeInteger (; 26 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $~lib/number/F64.isSafeInteger (; 26 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   (local $1 i32)
   local.get $0
   f64.abs
@@ -3758,7 +3758,7 @@
    local.get $1
   end
  )
- (func $~lib/number/F64.isInteger (; 27 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $~lib/number/F64.isInteger (; 27 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   (local $1 f64)
   (local $2 i32)
   block $~lib/builtins/isFinite<f64>|inlined.0 (result i32)
@@ -3782,7 +3782,7 @@
    local.get $2
   end
  )
- (func $start:number (; 28 ;) (type $_)
+ (func $start:number (; 28 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f32)
   (local $2 f64)
@@ -4567,9 +4567,9 @@
    unreachable
   end
  )
- (func $start (; 29 ;) (type $_)
+ (func $start (; 29 ;) (type $FUNCSIG$v)
   call $start:number
  )
- (func $null (; 30 ;) (type $_)
+ (func $null (; 30 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/object-literal.optimized.wat
+++ b/tests/compiler/object-literal.optimized.wat
@@ -1,10 +1,9 @@
 (module
- (type $_ (func))
- (type $ii (func (param i32) (result i32)))
- (type $i_ (func (param i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$v (func))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0b\00\00\00h\00e\00l\00l\00o\00 \00w\00o\00r\00l\00d")
@@ -16,7 +15,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -150,7 +149,7 @@
   call $~lib/internal/string/compareUnsafe
   i32.eqz
  )
- (func $object-literal/bar (; 4 ;) (type $i_) (param $0 i32)
+ (func $object-literal/bar (; 4 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.load
   i32.const 1
@@ -176,7 +175,7 @@
    unreachable
   end
  )
- (func $start:object-literal (; 5 ;) (type $_)
+ (func $start:object-literal (; 5 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 80
   global.set $~lib/allocator/arena/startOffset
@@ -227,10 +226,10 @@
    unreachable
   end
  )
- (func $start (; 6 ;) (type $_)
+ (func $start (; 6 ;) (type $FUNCSIG$v)
   call $start:object-literal
  )
- (func $null (; 7 ;) (type $_)
+ (func $null (; 7 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/object-literal.untouched.wat
+++ b/tests/compiler/object-literal.untouched.wat
@@ -1,10 +1,10 @@
 (module
- (type $_ (func))
- (type $ii (func (param i32) (result i32)))
- (type $i_ (func (param i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $iiiiii (func (param i32 i32 i32 i32 i32) (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$iiiiii (func (param i32 i32 i32 i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0b\00\00\00h\00e\00l\00l\00o\00 \00w\00o\00r\00l\00d\00")
@@ -17,7 +17,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:~lib/allocator/arena (; 1 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 1 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -29,7 +29,7 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -108,12 +108,12 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/memory/memory.allocate (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/memory/memory.allocate (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/allocator/arena/__memory_allocate
   return
  )
- (func $~lib/internal/string/compareUnsafe (; 4 ;) (type $iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/internal/string/compareUnsafe (; 4 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -166,7 +166,7 @@
   end
   local.get $5
  )
- (func $~lib/string/String.__eq (; 5 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 5 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -210,7 +210,7 @@
   call $~lib/internal/string/compareUnsafe
   i32.eqz
  )
- (func $object-literal/bar (; 6 ;) (type $i_) (param $0 i32)
+ (func $object-literal/bar (; 6 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.load
   i32.const 1
@@ -238,7 +238,7 @@
    unreachable
   end
  )
- (func $object-literal/bar2 (; 7 ;) (type $i_) (param $0 i32)
+ (func $object-literal/bar2 (; 7 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.load
   i32.const 2
@@ -253,7 +253,7 @@
    unreachable
   end
  )
- (func $object-literal/Foo2#test (; 8 ;) (type $i_) (param $0 i32)
+ (func $object-literal/Foo2#test (; 8 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.load
   i32.const 3
@@ -268,7 +268,7 @@
    unreachable
   end
  )
- (func $start:object-literal (; 9 ;) (type $_)
+ (func $start:object-literal (; 9 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -307,9 +307,9 @@
   end
   call $object-literal/Foo2#test
  )
- (func $start (; 10 ;) (type $_)
+ (func $start (; 10 ;) (type $FUNCSIG$v)
   call $start:object-literal
  )
- (func $null (; 11 ;) (type $_)
+ (func $null (; 11 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/optional-typeparameters.optimized.wat
+++ b/tests/compiler/optional-typeparameters.optimized.wat
@@ -1,5 +1,5 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (type $FUNCSIG$i (func (result i32)))
  (memory $0 0)
  (table $0 1 funcref)
@@ -61,7 +61,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $0
  )
- (func $start (; 1 ;) (type $_)
+ (func $start (; 1 ;) (type $FUNCSIG$v)
   i32.const 8
   global.set $~lib/allocator/arena/startOffset
   global.get $~lib/allocator/arena/startOffset
@@ -71,7 +71,7 @@
   call $~lib/allocator/arena/__memory_allocate
   global.set $optional-typeparameters/tDerived
  )
- (func $null (; 2 ;) (type $_)
+ (func $null (; 2 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/optional-typeparameters.untouched.wat
+++ b/tests/compiler/optional-typeparameters.untouched.wat
@@ -1,8 +1,8 @@
 (module
- (type $ii (func (param i32) (result i32)))
- (type $_ (func))
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iFFF (func (param i32 f64 f64) (result f64)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$didd (func (param i32 f64 f64) (result f64)))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -14,13 +14,13 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $optional-typeparameters/testConcrete<i32,i32> (; 0 ;) (type $ii) (param $0 i32) (result i32)
+ (func $optional-typeparameters/testConcrete<i32,i32> (; 0 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $optional-typeparameters/testDerived<i32,i32> (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $optional-typeparameters/testDerived<i32,i32> (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $start:~lib/allocator/arena (; 2 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 2 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -32,7 +32,7 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $~lib/allocator/arena/__memory_allocate (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -111,12 +111,12 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/memory/memory.allocate (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/memory/memory.allocate (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/allocator/arena/__memory_allocate
   return
  )
- (func $optional-typeparameters/TestConcrete<i32,i32>#constructor (; 5 ;) (type $ii) (param $0 i32) (result i32)
+ (func $optional-typeparameters/TestConcrete<i32,i32>#constructor (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -126,12 +126,12 @@
   end
   local.get $0
  )
- (func $optional-typeparameters/TestConcrete<i32,i32>#test<i32> (; 6 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $optional-typeparameters/TestConcrete<i32,i32>#test<i32> (; 6 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   local.get $2
   i32.add
  )
- (func $optional-typeparameters/TestDerived<f64,f64>#constructor (; 7 ;) (type $ii) (param $0 i32) (result i32)
+ (func $optional-typeparameters/TestDerived<f64,f64>#constructor (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -141,12 +141,12 @@
   end
   local.get $0
  )
- (func $optional-typeparameters/TestDerived<f64,f64>#test<f64> (; 8 ;) (type $iFFF) (param $0 i32) (param $1 f64) (param $2 f64) (result f64)
+ (func $optional-typeparameters/TestDerived<f64,f64>#test<f64> (; 8 ;) (type $FUNCSIG$didd) (param $0 i32) (param $1 f64) (param $2 f64) (result f64)
   local.get $1
   local.get $2
   f64.add
  )
- (func $start:optional-typeparameters (; 9 ;) (type $_)
+ (func $start:optional-typeparameters (; 9 ;) (type $FUNCSIG$v)
   i32.const 1
   call $optional-typeparameters/testConcrete<i32,i32>
   drop
@@ -171,9 +171,9 @@
   call $optional-typeparameters/TestDerived<f64,f64>#test<f64>
   drop
  )
- (func $start (; 10 ;) (type $_)
+ (func $start (; 10 ;) (type $FUNCSIG$v)
   call $start:optional-typeparameters
  )
- (func $null (; 11 ;) (type $_)
+ (func $null (; 11 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/overflow.optimized.wat
+++ b/tests/compiler/overflow.optimized.wat
@@ -1,12 +1,12 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 1)
  (data (i32.const 8) "\0b\00\00\00o\00v\00e\00r\00f\00l\00o\00w\00.\00t\00s")
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $start (; 0 ;) (type $_)
+ (func $start (; 0 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/overflow.untouched.wat
+++ b/tests/compiler/overflow.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0b\00\00\00o\00v\00e\00r\00f\00l\00o\00w\00.\00t\00s\00")
@@ -10,7 +10,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:overflow (; 1 ;) (type $_)
+ (func $start:overflow (; 1 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -755,9 +755,9 @@
    end
   end
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   call $start:overflow
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/portable-conversions.optimized.wat
+++ b/tests/compiler/portable-conversions.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\17\00\00\00p\00o\00r\00t\00a\00b\00l\00e\00-\00c\00o\00n\00v\00e\00r\00s\00i\00o\00n\00s\00.\00t\00s")
@@ -13,7 +13,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:portable-conversions (; 1 ;) (type $_)
+ (func $start:portable-conversions (; 1 ;) (type $FUNCSIG$v)
   global.get $portable-conversions/i
   i32.const 255
   i32.and
@@ -614,10 +614,10 @@
    unreachable
   end
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   call $start:portable-conversions
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/portable-conversions.untouched.wat
+++ b/tests/compiler/portable-conversions.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\17\00\00\00p\00o\00r\00t\00a\00b\00l\00e\00-\00c\00o\00n\00v\00e\00r\00s\00i\00o\00n\00s\00.\00t\00s\00")
@@ -14,7 +14,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:portable-conversions (; 1 ;) (type $_)
+ (func $start:portable-conversions (; 1 ;) (type $FUNCSIG$v)
   global.get $portable-conversions/i
   i32.const 24
   i32.shl
@@ -636,9 +636,9 @@
    unreachable
   end
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   call $start:portable-conversions
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/recursive.optimized.wat
+++ b/tests/compiler/recursive.optimized.wat
@@ -1,13 +1,13 @@
 (module
- (type $ii (func (param i32) (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "fib" (func $recursive/fib))
- (func $recursive/fib (; 0 ;) (type $ii) (param $0 i32) (result i32)
+ (func $recursive/fib (; 0 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 1
   i32.le_s
@@ -25,7 +25,7 @@
   call $recursive/fib
   i32.add
  )
- (func $null (; 1 ;) (type $_)
+ (func $null (; 1 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/recursive.untouched.wat
+++ b/tests/compiler/recursive.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $ii (func (param i32) (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -8,7 +8,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "fib" (func $recursive/fib))
- (func $recursive/fib (; 0 ;) (type $ii) (param $0 i32) (result i32)
+ (func $recursive/fib (; 0 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 1
   i32.le_s
@@ -26,6 +26,6 @@
   call $recursive/fib
   i32.add
  )
- (func $null (; 1 ;) (type $_)
+ (func $null (; 1 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/reexport.optimized.wat
+++ b/tests/compiler/reexport.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iii (func (param i32 i32) (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $export/ns.one)
@@ -20,22 +20,22 @@
  (export "renamed_add" (func $export/add))
  (export "rerenamed_sub" (func $export/mul))
  (export "renamed_ns.two" (func $export/ns.one))
- (func $export/add (; 0 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/add (; 0 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $export/mul (; 1 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/mul (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.mul
  )
- (func $export/sub (; 2 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/sub (; 2 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $export/ns.one (; 3 ;) (type $_)
+ (func $export/ns.one (; 3 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/reexport.untouched.wat
+++ b/tests/compiler/reexport.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iii (func (param i32 i32) (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -22,17 +22,17 @@
  (export "rerenamed_sub" (func $export/mul))
  (export "renamed_ns.two" (func $export/ns.two))
  (start $start)
- (func $export/add (; 0 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/add (; 0 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $export/mul (; 1 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/mul (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.mul
  )
- (func $start:reexport (; 2 ;) (type $_)
+ (func $start:reexport (; 2 ;) (type $FUNCSIG$v)
   i32.const 1
   i32.const 2
   call $export/add
@@ -42,20 +42,20 @@
   i32.add
   drop
  )
- (func $export/sub (; 3 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/sub (; 3 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $export/ns.one (; 4 ;) (type $_)
+ (func $export/ns.one (; 4 ;) (type $FUNCSIG$v)
   nop
  )
- (func $export/ns.two (; 5 ;) (type $_)
+ (func $export/ns.two (; 5 ;) (type $FUNCSIG$v)
   nop
  )
- (func $start (; 6 ;) (type $_)
+ (func $start (; 6 ;) (type $FUNCSIG$v)
   call $start:reexport
  )
- (func $null (; 7 ;) (type $_)
+ (func $null (; 7 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/rereexport.optimized.wat
+++ b/tests/compiler/rereexport.optimized.wat
@@ -1,5 +1,5 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
@@ -11,7 +11,7 @@
  (export "renamed_a" (global $export/a))
  (export "renamed_b" (global $export/b))
  (export "renamed_renamed_b" (global $export/b))
- (func $start (; 0 ;) (type $_)
+ (func $start (; 0 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/rereexport.untouched.wat
+++ b/tests/compiler/rereexport.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iii (func (param i32 i32) (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -15,17 +15,17 @@
  (export "renamed_b" (global $export/b))
  (export "renamed_renamed_b" (global $export/b))
  (start $start)
- (func $export/add (; 0 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/add (; 0 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $export/mul (; 1 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/mul (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.mul
  )
- (func $start:reexport (; 2 ;) (type $_)
+ (func $start:reexport (; 2 ;) (type $FUNCSIG$v)
   i32.const 1
   i32.const 2
   call $export/add
@@ -35,12 +35,12 @@
   i32.add
   drop
  )
- (func $start:rereexport (; 3 ;) (type $_)
+ (func $start:rereexport (; 3 ;) (type $FUNCSIG$v)
   call $start:reexport
  )
- (func $start (; 4 ;) (type $_)
+ (func $start (; 4 ;) (type $FUNCSIG$v)
   call $start:rereexport
  )
- (func $null (; 5 ;) (type $_)
+ (func $null (; 5 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/resolve-nested.optimized.wat
+++ b/tests/compiler/resolve-nested.optimized.wat
@@ -1,8 +1,8 @@
 (module
- (type $iiiiii_ (func (param i32 i32 i32 i32 i32 i32)))
- (type $iiiii_ (func (param i32 i32 i32 i32 i32)))
- (type $iii_ (func (param i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiiiii (func (param i32 i32 i32 i32 i32 i32)))
+ (type $FUNCSIG$viiiii (func (param i32 i32 i32 i32 i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -11,16 +11,16 @@
  (export "Outer.Inner.evenInner" (func $resolve-nested/Outer.Inner.evenInner))
  (export "Outer.inner" (func $resolve-nested/Outer.inner))
  (export "outer" (func $resolve-nested/outer))
- (func $resolve-nested/Outer.Inner.evenInner (; 0 ;) (type $iiiiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (param $5 i32)
+ (func $resolve-nested/Outer.Inner.evenInner (; 0 ;) (type $FUNCSIG$viiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (param $5 i32)
   nop
  )
- (func $resolve-nested/Outer.inner (; 1 ;) (type $iiiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
+ (func $resolve-nested/Outer.inner (; 1 ;) (type $FUNCSIG$viiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
   nop
  )
- (func $resolve-nested/outer (; 2 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $resolve-nested/outer (; 2 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   nop
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/resolve-nested.untouched.wat
+++ b/tests/compiler/resolve-nested.untouched.wat
@@ -1,8 +1,8 @@
 (module
- (type $iiiiii_ (func (param i32 i32 i32 i32 i32 i32)))
- (type $iiiii_ (func (param i32 i32 i32 i32 i32)))
- (type $iii_ (func (param i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiiiii (func (param i32 i32 i32 i32 i32 i32)))
+ (type $FUNCSIG$viiiii (func (param i32 i32 i32 i32 i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -26,15 +26,15 @@
  (export "Outer.Inner.evenInner" (func $resolve-nested/Outer.Inner.evenInner))
  (export "Outer.inner" (func $resolve-nested/Outer.inner))
  (export "outer" (func $resolve-nested/outer))
- (func $resolve-nested/Outer.Inner.evenInner (; 0 ;) (type $iiiiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (param $5 i32)
+ (func $resolve-nested/Outer.Inner.evenInner (; 0 ;) (type $FUNCSIG$viiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (param $5 i32)
   nop
  )
- (func $resolve-nested/Outer.inner (; 1 ;) (type $iiiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
+ (func $resolve-nested/Outer.inner (; 1 ;) (type $FUNCSIG$viiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
   nop
  )
- (func $resolve-nested/outer (; 2 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $resolve-nested/outer (; 2 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   nop
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/retain-i32.optimized.wat
+++ b/tests/compiler/retain-i32.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0d\00\00\00r\00e\00t\00a\00i\00n\00-\00i\003\002\00.\00t\00s")
@@ -11,7 +11,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:retain-i32 (; 1 ;) (type $_)
+ (func $start:retain-i32 (; 1 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const -128
   local.set $0
@@ -258,10 +258,10 @@
    unreachable
   end
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   call $start:retain-i32
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/retain-i32.untouched.wat
+++ b/tests/compiler/retain-i32.untouched.wat
@@ -1,7 +1,7 @@
 (module
- (type $ii_ (func (param i32 i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0d\00\00\00r\00e\00t\00a\00i\00n\00-\00i\003\002\00.\00t\00s\00")
@@ -22,7 +22,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $retain-i32/test (; 1 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $retain-i32/test (; 1 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.add
@@ -332,7 +332,7 @@
    unreachable
   end
  )
- (func $start:retain-i32 (; 2 ;) (type $_)
+ (func $start:retain-i32 (; 2 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   global.get $~lib/builtins/i8.MAX_VALUE
@@ -792,9 +792,9 @@
    unreachable
   end
  )
- (func $start (; 3 ;) (type $_)
+ (func $start (; 3 ;) (type $FUNCSIG$v)
   call $start:retain-i32
  )
- (func $null (; 4 ;) (type $_)
+ (func $null (; 4 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/scoped.optimized.wat
+++ b/tests/compiler/scoped.optimized.wat
@@ -1,12 +1,12 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:scoped (; 0 ;) (type $_)
+ (func $start:scoped (; 0 ;) (type $FUNCSIG$v)
   (local $0 i32)
   loop $repeat|0
    local.get $0
@@ -35,10 +35,10 @@
    end
   end
  )
- (func $start (; 1 ;) (type $_)
+ (func $start (; 1 ;) (type $FUNCSIG$v)
   call $start:scoped
  )
- (func $null (; 2 ;) (type $_)
+ (func $null (; 2 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/scoped.untouched.wat
+++ b/tests/compiler/scoped.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $i_ (func (param i32)))
- (type $_ (func))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -11,14 +11,14 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $scoped/fn (; 0 ;) (type $i_) (param $0 i32)
+ (func $scoped/fn (; 0 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   i32.const 0
   local.set $1
   local.get $0
   local.set $1
  )
- (func $start:scoped (; 1 ;) (type $_)
+ (func $start:scoped (; 1 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i64)
@@ -71,9 +71,9 @@
   i32.const 42
   call $scoped/fn
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   call $start:scoped
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/simd.optimized.wat
+++ b/tests/compiler/simd.optimized.wat
@@ -1,5 +1,5 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 1)
  (data (i32.const 8) "\07\00\00\00s\00i\00m\00d\00.\00t\00s")
  (table $0 1 funcref)
@@ -9,13 +9,13 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 0 ;) (type $_)
+ (func $start (; 0 ;) (type $FUNCSIG$v)
   i32.const 32
   global.set $~lib/allocator/arena/startOffset
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $null (; 1 ;) (type $_)
+ (func $null (; 1 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/simd.untouched.wat
+++ b/tests/compiler/simd.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $_ (func))
- (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\07\00\00\00s\00i\00m\00d\00.\00t\00s\00")
@@ -13,7 +13,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:~lib/allocator/arena (; 1 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 1 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -25,7 +25,7 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $simd/test_v128 (; 2 ;) (type $_)
+ (func $simd/test_v128 (; 2 ;) (type $FUNCSIG$v)
   v128.const i32 0x1 0x2 0x3 0x4 0x5 0x6 0x7 0x8 0x9 0xa 0xb 0xc 0xd 0xe 0xf 0x10
   v128.const i32 0x1 0x2 0x3 0x4 0x5 0x6 0x7 0x8 0x9 0xa 0xb 0xc 0xd 0xe 0xf 0x10
   i8x16.eq
@@ -142,7 +142,7 @@
    unreachable
   end
  )
- (func $simd/test_i8x16 (; 3 ;) (type $_)
+ (func $simd/test_i8x16 (; 3 ;) (type $FUNCSIG$v)
   (local $0 v128)
   (local $1 v128)
   (local $2 v128)
@@ -687,7 +687,7 @@
    unreachable
   end
  )
- (func $simd/test_i16x8 (; 4 ;) (type $_)
+ (func $simd/test_i16x8 (; 4 ;) (type $FUNCSIG$v)
   (local $0 v128)
   (local $1 v128)
   (local $2 v128)
@@ -1232,7 +1232,7 @@
    unreachable
   end
  )
- (func $simd/test_i32x4 (; 5 ;) (type $_)
+ (func $simd/test_i32x4 (; 5 ;) (type $FUNCSIG$v)
   (local $0 v128)
   (local $1 v128)
   (local $2 v128)
@@ -1714,7 +1714,7 @@
    unreachable
   end
  )
- (func $simd/test_i64x2 (; 6 ;) (type $_)
+ (func $simd/test_i64x2 (; 6 ;) (type $FUNCSIG$v)
   (local $0 v128)
   (local $1 v128)
   (local $2 v128)
@@ -1990,7 +1990,7 @@
    unreachable
   end
  )
- (func $simd/test_f32x4 (; 7 ;) (type $_)
+ (func $simd/test_f32x4 (; 7 ;) (type $FUNCSIG$v)
   (local $0 v128)
   (local $1 v128)
   (local $2 v128)
@@ -2420,7 +2420,7 @@
    unreachable
   end
  )
- (func $simd/test_f64x2 (; 8 ;) (type $_)
+ (func $simd/test_f64x2 (; 8 ;) (type $FUNCSIG$v)
   (local $0 v128)
   (local $1 v128)
   (local $2 v128)
@@ -2850,7 +2850,7 @@
    unreachable
   end
  )
- (func $simd/test_v8x16 (; 9 ;) (type $_)
+ (func $simd/test_v8x16 (; 9 ;) (type $FUNCSIG$v)
   (local $0 v128)
   (local $1 v128)
   v128.const i32 0x0 0x1 0x2 0x3 0x4 0x5 0x6 0x7 0x8 0x9 0xa 0xb 0xc 0xd 0xe 0xf
@@ -2875,7 +2875,7 @@
    unreachable
   end
  )
- (func $start:simd (; 10 ;) (type $_)
+ (func $start:simd (; 10 ;) (type $FUNCSIG$v)
   call $start:~lib/allocator/arena
   block
    call $simd/test_v128
@@ -2888,9 +2888,9 @@
    call $simd/test_v8x16
   end
  )
- (func $start (; 11 ;) (type $_)
+ (func $start (; 11 ;) (type $FUNCSIG$v)
   call $start:simd
  )
- (func $null (; 12 ;) (type $_)
+ (func $null (; 12 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/static-this.optimized.wat
+++ b/tests/compiler/static-this.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0e\00\00\00s\00t\00a\00t\00i\00c\00-\00t\00h\00i\00s\00.\00t\00s")
@@ -10,7 +10,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 1 ;) (type $_)
+ (func $start (; 1 ;) (type $FUNCSIG$v)
   global.get $static-this/Foo.bar
   i32.const 42
   i32.ne
@@ -23,7 +23,7 @@
    unreachable
   end
  )
- (func $null (; 2 ;) (type $_)
+ (func $null (; 2 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/static-this.untouched.wat
+++ b/tests/compiler/static-this.untouched.wat
@@ -1,7 +1,7 @@
 (module
- (type $i (func (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0e\00\00\00s\00t\00a\00t\00i\00c\00-\00t\00h\00i\00s\00.\00t\00s\00")
@@ -12,10 +12,10 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $static-this/Foo.getBar (; 1 ;) (type $i) (result i32)
+ (func $static-this/Foo.getBar (; 1 ;) (type $FUNCSIG$i) (result i32)
   global.get $static-this/Foo.bar
  )
- (func $start:static-this (; 2 ;) (type $_)
+ (func $start:static-this (; 2 ;) (type $FUNCSIG$v)
   call $static-this/Foo.getBar
   i32.const 42
   i32.eq
@@ -29,9 +29,9 @@
    unreachable
   end
  )
- (func $start (; 3 ;) (type $_)
+ (func $start (; 3 ;) (type $FUNCSIG$v)
   call $start:static-this
  )
- (func $null (; 4 ;) (type $_)
+ (func $null (; 4 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/allocator_arena.optimized.wat
+++ b/tests/compiler/std/allocator_arena.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $_ (func))
- (type $iiii_ (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$i (func (result i32)))
  (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$vii (func (param i32 i32)))
@@ -1363,7 +1363,7 @@
    i32.const 0
   end
  )
- (func $start:std/allocator_arena (; 6 ;) (type $_)
+ (func $start:std/allocator_arena (; 6 ;) (type $FUNCSIG$v)
   i32.const 56
   global.set $~lib/allocator/arena/startOffset
   global.get $~lib/allocator/arena/startOffset
@@ -1475,10 +1475,10 @@
    unreachable
   end
  )
- (func $start (; 7 ;) (type $_)
+ (func $start (; 7 ;) (type $FUNCSIG$v)
   call $start:std/allocator_arena
  )
- (func $null (; 8 ;) (type $_)
+ (func $null (; 8 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/allocator_arena.untouched.wat
+++ b/tests/compiler/std/allocator_arena.untouched.wat
@@ -1,10 +1,10 @@
 (module
- (type $_ (func))
- (type $ii (func (param i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $iii_ (func (param i32 i32 i32)))
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $i_ (func (param i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\16\00\00\00s\00t\00d\00/\00a\00l\00l\00o\00c\00a\00t\00o\00r\00_\00a\00r\00e\00n\00a\00.\00t\00s\00")
@@ -20,7 +20,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:~lib/allocator/arena (; 1 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 1 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -32,7 +32,7 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -111,7 +111,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/internal/memory/memset (; 3 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 3 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -365,7 +365,7 @@
    end
   end
  )
- (func $~lib/internal/memory/memcpy (; 4 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 4 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1566,7 +1566,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 5 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 5 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -1793,7 +1793,7 @@
    end
   end
  )
- (func $~lib/internal/memory/memcmp (; 6 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/internal/memory/memcmp (; 6 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -1847,14 +1847,14 @@
    i32.const 0
   end
  )
- (func $~lib/allocator/arena/__memory_free (; 7 ;) (type $i_) (param $0 i32)
+ (func $~lib/allocator/arena/__memory_free (; 7 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $~lib/allocator/arena/__memory_reset (; 8 ;) (type $_)
+ (func $~lib/allocator/arena/__memory_reset (; 8 ;) (type $FUNCSIG$v)
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $start:std/allocator_arena (; 9 ;) (type $_)
+ (func $start:std/allocator_arena (; 9 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2045,9 +2045,9 @@
    unreachable
   end
  )
- (func $start (; 10 ;) (type $_)
+ (func $start (; 10 ;) (type $FUNCSIG$v)
   call $start:std/allocator_arena
  )
- (func $null (; 11 ;) (type $_)
+ (func $null (; 11 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/array-access.optimized.wat
+++ b/tests/compiler/std/array-access.optimized.wat
@@ -1,9 +1,8 @@
 (module
- (type $ii (func (param i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
- (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 16) "\0e\00\00\00~\00l\00i\00b\00/\00s\00t\00r\00i\00n\00g\00.\00t\00s")
@@ -17,7 +16,7 @@
  (export "stringArrayMethodCall" (func $std/array-access/stringArrayMethodCall))
  (export "stringArrayArrayPropertyAccess" (func $std/array-access/stringArrayArrayPropertyAccess))
  (export "stringArrayArrayMethodCall" (func $std/array-access/stringArrayArrayMethodCall))
- (func $std/array-access/i32ArrayArrayElementAccess (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array-access/i32ArrayArrayElementAccess (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   i32.const 0
   local.get $0
@@ -48,7 +47,7 @@
    unreachable
   end
  )
- (func $std/array-access/stringArrayPropertyAccess (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array-access/stringArrayPropertyAccess (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load
@@ -146,7 +145,7 @@
   call $~lib/internal/string/compareUnsafe
   i32.eqz
  )
- (func $std/array-access/stringArrayMethodCall (; 5 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array-access/stringArrayMethodCall (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load
@@ -163,7 +162,7 @@
   end
   call $~lib/string/String#startsWith
  )
- (func $std/array-access/stringArrayArrayPropertyAccess (; 6 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array-access/stringArrayArrayPropertyAccess (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   i32.const 0
   local.get $0
@@ -195,7 +194,7 @@
   end
   i32.load
  )
- (func $std/array-access/stringArrayArrayMethodCall (; 7 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array-access/stringArrayArrayMethodCall (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   i32.const 0
   local.get $0
@@ -227,7 +226,7 @@
   end
   call $~lib/string/String#startsWith
  )
- (func $null (; 8 ;) (type $_)
+ (func $null (; 8 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/array-access.untouched.wat
+++ b/tests/compiler/std/array-access.untouched.wat
@@ -1,10 +1,10 @@
 (module
- (type $ii (func (param i32) (result i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $iiiiii (func (param i32 i32 i32 i32 i32) (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$iiiiii (func (param i32 i32 i32 i32 i32) (result i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\00\00\00\00")
@@ -20,7 +20,7 @@
  (export "stringArrayMethodCall" (func $std/array-access/stringArrayMethodCall))
  (export "stringArrayArrayPropertyAccess" (func $std/array-access/stringArrayArrayPropertyAccess))
  (export "stringArrayArrayMethodCall" (func $std/array-access/stringArrayArrayMethodCall))
- (func $~lib/array/Array<Array<i32>>#__get (; 1 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Array<i32>>#__get (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -53,7 +53,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<i32>#__get (; 2 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (; 2 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -86,14 +86,14 @@
    unreachable
   end
  )
- (func $std/array-access/i32ArrayArrayElementAccess (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array-access/i32ArrayArrayElementAccess (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
   call $~lib/array/Array<Array<i32>>#__get
   i32.const 1
   call $~lib/array/Array<i32>#__get
  )
- (func $~lib/array/Array<String>#__get (; 4 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<String>#__get (; 4 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -126,13 +126,13 @@
    unreachable
   end
  )
- (func $std/array-access/stringArrayPropertyAccess (; 5 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array-access/stringArrayPropertyAccess (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
   call $~lib/array/Array<String>#__get
   i32.load
  )
- (func $~lib/internal/string/compareUnsafe (; 6 ;) (type $iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/internal/string/compareUnsafe (; 6 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -185,7 +185,7 @@
   end
   local.get $5
  )
- (func $~lib/string/String#startsWith (; 7 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#startsWith (; 7 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -252,7 +252,7 @@
   call $~lib/internal/string/compareUnsafe
   i32.eqz
  )
- (func $std/array-access/stringArrayMethodCall (; 8 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array-access/stringArrayMethodCall (; 8 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
   call $~lib/array/Array<String>#__get
@@ -260,7 +260,7 @@
   i32.const 0
   call $~lib/string/String#startsWith
  )
- (func $~lib/array/Array<Array<String>>#__get (; 9 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Array<String>>#__get (; 9 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -293,7 +293,7 @@
    unreachable
   end
  )
- (func $std/array-access/stringArrayArrayPropertyAccess (; 10 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array-access/stringArrayArrayPropertyAccess (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
   call $~lib/array/Array<Array<String>>#__get
@@ -301,7 +301,7 @@
   call $~lib/array/Array<String>#__get
   i32.load
  )
- (func $std/array-access/stringArrayArrayMethodCall (; 11 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array-access/stringArrayArrayMethodCall (; 11 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
   call $~lib/array/Array<Array<String>>#__get
@@ -311,6 +311,6 @@
   i32.const 0
   call $~lib/string/String#startsWith
  )
- (func $null (; 12 ;) (type $_)
+ (func $null (; 12 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -1,7 +1,7 @@
 (module
- (type $_ (func))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $ii (func (param i32) (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$vii (func (param i32 i32)))
  (type $FUNCSIG$i (func (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
@@ -29,7 +29,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -91,7 +91,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/internal/arraybuffer/allocateUnsafe (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/allocateUnsafe (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 1073741816
@@ -391,7 +391,7 @@
   call $~lib/internal/memory/memset
   local.get $0
  )
- (func $start:std/array-literal (; 6 ;) (type $_)
+ (func $start:std/array-literal (; 6 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 232
@@ -895,10 +895,10 @@
    unreachable
   end
  )
- (func $start (; 7 ;) (type $_)
+ (func $start (; 7 ;) (type $FUNCSIG$v)
   call $start:std/array-literal
  )
- (func $null (; 8 ;) (type $_)
+ (func $null (; 8 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -1,9 +1,9 @@
 (module
- (type $_ (func))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $ii (func (param i32) (result i32)))
- (type $iii_ (func (param i32 i32 i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\03\00\00\00\00\00\00\00\00\01\02\00\00\00\00\00")
@@ -31,7 +31,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:~lib/allocator/arena (; 1 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 1 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -43,7 +43,7 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $~lib/array/Array<i8>#__get (; 2 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__get (; 2 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -76,7 +76,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<i32>#__get (; 3 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (; 3 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -109,7 +109,7 @@
    unreachable
   end
  )
- (func $~lib/internal/arraybuffer/computeSize (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/computeSize (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   i32.const 32
   local.get $0
@@ -121,7 +121,7 @@
   i32.sub
   i32.shl
  )
- (func $~lib/allocator/arena/__memory_allocate (; 5 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -200,7 +200,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/internal/arraybuffer/allocateUnsafe (; 6 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/allocateUnsafe (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -229,12 +229,12 @@
   i32.store
   local.get $1
  )
- (func $~lib/memory/memory.allocate (; 7 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/memory/memory.allocate (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/allocator/arena/__memory_allocate
   return
  )
- (func $~lib/internal/memory/memset (; 8 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 8 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -488,7 +488,7 @@
    end
   end
  )
- (func $~lib/array/Array<i8>#constructor (; 9 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#constructor (; 9 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -549,7 +549,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<i8>#__unchecked_set (; 10 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i8>#__unchecked_set (; 10 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -573,7 +573,7 @@
   local.get $5
   i32.store8 offset=8
  )
- (func $~lib/array/Array<i32>#constructor (; 11 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#constructor (; 11 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -634,7 +634,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<i32>#__unchecked_set (; 12 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__unchecked_set (; 12 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -658,7 +658,7 @@
   local.get $5
   i32.store offset=8
  )
- (func $std/array-literal/Ref#constructor (; 13 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array-literal/Ref#constructor (; 13 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -668,7 +668,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<Ref>#constructor (; 14 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Ref>#constructor (; 14 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -729,7 +729,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<Ref>#__unchecked_set (; 15 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<Ref>#__unchecked_set (; 15 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -753,7 +753,7 @@
   local.get $5
   i32.store offset=8
  )
- (func $std/array-literal/RefWithCtor#constructor (; 16 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array-literal/RefWithCtor#constructor (; 16 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -763,7 +763,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<RefWithCtor>#constructor (; 17 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<RefWithCtor>#constructor (; 17 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -824,7 +824,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<RefWithCtor>#__unchecked_set (; 18 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<RefWithCtor>#__unchecked_set (; 18 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -848,7 +848,7 @@
   local.get $5
   i32.store offset=8
  )
- (func $start:std/array-literal (; 19 ;) (type $_)
+ (func $start:std/array-literal (; 19 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1279,9 +1279,9 @@
    unreachable
   end
  )
- (func $start (; 20 ;) (type $_)
+ (func $start (; 20 ;) (type $FUNCSIG$v)
   call $start:std/array-literal
  )
- (func $null (; 21 ;) (type $_)
+ (func $null (; 21 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -1,33 +1,26 @@
 (module
- (type $_ (func))
- (type $iii (func (param i32 i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $ii (func (param i32) (result i32)))
- (type $iii_ (func (param i32 i32 i32)))
- (type $iiiii (func (param i32 i32 i32 i32) (result i32)))
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $i_ (func (param i32)))
- (type $ii_ (func (param i32 i32)))
- (type $iiif (func (param i32 i32 i32) (result f32)))
- (type $F (func (result f64)))
- (type $I_ (func (param i64)))
- (type $ffi (func (param f32 f32) (result i32)))
- (type $FFi (func (param f64 f64) (result i32)))
- (type $Fi (func (param f64) (result i32)))
- (type $iiiii_ (func (param i32 i32 i32 i32 i32)))
- (type $iFi (func (param i32 f64) (result i32)))
- (type $iIiIiIii (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
- (type $iiFi (func (param i32 i32 f64) (result i32)))
- (type $Ii (func (param i64) (result i32)))
- (type $iIi_ (func (param i32 i64 i32)))
- (type $iiIi (func (param i32 i32 i64) (result i32)))
- (type $FUNCSIG$ii (func (param i32) (result i32)))
- (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$viii (func (param i32 i32 i32)))
- (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$iiiii (func (param i32 i32 i32 i32) (result i32)))
  (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
  (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$fiii (func (param i32 i32 i32) (result f32)))
+ (type $FUNCSIG$d (func (result f64)))
+ (type $FUNCSIG$vj (func (param i64)))
+ (type $FUNCSIG$iff (func (param f32 f32) (result i32)))
+ (type $FUNCSIG$idd (func (param f64 f64) (result i32)))
+ (type $FUNCSIG$id (func (param f64) (result i32)))
+ (type $FUNCSIG$viiiii (func (param i32 i32 i32 i32 i32)))
+ (type $FUNCSIG$iid (func (param i32 f64) (result i32)))
+ (type $FUNCSIG$iijijiji (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
+ (type $FUNCSIG$iiid (func (param i32 i32 f64) (result i32)))
+ (type $FUNCSIG$ij (func (param i64) (result i32)))
+ (type $FUNCSIG$viji (func (param i32 i64 i32)))
+ (type $FUNCSIG$iiij (func (param i32 i32 i64) (result i32)))
  (type $FUNCSIG$i (func (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (import "Math" "random" (func $~lib/bindings/Math/random (result f64)))
@@ -398,7 +391,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -460,7 +453,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/internal/arraybuffer/allocateUnsafe (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/allocateUnsafe (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 1073741816
@@ -487,7 +480,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memset (; 4 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 4 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i64)
   local.get $2
@@ -1041,7 +1034,7 @@
    end
   end
  )
- (func $std/array/isArraysEqual<u32> (; 11 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<u32> (; 11 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -1147,7 +1140,7 @@
   local.get $3
   call $~lib/array/Array<u32>#fill
  )
- (func $~lib/internal/memory/memcpy (; 13 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 13 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2044,7 +2037,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 14 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 14 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -2242,7 +2235,7 @@
    end
   end
  )
- (func $~lib/internal/arraybuffer/reallocateUnsafe (; 15 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/arraybuffer/reallocateUnsafe (; 15 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -2375,7 +2368,7 @@
   local.get $1
   i32.store offset=8
  )
- (func $~lib/array/Array<i32>#pop (; 17 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#pop (; 17 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -2407,7 +2400,7 @@
   i32.store offset=4
   local.get $2
  )
- (func $~lib/array/Array<i32>#concat (; 18 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#concat (; 18 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2459,7 +2452,7 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<i32>#copyWithin (; 19 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/array/Array<i32>#copyWithin (; 19 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -2718,7 +2711,7 @@
   local.get $4
   i32.store offset=4
  )
- (func $~lib/array/Array<i32>#shift (; 22 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#shift (; 22 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2820,7 +2813,7 @@
    end
   end
  )
- (func $~lib/array/Array<i32>#indexOf (; 24 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#indexOf (; 24 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -2884,7 +2877,7 @@
   end
   i32.const -1
  )
- (func $~lib/array/Array<i32>#splice (; 25 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#splice (; 25 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2998,7 +2991,7 @@
   local.get $2
   call $~lib/array/Array<i32>#splice
  )
- (func $~lib/array/Array<i32>#__set (; 27 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__set (; 27 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -3044,11 +3037,11 @@
   local.get $2
   i32.store offset=8
  )
- (func $start:std/array~anonymous|0 (; 28 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|0 (; 28 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.eqz
  )
- (func $~lib/array/Array<i32>#findIndex (; 29 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#findIndex (; 29 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3081,7 +3074,7 @@
     local.get $2
     local.get $0
     local.get $1
-    call_indirect (type $iiii)
+    call_indirect (type $FUNCSIG$iiii)
     if
      local.get $2
      return
@@ -3097,17 +3090,17 @@
   end
   i32.const -1
  )
- (func $start:std/array~anonymous|1 (; 30 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|1 (; 30 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 1
   i32.eq
  )
- (func $start:std/array~anonymous|2 (; 31 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|2 (; 31 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 100
   i32.eq
  )
- (func $start:std/array~anonymous|3 (; 32 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|3 (; 32 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3115,7 +3108,7 @@
   i32.const 100
   i32.eq
  )
- (func $start:std/array~anonymous|5 (; 33 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|5 (; 33 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -3123,12 +3116,12 @@
   i32.const 100
   i32.eq
  )
- (func $start:std/array~anonymous|6 (; 34 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|6 (; 34 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 0
   i32.ge_s
  )
- (func $~lib/array/Array<i32>#every (; 35 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#every (; 35 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3161,7 +3154,7 @@
     local.get $2
     local.get $0
     local.get $1
-    call_indirect (type $iiii)
+    call_indirect (type $FUNCSIG$iiii)
     if
      local.get $2
      i32.const 1
@@ -3177,12 +3170,12 @@
   end
   i32.const 1
  )
- (func $start:std/array~anonymous|7 (; 36 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|7 (; 36 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 0
   i32.le_s
  )
- (func $start:std/array~anonymous|8 (; 37 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|8 (; 37 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3190,12 +3183,12 @@
   i32.const 10
   i32.lt_s
  )
- (func $start:std/array~anonymous|9 (; 38 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|9 (; 38 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 10
   i32.lt_s
  )
- (func $start:std/array~anonymous|10 (; 39 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|10 (; 39 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -3203,12 +3196,12 @@
   i32.const 3
   i32.lt_s
  )
- (func $start:std/array~anonymous|11 (; 40 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|11 (; 40 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 3
   i32.ge_s
  )
- (func $~lib/array/Array<i32>#some (; 41 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#some (; 41 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3241,7 +3234,7 @@
     local.get $2
     local.get $0
     local.get $1
-    call_indirect (type $iiii)
+    call_indirect (type $FUNCSIG$iiii)
     if
      i32.const 1
      return
@@ -3257,12 +3250,12 @@
   end
   i32.const 0
  )
- (func $start:std/array~anonymous|12 (; 42 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|12 (; 42 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const -1
   i32.le_s
  )
- (func $start:std/array~anonymous|13 (; 43 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|13 (; 43 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3270,12 +3263,12 @@
   i32.const 10
   i32.gt_s
  )
- (func $start:std/array~anonymous|14 (; 44 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|14 (; 44 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 10
   i32.gt_s
  )
- (func $start:std/array~anonymous|15 (; 45 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|15 (; 45 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -3283,13 +3276,13 @@
   i32.const 3
   i32.gt_s
  )
- (func $start:std/array~anonymous|16 (; 46 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|16 (; 46 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   global.get $std/array/i
   local.get $0
   i32.add
   global.set $std/array/i
  )
- (func $~lib/array/Array<i32>#forEach (; 47 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#forEach (; 47 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3322,7 +3315,7 @@
     local.get $2
     local.get $0
     local.get $1
-    call_indirect (type $iii_)
+    call_indirect (type $FUNCSIG$viii)
     local.get $2
     i32.const 1
     i32.add
@@ -3333,7 +3326,7 @@
    unreachable
   end
  )
- (func $start:std/array~anonymous|17 (; 48 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|17 (; 48 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3342,7 +3335,7 @@
   i32.add
   global.set $std/array/i
  )
- (func $start:std/array~anonymous|19 (; 49 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|19 (; 49 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -3351,7 +3344,7 @@
   i32.add
   global.set $std/array/i
  )
- (func $start:std/array~anonymous|20 (; 50 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|20 (; 50 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
   i32.eqz
@@ -3448,7 +3441,7 @@
    end
   end
  )
- (func $start:std/array~anonymous|21 (; 51 ;) (type $iiif) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
+ (func $start:std/array~anonymous|21 (; 51 ;) (type $FUNCSIG$fiii) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
   local.get $0
   f32.convert_i32_s
  )
@@ -3494,7 +3487,7 @@
     local.get $2
     local.get $0
     i32.const 22
-    call_indirect (type $iiif)
+    call_indirect (type $FUNCSIG$fiii)
     f32.store offset=8
     local.get $2
     i32.const 1
@@ -3505,7 +3498,7 @@
   end
   local.get $4
  )
- (func $start:std/array~anonymous|22 (; 53 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|22 (; 53 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3555,7 +3548,7 @@
     local.get $3
     local.get $0
     local.get $1
-    call_indirect (type $iiii)
+    call_indirect (type $FUNCSIG$iiii)
     i32.store offset=8
     local.get $3
     i32.const 1
@@ -3565,14 +3558,14 @@
    end
   end
  )
- (func $start:std/array~anonymous|23 (; 55 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|23 (; 55 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   global.get $std/array/i
   local.get $0
   i32.add
   global.set $std/array/i
   local.get $0
  )
- (func $start:std/array~anonymous|24 (; 56 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|24 (; 56 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -3582,12 +3575,12 @@
   global.set $std/array/i
   local.get $0
  )
- (func $start:std/array~anonymous|25 (; 57 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|25 (; 57 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.ge_s
  )
- (func $~lib/array/Array<i32>#filter (; 58 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#filter (; 58 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3626,7 +3619,7 @@
     local.get $3
     local.get $0
     local.get $1
-    call_indirect (type $iiii)
+    call_indirect (type $FUNCSIG$iiii)
     if
      local.get $4
      local.get $2
@@ -3641,7 +3634,7 @@
   end
   local.get $4
  )
- (func $start:std/array~anonymous|26 (; 59 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|26 (; 59 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -3653,7 +3646,7 @@
   i32.const 2
   i32.ge_s
  )
- (func $start:std/array~anonymous|27 (; 60 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|27 (; 60 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   global.get $std/array/i
   local.get $0
   i32.add
@@ -3662,7 +3655,7 @@
   i32.const 2
   i32.ge_s
  )
- (func $start:std/array~anonymous|28 (; 61 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|28 (; 61 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -3674,12 +3667,12 @@
   i32.const 2
   i32.ge_s
  )
- (func $start:std/array~anonymous|29 (; 62 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|29 (; 62 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $~lib/array/Array<i32>#reduce<i32> (; 63 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduce<i32> (; 63 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3716,7 +3709,7 @@
     local.get $2
     local.get $0
     local.get $1
-    call_indirect (type $iiiii)
+    call_indirect (type $FUNCSIG$iiiii)
     local.set $3
     local.get $2
     i32.const 1
@@ -3727,7 +3720,7 @@
   end
   local.get $3
  )
- (func $start:std/array~anonymous|31 (; 64 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|31 (; 64 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 2
@@ -3735,7 +3728,7 @@
   local.get $0
   select
  )
- (func $start:std/array~anonymous|32 (; 65 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|32 (; 65 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.const 100
@@ -3743,7 +3736,7 @@
   local.get $0
   select
  )
- (func $start:std/array~anonymous|33 (; 66 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|33 (; 66 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $3
   i32.const 1
   call $~lib/array/Array<i32>#push
@@ -3751,7 +3744,7 @@
   local.get $1
   i32.add
  )
- (func $start:std/array~anonymous|35 (; 67 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|35 (; 67 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $3
   call $~lib/array/Array<i32>#pop
   drop
@@ -3759,7 +3752,7 @@
   local.get $1
   i32.add
  )
- (func $~lib/array/Array<i32>#reduceRight<i32> (; 68 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduceRight<i32> (; 68 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load offset=4
@@ -3785,7 +3778,7 @@
     local.get $3
     local.get $0
     local.get $1
-    call_indirect (type $iiiii)
+    call_indirect (type $FUNCSIG$iiiii)
     local.set $2
     local.get $3
     i32.const 1
@@ -3796,7 +3789,7 @@
   end
   local.get $2
  )
- (func $~lib/math/splitMix32 (; 69 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/math/splitMix32 (; 69 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 1831565813
   i32.add
@@ -3828,7 +3821,7 @@
   i32.shr_u
   i32.xor
  )
- (func $~lib/math/NativeMath.seedRandom (; 70 ;) (type $I_) (param $0 i64)
+ (func $~lib/math/NativeMath.seedRandom (; 70 ;) (type $FUNCSIG$vj) (param $0 i64)
   (local $1 i64)
   local.get $0
   i64.eqz
@@ -3934,7 +3927,7 @@
        local.get $5
        local.get $6
        local.get $2
-       call_indirect (type $ffi)
+       call_indirect (type $FUNCSIG$iff)
        i32.const 0
        i32.ge_s
        br_if $break|1
@@ -4055,7 +4048,7 @@
     local.get $6
     local.get $5
     local.get $2
-    call_indirect (type $ffi)
+    call_indirect (type $FUNCSIG$iff)
     i32.const 0
     i32.lt_s
     if
@@ -4172,7 +4165,7 @@
       local.get $5
       local.get $6
       local.get $2
-      call_indirect (type $ffi)
+      call_indirect (type $FUNCSIG$iff)
       i32.const 0
       i32.lt_s
       if
@@ -4275,7 +4268,7 @@
    local.get $3
    local.get $4
    local.get $1
-   call_indirect (type $ffi)
+   call_indirect (type $FUNCSIG$iff)
    i32.const 0
    i32.lt_s
    if
@@ -4308,7 +4301,7 @@
    call $~lib/internal/sort/weakHeapSort<f32>
   end
  )
- (func $~lib/internal/sort/COMPARATOR<f32>~anonymous|0 (; 74 ;) (type $ffi) (param $0 f32) (param $1 f32) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<f32>~anonymous|0 (; 74 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -4503,7 +4496,7 @@
        local.get $5
        local.get $6
        local.get $2
-       call_indirect (type $FFi)
+       call_indirect (type $FUNCSIG$idd)
        i32.const 0
        i32.ge_s
        br_if $break|1
@@ -4624,7 +4617,7 @@
     local.get $6
     local.get $5
     local.get $2
-    call_indirect (type $FFi)
+    call_indirect (type $FUNCSIG$idd)
     i32.const 0
     i32.lt_s
     if
@@ -4741,7 +4734,7 @@
       local.get $5
       local.get $6
       local.get $2
-      call_indirect (type $FFi)
+      call_indirect (type $FUNCSIG$idd)
       i32.const 0
       i32.lt_s
       if
@@ -4844,7 +4837,7 @@
    local.get $3
    local.get $4
    local.get $1
-   call_indirect (type $FFi)
+   call_indirect (type $FUNCSIG$idd)
    i32.const 0
    i32.lt_s
    if
@@ -4877,7 +4870,7 @@
    call $~lib/internal/sort/weakHeapSort<f64>
   end
  )
- (func $~lib/internal/sort/COMPARATOR<f64>~anonymous|0 (; 79 ;) (type $FFi) (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<f64>~anonymous|0 (; 79 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   local.get $0
@@ -5072,7 +5065,7 @@
        local.get $5
        local.get $6
        local.get $2
-       call_indirect (type $iii)
+       call_indirect (type $FUNCSIG$iii)
        i32.const 0
        i32.ge_s
        br_if $break|1
@@ -5193,7 +5186,7 @@
     local.get $5
     local.get $3
     local.get $2
-    call_indirect (type $iii)
+    call_indirect (type $FUNCSIG$iii)
     i32.const 0
     i32.lt_s
     if
@@ -5310,7 +5303,7 @@
       local.get $6
       local.get $3
       local.get $2
-      call_indirect (type $iii)
+      call_indirect (type $FUNCSIG$iii)
       i32.const 0
       i32.lt_s
       if
@@ -5370,7 +5363,7 @@
   local.get $3
   i32.store offset=8
  )
- (func $~lib/array/Array<i32>#sort (; 83 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#sort (; 83 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5413,7 +5406,7 @@
    local.get $3
    local.get $4
    local.get $1
-   call_indirect (type $iii)
+   call_indirect (type $FUNCSIG$iii)
    i32.const 0
    i32.lt_s
    if
@@ -5449,12 +5442,12 @@
   end
   local.get $0
  )
- (func $~lib/internal/sort/COMPARATOR<i32>~anonymous|0 (; 84 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<i32>~anonymous|0 (; 84 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $~lib/internal/sort/COMPARATOR<u32>~anonymous|0 (; 85 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<u32>~anonymous|0 (; 85 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.gt_u
@@ -5463,7 +5456,7 @@
   i32.lt_u
   i32.sub
  )
- (func $std/array/createReverseOrderedArray (; 86 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array/createReverseOrderedArray (; 86 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/array/Array<i32>#constructor
@@ -5495,7 +5488,7 @@
   end
   local.get $1
  )
- (func $~lib/math/NativeMath.random (; 87 ;) (type $F) (result f64)
+ (func $~lib/math/NativeMath.random (; 87 ;) (type $FUNCSIG$d) (result f64)
   (local $0 i64)
   (local $1 i64)
   global.get $~lib/math/random_seeded
@@ -5542,7 +5535,7 @@
   f64.const 1
   f64.sub
  )
- (func $std/array/createRandomOrderedArray (; 88 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array/createRandomOrderedArray (; 88 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/array/Array<i32>#constructor
@@ -5572,7 +5565,7 @@
   end
   local.get $0
  )
- (func $std/array/isSorted<i32> (; 89 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<i32> (; 89 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5629,7 +5622,7 @@
      unreachable
     end
     local.get $1
-    call_indirect (type $iii)
+    call_indirect (type $FUNCSIG$iii)
     i32.const 0
     i32.gt_s
     if
@@ -5647,7 +5640,7 @@
   end
   i32.const 1
  )
- (func $std/array/assertSorted<i32> (; 90 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<i32> (; 90 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   call $~lib/array/Array<i32>#sort
@@ -5663,12 +5656,12 @@
    unreachable
   end
  )
- (func $std/array/assertSortedDefault<i32> (; 91 ;) (type $i_) (param $0 i32)
+ (func $std/array/assertSortedDefault<i32> (; 91 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 48
   call $std/array/assertSorted<i32>
  )
- (func $start:std/array~anonymous|44 (; 92 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|44 (; 92 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.sub
@@ -5726,7 +5719,7 @@
   end
   local.get $1
  )
- (func $start:std/array~anonymous|47 (; 94 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|47 (; 94 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load
@@ -5757,7 +5750,7 @@
   end
   i32.sub
  )
- (func $~lib/array/Array<Array<i32>>#sort (; 95 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Array<i32>>#sort (; 95 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5800,7 +5793,7 @@
    local.get $2
    local.get $4
    local.get $1
-   call_indirect (type $iii)
+   call_indirect (type $FUNCSIG$iii)
    i32.const 0
    i32.lt_s
    if
@@ -5822,7 +5815,7 @@
   call $~lib/internal/sort/insertionSort<i32>
   local.get $0
  )
- (func $std/array/assertSorted<Array<i32>> (; 96 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<Array<i32>> (; 96 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   call $~lib/array/Array<Array<i32>>#sort
@@ -5877,7 +5870,7 @@
   end
   local.get $0
  )
- (func $start:std/array~anonymous|48 (; 98 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|48 (; 98 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load
   local.get $1
@@ -5917,7 +5910,7 @@
   end
   local.get $3
  )
- (func $~lib/internal/sort/COMPARATOR<String>~anonymous|0 (; 100 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<String>~anonymous|0 (; 100 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6003,7 +5996,7 @@
   local.get $1
   call $std/array/assertSorted<Array<i32>>
  )
- (func $~lib/string/String.__eq (; 102 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 102 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -6120,7 +6113,7 @@
   end
   i32.const 1
  )
- (func $~lib/internal/string/allocateUnsafe (; 104 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/string/allocateUnsafe (; 104 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 0
@@ -6175,7 +6168,7 @@
   i32.store16 offset=4
   local.get $1
  )
- (func $~lib/internal/string/copyUnsafe (; 106 ;) (type $iiiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
+ (func $~lib/internal/string/copyUnsafe (; 106 ;) (type $FUNCSIG$viiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
   local.get $1
   i32.const 1
   i32.shl
@@ -6195,7 +6188,7 @@
   i32.shl
   call $~lib/internal/memory/memmove
  )
- (func $~lib/string/String#concat (; 107 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#concat (; 107 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6242,7 +6235,7 @@
   call $~lib/internal/string/copyUnsafe
   local.get $2
  )
- (func $~lib/string/String.__concat (; 108 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (; 108 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.const 4144
   local.get $0
@@ -6250,7 +6243,7 @@
   local.get $1
   call $~lib/string/String#concat
  )
- (func $std/array/createRandomString (; 109 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array/createRandomString (; 109 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 3904
@@ -6538,7 +6531,7 @@
   end
   local.get $3
  )
- (func $~lib/internal/number/decimalCount32 (; 113 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/decimalCount32 (; 113 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -6592,7 +6585,7 @@
    end
   end
  )
- (func $~lib/internal/number/utoa32_lut (; 114 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/number/utoa32_lut (; 114 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   i32.const 4832
@@ -6702,7 +6695,7 @@
    i32.store16 offset=4
   end
  )
- (func $~lib/internal/number/itoa32 (; 115 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/itoa32 (; 115 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6740,7 +6733,7 @@
   end
   local.get $2
  )
- (func $~lib/internal/number/itoa_stream<i32> (; 116 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/internal/number/itoa_stream<i32> (; 116 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   i32.const 1
   i32.shl
@@ -6784,7 +6777,7 @@
   end
   local.get $2
  )
- (func $~lib/array/Array<i32>#join (; 117 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#join (; 117 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6900,7 +6893,7 @@
   end
   local.get $3
  )
- (func $~lib/internal/number/utoa32 (; 118 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/utoa32 (; 118 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -6919,7 +6912,7 @@
   call $~lib/internal/number/utoa32_lut
   local.get $2
  )
- (func $~lib/internal/number/itoa_stream<u32> (; 119 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/internal/number/itoa_stream<u32> (; 119 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 1
@@ -6944,7 +6937,7 @@
   call $~lib/internal/number/utoa32_lut
   local.get $3
  )
- (func $~lib/array/Array<u32>#join (; 120 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#join (; 120 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7060,7 +7053,7 @@
   end
   local.get $3
  )
- (func $~lib/internal/number/genDigits (; 121 ;) (type $iIiIiIii) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/internal/number/genDigits (; 121 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i32)
@@ -7474,7 +7467,7 @@
    local.get $10
   end
  )
- (func $~lib/internal/number/prettify (; 122 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/internal/number/prettify (; 122 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7748,7 +7741,7 @@
    end
   end
  )
- (func $~lib/internal/number/dtoa_core (; 123 ;) (type $iFi) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/internal/number/dtoa_core (; 123 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   (local $4 i32)
@@ -8063,7 +8056,7 @@
   local.get $13
   i32.add
  )
- (func $~lib/internal/number/dtoa (; 124 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $~lib/internal/number/dtoa (; 124 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -8116,7 +8109,7 @@
   end
   local.get $1
  )
- (func $~lib/internal/number/dtoa_stream (; 125 ;) (type $iiFi) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
+ (func $~lib/internal/number/dtoa_stream (; 125 ;) (type $FUNCSIG$iiid) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
   local.get $1
   i32.const 1
   i32.shl
@@ -8306,7 +8299,7 @@
   end
   local.get $1
  )
- (func $~lib/array/Array<String>#join (; 127 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<String>#join (; 127 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8572,7 +8565,7 @@
   end
   local.get $3
  )
- (func $~lib/internal/number/itoa_stream<i8> (; 129 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/internal/number/itoa_stream<i8> (; 129 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 1
@@ -8740,7 +8733,7 @@
   end
   local.get $1
  )
- (func $~lib/internal/number/itoa_stream<u16> (; 131 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/internal/number/itoa_stream<u16> (; 131 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   i32.const 1
   i32.shl
@@ -8887,7 +8880,7 @@
   end
   local.get $1
  )
- (func $~lib/internal/number/decimalCount64 (; 133 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/number/decimalCount64 (; 133 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   local.get $0
   i64.const 1000000000000000
   i64.lt_u
@@ -8941,7 +8934,7 @@
    end
   end
  )
- (func $~lib/internal/number/utoa64_lut (; 134 ;) (type $iIi_) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/internal/number/utoa64_lut (; 134 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9038,7 +9031,7 @@
   local.get $2
   call $~lib/internal/number/utoa32_lut
  )
- (func $~lib/internal/number/utoa64 (; 135 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/number/utoa64 (; 135 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9074,7 +9067,7 @@
   end
   local.get $2
  )
- (func $~lib/internal/number/itoa_stream<u64> (; 136 ;) (type $iiIi) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/internal/number/itoa_stream<u64> (; 136 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 1
@@ -9231,7 +9224,7 @@
   end
   local.get $1
  )
- (func $~lib/internal/number/itoa64 (; 138 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/number/itoa64 (; 138 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9290,7 +9283,7 @@
   end
   local.get $3
  )
- (func $~lib/internal/number/itoa_stream<i64> (; 139 ;) (type $iiIi) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/internal/number/itoa_stream<i64> (; 139 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -9565,7 +9558,7 @@
   end
   local.get $1
  )
- (func $~lib/internal/number/itoa_stream<u8> (; 142 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/internal/number/itoa_stream<u8> (; 142 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   i32.const 1
   i32.shl
@@ -9986,7 +9979,7 @@
   end
   local.get $1
  )
- (func $start:std/array (; 147 ;) (type $_)
+ (func $start:std/array (; 147 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 7912
@@ -14392,10 +14385,10 @@
    unreachable
   end
  )
- (func $start (; 148 ;) (type $_)
+ (func $start (; 148 ;) (type $FUNCSIG$v)
   call $start:std/array
  )
- (func $null (; 149 ;) (type $_)
+ (func $null (; 149 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -1,31 +1,31 @@
 (module
- (type $_ (func))
- (type $iii (func (param i32 i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $ii (func (param i32) (result i32)))
- (type $iii_ (func (param i32 i32 i32)))
- (type $iiiii (func (param i32 i32 i32 i32) (result i32)))
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $i_ (func (param i32)))
- (type $ii_ (func (param i32 i32)))
- (type $iiif (func (param i32 i32 i32) (result f32)))
- (type $iif (func (param i32 i32) (result f32)))
- (type $F (func (result f64)))
- (type $I_ (func (param i64)))
- (type $II (func (param i64) (result i64)))
- (type $ffi (func (param f32 f32) (result i32)))
- (type $fi (func (param f32) (result i32)))
- (type $FFi (func (param f64 f64) (result i32)))
- (type $iiF (func (param i32 i32) (result f64)))
- (type $Fi (func (param f64) (result i32)))
- (type $iiiiii (func (param i32 i32 i32 i32 i32) (result i32)))
- (type $iiiii_ (func (param i32 i32 i32 i32 i32)))
- (type $iFi (func (param i32 f64) (result i32)))
- (type $iIiIiIii (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
- (type $iiFi (func (param i32 i32 f64) (result i32)))
- (type $Ii (func (param i64) (result i32)))
- (type $iIi_ (func (param i32 i64 i32)))
- (type $iiIi (func (param i32 i32 i64) (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$iiiii (func (param i32 i32 i32 i32) (result i32)))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$fiii (func (param i32 i32 i32) (result f32)))
+ (type $FUNCSIG$fii (func (param i32 i32) (result f32)))
+ (type $FUNCSIG$d (func (result f64)))
+ (type $FUNCSIG$vj (func (param i64)))
+ (type $FUNCSIG$jj (func (param i64) (result i64)))
+ (type $FUNCSIG$iff (func (param f32 f32) (result i32)))
+ (type $FUNCSIG$if (func (param f32) (result i32)))
+ (type $FUNCSIG$idd (func (param f64 f64) (result i32)))
+ (type $FUNCSIG$dii (func (param i32 i32) (result f64)))
+ (type $FUNCSIG$id (func (param f64) (result i32)))
+ (type $FUNCSIG$iiiiii (func (param i32 i32 i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viiiii (func (param i32 i32 i32 i32 i32)))
+ (type $FUNCSIG$iid (func (param i32 f64) (result i32)))
+ (type $FUNCSIG$iijijiji (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
+ (type $FUNCSIG$iiid (func (param i32 i32 f64) (result i32)))
+ (type $FUNCSIG$ij (func (param i64) (result i32)))
+ (type $FUNCSIG$viji (func (param i32 i64 i32)))
+ (type $FUNCSIG$iiij (func (param i32 i32 i64) (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (import "Math" "random" (func $~lib/bindings/Math/random (result f64)))
  (memory $0 1)
@@ -400,7 +400,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:~lib/allocator/arena (; 2 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 2 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -412,7 +412,7 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $~lib/internal/arraybuffer/computeSize (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/computeSize (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   i32.const 32
   local.get $0
@@ -424,7 +424,7 @@
   i32.sub
   i32.shl
  )
- (func $~lib/allocator/arena/__memory_allocate (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -503,7 +503,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/internal/arraybuffer/allocateUnsafe (; 5 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/allocateUnsafe (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -532,12 +532,12 @@
   i32.store
   local.get $1
  )
- (func $~lib/memory/memory.allocate (; 6 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/memory/memory.allocate (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/allocator/arena/__memory_allocate
   return
  )
- (func $~lib/internal/memory/memset (; 7 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 7 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -791,7 +791,7 @@
    end
   end
  )
- (func $~lib/array/Array<i32>#constructor (; 8 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#constructor (; 8 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -852,7 +852,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array.isArray<Array<i32> | null> (; 9 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array.isArray<Array<i32> | null> (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   if (result i32)
    local.get $0
@@ -862,7 +862,7 @@
    i32.const 1
   end
  )
- (func $~lib/array/Array.isArray<Array<i32>> (; 10 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array.isArray<Array<i32>> (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   if (result i32)
    local.get $0
@@ -872,7 +872,7 @@
    i32.const 1
   end
  )
- (func $std/array/P#constructor (; 11 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array/P#constructor (; 11 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -882,7 +882,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array.isArray<P> (; 12 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array.isArray<P> (; 12 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   if (result i32)
    local.get $0
@@ -892,7 +892,7 @@
    i32.const 0
   end
  )
- (func $~lib/internal/typedarray/TypedArray<u8>#constructor (; 13 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<u8>#constructor (; 13 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -959,7 +959,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/typedarray/Uint8Array#constructor (; 14 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#constructor (; 14 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -973,7 +973,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/array/Array.isArray<Uint8Array> (; 15 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array.isArray<Uint8Array> (; 15 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   if (result i32)
    local.get $0
@@ -983,7 +983,7 @@
    i32.const 0
   end
  )
- (func $~lib/array/Array.isArray<i32> (; 16 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array.isArray<i32> (; 16 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   if (result i32)
    local.get $0
@@ -993,7 +993,7 @@
    i32.const 0
   end
  )
- (func $~lib/array/Array.isArray<String> (; 17 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array.isArray<String> (; 17 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   if (result i32)
    local.get $0
@@ -1003,7 +1003,7 @@
    i32.const 0
   end
  )
- (func $~lib/array/Array<u8>#fill (; 18 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/array/Array<u8>#fill (; 18 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1088,7 +1088,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<u8>#__get (; 19 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__get (; 19 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1121,7 +1121,7 @@
    unreachable
   end
  )
- (func $std/array/isArraysEqual<u8> (; 20 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<u8> (; 20 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
@@ -1188,7 +1188,7 @@
   end
   i32.const 1
  )
- (func $~lib/array/Array<u8>#fill|trampoline (; 21 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/array/Array<u8>#fill|trampoline (; 21 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -1212,7 +1212,7 @@
   local.get $3
   call $~lib/array/Array<u8>#fill
  )
- (func $~lib/array/Array<u32>#fill (; 22 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/array/Array<u32>#fill (; 22 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1312,7 +1312,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<u32>#__get (; 23 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#__get (; 23 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1345,7 +1345,7 @@
    unreachable
   end
  )
- (func $std/array/isArraysEqual<u32> (; 24 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<u32> (; 24 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
@@ -1408,7 +1408,7 @@
   end
   i32.const 1
  )
- (func $~lib/array/Array<u32>#fill|trampoline (; 25 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/array/Array<u32>#fill|trampoline (; 25 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -1432,7 +1432,7 @@
   local.get $3
   call $~lib/array/Array<u32>#fill
  )
- (func $std/array/internalCapacity<i32> (; 26 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array/internalCapacity<i32> (; 26 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.load
@@ -1442,7 +1442,7 @@
   i32.const 2
   i32.shr_s
  )
- (func $~lib/internal/memory/memcpy (; 27 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 27 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2643,7 +2643,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 28 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 28 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -2870,10 +2870,10 @@
    end
   end
  )
- (func $~lib/allocator/arena/__memory_free (; 29 ;) (type $i_) (param $0 i32)
+ (func $~lib/allocator/arena/__memory_free (; 29 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $~lib/internal/arraybuffer/reallocateUnsafe (; 30 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/arraybuffer/reallocateUnsafe (; 30 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2980,7 +2980,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<i32>#push (; 31 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#push (; 31 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3053,7 +3053,7 @@
   end
   local.get $5
  )
- (func $~lib/array/Array<i32>#__get (; 32 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (; 32 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3086,7 +3086,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<i32>#pop (; 33 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#pop (; 33 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3132,7 +3132,7 @@
   i32.store offset=4
   local.get $5
  )
- (func $~lib/array/Array<i32>#concat (; 34 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#concat (; 34 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3207,7 +3207,7 @@
   end
   local.get $5
  )
- (func $~lib/array/Array<i32>#copyWithin (; 35 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/array/Array<i32>#copyWithin (; 35 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3432,7 +3432,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<i32>#copyWithin|trampoline (; 36 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/array/Array<i32>#copyWithin|trampoline (; 36 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -3452,7 +3452,7 @@
   local.get $3
   call $~lib/array/Array<i32>#copyWithin
  )
- (func $std/array/isArraysEqual<i32> (; 37 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<i32> (; 37 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
@@ -3515,7 +3515,7 @@
   end
   i32.const 1
  )
- (func $~lib/array/Array<i32>#unshift (; 38 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#unshift (; 38 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3615,7 +3615,7 @@
   i32.store offset=4
   local.get $5
  )
- (func $~lib/array/Array<i32>#shift (; 39 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#shift (; 39 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3706,7 +3706,7 @@
   i32.store offset=4
   local.get $6
  )
- (func $~lib/array/Array<i32>#reverse (; 40 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#reverse (; 40 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3824,7 +3824,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<i32>#indexOf (; 41 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#indexOf (; 41 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3907,7 +3907,7 @@
   end
   i32.const -1
  )
- (func $~lib/array/Array<i32>#splice (; 42 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#splice (; 42 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4030,7 +4030,7 @@
   i32.store offset=4
   local.get $7
  )
- (func $~lib/array/Array<i32>#splice|trampoline (; 43 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#splice|trampoline (; 43 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -4049,7 +4049,7 @@
   local.get $2
   call $~lib/array/Array<i32>#splice
  )
- (func $~lib/array/Array<i32>#__set (; 44 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__set (; 44 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4116,12 +4116,12 @@
    i32.store offset=8
   end
  )
- (func $start:std/array~anonymous|0 (; 45 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|0 (; 45 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 0
   i32.eq
  )
- (func $~lib/array/Array<i32>#findIndex (; 46 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#findIndex (; 46 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4172,7 +4172,7 @@
      local.get $2
      local.get $0
      local.get $1
-     call_indirect (type $iiii)
+     call_indirect (type $FUNCSIG$iiii)
     end
     i32.const 0
     i32.ne
@@ -4191,17 +4191,17 @@
   end
   i32.const -1
  )
- (func $start:std/array~anonymous|1 (; 47 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|1 (; 47 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 1
   i32.eq
  )
- (func $start:std/array~anonymous|2 (; 48 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|2 (; 48 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 100
   i32.eq
  )
- (func $start:std/array~anonymous|3 (; 49 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|3 (; 49 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -4210,12 +4210,12 @@
   i32.const 100
   i32.eq
  )
- (func $start:std/array~anonymous|4 (; 50 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|4 (; 50 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 100
   i32.eq
  )
- (func $start:std/array~anonymous|5 (; 51 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|5 (; 51 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -4223,12 +4223,12 @@
   i32.const 100
   i32.eq
  )
- (func $start:std/array~anonymous|6 (; 52 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|6 (; 52 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 0
   i32.ge_s
  )
- (func $~lib/array/Array<i32>#every (; 53 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#every (; 53 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4279,7 +4279,7 @@
      local.get $2
      local.get $0
      local.get $1
-     call_indirect (type $iiii)
+     call_indirect (type $FUNCSIG$iiii)
     end
     i32.const 0
     i32.ne
@@ -4299,12 +4299,12 @@
   end
   i32.const 1
  )
- (func $start:std/array~anonymous|7 (; 54 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|7 (; 54 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 0
   i32.le_s
  )
- (func $start:std/array~anonymous|8 (; 55 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|8 (; 55 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -4313,12 +4313,12 @@
   i32.const 10
   i32.lt_s
  )
- (func $start:std/array~anonymous|9 (; 56 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|9 (; 56 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 10
   i32.lt_s
  )
- (func $start:std/array~anonymous|10 (; 57 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|10 (; 57 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -4326,12 +4326,12 @@
   i32.const 3
   i32.lt_s
  )
- (func $start:std/array~anonymous|11 (; 58 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|11 (; 58 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 3
   i32.ge_s
  )
- (func $~lib/array/Array<i32>#some (; 59 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#some (; 59 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4382,7 +4382,7 @@
      local.get $2
      local.get $0
      local.get $1
-     call_indirect (type $iiii)
+     call_indirect (type $FUNCSIG$iiii)
     end
     i32.const 0
     i32.ne
@@ -4401,12 +4401,12 @@
   end
   i32.const 0
  )
- (func $start:std/array~anonymous|12 (; 60 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|12 (; 60 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const -1
   i32.le_s
  )
- (func $start:std/array~anonymous|13 (; 61 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|13 (; 61 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -4415,12 +4415,12 @@
   i32.const 10
   i32.gt_s
  )
- (func $start:std/array~anonymous|14 (; 62 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|14 (; 62 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 10
   i32.gt_s
  )
- (func $start:std/array~anonymous|15 (; 63 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|15 (; 63 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -4428,13 +4428,13 @@
   i32.const 3
   i32.gt_s
  )
- (func $start:std/array~anonymous|16 (; 64 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|16 (; 64 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   global.get $std/array/i
   local.get $0
   i32.add
   global.set $std/array/i
  )
- (func $~lib/array/Array<i32>#forEach (; 65 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#forEach (; 65 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4485,7 +4485,7 @@
      local.get $2
      local.get $0
      local.get $1
-     call_indirect (type $iii_)
+     call_indirect (type $FUNCSIG$viii)
     end
     local.get $2
     i32.const 1
@@ -4497,7 +4497,7 @@
    unreachable
   end
  )
- (func $start:std/array~anonymous|17 (; 66 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|17 (; 66 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -4507,13 +4507,13 @@
   i32.add
   global.set $std/array/i
  )
- (func $start:std/array~anonymous|18 (; 67 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|18 (; 67 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   global.get $std/array/i
   local.get $0
   i32.add
   global.set $std/array/i
  )
- (func $start:std/array~anonymous|19 (; 68 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|19 (; 68 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -4522,7 +4522,7 @@
   i32.add
   global.set $std/array/i
  )
- (func $start:std/array~anonymous|20 (; 69 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|20 (; 69 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
   i32.const 0
@@ -4637,11 +4637,11 @@
    end
   end
  )
- (func $start:std/array~anonymous|21 (; 70 ;) (type $iiif) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
+ (func $start:std/array~anonymous|21 (; 70 ;) (type $FUNCSIG$fiii) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
   local.get $0
   f32.convert_i32_s
  )
- (func $~lib/array/Array<f32>#constructor (; 71 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f32>#constructor (; 71 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4702,7 +4702,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<i32>#map<f32> (; 72 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#map<f32> (; 72 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4768,7 +4768,7 @@
       local.get $5
       local.get $0
       local.get $1
-      call_indirect (type $iiif)
+      call_indirect (type $FUNCSIG$fiii)
      end
      local.set $11
      i32.const 0
@@ -4794,7 +4794,7 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<f32>#__get (; 73 ;) (type $iif) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__get (; 73 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4827,7 +4827,7 @@
    unreachable
   end
  )
- (func $start:std/array~anonymous|22 (; 74 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|22 (; 74 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -4838,7 +4838,7 @@
   global.set $std/array/i
   local.get $0
  )
- (func $~lib/array/Array<i32>#map<i32> (; 75 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#map<i32> (; 75 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4903,7 +4903,7 @@
       local.get $5
       local.get $0
       local.get $1
-      call_indirect (type $iiii)
+      call_indirect (type $FUNCSIG$iiii)
      end
      local.set $10
      i32.const 0
@@ -4929,14 +4929,14 @@
   end
   local.get $3
  )
- (func $start:std/array~anonymous|23 (; 76 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|23 (; 76 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   global.get $std/array/i
   local.get $0
   i32.add
   global.set $std/array/i
   local.get $0
  )
- (func $start:std/array~anonymous|24 (; 77 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|24 (; 77 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -4946,12 +4946,12 @@
   global.set $std/array/i
   local.get $0
  )
- (func $start:std/array~anonymous|25 (; 78 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|25 (; 78 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.ge_s
  )
- (func $~lib/array/Array<i32>#filter (; 79 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#filter (; 79 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5010,7 +5010,7 @@
       local.get $3
       local.get $0
       local.get $1
-      call_indirect (type $iiii)
+      call_indirect (type $FUNCSIG$iiii)
      end
      i32.const 0
      i32.ne
@@ -5032,7 +5032,7 @@
   end
   local.get $2
  )
- (func $start:std/array~anonymous|26 (; 80 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|26 (; 80 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   i32.const 100
   call $~lib/array/Array<i32>#push
@@ -5045,7 +5045,7 @@
   i32.const 2
   i32.ge_s
  )
- (func $start:std/array~anonymous|27 (; 81 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|27 (; 81 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   global.get $std/array/i
   local.get $0
   i32.add
@@ -5054,7 +5054,7 @@
   i32.const 2
   i32.ge_s
  )
- (func $start:std/array~anonymous|28 (; 82 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|28 (; 82 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/array/Array<i32>#pop
   drop
@@ -5066,12 +5066,12 @@
   i32.const 2
   i32.ge_s
  )
- (func $start:std/array~anonymous|29 (; 83 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|29 (; 83 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $~lib/array/Array<i32>#reduce<i32> (; 84 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduce<i32> (; 84 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5126,7 +5126,7 @@
      local.get $4
      local.get $0
      local.get $1
-     call_indirect (type $iiiii)
+     call_indirect (type $FUNCSIG$iiiii)
     end
     local.set $3
     local.get $4
@@ -5140,12 +5140,12 @@
   end
   local.get $3
  )
- (func $start:std/array~anonymous|30 (; 85 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|30 (; 85 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $start:std/array~anonymous|31 (; 86 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|31 (; 86 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   i32.const 0
   i32.ne
@@ -5157,7 +5157,7 @@
    i32.gt_s
   end
  )
- (func $~lib/array/Array<i32>#reduce<bool> (; 87 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduce<bool> (; 87 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5212,7 +5212,7 @@
      local.get $4
      local.get $0
      local.get $1
-     call_indirect (type $iiiii)
+     call_indirect (type $FUNCSIG$iiiii)
     end
     local.set $3
     local.get $4
@@ -5226,7 +5226,7 @@
   end
   local.get $3
  )
- (func $start:std/array~anonymous|32 (; 88 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|32 (; 88 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   i32.const 0
   i32.ne
@@ -5238,7 +5238,7 @@
    i32.gt_s
   end
  )
- (func $start:std/array~anonymous|33 (; 89 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|33 (; 89 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $3
   i32.const 1
   call $~lib/array/Array<i32>#push
@@ -5247,12 +5247,12 @@
   local.get $1
   i32.add
  )
- (func $start:std/array~anonymous|34 (; 90 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|34 (; 90 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $start:std/array~anonymous|35 (; 91 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|35 (; 91 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $3
   call $~lib/array/Array<i32>#pop
   drop
@@ -5260,12 +5260,12 @@
   local.get $1
   i32.add
  )
- (func $start:std/array~anonymous|36 (; 92 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|36 (; 92 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $~lib/array/Array<i32>#reduceRight<i32> (; 93 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduceRight<i32> (; 93 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5309,7 +5309,7 @@
      local.get $4
      local.get $0
      local.get $1
-     call_indirect (type $iiiii)
+     call_indirect (type $FUNCSIG$iiiii)
     end
     local.set $3
     local.get $4
@@ -5323,12 +5323,12 @@
   end
   local.get $3
  )
- (func $start:std/array~anonymous|37 (; 94 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|37 (; 94 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $start:std/array~anonymous|38 (; 95 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|38 (; 95 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   i32.const 0
   i32.ne
@@ -5340,7 +5340,7 @@
    i32.gt_s
   end
  )
- (func $~lib/array/Array<i32>#reduceRight<bool> (; 96 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduceRight<bool> (; 96 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5384,7 +5384,7 @@
      local.get $4
      local.get $0
      local.get $1
-     call_indirect (type $iiiii)
+     call_indirect (type $FUNCSIG$iiiii)
     end
     local.set $3
     local.get $4
@@ -5398,7 +5398,7 @@
   end
   local.get $3
  )
- (func $start:std/array~anonymous|39 (; 97 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|39 (; 97 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   i32.const 0
   i32.ne
@@ -5410,7 +5410,7 @@
    i32.gt_s
   end
  )
- (func $start:std/array~anonymous|40 (; 98 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|40 (; 98 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $3
   i32.const 1
   call $~lib/array/Array<i32>#push
@@ -5419,12 +5419,12 @@
   local.get $1
   i32.add
  )
- (func $start:std/array~anonymous|41 (; 99 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|41 (; 99 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $start:std/array~anonymous|42 (; 100 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|42 (; 100 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $3
   call $~lib/array/Array<i32>#pop
   drop
@@ -5432,7 +5432,7 @@
   local.get $1
   i32.add
  )
- (func $~lib/math/murmurHash3 (; 101 ;) (type $II) (param $0 i64) (result i64)
+ (func $~lib/math/murmurHash3 (; 101 ;) (type $FUNCSIG$jj) (param $0 i64) (result i64)
   local.get $0
   local.get $0
   i64.const 33
@@ -5461,7 +5461,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/math/splitMix32 (; 102 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/math/splitMix32 (; 102 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 1831565813
   i32.add
@@ -5496,7 +5496,7 @@
   i32.shr_u
   i32.xor
  )
- (func $~lib/math/NativeMath.seedRandom (; 103 ;) (type $I_) (param $0 i64)
+ (func $~lib/math/NativeMath.seedRandom (; 103 ;) (type $FUNCSIG$vj) (param $0 i64)
   local.get $0
   i64.eqz
   if
@@ -5525,7 +5525,7 @@
   call $~lib/math/splitMix32
   global.set $~lib/math/random_state1_32
  )
- (func $~lib/internal/sort/insertionSort<f32> (; 104 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<f32> (; 104 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -5595,7 +5595,7 @@
           local.get $8
           local.get $10
           local.get $3
-          call_indirect (type $ffi)
+          call_indirect (type $FUNCSIG$iff)
          end
          i32.const 0
          i32.lt_s
@@ -5666,7 +5666,7 @@
    unreachable
   end
  )
- (func $~lib/internal/sort/weakHeapSort<f32> (; 105 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/weakHeapSort<f32> (; 105 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -5796,7 +5796,7 @@
       local.get $12
       local.get $13
       local.get $3
-      call_indirect (type $ffi)
+      call_indirect (type $FUNCSIG$iff)
      end
      i32.const 0
      i32.lt_s
@@ -6033,7 +6033,7 @@
           local.get $13
           local.get $12
           local.get $3
-          call_indirect (type $ffi)
+          call_indirect (type $FUNCSIG$iff)
          end
          i32.const 0
          i32.lt_s
@@ -6196,7 +6196,7 @@
    f32.store offset=8
   end
  )
- (func $~lib/array/Array<f32>#sort (; 106 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f32>#sort (; 106 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6273,7 +6273,7 @@
     local.get $7
     local.get $8
     local.get $1
-    call_indirect (type $ffi)
+    call_indirect (type $FUNCSIG$iff)
    end
    i32.const 0
    i32.lt_s
@@ -6348,7 +6348,7 @@
   end
   local.get $0
  )
- (func $~lib/internal/sort/COMPARATOR<f32>~anonymous|0 (; 107 ;) (type $ffi) (param $0 f32) (param $1 f32) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<f32>~anonymous|0 (; 107 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -6381,7 +6381,7 @@
   i32.lt_s
   i32.sub
  )
- (func $~lib/array/Array<f32>#sort|trampoline (; 108 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f32>#sort|trampoline (; 108 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -6400,12 +6400,12 @@
   local.get $1
   call $~lib/array/Array<f32>#sort
  )
- (func $~lib/builtins/isNaN<f32> (; 109 ;) (type $fi) (param $0 f32) (result i32)
+ (func $~lib/builtins/isNaN<f32> (; 109 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
   local.get $0
   local.get $0
   f32.ne
  )
- (func $std/array/isArraysEqual<f32> (; 110 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<f32> (; 110 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
@@ -6484,7 +6484,7 @@
   end
   i32.const 1
  )
- (func $~lib/internal/sort/insertionSort<f64> (; 111 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<f64> (; 111 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -6554,7 +6554,7 @@
           local.get $8
           local.get $10
           local.get $3
-          call_indirect (type $FFi)
+          call_indirect (type $FUNCSIG$idd)
          end
          i32.const 0
          i32.lt_s
@@ -6625,7 +6625,7 @@
    unreachable
   end
  )
- (func $~lib/internal/sort/weakHeapSort<f64> (; 112 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/weakHeapSort<f64> (; 112 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -6755,7 +6755,7 @@
       local.get $12
       local.get $13
       local.get $3
-      call_indirect (type $FFi)
+      call_indirect (type $FUNCSIG$idd)
      end
      i32.const 0
      i32.lt_s
@@ -6992,7 +6992,7 @@
           local.get $13
           local.get $12
           local.get $3
-          call_indirect (type $FFi)
+          call_indirect (type $FUNCSIG$idd)
          end
          i32.const 0
          i32.lt_s
@@ -7155,7 +7155,7 @@
    f64.store offset=8
   end
  )
- (func $~lib/array/Array<f64>#sort (; 113 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f64>#sort (; 113 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7232,7 +7232,7 @@
     local.get $7
     local.get $8
     local.get $1
-    call_indirect (type $FFi)
+    call_indirect (type $FUNCSIG$idd)
    end
    i32.const 0
    i32.lt_s
@@ -7307,7 +7307,7 @@
   end
   local.get $0
  )
- (func $~lib/internal/sort/COMPARATOR<f64>~anonymous|0 (; 114 ;) (type $FFi) (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<f64>~anonymous|0 (; 114 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   local.get $0
@@ -7340,7 +7340,7 @@
   i64.lt_s
   i32.sub
  )
- (func $~lib/array/Array<f64>#sort|trampoline (; 115 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f64>#sort|trampoline (; 115 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -7359,7 +7359,7 @@
   local.get $1
   call $~lib/array/Array<f64>#sort
  )
- (func $~lib/array/Array<f64>#__get (; 116 ;) (type $iiF) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__get (; 116 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7392,12 +7392,12 @@
    unreachable
   end
  )
- (func $~lib/builtins/isNaN<f64> (; 117 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $~lib/builtins/isNaN<f64> (; 117 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   local.get $0
   f64.ne
  )
- (func $std/array/isArraysEqual<f64> (; 118 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<f64> (; 118 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
@@ -7476,7 +7476,7 @@
   end
   i32.const 1
  )
- (func $~lib/internal/sort/insertionSort<i32> (; 119 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<i32> (; 119 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -7546,7 +7546,7 @@
           local.get $7
           local.get $9
           local.get $3
-          call_indirect (type $iii)
+          call_indirect (type $FUNCSIG$iii)
          end
          i32.const 0
          i32.lt_s
@@ -7617,7 +7617,7 @@
    unreachable
   end
  )
- (func $~lib/internal/sort/weakHeapSort<i32> (; 120 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/weakHeapSort<i32> (; 120 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -7747,7 +7747,7 @@
       local.get $11
       local.get $12
       local.get $3
-      call_indirect (type $iii)
+      call_indirect (type $FUNCSIG$iii)
      end
      i32.const 0
      i32.lt_s
@@ -7984,7 +7984,7 @@
           local.get $5
           local.get $10
           local.get $3
-          call_indirect (type $iii)
+          call_indirect (type $FUNCSIG$iii)
          end
          i32.const 0
          i32.lt_s
@@ -8147,7 +8147,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<i32>#sort (; 121 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#sort (; 121 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8223,7 +8223,7 @@
     local.get $6
     local.get $7
     local.get $1
-    call_indirect (type $iii)
+    call_indirect (type $FUNCSIG$iii)
    end
    i32.const 0
    i32.lt_s
@@ -8298,12 +8298,12 @@
   end
   local.get $0
  )
- (func $~lib/internal/sort/COMPARATOR<i32>~anonymous|0 (; 122 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<i32>~anonymous|0 (; 122 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $~lib/array/Array<i32>#sort|trampoline (; 123 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#sort|trampoline (; 123 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -8322,7 +8322,7 @@
   local.get $1
   call $~lib/array/Array<i32>#sort
  )
- (func $~lib/internal/sort/insertionSort<u32> (; 124 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<u32> (; 124 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -8392,7 +8392,7 @@
           local.get $7
           local.get $9
           local.get $3
-          call_indirect (type $iii)
+          call_indirect (type $FUNCSIG$iii)
          end
          i32.const 0
          i32.lt_s
@@ -8463,7 +8463,7 @@
    unreachable
   end
  )
- (func $~lib/internal/sort/weakHeapSort<u32> (; 125 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/weakHeapSort<u32> (; 125 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -8593,7 +8593,7 @@
       local.get $11
       local.get $12
       local.get $3
-      call_indirect (type $iii)
+      call_indirect (type $FUNCSIG$iii)
      end
      i32.const 0
      i32.lt_s
@@ -8830,7 +8830,7 @@
           local.get $5
           local.get $10
           local.get $3
-          call_indirect (type $iii)
+          call_indirect (type $FUNCSIG$iii)
          end
          i32.const 0
          i32.lt_s
@@ -8993,7 +8993,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<u32>#sort (; 126 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#sort (; 126 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9069,7 +9069,7 @@
     local.get $6
     local.get $7
     local.get $1
-    call_indirect (type $iii)
+    call_indirect (type $FUNCSIG$iii)
    end
    i32.const 0
    i32.lt_s
@@ -9144,7 +9144,7 @@
   end
   local.get $0
  )
- (func $~lib/internal/sort/COMPARATOR<u32>~anonymous|0 (; 127 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<u32>~anonymous|0 (; 127 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.gt_u
@@ -9153,7 +9153,7 @@
   i32.lt_u
   i32.sub
  )
- (func $~lib/array/Array<u32>#sort|trampoline (; 128 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#sort|trampoline (; 128 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -9172,7 +9172,7 @@
   local.get $1
   call $~lib/array/Array<u32>#sort
  )
- (func $std/array/createReverseOrderedArray (; 129 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array/createReverseOrderedArray (; 129 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9218,7 +9218,7 @@
   end
   local.get $1
  )
- (func $~lib/math/NativeMath.random (; 130 ;) (type $F) (result f64)
+ (func $~lib/math/NativeMath.random (; 130 ;) (type $FUNCSIG$d) (result f64)
   (local $0 i64)
   (local $1 i64)
   (local $2 i64)
@@ -9275,7 +9275,7 @@
   f64.const 1
   f64.sub
  )
- (func $std/array/createRandomOrderedArray (; 131 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array/createRandomOrderedArray (; 131 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9321,12 +9321,12 @@
   end
   local.get $1
  )
- (func $~lib/internal/sort/COMPARATOR<i32>~anonymous|1 (; 132 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<i32>~anonymous|1 (; 132 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $std/array/isSorted<i32> (; 133 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<i32> (; 133 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   block $break|0
@@ -9359,7 +9359,7 @@
      local.get $2
      call $~lib/array/Array<i32>#__get
      local.get $1
-     call_indirect (type $iii)
+     call_indirect (type $FUNCSIG$iii)
     end
     i32.const 0
     i32.gt_s
@@ -9378,7 +9378,7 @@
   end
   i32.const 1
  )
- (func $std/array/assertSorted<i32> (; 134 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<i32> (; 134 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   call $~lib/array/Array<i32>#sort
@@ -9394,7 +9394,7 @@
    unreachable
   end
  )
- (func $std/array/assertSortedDefault<i32> (; 135 ;) (type $i_) (param $0 i32)
+ (func $std/array/assertSortedDefault<i32> (; 135 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   block $~lib/internal/sort/COMPARATOR<i32>|inlined.1 (result i32)
    i32.const 48
@@ -9402,27 +9402,27 @@
   end
   call $std/array/assertSorted<i32>
  )
- (func $start:std/array~anonymous|43 (; 136 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|43 (; 136 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $start:std/array~anonymous|44 (; 137 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|44 (; 137 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.sub
  )
- (func $start:std/array~anonymous|45 (; 138 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|45 (; 138 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $start:std/array~anonymous|46 (; 139 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|46 (; 139 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.sub
  )
- (func $~lib/array/Array<Array<i32>>#constructor (; 140 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Array<i32>>#constructor (; 140 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9483,7 +9483,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<Array<i32>>#__set (; 141 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<Array<i32>>#__set (; 141 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9550,7 +9550,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<Array<i32>>#__get (; 142 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Array<i32>>#__get (; 142 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9583,7 +9583,7 @@
    unreachable
   end
  )
- (func $std/array/createReverseOrderedNestedArray (; 143 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array/createReverseOrderedNestedArray (; 143 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9639,7 +9639,7 @@
   end
   local.get $1
  )
- (func $start:std/array~anonymous|47 (; 144 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|47 (; 144 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.const 0
   call $~lib/array/Array<i32>#__get
@@ -9648,7 +9648,7 @@
   call $~lib/array/Array<i32>#__get
   i32.sub
  )
- (func $~lib/internal/sort/insertionSort<Array<i32>> (; 145 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<Array<i32>> (; 145 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -9718,7 +9718,7 @@
           local.get $7
           local.get $9
           local.get $3
-          call_indirect (type $iii)
+          call_indirect (type $FUNCSIG$iii)
          end
          i32.const 0
          i32.lt_s
@@ -9789,7 +9789,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<Array<i32>>#sort (; 146 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Array<i32>>#sort (; 146 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9865,7 +9865,7 @@
     local.get $6
     local.get $7
     local.get $1
-    call_indirect (type $iii)
+    call_indirect (type $FUNCSIG$iii)
    end
    i32.const 0
    i32.lt_s
@@ -9929,7 +9929,7 @@
   end
   local.get $0
  )
- (func $std/array/isSorted<Array<i32>> (; 147 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<Array<i32>> (; 147 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   block $break|0
@@ -9962,7 +9962,7 @@
      local.get $2
      call $~lib/array/Array<Array<i32>>#__get
      local.get $1
-     call_indirect (type $iii)
+     call_indirect (type $FUNCSIG$iii)
     end
     i32.const 0
     i32.gt_s
@@ -9981,7 +9981,7 @@
   end
   i32.const 1
  )
- (func $std/array/assertSorted<Array<i32>> (; 148 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<Array<i32>> (; 148 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   call $~lib/array/Array<Array<i32>>#sort
@@ -9997,7 +9997,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<Proxy<i32>>#constructor (; 149 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Proxy<i32>>#constructor (; 149 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10058,7 +10058,7 @@
   end
   local.get $0
  )
- (func $std/array/Proxy<i32>#constructor (; 150 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/Proxy<i32>#constructor (; 150 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -10071,7 +10071,7 @@
   i32.store
   local.get $0
  )
- (func $~lib/array/Array<Proxy<i32>>#__set (; 151 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<Proxy<i32>>#__set (; 151 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -10138,7 +10138,7 @@
    i32.store offset=8
   end
  )
- (func $std/array/createReverseOrderedElementsArray (; 152 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array/createReverseOrderedElementsArray (; 152 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -10186,14 +10186,14 @@
   end
   local.get $1
  )
- (func $start:std/array~anonymous|48 (; 153 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|48 (; 153 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load
   local.get $1
   i32.load
   i32.sub
  )
- (func $~lib/internal/sort/insertionSort<Proxy<i32>> (; 154 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<Proxy<i32>> (; 154 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -10263,7 +10263,7 @@
           local.get $7
           local.get $9
           local.get $3
-          call_indirect (type $iii)
+          call_indirect (type $FUNCSIG$iii)
          end
          i32.const 0
          i32.lt_s
@@ -10334,7 +10334,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<Proxy<i32>>#sort (; 155 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Proxy<i32>>#sort (; 155 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10410,7 +10410,7 @@
     local.get $6
     local.get $7
     local.get $1
-    call_indirect (type $iii)
+    call_indirect (type $FUNCSIG$iii)
    end
    i32.const 0
    i32.lt_s
@@ -10474,7 +10474,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<Proxy<i32>>#__get (; 156 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Proxy<i32>>#__get (; 156 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10507,7 +10507,7 @@
    unreachable
   end
  )
- (func $std/array/isSorted<Proxy<i32>> (; 157 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<Proxy<i32>> (; 157 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   block $break|0
@@ -10540,7 +10540,7 @@
      local.get $2
      call $~lib/array/Array<Proxy<i32>>#__get
      local.get $1
-     call_indirect (type $iii)
+     call_indirect (type $FUNCSIG$iii)
     end
     i32.const 0
     i32.gt_s
@@ -10559,7 +10559,7 @@
   end
   i32.const 1
  )
- (func $std/array/assertSorted<Proxy<i32>> (; 158 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<Proxy<i32>> (; 158 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   call $~lib/array/Array<Proxy<i32>>#sort
@@ -10575,7 +10575,7 @@
    unreachable
   end
  )
- (func $~lib/internal/sort/insertionSort<String> (; 159 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<String> (; 159 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -10645,7 +10645,7 @@
           local.get $7
           local.get $9
           local.get $3
-          call_indirect (type $iii)
+          call_indirect (type $FUNCSIG$iii)
          end
          i32.const 0
          i32.lt_s
@@ -10716,7 +10716,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<String>#sort (; 160 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<String>#sort (; 160 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10792,7 +10792,7 @@
     local.get $6
     local.get $7
     local.get $1
-    call_indirect (type $iii)
+    call_indirect (type $FUNCSIG$iii)
    end
    i32.const 0
    i32.lt_s
@@ -10856,7 +10856,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<String>#__get (; 161 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<String>#__get (; 161 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10889,7 +10889,7 @@
    unreachable
   end
  )
- (func $std/array/isSorted<String> (; 162 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<String> (; 162 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   block $break|0
@@ -10922,7 +10922,7 @@
      local.get $2
      call $~lib/array/Array<String>#__get
      local.get $1
-     call_indirect (type $iii)
+     call_indirect (type $FUNCSIG$iii)
     end
     i32.const 0
     i32.gt_s
@@ -10941,7 +10941,7 @@
   end
   i32.const 1
  )
- (func $std/array/assertSorted<String> (; 163 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<String> (; 163 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   call $~lib/array/Array<String>#sort
@@ -10957,7 +10957,7 @@
    unreachable
   end
  )
- (func $~lib/internal/string/compareUnsafe (; 164 ;) (type $iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/internal/string/compareUnsafe (; 164 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -11010,7 +11010,7 @@
   end
   local.get $5
  )
- (func $~lib/internal/sort/COMPARATOR<String>~anonymous|0 (; 165 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<String>~anonymous|0 (; 165 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11083,7 +11083,7 @@
   select
   call $~lib/internal/string/compareUnsafe
  )
- (func $std/array/assertSorted<String>|trampoline (; 166 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<String>|trampoline (; 166 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -11104,7 +11104,7 @@
   local.get $1
   call $std/array/assertSorted<String>
  )
- (func $~lib/string/String.__eq (; 167 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 167 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -11148,13 +11148,13 @@
   call $~lib/internal/string/compareUnsafe
   i32.eqz
  )
- (func $~lib/string/String.__ne (; 168 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__ne (; 168 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/string/String.__eq
   i32.eqz
  )
- (func $std/array/isArraysEqual<String> (; 169 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<String> (; 169 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
@@ -11217,7 +11217,7 @@
   end
   i32.const 1
  )
- (func $~lib/array/Array<String>#constructor (; 170 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<String>#constructor (; 170 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11278,7 +11278,7 @@
   end
   local.get $0
  )
- (func $~lib/internal/string/allocateUnsafe (; 171 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/string/allocateUnsafe (; 171 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -11318,7 +11318,7 @@
   i32.store
   local.get $2
  )
- (func $~lib/string/String#charAt (; 172 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#charAt (; 172 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   i32.const 0
@@ -11353,7 +11353,7 @@
   i32.store16 offset=4
   local.get $2
  )
- (func $~lib/internal/string/copyUnsafe (; 173 ;) (type $iiiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
+ (func $~lib/internal/string/copyUnsafe (; 173 ;) (type $FUNCSIG$viiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -11382,7 +11382,7 @@
   local.get $7
   call $~lib/internal/memory/memmove
  )
- (func $~lib/string/String#concat (; 174 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#concat (; 174 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11440,7 +11440,7 @@
   call $~lib/internal/string/copyUnsafe
   local.get $5
  )
- (func $~lib/string/String.__concat (; 175 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (; 175 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -11451,7 +11451,7 @@
   local.get $1
   call $~lib/string/String#concat
  )
- (func $std/array/createRandomString (; 176 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array/createRandomString (; 176 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -11493,7 +11493,7 @@
   end
   local.get $1
  )
- (func $~lib/array/Array<String>#__set (; 177 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<String>#__set (; 177 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -11560,7 +11560,7 @@
    i32.store offset=8
   end
  )
- (func $std/array/createRandomStringArray (; 178 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array/createRandomStringArray (; 178 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -11601,7 +11601,7 @@
   end
   local.get $1
  )
- (func $~lib/string/String#substring (; 179 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substring (; 179 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -11711,7 +11711,7 @@
   call $~lib/internal/string/copyUnsafe
   local.get $10
  )
- (func $~lib/array/Array<bool>#join (; 180 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<bool>#join (; 180 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11938,7 +11938,7 @@
   local.get $14
   return
  )
- (func $~lib/internal/number/decimalCount32 (; 181 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/decimalCount32 (; 181 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 100000
@@ -12007,7 +12007,7 @@
   unreachable
   unreachable
  )
- (func $~lib/internal/number/utoa32_lut (; 182 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/number/utoa32_lut (; 182 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12193,7 +12193,7 @@
    i32.store16 offset=4
   end
  )
- (func $~lib/internal/number/itoa32 (; 183 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/itoa32 (; 183 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -12245,12 +12245,12 @@
   end
   local.get $3
  )
- (func $~lib/internal/number/itoa<i32> (; 184 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/itoa<i32> (; 184 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/internal/number/itoa32
   return
  )
- (func $~lib/internal/number/itoa_stream<i32> (; 185 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/internal/number/itoa_stream<i32> (; 185 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12309,7 +12309,7 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<i32>#join (; 186 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#join (; 186 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12499,7 +12499,7 @@
   local.get $13
   return
  )
- (func $~lib/internal/number/utoa32 (; 187 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/utoa32 (; 187 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -12531,12 +12531,12 @@
   end
   local.get $2
  )
- (func $~lib/internal/number/itoa<u32> (; 188 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/itoa<u32> (; 188 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/internal/number/utoa32
   return
  )
- (func $~lib/internal/number/itoa_stream<u32> (; 189 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/internal/number/itoa_stream<u32> (; 189 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12575,7 +12575,7 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<u32>#join (; 190 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#join (; 190 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12765,14 +12765,14 @@
   local.get $13
   return
  )
- (func $~lib/builtins/isFinite<f64> (; 191 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $~lib/builtins/isFinite<f64> (; 191 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   local.get $0
   f64.sub
   f64.const 0
   f64.eq
  )
- (func $~lib/internal/number/genDigits (; 192 ;) (type $iIiIiIii) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/internal/number/genDigits (; 192 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -13363,7 +13363,7 @@
   end
   local.get $15
  )
- (func $~lib/internal/number/prettify (; 193 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/internal/number/prettify (; 193 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -13732,7 +13732,7 @@
   unreachable
   unreachable
  )
- (func $~lib/internal/number/dtoa_core (; 194 ;) (type $iFi) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/internal/number/dtoa_core (; 194 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 f64)
   (local $4 i32)
@@ -14205,7 +14205,7 @@
   local.get $2
   i32.add
  )
- (func $~lib/internal/number/dtoa (; 195 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $~lib/internal/number/dtoa (; 195 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -14271,7 +14271,7 @@
   end
   local.get $3
  )
- (func $~lib/internal/number/dtoa_stream (; 196 ;) (type $iiFi) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
+ (func $~lib/internal/number/dtoa_stream (; 196 ;) (type $FUNCSIG$iiid) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -14360,7 +14360,7 @@
   local.get $2
   call $~lib/internal/number/dtoa_core
  )
- (func $~lib/array/Array<f64>#join (; 197 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f64>#join (; 197 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 f64)
@@ -14550,7 +14550,7 @@
   local.get $13
   return
  )
- (func $~lib/array/Array<String>#join (; 198 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<String>#join (; 198 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14762,7 +14762,7 @@
   local.get $9
   return
  )
- (func $std/array/Ref#constructor (; 199 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/array/Ref#constructor (; 199 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -14772,7 +14772,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<Ref>#constructor (; 200 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Ref>#constructor (; 200 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14833,7 +14833,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<Ref>#__unchecked_set (; 201 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<Ref>#__unchecked_set (; 201 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -14857,7 +14857,7 @@
   local.get $5
   i32.store offset=8
  )
- (func $~lib/array/Array<Ref>#join (; 202 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Ref>#join (; 202 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15041,7 +15041,7 @@
   local.get $11
   return
  )
- (func $~lib/internal/number/itoa<i8> (; 203 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/itoa<i8> (; 203 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -15050,7 +15050,7 @@
   call $~lib/internal/number/itoa32
   return
  )
- (func $~lib/internal/number/itoa_stream<i8> (; 204 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/internal/number/itoa_stream<i8> (; 204 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15125,7 +15125,7 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<i8>#join (; 205 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#join (; 205 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15315,14 +15315,14 @@
   local.get $13
   return
  )
- (func $~lib/internal/number/itoa<u16> (; 206 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/itoa<u16> (; 206 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   call $~lib/internal/number/utoa32
   return
  )
- (func $~lib/internal/number/itoa_stream<u16> (; 207 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/internal/number/itoa_stream<u16> (; 207 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15367,7 +15367,7 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<u16>#join (; 208 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#join (; 208 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15557,7 +15557,7 @@
   local.get $13
   return
  )
- (func $~lib/internal/number/decimalCount64 (; 209 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/number/decimalCount64 (; 209 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   local.get $0
   i64.const 1000000000000000
@@ -15626,7 +15626,7 @@
   unreachable
   unreachable
  )
- (func $~lib/internal/number/utoa64_lut (; 210 ;) (type $iIi_) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/internal/number/utoa64_lut (; 210 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -15797,7 +15797,7 @@
   local.get $2
   call $~lib/internal/number/utoa32_lut
  )
- (func $~lib/internal/number/utoa64 (; 211 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/number/utoa64 (; 211 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -15859,12 +15859,12 @@
   end
   local.get $1
  )
- (func $~lib/internal/number/itoa<u64> (; 212 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/number/itoa<u64> (; 212 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   local.get $0
   call $~lib/internal/number/utoa64
   return
  )
- (func $~lib/internal/number/itoa_stream<u64> (; 213 ;) (type $iiIi) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/internal/number/itoa_stream<u64> (; 213 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15930,7 +15930,7 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<u64>#join (; 214 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u64>#join (; 214 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i64)
@@ -16120,7 +16120,7 @@
   local.get $13
   return
  )
- (func $~lib/internal/number/itoa64 (; 215 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/number/itoa64 (; 215 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -16204,12 +16204,12 @@
   end
   local.get $2
  )
- (func $~lib/internal/number/itoa<i64> (; 216 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/number/itoa<i64> (; 216 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   local.get $0
   call $~lib/internal/number/itoa64
   return
  )
- (func $~lib/internal/number/itoa_stream<i64> (; 217 ;) (type $iiIi) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/internal/number/itoa_stream<i64> (; 217 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16297,7 +16297,7 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<i64>#join (; 218 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i64>#join (; 218 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i64)
@@ -16487,7 +16487,7 @@
   local.get $13
   return
  )
- (func $~lib/array/Array<Array<i32>>#join (; 219 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Array<i32>>#join (; 219 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16634,14 +16634,14 @@
   local.get $3
   return
  )
- (func $~lib/internal/number/itoa<u8> (; 220 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/itoa<u8> (; 220 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   call $~lib/internal/number/utoa32
   return
  )
- (func $~lib/internal/number/itoa_stream<u8> (; 221 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/internal/number/itoa_stream<u8> (; 221 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16686,7 +16686,7 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<u8>#join (; 222 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#join (; 222 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16876,7 +16876,7 @@
   local.get $13
   return
  )
- (func $~lib/array/Array<Array<u8>>#join (; 223 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Array<u8>>#join (; 223 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17023,7 +17023,7 @@
   local.get $3
   return
  )
- (func $~lib/array/Array<Array<u32>>#join (; 224 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Array<u32>>#join (; 224 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17170,7 +17170,7 @@
   local.get $3
   return
  )
- (func $~lib/array/Array<Array<Array<u32>>>#join (; 225 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<Array<Array<u32>>>#join (; 225 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17317,7 +17317,7 @@
   local.get $3
   return
  )
- (func $start:std/array (; 226 ;) (type $_)
+ (func $start:std/array (; 226 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -21809,9 +21809,9 @@
    unreachable
   end
  )
- (func $start (; 227 ;) (type $_)
+ (func $start (; 227 ;) (type $FUNCSIG$v)
   call $start:std/array
  )
- (func $null (; 228 ;) (type $_)
+ (func $null (; 228 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -1,12 +1,11 @@
 (module
- (type $_ (func))
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $ii (func (param i32) (result i32)))
- (type $iii_ (func (param i32 i32 i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
  (type $FUNCSIG$vii (func (param i32 i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
- (type $FUNCSIG$ii (func (param i32) (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\13\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s")
@@ -27,7 +26,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -89,7 +88,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/internal/arraybuffer/allocateUnsafe (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/allocateUnsafe (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 1073741816
@@ -335,7 +334,7 @@
    end
   end
  )
- (func $~lib/internal/memory/memcpy (; 4 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 4 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1232,7 +1231,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 5 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 5 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -1430,7 +1429,7 @@
    end
   end
  )
- (func $~lib/arraybuffer/ArrayBuffer#slice (; 6 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#slice (; 6 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -1643,7 +1642,7 @@
   i32.store offset=8
   local.get $2
  )
- (func $start:std/arraybuffer (; 11 ;) (type $_)
+ (func $start:std/arraybuffer (; 11 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 288
@@ -1917,10 +1916,10 @@
    unreachable
   end
  )
- (func $start (; 12 ;) (type $_)
+ (func $start (; 12 ;) (type $FUNCSIG$v)
   call $start:std/arraybuffer
  )
- (func $null (; 13 ;) (type $_)
+ (func $null (; 13 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/arraybuffer.untouched.wat
+++ b/tests/compiler/std/arraybuffer.untouched.wat
@@ -1,11 +1,11 @@
 (module
- (type $_ (func))
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $ii (func (param i32) (result i32)))
- (type $iii_ (func (param i32 i32 i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $iiiii (func (param i32 i32 i32 i32) (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$iiiii (func (param i32 i32 i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\13\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
@@ -28,7 +28,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:~lib/allocator/arena (; 1 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 1 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -40,7 +40,7 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $~lib/internal/arraybuffer/computeSize (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/computeSize (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   i32.const 32
   local.get $0
@@ -52,7 +52,7 @@
   i32.sub
   i32.shl
  )
- (func $~lib/allocator/arena/__memory_allocate (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -131,7 +131,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/internal/arraybuffer/allocateUnsafe (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/allocateUnsafe (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -160,7 +160,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memset (; 5 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 5 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -414,7 +414,7 @@
    end
   end
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (; 6 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (; 6 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -453,7 +453,7 @@
   end
   local.get $3
  )
- (func $~lib/internal/memory/memcpy (; 7 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 7 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1654,7 +1654,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 8 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 8 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -1881,7 +1881,7 @@
    end
   end
  )
- (func $~lib/arraybuffer/ArrayBuffer#slice (; 9 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#slice (; 9 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1974,7 +1974,7 @@
   end
   local.get $6
  )
- (func $~lib/arraybuffer/ArrayBuffer#slice|trampoline (; 10 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#slice|trampoline (; 10 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -1995,7 +1995,7 @@
   local.get $2
   call $~lib/arraybuffer/ArrayBuffer#slice
  )
- (func $~lib/arraybuffer/ArrayBuffer.isView<Array<i32>> (; 11 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer.isView<Array<i32>> (; 11 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
   i32.eq
@@ -2005,7 +2005,7 @@
   end
   i32.const 0
  )
- (func $~lib/arraybuffer/ArrayBuffer.isView<usize> (; 12 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer.isView<usize> (; 12 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
   i32.eq
@@ -2015,18 +2015,7 @@
   end
   i32.const 0
  )
- (func $~lib/arraybuffer/ArrayBuffer.isView<Uint8Array> (; 13 ;) (type $ii) (param $0 i32) (result i32)
-  local.get $0
-  i32.const 0
-  i32.eq
-  if
-   i32.const 0
-   return
-  end
-  i32.const 1
-  return
- )
- (func $~lib/arraybuffer/ArrayBuffer.isView<Int32Array> (; 14 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer.isView<Uint8Array> (; 13 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
   i32.eq
@@ -2037,7 +2026,7 @@
   i32.const 1
   return
  )
- (func $~lib/arraybuffer/ArrayBuffer.isView<DataView> (; 15 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer.isView<Int32Array> (; 14 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
   i32.eq
@@ -2048,12 +2037,23 @@
   i32.const 1
   return
  )
- (func $~lib/memory/memory.allocate (; 16 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer.isView<DataView> (; 15 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.const 0
+  i32.eq
+  if
+   i32.const 0
+   return
+  end
+  i32.const 1
+  return
+ )
+ (func $~lib/memory/memory.allocate (; 16 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/allocator/arena/__memory_allocate
   return
  )
- (func $~lib/internal/typedarray/TypedArray<u8>#constructor (; 17 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<u8>#constructor (; 17 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2120,7 +2120,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/typedarray/Uint8Array#constructor (; 18 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#constructor (; 18 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -2134,7 +2134,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/internal/typedarray/TypedArray<i32>#constructor (; 19 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<i32>#constructor (; 19 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2201,7 +2201,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/typedarray/Int32Array#constructor (; 20 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#constructor (; 20 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -2215,7 +2215,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/dataview/DataView#constructor (; 21 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/dataview/DataView#constructor (; 21 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $3
   global.get $~lib/builtins/i32.MIN_VALUE
   i32.eq
@@ -2280,7 +2280,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/dataview/DataView#constructor|trampoline (; 22 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/dataview/DataView#constructor|trampoline (; 22 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -2304,7 +2304,7 @@
   local.get $3
   call $~lib/dataview/DataView#constructor
  )
- (func $start:std/arraybuffer (; 23 ;) (type $_)
+ (func $start:std/arraybuffer (; 23 ;) (type $FUNCSIG$v)
   (local $0 i32)
   call $start:~lib/allocator/arena
   i32.const 0
@@ -2654,9 +2654,9 @@
    unreachable
   end
  )
- (func $start (; 24 ;) (type $_)
+ (func $start (; 24 ;) (type $FUNCSIG$v)
   call $start:std/arraybuffer
  )
- (func $null (; 25 ;) (type $_)
+ (func $null (; 25 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/dataview.optimized.wat
+++ b/tests/compiler/std/dataview.optimized.wat
@@ -1,21 +1,18 @@
 (module
- (type $_ (func))
- (type $iii (func (param i32 i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $ii (func (param i32) (result i32)))
- (type $iii_ (func (param i32 i32 i32)))
- (type $iiif (func (param i32 i32 i32) (result f32)))
- (type $II (func (param i64) (result i64)))
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$fiii (func (param i32 i32 i32) (result f32)))
+ (type $FUNCSIG$jj (func (param i64) (result i64)))
  (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$dii (func (param i32 i32) (result f64)))
  (type $FUNCSIG$jii (func (param i32 i32) (result i64)))
  (type $FUNCSIG$vifi (func (param i32 f32 i32)))
  (type $FUNCSIG$vidi (func (param i32 f64 i32)))
  (type $FUNCSIG$vii (func (param i32 i32)))
- (type $FUNCSIG$viii (func (param i32 i32 i32)))
  (type $FUNCSIG$viji (func (param i32 i64 i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -32,7 +29,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -176,7 +173,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/internal/typedarray/TypedArray<u8>#__set (; 4 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<u8>#__set (; 4 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -260,7 +257,7 @@
   i32.store offset=8
   local.get $3
  )
- (func $~lib/dataview/DataView#getFloat32 (; 6 ;) (type $iiif) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
+ (func $~lib/dataview/DataView#getFloat32 (; 6 ;) (type $FUNCSIG$fiii) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -321,7 +318,7 @@
    f32.reinterpret_i32
   end
  )
- (func $~lib/polyfills/bswap<u64> (; 7 ;) (type $II) (param $0 i64) (result i64)
+ (func $~lib/polyfills/bswap<u64> (; 7 ;) (type $FUNCSIG$jj) (param $0 i64) (result i64)
   (local $1 i64)
   local.get $0
   i64.const 8
@@ -380,7 +377,7 @@
    f64.reinterpret_i64
   end
  )
- (func $~lib/dataview/DataView#getInt8 (; 9 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/dataview/DataView#getInt8 (; 9 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -418,7 +415,7 @@
   i32.add
   i32.load8_s offset=8
  )
- (func $~lib/dataview/DataView#getInt16 (; 10 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getInt16 (; 10 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -472,7 +469,7 @@
    i32.or
   end
  )
- (func $~lib/dataview/DataView#getInt32 (; 11 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getInt32 (; 11 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -555,7 +552,7 @@
    call $~lib/polyfills/bswap<u64>
   end
  )
- (func $~lib/dataview/DataView#getUint8 (; 13 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/dataview/DataView#getUint8 (; 13 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -593,7 +590,7 @@
   i32.add
   i32.load8_u offset=8
  )
- (func $~lib/dataview/DataView#getUint16 (; 14 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getUint16 (; 14 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -887,7 +884,7 @@
   local.get $1
   i32.store16 offset=8
  )
- (func $start:std/dataview (; 22 ;) (type $_)
+ (func $start:std/dataview (; 22 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 216
   global.set $~lib/allocator/arena/startOffset
@@ -2415,10 +2412,10 @@
    unreachable
   end
  )
- (func $start (; 23 ;) (type $_)
+ (func $start (; 23 ;) (type $FUNCSIG$v)
   call $start:std/dataview
  )
- (func $null (; 24 ;) (type $_)
+ (func $null (; 24 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/dataview.untouched.wat
+++ b/tests/compiler/std/dataview.untouched.wat
@@ -1,18 +1,18 @@
 (module
- (type $_ (func))
- (type $iii (func (param i32 i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $ii (func (param i32) (result i32)))
- (type $iii_ (func (param i32 i32 i32)))
- (type $iiiii (func (param i32 i32 i32 i32) (result i32)))
- (type $iiif (func (param i32 i32 i32) (result f32)))
- (type $iiiF (func (param i32 i32 i32) (result f64)))
- (type $II (func (param i64) (result i64)))
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiiI (func (param i32 i32 i32) (result i64)))
- (type $iifi_ (func (param i32 i32 f32 i32)))
- (type $iiFi_ (func (param i32 i32 f64 i32)))
- (type $iiIi_ (func (param i32 i32 i64 i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$iiiii (func (param i32 i32 i32 i32) (result i32)))
+ (type $FUNCSIG$fiii (func (param i32 i32 i32) (result f32)))
+ (type $FUNCSIG$diii (func (param i32 i32 i32) (result f64)))
+ (type $FUNCSIG$jj (func (param i64) (result i64)))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$jiii (func (param i32 i32 i32) (result i64)))
+ (type $FUNCSIG$viifi (func (param i32 i32 f32 i32)))
+ (type $FUNCSIG$viidi (func (param i32 i32 f64 i32)))
+ (type $FUNCSIG$viiji (func (param i32 i32 i64 i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\1b\00\00\00~\00l\00i\00b\00/\00i\00n\00t\00e\00r\00n\00a\00l\00/\00t\00y\00p\00e\00d\00a\00r\00r\00a\00y\00.\00t\00s\00")
@@ -30,7 +30,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:~lib/allocator/arena (; 1 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 1 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -42,7 +42,7 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $~lib/internal/arraybuffer/computeSize (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/computeSize (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   i32.const 32
   local.get $0
@@ -54,7 +54,7 @@
   i32.sub
   i32.shl
  )
- (func $~lib/allocator/arena/__memory_allocate (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -133,7 +133,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/internal/arraybuffer/allocateUnsafe (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/allocateUnsafe (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -162,7 +162,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memset (; 5 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 5 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -416,12 +416,12 @@
    end
   end
  )
- (func $~lib/memory/memory.allocate (; 6 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/memory/memory.allocate (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/allocator/arena/__memory_allocate
   return
  )
- (func $~lib/internal/typedarray/TypedArray<u8>#constructor (; 7 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<u8>#constructor (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -488,7 +488,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/typedarray/Uint8Array#constructor (; 8 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#constructor (; 8 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -502,7 +502,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/internal/typedarray/TypedArray<u8>#__set (; 9 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<u8>#__set (; 9 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -543,7 +543,7 @@
    i32.store8 offset=8
   end
  )
- (func $~lib/dataview/DataView#constructor (; 10 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/dataview/DataView#constructor (; 10 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $3
   global.get $~lib/builtins/i32.MIN_VALUE
   i32.eq
@@ -608,7 +608,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/polyfills/bswap<u32> (; 11 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<u32> (; 11 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const -16711936
   i32.and
@@ -622,7 +622,7 @@
   i32.or
   return
  )
- (func $~lib/dataview/DataView#getFloat32 (; 12 ;) (type $iiif) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
+ (func $~lib/dataview/DataView#getFloat32 (; 12 ;) (type $FUNCSIG$fiii) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -682,7 +682,7 @@
    f32.reinterpret_i32
   end
  )
- (func $~lib/polyfills/bswap<u64> (; 13 ;) (type $II) (param $0 i64) (result i64)
+ (func $~lib/polyfills/bswap<u64> (; 13 ;) (type $FUNCSIG$jj) (param $0 i64) (result i64)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -721,7 +721,7 @@
   i64.rotr
   return
  )
- (func $~lib/dataview/DataView#getFloat64 (; 14 ;) (type $iiiF) (param $0 i32) (param $1 i32) (param $2 i32) (result f64)
+ (func $~lib/dataview/DataView#getFloat64 (; 14 ;) (type $FUNCSIG$diii) (param $0 i32) (param $1 i32) (param $2 i32) (result f64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -781,7 +781,7 @@
    f64.reinterpret_i64
   end
  )
- (func $~lib/dataview/DataView#getInt8 (; 15 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/dataview/DataView#getInt8 (; 15 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -825,7 +825,7 @@
   i32.add
   i32.load8_s offset=8
  )
- (func $~lib/polyfills/bswap<i16> (; 16 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<i16> (; 16 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 8
   i32.shl
@@ -841,7 +841,7 @@
   i32.or
   return
  )
- (func $~lib/dataview/DataView#getInt16 (; 17 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getInt16 (; 17 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -896,7 +896,7 @@
    call $~lib/polyfills/bswap<i16>
   end
  )
- (func $~lib/polyfills/bswap<i32> (; 18 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<i32> (; 18 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const -16711936
   i32.and
@@ -910,7 +910,7 @@
   i32.or
   return
  )
- (func $~lib/dataview/DataView#getInt32 (; 19 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getInt32 (; 19 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -965,7 +965,7 @@
    call $~lib/polyfills/bswap<i32>
   end
  )
- (func $~lib/polyfills/bswap<i64> (; 20 ;) (type $II) (param $0 i64) (result i64)
+ (func $~lib/polyfills/bswap<i64> (; 20 ;) (type $FUNCSIG$jj) (param $0 i64) (result i64)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -1004,7 +1004,7 @@
   i64.rotr
   return
  )
- (func $~lib/dataview/DataView#getInt64 (; 21 ;) (type $iiiI) (param $0 i32) (param $1 i32) (param $2 i32) (result i64)
+ (func $~lib/dataview/DataView#getInt64 (; 21 ;) (type $FUNCSIG$jiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1059,7 +1059,7 @@
    call $~lib/polyfills/bswap<i64>
   end
  )
- (func $~lib/dataview/DataView#getUint8 (; 22 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/dataview/DataView#getUint8 (; 22 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1103,7 +1103,7 @@
   i32.add
   i32.load8_u offset=8
  )
- (func $~lib/polyfills/bswap<u16> (; 23 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<u16> (; 23 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 8
   i32.shl
@@ -1117,7 +1117,7 @@
   i32.or
   return
  )
- (func $~lib/dataview/DataView#getUint16 (; 24 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getUint16 (; 24 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1172,7 +1172,7 @@
    call $~lib/polyfills/bswap<u16>
   end
  )
- (func $~lib/dataview/DataView#getUint32 (; 25 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/dataview/DataView#getUint32 (; 25 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1227,7 +1227,7 @@
    call $~lib/polyfills/bswap<u32>
   end
  )
- (func $~lib/dataview/DataView#getUint64 (; 26 ;) (type $iiiI) (param $0 i32) (param $1 i32) (param $2 i32) (result i64)
+ (func $~lib/dataview/DataView#getUint64 (; 26 ;) (type $FUNCSIG$jiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1282,7 +1282,7 @@
    call $~lib/polyfills/bswap<u64>
   end
  )
- (func $~lib/dataview/DataView#setFloat32 (; 27 ;) (type $iifi_) (param $0 i32) (param $1 i32) (param $2 f32) (param $3 i32)
+ (func $~lib/dataview/DataView#setFloat32 (; 27 ;) (type $FUNCSIG$viifi) (param $0 i32) (param $1 i32) (param $2 f32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1344,7 +1344,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/dataview/DataView#setFloat64 (; 28 ;) (type $iiFi_) (param $0 i32) (param $1 i32) (param $2 f64) (param $3 i32)
+ (func $~lib/dataview/DataView#setFloat64 (; 28 ;) (type $FUNCSIG$viidi) (param $0 i32) (param $1 i32) (param $2 f64) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1406,7 +1406,7 @@
    i64.store offset=8
   end
  )
- (func $~lib/dataview/DataView#setInt8 (; 29 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/dataview/DataView#setInt8 (; 29 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1451,7 +1451,7 @@
   local.get $2
   i32.store8 offset=8
  )
- (func $~lib/dataview/DataView#setInt16 (; 30 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/dataview/DataView#setInt16 (; 30 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1504,7 +1504,7 @@
   end
   i32.store16 offset=8
  )
- (func $~lib/dataview/DataView#setInt32 (; 31 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/dataview/DataView#setInt32 (; 31 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1557,7 +1557,7 @@
   end
   i32.store offset=8
  )
- (func $~lib/dataview/DataView#setInt64 (; 32 ;) (type $iiIi_) (param $0 i32) (param $1 i32) (param $2 i64) (param $3 i32)
+ (func $~lib/dataview/DataView#setInt64 (; 32 ;) (type $FUNCSIG$viiji) (param $0 i32) (param $1 i32) (param $2 i64) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1610,7 +1610,7 @@
   end
   i64.store offset=8
  )
- (func $~lib/dataview/DataView#setUint8 (; 33 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/dataview/DataView#setUint8 (; 33 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1655,7 +1655,7 @@
   local.get $2
   i32.store8 offset=8
  )
- (func $~lib/dataview/DataView#setUint16 (; 34 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/dataview/DataView#setUint16 (; 34 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1708,7 +1708,7 @@
   end
   i32.store16 offset=8
  )
- (func $~lib/dataview/DataView#setUint32 (; 35 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/dataview/DataView#setUint32 (; 35 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1761,7 +1761,7 @@
   end
   i32.store offset=8
  )
- (func $~lib/dataview/DataView#setUint64 (; 36 ;) (type $iiIi_) (param $0 i32) (param $1 i32) (param $2 i64) (param $3 i32)
+ (func $~lib/dataview/DataView#setUint64 (; 36 ;) (type $FUNCSIG$viiji) (param $0 i32) (param $1 i32) (param $2 i64) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1814,7 +1814,7 @@
   end
   i64.store offset=8
  )
- (func $start:std/dataview (; 37 ;) (type $_)
+ (func $start:std/dataview (; 37 ;) (type $FUNCSIG$v)
   call $start:~lib/allocator/arena
   i32.const 0
   i32.const 8
@@ -3498,9 +3498,9 @@
    unreachable
   end
  )
- (func $start (; 38 ;) (type $_)
+ (func $start (; 38 ;) (type $FUNCSIG$v)
   call $start:std/dataview
  )
- (func $null (; 39 ;) (type $_)
+ (func $null (; 39 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/date.optimized.wat
+++ b/tests/compiler/std/date.optimized.wat
@@ -1,8 +1,8 @@
 (module
- (type $_ (func))
- (type $iiiiiiFF (func (param i32 i32 i32 i32 i32 i32 f64) (result f64)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $F (func (result f64)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$diiiiiid (func (param i32 i32 i32 i32 i32 i32 f64) (result f64)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$d (func (result f64)))
  (type $FUNCSIG$i (func (result i32)))
  (import "Date" "UTC" (func $~lib/bindings/Date/UTC (param i32 i32 i32 i32 i32 i32 f64) (result f64)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
@@ -68,7 +68,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $0
  )
- (func $start:std/date (; 4 ;) (type $_)
+ (func $start:std/date (; 4 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i64)
   i32.const 40
@@ -189,10 +189,10 @@
    unreachable
   end
  )
- (func $start (; 5 ;) (type $_)
+ (func $start (; 5 ;) (type $FUNCSIG$v)
   call $start:std/date
  )
- (func $null (; 6 ;) (type $_)
+ (func $null (; 6 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -1,12 +1,12 @@
 (module
- (type $_ (func))
- (type $iiiiiiFF (func (param i32 i32 i32 i32 i32 i32 f64) (result f64)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $F (func (result f64)))
- (type $iIi (func (param i32 i64) (result i32)))
- (type $ii (func (param i32) (result i32)))
- (type $iI (func (param i32) (result i64)))
- (type $iII (func (param i32 i64) (result i64)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$diiiiiid (func (param i32 i32 i32 i32 i32 i32 f64) (result f64)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$d (func (result f64)))
+ (type $FUNCSIG$iij (func (param i32 i64) (result i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$ji (func (param i32) (result i64)))
+ (type $FUNCSIG$jij (func (param i32 i64) (result i64)))
  (import "Date" "UTC" (func $~lib/bindings/Date/UTC (param i32 i32 i32 i32 i32 i32 f64) (result f64)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (import "Date" "now" (func $~lib/bindings/Date/now (result f64)))
@@ -22,7 +22,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:~lib/allocator/arena (; 3 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 3 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -34,7 +34,7 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $~lib/allocator/arena/__memory_allocate (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -113,12 +113,12 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/memory/memory.allocate (; 5 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/memory/memory.allocate (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/allocator/arena/__memory_allocate
   return
  )
- (func $~lib/date/Date#constructor (; 6 ;) (type $iIi) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/date/Date#constructor (; 6 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -136,17 +136,17 @@
   i64.store
   local.get $0
  )
- (func $~lib/date/Date#getTime (; 7 ;) (type $iI) (param $0 i32) (result i64)
+ (func $~lib/date/Date#getTime (; 7 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
   local.get $0
   i64.load
  )
- (func $~lib/date/Date#setTime (; 8 ;) (type $iII) (param $0 i32) (param $1 i64) (result i64)
+ (func $~lib/date/Date#setTime (; 8 ;) (type $FUNCSIG$jij) (param $0 i32) (param $1 i64) (result i64)
   local.get $0
   local.get $1
   i64.store
   local.get $1
  )
- (func $start:std/date (; 9 ;) (type $_)
+ (func $start:std/date (; 9 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -322,9 +322,9 @@
    unreachable
   end
  )
- (func $start (; 10 ;) (type $_)
+ (func $start (; 10 ;) (type $FUNCSIG$v)
   call $start:std/date
  )
- (func $null (; 11 ;) (type $_)
+ (func $null (; 11 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/gc-array.optimized.wat
+++ b/tests/compiler/std/gc-array.optimized.wat
@@ -1,13 +1,12 @@
 (module
- (type $_ (func))
- (type $i_ (func (param i32)))
- (type $ii (func (param i32) (result i32)))
- (type $ii_ (func (param i32 i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $iii_ (func (param i32 i32 i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $i (func (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$i (func (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 16) "\01")
@@ -29,7 +28,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "main" (func $std/gc-array/main))
- (func $~lib/arraybuffer/ArrayBuffer~gc (; 1 ;) (type $i_) (param $0 i32)
+ (func $~lib/arraybuffer/ArrayBuffer~gc (; 1 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.eqz
   if
@@ -38,7 +37,7 @@
   local.get $0
   call $~lib/collector/itcm/__gc_mark
  )
- (func $~lib/collector/itcm/ManagedObjectList#push (; 2 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/ManagedObjectList#push (; 2 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=4
@@ -66,7 +65,7 @@
   local.get $1
   i32.store offset=4
  )
- (func $~lib/collector/itcm/ManagedObject#makeGray (; 3 ;) (type $i_) (param $0 i32)
+ (func $~lib/collector/itcm/ManagedObject#makeGray (; 3 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   global.get $~lib/collector/itcm/iter
@@ -106,7 +105,7 @@
   i32.or
   i32.store
  )
- (func $~lib/collector/itcm/__gc_mark (; 4 ;) (type $i_) (param $0 i32)
+ (func $~lib/collector/itcm/__gc_mark (; 4 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   local.get $0
   if
@@ -125,7 +124,7 @@
    end
   end
  )
- (func $~lib/array/Array<Foo>~gc (; 5 ;) (type $i_) (param $0 i32)
+ (func $~lib/array/Array<Foo>~gc (; 5 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -155,7 +154,7 @@
    end
   end
  )
- (func $~lib/allocator/arena/__memory_allocate (; 6 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -217,10 +216,10 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/allocator/arena/__memory_free (; 7 ;) (type $i_) (param $0 i32)
+ (func $~lib/allocator/arena/__memory_free (; 7 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $~lib/collector/itcm/step (; 8 ;) (type $_)
+ (func $~lib/collector/itcm/step (; 8 ;) (type $FUNCSIG$v)
   (local $0 i32)
   block $break|0
    block $case3|0
@@ -267,7 +266,7 @@
      end
      global.get $std/gc-array/arr
      i32.const 3
-     call_indirect (type $i_)
+     call_indirect (type $FUNCSIG$vi)
      i32.const 2
      global.set $~lib/collector/itcm/state
      br $break|0
@@ -298,11 +297,11 @@
      i32.add
      local.get $0
      i32.load offset=8
-     call_indirect (type $i_)
+     call_indirect (type $FUNCSIG$vi)
     else     
      global.get $std/gc-array/arr
      i32.const 3
-     call_indirect (type $i_)
+     call_indirect (type $FUNCSIG$vi)
      global.get $~lib/collector/itcm/toSpace
      global.get $~lib/collector/itcm/iter
      i32.load
@@ -353,7 +352,7 @@
    end
   end
  )
- (func $~lib/collector/itcm/__gc_collect (; 9 ;) (type $_)
+ (func $~lib/collector/itcm/__gc_collect (; 9 ;) (type $FUNCSIG$v)
   (local $0 i32)
   block $break|0
    block $case1|0
@@ -379,7 +378,7 @@
    end
   end
  )
- (func $~lib/collector/itcm/__gc_allocate (; 10 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/collector/itcm/__gc_allocate (; 10 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   i32.const 1073741808
@@ -410,7 +409,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/internal/arraybuffer/allocateUnsafe (; 11 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/allocateUnsafe (; 11 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 1073741816
@@ -438,7 +437,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memcpy (; 12 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 12 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1335,7 +1334,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 13 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 13 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -1752,7 +1751,7 @@
    end
   end
  )
- (func $~lib/internal/arraybuffer/reallocateUnsafe (; 15 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/arraybuffer/reallocateUnsafe (; 15 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -1834,7 +1833,7 @@
   end
   local.get $0
  )
- (func $~lib/collector/itcm/__gc_link (; 16 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/__gc_link (; 16 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   global.get $~lib/collector/itcm/white
   i32.eqz
@@ -1864,7 +1863,7 @@
    call $~lib/collector/itcm/ManagedObject#makeGray
   end
  )
- (func $~lib/array/Array<Foo>#__set (; 17 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<Foo>#__set (; 17 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -1913,7 +1912,7 @@
   local.get $2
   call $~lib/collector/itcm/__gc_link
  )
- (func $start:std/gc-array (; 18 ;) (type $_)
+ (func $start:std/gc-array (; 18 ;) (type $FUNCSIG$v)
   i32.const 184
   global.set $~lib/allocator/arena/startOffset
   global.get $~lib/allocator/arena/startOffset
@@ -1941,7 +1940,7 @@
   call $~lib/array/Array<Foo>#__set
   call $~lib/collector/itcm/__gc_collect
  )
- (func $std/gc-array/main (; 19 ;) (type $i) (result i32)
+ (func $std/gc-array/main (; 19 ;) (type $FUNCSIG$i) (result i32)
   global.get $~lib/started
   i32.eqz
   if
@@ -1951,7 +1950,7 @@
   end
   i32.const 0
  )
- (func $null (; 20 ;) (type $_)
+ (func $null (; 20 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/gc-array.untouched.wat
+++ b/tests/compiler/std/gc-array.untouched.wat
@@ -1,12 +1,12 @@
 (module
- (type $_ (func))
- (type $i_ (func (param i32)))
- (type $ii (func (param i32) (result i32)))
- (type $ii_ (func (param i32 i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $iii_ (func (param i32 i32 i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $i (func (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$i (func (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\00\00\00\00\00\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
@@ -29,7 +29,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "main" (func $std/gc-array/main))
- (func $start:~lib/allocator/arena (; 1 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 1 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -41,7 +41,7 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $~lib/arraybuffer/ArrayBuffer~gc (; 2 ;) (type $i_) (param $0 i32)
+ (func $~lib/arraybuffer/ArrayBuffer~gc (; 2 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.eqz
   if
@@ -50,13 +50,13 @@
   local.get $0
   call $~lib/collector/itcm/__gc_mark
  )
- (func $~lib/collector/itcm/ManagedObject#get:color (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/collector/itcm/ManagedObject#get:color (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load
   i32.const 3
   i32.and
  )
- (func $~lib/collector/itcm/ManagedObject#get:next (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/collector/itcm/ManagedObject#get:next (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load
   i32.const 3
@@ -64,7 +64,7 @@
   i32.xor
   i32.and
  )
- (func $~lib/collector/itcm/ManagedObject#set:next (; 5 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/ManagedObject#set:next (; 5 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   local.get $0
@@ -74,7 +74,7 @@
   i32.or
   i32.store
  )
- (func $~lib/collector/itcm/ManagedObject#unlink (; 6 ;) (type $i_) (param $0 i32)
+ (func $~lib/collector/itcm/ManagedObject#unlink (; 6 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -90,7 +90,7 @@
   local.get $1
   call $~lib/collector/itcm/ManagedObject#set:next
  )
- (func $~lib/collector/itcm/ManagedObjectList#push (; 7 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/ManagedObjectList#push (; 7 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=4
@@ -108,7 +108,7 @@
   local.get $1
   i32.store offset=4
  )
- (func $~lib/collector/itcm/ManagedObject#makeGray (; 8 ;) (type $i_) (param $0 i32)
+ (func $~lib/collector/itcm/ManagedObject#makeGray (; 8 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   global.get $~lib/collector/itcm/iter
   i32.eq
@@ -133,7 +133,7 @@
   i32.or
   i32.store
  )
- (func $~lib/collector/itcm/__gc_mark (; 9 ;) (type $i_) (param $0 i32)
+ (func $~lib/collector/itcm/__gc_mark (; 9 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   local.get $0
   if
@@ -155,7 +155,7 @@
    end
   end
  )
- (func $~lib/array/Array<Foo>~gc (; 10 ;) (type $i_) (param $0 i32)
+ (func $~lib/array/Array<Foo>~gc (; 10 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -193,7 +193,7 @@
    end
   end
  )
- (func $~lib/allocator/arena/__memory_allocate (; 11 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 11 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -272,7 +272,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/collector/itcm/ManagedObjectList#clear (; 12 ;) (type $i_) (param $0 i32)
+ (func $~lib/collector/itcm/ManagedObjectList#clear (; 12 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   local.get $0
   i32.store
@@ -280,7 +280,7 @@
   local.get $0
   i32.store offset=4
  )
- (func $~lib/collector/itcm/ManagedObject#set:color (; 13 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/ManagedObject#set:color (; 13 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $0
   i32.load
@@ -292,10 +292,10 @@
   i32.or
   i32.store
  )
- (func $~lib/allocator/arena/__memory_free (; 14 ;) (type $i_) (param $0 i32)
+ (func $~lib/allocator/arena/__memory_free (; 14 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $~lib/collector/itcm/step (; 15 ;) (type $_)
+ (func $~lib/collector/itcm/step (; 15 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   block $break|0
@@ -391,7 +391,7 @@
       end
       local.get $0
       i32.load offset=8
-      call_indirect (type $i_)
+      call_indirect (type $FUNCSIG$vi)
      else      
       i32.const 3
       call $~iterateRoots
@@ -457,7 +457,7 @@
    unreachable
   end
  )
- (func $~lib/collector/itcm/__gc_collect (; 16 ;) (type $_)
+ (func $~lib/collector/itcm/__gc_collect (; 16 ;) (type $FUNCSIG$v)
   (local $0 i32)
   block $break|0
    block $case1|0
@@ -489,11 +489,11 @@
    end
   end
  )
- (func $~lib/gc/gc.collect (; 17 ;) (type $_)
+ (func $~lib/gc/gc.collect (; 17 ;) (type $FUNCSIG$v)
   call $~lib/collector/itcm/__gc_collect
   return
  )
- (func $~lib/collector/itcm/__gc_allocate (; 18 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/collector/itcm/__gc_allocate (; 18 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -532,7 +532,7 @@
    i32.add
   end
  )
- (func $std/gc-array/Foo~gc (; 19 ;) (type $i_) (param $0 i32)
+ (func $std/gc-array/Foo~gc (; 19 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.eqz
   if
@@ -541,7 +541,7 @@
   local.get $0
   call $~lib/collector/itcm/__gc_mark
  )
- (func $~lib/string/String~gc (; 20 ;) (type $i_) (param $0 i32)
+ (func $~lib/string/String~gc (; 20 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.eqz
   if
@@ -550,7 +550,7 @@
   local.get $0
   call $~lib/collector/itcm/__gc_mark
  )
- (func $~lib/internal/arraybuffer/computeSize (; 21 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/computeSize (; 21 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   i32.const 32
   local.get $0
@@ -562,10 +562,10 @@
   i32.sub
   i32.shl
  )
- (func $~lib/internal/arraybuffer/__gc (; 22 ;) (type $i_) (param $0 i32)
+ (func $~lib/internal/arraybuffer/__gc (; 22 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $~lib/internal/arraybuffer/allocateUnsafe (; 23 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/allocateUnsafe (; 23 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 1073741816
@@ -589,7 +589,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memcpy (; 24 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 24 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1790,7 +1790,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 25 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 25 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -2017,7 +2017,7 @@
    end
   end
  )
- (func $~lib/internal/memory/memset (; 26 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 26 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -2271,7 +2271,7 @@
    end
   end
  )
- (func $~lib/internal/arraybuffer/reallocateUnsafe (; 27 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/arraybuffer/reallocateUnsafe (; 27 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2371,7 +2371,7 @@
   end
   local.get $0
  )
- (func $~lib/collector/itcm/__gc_link (; 28 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/__gc_link (; 28 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   block $~lib/collector/itcm/refToObj|inlined.1 (result i32)
@@ -2407,7 +2407,7 @@
    call $~lib/collector/itcm/ManagedObject#makeGray
   end
  )
- (func $~lib/array/Array<Foo>#__set (; 29 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<Foo>#__set (; 29 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2477,7 +2477,7 @@
   local.get $2
   call $~lib/collector/itcm/__gc_link
  )
- (func $start:std/gc-array (; 30 ;) (type $_)
+ (func $start:std/gc-array (; 30 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2517,7 +2517,7 @@
   call $~lib/array/Array<Foo>#__set
   call $~lib/gc/gc.collect
  )
- (func $std/gc-array/main (; 31 ;) (type $i) (result i32)
+ (func $std/gc-array/main (; 31 ;) (type $FUNCSIG$i) (result i32)
   global.get $~lib/started
   i32.eqz
   if
@@ -2527,14 +2527,14 @@
   end
   i32.const 0
  )
- (func $start (; 32 ;) (type $_)
+ (func $start (; 32 ;) (type $FUNCSIG$v)
   call $start:std/gc-array
  )
- (func $null (; 33 ;) (type $_)
+ (func $null (; 33 ;) (type $FUNCSIG$v)
  )
- (func $~iterateRoots (; 34 ;) (type $i_) (param $0 i32)
+ (func $~iterateRoots (; 34 ;) (type $FUNCSIG$vi) (param $0 i32)
   global.get $std/gc-array/arr
   local.get $0
-  call_indirect (type $i_)
+  call_indirect (type $FUNCSIG$vi)
  )
 )

--- a/tests/compiler/std/gc-basics.optimized.wat
+++ b/tests/compiler/std/gc-basics.optimized.wat
@@ -1,10 +1,9 @@
 (module
- (type $_ (func))
- (type $i_ (func (param i32)))
- (type $ii (func (param i32) (result i32)))
- (type $ii_ (func (param i32 i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $i (func (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$i (func (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -25,10 +24,10 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "main" (func $std/gc-basics/main))
- (func $std/gc-basics/MyObject_visit (; 1 ;) (type $i_) (param $0 i32)
+ (func $std/gc-basics/MyObject_visit (; 1 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -90,7 +89,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/collector/itcm/ManagedObjectList#push (; 3 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/ManagedObjectList#push (; 3 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=4
@@ -118,7 +117,7 @@
   local.get $1
   i32.store offset=4
  )
- (func $~lib/collector/itcm/ManagedObject#makeGray (; 4 ;) (type $i_) (param $0 i32)
+ (func $~lib/collector/itcm/ManagedObject#makeGray (; 4 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   global.get $~lib/collector/itcm/iter
@@ -158,7 +157,7 @@
   i32.or
   i32.store
  )
- (func $~lib/collector/itcm/__gc_mark (; 5 ;) (type $i_) (param $0 i32)
+ (func $~lib/collector/itcm/__gc_mark (; 5 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   local.get $0
   if
@@ -177,7 +176,7 @@
    end
   end
  )
- (func $~lib/collector/itcm/step (; 6 ;) (type $_)
+ (func $~lib/collector/itcm/step (; 6 ;) (type $FUNCSIG$v)
   (local $0 i32)
   block $break|0
    block $case3|0
@@ -224,10 +223,10 @@
      end
      global.get $std/gc-basics/obj
      i32.const 2
-     call_indirect (type $i_)
+     call_indirect (type $FUNCSIG$vi)
      global.get $std/gc-basics/obj2
      i32.const 2
-     call_indirect (type $i_)
+     call_indirect (type $FUNCSIG$vi)
      i32.const 2
      global.set $~lib/collector/itcm/state
      br $break|0
@@ -258,14 +257,14 @@
      i32.add
      local.get $0
      i32.load offset=8
-     call_indirect (type $i_)
+     call_indirect (type $FUNCSIG$vi)
     else     
      global.get $std/gc-basics/obj
      i32.const 2
-     call_indirect (type $i_)
+     call_indirect (type $FUNCSIG$vi)
      global.get $std/gc-basics/obj2
      i32.const 2
-     call_indirect (type $i_)
+     call_indirect (type $FUNCSIG$vi)
      global.get $~lib/collector/itcm/toSpace
      global.get $~lib/collector/itcm/iter
      i32.load
@@ -339,7 +338,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/string/String~gc (; 8 ;) (type $i_) (param $0 i32)
+ (func $~lib/string/String~gc (; 8 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.eqz
   if
@@ -348,7 +347,7 @@
   local.get $0
   call $~lib/collector/itcm/__gc_mark
  )
- (func $~lib/collector/itcm/__gc_collect (; 9 ;) (type $_)
+ (func $~lib/collector/itcm/__gc_collect (; 9 ;) (type $FUNCSIG$v)
   (local $0 i32)
   block $break|0
    block $case1|0
@@ -374,7 +373,7 @@
    end
   end
  )
- (func $start:std/gc-basics (; 10 ;) (type $_)
+ (func $start:std/gc-basics (; 10 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -467,7 +466,7 @@
   global.set $std/gc-basics/obj
   call $~lib/collector/itcm/__gc_collect
  )
- (func $std/gc-basics/main (; 11 ;) (type $i) (result i32)
+ (func $std/gc-basics/main (; 11 ;) (type $FUNCSIG$i) (result i32)
   global.get $~lib/started
   i32.eqz
   if
@@ -477,7 +476,7 @@
   end
   i32.const 0
  )
- (func $null (; 12 ;) (type $_)
+ (func $null (; 12 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/gc-basics.untouched.wat
+++ b/tests/compiler/std/gc-basics.untouched.wat
@@ -1,11 +1,11 @@
 (module
- (type $_ (func))
- (type $i_ (func (param i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $ii (func (param i32) (result i32)))
- (type $ii_ (func (param i32 i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $i (func (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$i (func (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\00\00\00\00\00\00\00\00\03\00\00\00\00\00\00\00\10\00\00\00s\00t\00d\00/\00g\00c\00-\00b\00a\00s\00i\00c\00s\00.\00t\00s\00")
@@ -26,7 +26,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "main" (func $std/gc-basics/main))
- (func $start:~lib/allocator/arena (; 1 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 1 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -38,10 +38,10 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $std/gc-basics/MyObject_visit (; 2 ;) (type $i_) (param $0 i32)
+ (func $std/gc-basics/MyObject_visit (; 2 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $~lib/allocator/arena/__memory_allocate (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -120,7 +120,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/collector/itcm/ManagedObjectList#clear (; 4 ;) (type $i_) (param $0 i32)
+ (func $~lib/collector/itcm/ManagedObjectList#clear (; 4 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   local.get $0
   i32.store
@@ -128,13 +128,13 @@
   local.get $0
   i32.store offset=4
  )
- (func $~lib/collector/itcm/ManagedObject#get:color (; 5 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/collector/itcm/ManagedObject#get:color (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load
   i32.const 3
   i32.and
  )
- (func $~lib/collector/itcm/ManagedObject#get:next (; 6 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/collector/itcm/ManagedObject#get:next (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load
   i32.const 3
@@ -142,7 +142,7 @@
   i32.xor
   i32.and
  )
- (func $~lib/collector/itcm/ManagedObject#set:next (; 7 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/ManagedObject#set:next (; 7 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   local.get $0
@@ -152,7 +152,7 @@
   i32.or
   i32.store
  )
- (func $~lib/collector/itcm/ManagedObject#unlink (; 8 ;) (type $i_) (param $0 i32)
+ (func $~lib/collector/itcm/ManagedObject#unlink (; 8 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -168,7 +168,7 @@
   local.get $1
   call $~lib/collector/itcm/ManagedObject#set:next
  )
- (func $~lib/collector/itcm/ManagedObjectList#push (; 9 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/ManagedObjectList#push (; 9 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=4
@@ -186,7 +186,7 @@
   local.get $1
   i32.store offset=4
  )
- (func $~lib/collector/itcm/ManagedObject#makeGray (; 10 ;) (type $i_) (param $0 i32)
+ (func $~lib/collector/itcm/ManagedObject#makeGray (; 10 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   global.get $~lib/collector/itcm/iter
   i32.eq
@@ -211,7 +211,7 @@
   i32.or
   i32.store
  )
- (func $~lib/collector/itcm/__gc_mark (; 11 ;) (type $i_) (param $0 i32)
+ (func $~lib/collector/itcm/__gc_mark (; 11 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   local.get $0
   if
@@ -233,7 +233,7 @@
    end
   end
  )
- (func $~lib/collector/itcm/ManagedObject#set:color (; 12 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/ManagedObject#set:color (; 12 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $0
   i32.load
@@ -245,10 +245,10 @@
   i32.or
   i32.store
  )
- (func $~lib/allocator/arena/__memory_free (; 13 ;) (type $i_) (param $0 i32)
+ (func $~lib/allocator/arena/__memory_free (; 13 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $~lib/collector/itcm/step (; 14 ;) (type $_)
+ (func $~lib/collector/itcm/step (; 14 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   block $break|0
@@ -344,7 +344,7 @@
       end
       local.get $0
       i32.load offset=8
-      call_indirect (type $i_)
+      call_indirect (type $FUNCSIG$vi)
      else      
       i32.const 2
       call $~iterateRoots
@@ -410,7 +410,7 @@
    unreachable
   end
  )
- (func $~lib/collector/itcm/__gc_allocate (; 15 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/collector/itcm/__gc_allocate (; 15 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -449,7 +449,7 @@
    i32.add
   end
  )
- (func $~lib/string/String~gc (; 16 ;) (type $i_) (param $0 i32)
+ (func $~lib/string/String~gc (; 16 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.eqz
   if
@@ -458,7 +458,7 @@
   local.get $0
   call $~lib/collector/itcm/__gc_mark
  )
- (func $~lib/collector/itcm/__gc_collect (; 17 ;) (type $_)
+ (func $~lib/collector/itcm/__gc_collect (; 17 ;) (type $FUNCSIG$v)
   (local $0 i32)
   block $break|0
    block $case1|0
@@ -490,11 +490,11 @@
    end
   end
  )
- (func $~lib/gc/gc.collect (; 18 ;) (type $_)
+ (func $~lib/gc/gc.collect (; 18 ;) (type $FUNCSIG$v)
   call $~lib/collector/itcm/__gc_collect
   return
  )
- (func $start:std/gc-basics (; 19 ;) (type $_)
+ (func $start:std/gc-basics (; 19 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -603,7 +603,7 @@
   global.set $std/gc-basics/obj
   call $~lib/gc/gc.collect
  )
- (func $std/gc-basics/main (; 20 ;) (type $i) (result i32)
+ (func $std/gc-basics/main (; 20 ;) (type $FUNCSIG$i) (result i32)
   global.get $~lib/started
   i32.eqz
   if
@@ -613,17 +613,17 @@
   end
   i32.const 0
  )
- (func $start (; 21 ;) (type $_)
+ (func $start (; 21 ;) (type $FUNCSIG$v)
   call $start:std/gc-basics
  )
- (func $null (; 22 ;) (type $_)
+ (func $null (; 22 ;) (type $FUNCSIG$v)
  )
- (func $~iterateRoots (; 23 ;) (type $i_) (param $0 i32)
+ (func $~iterateRoots (; 23 ;) (type $FUNCSIG$vi) (param $0 i32)
   global.get $std/gc-basics/obj
   local.get $0
-  call_indirect (type $i_)
+  call_indirect (type $FUNCSIG$vi)
   global.get $std/gc-basics/obj2
   local.get $0
-  call_indirect (type $i_)
+  call_indirect (type $FUNCSIG$vi)
  )
 )

--- a/tests/compiler/std/gc-integration.optimized.wat
+++ b/tests/compiler/std/gc-integration.optimized.wat
@@ -1,7 +1,7 @@
 (module
- (type $i_ (func (param i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\15\00\00\00s\00t\00d\00/\00g\00c\00-\00i\00n\00t\00e\00g\00r\00a\00t\00i\00o\00n\00.\00t\00s")
@@ -14,7 +14,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:std/gc-integration~anonymous|0 (; 1 ;) (type $i_) (param $0 i32)
+ (func $start:std/gc-integration~anonymous|0 (; 1 ;) (type $FUNCSIG$vi) (param $0 i32)
   global.get $std/gc-integration/i
   i32.const 1
   i32.add
@@ -33,19 +33,19 @@
    unreachable
   end
  )
- (func $start:std/gc-integration (; 2 ;) (type $_)
+ (func $start:std/gc-integration (; 2 ;) (type $FUNCSIG$v)
   i32.const 8
   i32.const 1
-  call_indirect (type $i_)
+  call_indirect (type $FUNCSIG$vi)
   global.get $std/gc-integration/B.d
   i32.const 1
-  call_indirect (type $i_)
+  call_indirect (type $FUNCSIG$vi)
   global.get $std/gc-integration/a_ref
   i32.const 1
-  call_indirect (type $i_)
+  call_indirect (type $FUNCSIG$vi)
   global.get $std/gc-integration/b_ref
   i32.const 1
-  call_indirect (type $i_)
+  call_indirect (type $FUNCSIG$vi)
   global.get $std/gc-integration/i
   i32.const 4
   i32.ne
@@ -58,10 +58,10 @@
    unreachable
   end
  )
- (func $start (; 3 ;) (type $_)
+ (func $start (; 3 ;) (type $FUNCSIG$v)
   call $start:std/gc-integration
  )
- (func $null (; 4 ;) (type $_)
+ (func $null (; 4 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/gc-integration.untouched.wat
+++ b/tests/compiler/std/gc-integration.untouched.wat
@@ -1,7 +1,7 @@
 (module
- (type $i_ (func (param i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\15\00\00\00s\00t\00d\00/\00g\00c\00-\00i\00n\00t\00e\00g\00r\00a\00t\00i\00o\00n\00.\00t\00s\00")
@@ -17,7 +17,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:std/gc-integration~anonymous|0 (; 1 ;) (type $i_) (param $0 i32)
+ (func $start:std/gc-integration~anonymous|0 (; 1 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   block (result i32)
    global.get $std/gc-integration/i
@@ -39,7 +39,7 @@
    unreachable
   end
  )
- (func $start:std/gc-integration (; 2 ;) (type $_)
+ (func $start:std/gc-integration (; 2 ;) (type $FUNCSIG$v)
   global.get $std/gc-integration/B.c
   drop
   global.get $std/gc-integration/B.d
@@ -59,23 +59,23 @@
    unreachable
   end
  )
- (func $start (; 3 ;) (type $_)
+ (func $start (; 3 ;) (type $FUNCSIG$v)
   call $start:std/gc-integration
  )
- (func $null (; 4 ;) (type $_)
+ (func $null (; 4 ;) (type $FUNCSIG$v)
  )
- (func $~iterateRoots (; 5 ;) (type $i_) (param $0 i32)
+ (func $~iterateRoots (; 5 ;) (type $FUNCSIG$vi) (param $0 i32)
   global.get $std/gc-integration/B.c
   local.get $0
-  call_indirect (type $i_)
+  call_indirect (type $FUNCSIG$vi)
   global.get $std/gc-integration/B.d
   local.get $0
-  call_indirect (type $i_)
+  call_indirect (type $FUNCSIG$vi)
   global.get $std/gc-integration/a_ref
   local.get $0
-  call_indirect (type $i_)
+  call_indirect (type $FUNCSIG$vi)
   global.get $std/gc-integration/b_ref
   local.get $0
-  call_indirect (type $i_)
+  call_indirect (type $FUNCSIG$vi)
  )
 )

--- a/tests/compiler/std/gc-object.optimized.wat
+++ b/tests/compiler/std/gc-object.optimized.wat
@@ -1,9 +1,9 @@
 (module
- (type $_ (func))
- (type $iii (func (param i32 i32) (result i32)))
- (type $ii (func (param i32) (result i32)))
- (type $i_ (func (param i32)))
- (type $ii_ (func (param i32 i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$vii (func (param i32 i32)))
  (type $FUNCSIG$i (func (result i32)))
  (memory $0 0)
  (table $0 4 funcref)
@@ -21,7 +21,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "main" (func $std/gc-object/main))
- (func $~lib/allocator/arena/__memory_allocate (; 0 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 0 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -83,7 +83,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/collector/itcm/ManagedObjectList#push (; 1 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/ManagedObjectList#push (; 1 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=4
@@ -111,7 +111,7 @@
   local.get $1
   i32.store offset=4
  )
- (func $~lib/collector/itcm/ManagedObject#makeGray (; 2 ;) (type $i_) (param $0 i32)
+ (func $~lib/collector/itcm/ManagedObject#makeGray (; 2 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   global.get $~lib/collector/itcm/iter
@@ -151,7 +151,7 @@
   i32.or
   i32.store
  )
- (func $~lib/collector/itcm/__gc_mark (; 3 ;) (type $i_) (param $0 i32)
+ (func $~lib/collector/itcm/__gc_mark (; 3 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   local.get $0
   if
@@ -170,7 +170,7 @@
    end
   end
  )
- (func $~lib/collector/itcm/step (; 4 ;) (type $_)
+ (func $~lib/collector/itcm/step (; 4 ;) (type $FUNCSIG$v)
   (local $0 i32)
   block $break|0
    block $case3|0
@@ -217,7 +217,7 @@
      end
      global.get $std/gc-object/obj
      i32.const 1
-     call_indirect (type $i_)
+     call_indirect (type $FUNCSIG$vi)
      i32.const 2
      global.set $~lib/collector/itcm/state
      br $break|0
@@ -248,11 +248,11 @@
      i32.add
      local.get $0
      i32.load offset=8
-     call_indirect (type $i_)
+     call_indirect (type $FUNCSIG$vi)
     else     
      global.get $std/gc-object/obj
      i32.const 1
-     call_indirect (type $i_)
+     call_indirect (type $FUNCSIG$vi)
      global.get $~lib/collector/itcm/toSpace
      global.get $~lib/collector/itcm/iter
      i32.load
@@ -303,7 +303,7 @@
    end
   end
  )
- (func $~lib/collector/itcm/__gc_allocate (; 5 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/collector/itcm/__gc_allocate (; 5 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   i32.const 1073741808
@@ -334,7 +334,7 @@
   i32.const 16
   i32.add
  )
- (func $std/gc-object/Base~gc (; 6 ;) (type $i_) (param $0 i32)
+ (func $std/gc-object/Base~gc (; 6 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.eqz
   if
@@ -343,7 +343,7 @@
   local.get $0
   call $~lib/collector/itcm/__gc_mark
  )
- (func $std/gc-object/Custom~gc (; 7 ;) (type $i_) (param $0 i32)
+ (func $std/gc-object/Custom~gc (; 7 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.eqz
   if
@@ -351,7 +351,7 @@
   end
   local.get $0
   i32.const 2
-  call_indirect (type $i_)
+  call_indirect (type $FUNCSIG$vi)
   local.get $0
   i32.load
   call $~lib/collector/itcm/__gc_mark
@@ -380,7 +380,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $~lib/collector/itcm/__gc_collect (; 9 ;) (type $_)
+ (func $~lib/collector/itcm/__gc_collect (; 9 ;) (type $FUNCSIG$v)
   (local $0 i32)
   block $break|0
    block $case1|0
@@ -406,7 +406,7 @@
    end
   end
  )
- (func $start:std/gc-object (; 10 ;) (type $_)
+ (func $start:std/gc-object (; 10 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 8
   global.set $~lib/allocator/arena/startOffset
@@ -424,7 +424,7 @@
   global.set $std/gc-object/obj
   call $~lib/collector/itcm/__gc_collect
  )
- (func $std/gc-object/main (; 11 ;) (type $_)
+ (func $std/gc-object/main (; 11 ;) (type $FUNCSIG$v)
   global.get $~lib/started
   i32.eqz
   if
@@ -433,7 +433,7 @@
    global.set $~lib/started
   end
  )
- (func $null (; 12 ;) (type $_)
+ (func $null (; 12 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/gc-object.untouched.wat
+++ b/tests/compiler/std/gc-object.untouched.wat
@@ -1,9 +1,9 @@
 (module
- (type $_ (func))
- (type $iii (func (param i32 i32) (result i32)))
- (type $ii (func (param i32) (result i32)))
- (type $i_ (func (param i32)))
- (type $ii_ (func (param i32 i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$vii (func (param i32 i32)))
  (memory $0 0)
  (table $0 4 funcref)
  (elem (i32.const 0) $null $~lib/collector/itcm/__gc_mark $std/gc-object/Base~gc $std/gc-object/Custom~gc)
@@ -21,7 +21,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "main" (func $std/gc-object/main))
- (func $start:~lib/allocator/arena (; 0 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 0 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -33,7 +33,7 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -112,7 +112,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/collector/itcm/ManagedObjectList#clear (; 2 ;) (type $i_) (param $0 i32)
+ (func $~lib/collector/itcm/ManagedObjectList#clear (; 2 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   local.get $0
   i32.store
@@ -120,13 +120,13 @@
   local.get $0
   i32.store offset=4
  )
- (func $~lib/collector/itcm/ManagedObject#get:color (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/collector/itcm/ManagedObject#get:color (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load
   i32.const 3
   i32.and
  )
- (func $~lib/collector/itcm/ManagedObject#get:next (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/collector/itcm/ManagedObject#get:next (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load
   i32.const 3
@@ -134,7 +134,7 @@
   i32.xor
   i32.and
  )
- (func $~lib/collector/itcm/ManagedObject#set:next (; 5 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/ManagedObject#set:next (; 5 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   local.get $0
@@ -144,7 +144,7 @@
   i32.or
   i32.store
  )
- (func $~lib/collector/itcm/ManagedObject#unlink (; 6 ;) (type $i_) (param $0 i32)
+ (func $~lib/collector/itcm/ManagedObject#unlink (; 6 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -160,7 +160,7 @@
   local.get $1
   call $~lib/collector/itcm/ManagedObject#set:next
  )
- (func $~lib/collector/itcm/ManagedObjectList#push (; 7 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/ManagedObjectList#push (; 7 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=4
@@ -178,7 +178,7 @@
   local.get $1
   i32.store offset=4
  )
- (func $~lib/collector/itcm/ManagedObject#makeGray (; 8 ;) (type $i_) (param $0 i32)
+ (func $~lib/collector/itcm/ManagedObject#makeGray (; 8 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   global.get $~lib/collector/itcm/iter
   i32.eq
@@ -203,7 +203,7 @@
   i32.or
   i32.store
  )
- (func $~lib/collector/itcm/__gc_mark (; 9 ;) (type $i_) (param $0 i32)
+ (func $~lib/collector/itcm/__gc_mark (; 9 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   local.get $0
   if
@@ -225,7 +225,7 @@
    end
   end
  )
- (func $~lib/collector/itcm/ManagedObject#set:color (; 10 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/collector/itcm/ManagedObject#set:color (; 10 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $0
   i32.load
@@ -237,10 +237,10 @@
   i32.or
   i32.store
  )
- (func $~lib/allocator/arena/__memory_free (; 11 ;) (type $i_) (param $0 i32)
+ (func $~lib/allocator/arena/__memory_free (; 11 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $~lib/collector/itcm/step (; 12 ;) (type $_)
+ (func $~lib/collector/itcm/step (; 12 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   block $break|0
@@ -336,7 +336,7 @@
       end
       local.get $0
       i32.load offset=8
-      call_indirect (type $i_)
+      call_indirect (type $FUNCSIG$vi)
      else      
       i32.const 1
       call $~iterateRoots
@@ -402,7 +402,7 @@
    unreachable
   end
  )
- (func $~lib/collector/itcm/__gc_allocate (; 13 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/collector/itcm/__gc_allocate (; 13 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -441,7 +441,7 @@
    i32.add
   end
  )
- (func $std/gc-object/Base~gc (; 14 ;) (type $i_) (param $0 i32)
+ (func $std/gc-object/Base~gc (; 14 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.eqz
   if
@@ -450,7 +450,7 @@
   local.get $0
   call $~lib/collector/itcm/__gc_mark
  )
- (func $std/gc-object/Base#constructor (; 15 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/gc-object/Base#constructor (; 15 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -461,7 +461,7 @@
   end
   local.get $0
  )
- (func $std/gc-object/Custom~gc (; 16 ;) (type $i_) (param $0 i32)
+ (func $std/gc-object/Custom~gc (; 16 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.eqz
   if
@@ -469,7 +469,7 @@
   end
   local.get $0
   i32.const 2
-  call_indirect (type $i_)
+  call_indirect (type $FUNCSIG$vi)
   local.get $0
   i32.load
   call $~lib/collector/itcm/__gc_mark
@@ -477,7 +477,7 @@
   i32.load offset=4
   call $~lib/collector/itcm/__gc_mark
  )
- (func $std/gc-object/Custom#constructor (; 17 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/gc-object/Custom#constructor (; 17 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -497,7 +497,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $~lib/collector/itcm/__gc_collect (; 18 ;) (type $_)
+ (func $~lib/collector/itcm/__gc_collect (; 18 ;) (type $FUNCSIG$v)
   (local $0 i32)
   block $break|0
    block $case1|0
@@ -529,11 +529,11 @@
    end
   end
  )
- (func $~lib/gc/gc.collect (; 19 ;) (type $_)
+ (func $~lib/gc/gc.collect (; 19 ;) (type $FUNCSIG$v)
   call $~lib/collector/itcm/__gc_collect
   return
  )
- (func $start:std/gc-object (; 20 ;) (type $_)
+ (func $start:std/gc-object (; 20 ;) (type $FUNCSIG$v)
   call $start:~lib/allocator/arena
   i32.const 0
   call $std/gc-object/Custom#constructor
@@ -547,7 +547,7 @@
   global.set $std/gc-object/obj
   call $~lib/gc/gc.collect
  )
- (func $std/gc-object/main (; 21 ;) (type $_)
+ (func $std/gc-object/main (; 21 ;) (type $FUNCSIG$v)
   global.get $~lib/started
   i32.eqz
   if
@@ -556,14 +556,14 @@
    global.set $~lib/started
   end
  )
- (func $start (; 22 ;) (type $_)
+ (func $start (; 22 ;) (type $FUNCSIG$v)
   call $start:std/gc-object
  )
- (func $null (; 23 ;) (type $_)
+ (func $null (; 23 ;) (type $FUNCSIG$v)
  )
- (func $~iterateRoots (; 24 ;) (type $i_) (param $0 i32)
+ (func $~iterateRoots (; 24 ;) (type $FUNCSIG$vi) (param $0 i32)
   global.get $std/gc-object/obj
   local.get $0
-  call_indirect (type $i_)
+  call_indirect (type $FUNCSIG$vi)
  )
 )

--- a/tests/compiler/std/hash.optimized.wat
+++ b/tests/compiler/std/hash.optimized.wat
@@ -1,7 +1,7 @@
 (module
- (type $ii (func (param i32) (result i32)))
- (type $Ii (func (param i64) (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$ij (func (param i64) (result i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 1)
  (data (i32.const 16) "\01\00\00\00a")
  (data (i32.const 24) "\02\00\00\00a\00b")
@@ -11,7 +11,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $~lib/internal/hash/hashStr (; 0 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/hash/hashStr (; 0 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -46,7 +46,7 @@
   end
   local.get $2
  )
- (func $~lib/internal/hash/hash32 (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/hash/hash32 (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -77,7 +77,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/internal/hash/hash64 (; 2 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/hash/hash64 (; 2 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   local.get $0
   i32.wrap_i64
@@ -143,7 +143,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $start:std/hash (; 3 ;) (type $_)
+ (func $start:std/hash (; 3 ;) (type $FUNCSIG$v)
   i32.const 0
   call $~lib/internal/hash/hashStr
   drop
@@ -196,10 +196,10 @@
   call $~lib/internal/hash/hash64
   drop
  )
- (func $start (; 4 ;) (type $_)
+ (func $start (; 4 ;) (type $FUNCSIG$v)
   call $start:std/hash
  )
- (func $null (; 5 ;) (type $_)
+ (func $null (; 5 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/hash.untouched.wat
+++ b/tests/compiler/std/hash.untouched.wat
@@ -1,7 +1,7 @@
 (module
- (type $ii (func (param i32) (result i32)))
- (type $Ii (func (param i64) (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$ij (func (param i64) (result i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 1)
  (data (i32.const 8) "\00\00\00\00")
  (data (i32.const 16) "\01\00\00\00a\00")
@@ -13,7 +13,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $~lib/internal/hash/hashStr (; 0 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/hash/hashStr (; 0 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -55,10 +55,10 @@
   end
   local.get $1
  )
- (func $std/hash/check (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/hash/check (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
  )
- (func $~lib/internal/hash/hash32 (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/hash/hash32 (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   i32.const -2128831035
   local.set $1
@@ -100,7 +100,7 @@
   local.set $1
   local.get $1
  )
- (func $~lib/internal/hash/hash64 (; 3 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/hash/hash64 (; 3 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -188,7 +188,7 @@
   local.set $3
   local.get $3
  )
- (func $start:std/hash (; 4 ;) (type $_)
+ (func $start:std/hash (; 4 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f32)
   (local $2 f64)
@@ -358,9 +358,9 @@
   call $std/hash/check
   drop
  )
- (func $start (; 5 ;) (type $_)
+ (func $start (; 5 ;) (type $FUNCSIG$v)
   call $start:std/hash
  )
- (func $null (; 6 ;) (type $_)
+ (func $null (; 6 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/libm.optimized.wat
+++ b/tests/compiler/std/libm.optimized.wat
@@ -1,9 +1,9 @@
 (module
- (type $FF (func (param f64) (result f64)))
- (type $FFF (func (param f64 f64) (result f64)))
- (type $FiF (func (param f64 i32) (result f64)))
- (type $Ff (func (param f64) (result f32)))
- (type $_ (func))
+ (type $FUNCSIG$dd (func (param f64) (result f64)))
+ (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))
+ (type $FUNCSIG$ddi (func (param f64 i32) (result f64)))
+ (type $FUNCSIG$fd (func (param f64) (result f32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -59,11 +59,11 @@
  (export "tan" (func $std/libm/cos))
  (export "tanh" (func $std/libm/tanh))
  (export "trunc" (func $std/libm/trunc))
- (func $std/libm/abs (; 0 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/abs (; 0 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   f64.abs
  )
- (func $~lib/math/R (; 1 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/R (; 1 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   f64.const 0.16666666666666666
   local.get $0
@@ -106,7 +106,7 @@
   f64.add
   f64.div
  )
- (func $~lib/math/NativeMath.acos (; 2 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.acos (; 2 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -234,11 +234,11 @@
   f64.add
   f64.mul
  )
- (func $std/libm/acos (; 3 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/acos (; 3 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.acos
  )
- (func $~lib/math/NativeMath.log1p (; 4 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log1p (; 4 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -440,7 +440,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.log (; 5 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log (; 5 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -618,7 +618,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.acosh (; 6 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.acosh (; 6 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   local.get $0
   i64.reinterpret_f64
@@ -672,11 +672,11 @@
   f64.const 0.6931471805599453
   f64.add
  )
- (func $std/libm/acosh (; 7 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/acosh (; 7 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.acosh
  )
- (func $~lib/math/NativeMath.asin (; 8 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.asin (; 8 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -817,11 +817,11 @@
   end
   local.get $0
  )
- (func $std/libm/asin (; 9 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/asin (; 9 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.asin
  )
- (func $~lib/math/NativeMath.asinh (; 10 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.asinh (; 10 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i64)
   local.get $0
@@ -891,11 +891,11 @@
   local.get $0
   f64.copysign
  )
- (func $std/libm/asinh (; 11 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/asinh (; 11 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.asinh
  )
- (func $~lib/math/NativeMath.atan (; 12 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atan (; 12 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -1118,11 +1118,11 @@
   local.get $4
   f64.copysign
  )
- (func $std/libm/atan (; 13 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/atan (; 13 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.atan
  )
- (func $~lib/math/NativeMath.atanh (; 14 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atanh (; 14 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i64)
   (local $3 i64)
@@ -1181,11 +1181,11 @@
   local.get $0
   f64.copysign
  )
- (func $std/libm/atanh (; 15 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/atanh (; 15 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.atanh
  )
- (func $~lib/math/NativeMath.atan2 (; 16 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.atan2 (; 16 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1429,12 +1429,12 @@
   i32.and
   select
  )
- (func $std/libm/atan2 (; 17 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $std/libm/atan2 (; 17 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.atan2
  )
- (func $~lib/math/NativeMath.cbrt (; 18 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cbrt (; 18 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   (local $3 i32)
@@ -1555,15 +1555,15 @@
   f64.mul
   f64.add
  )
- (func $std/libm/cbrt (; 19 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/cbrt (; 19 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.cbrt
  )
- (func $std/libm/ceil (; 20 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/ceil (; 20 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   f64.ceil
  )
- (func $~lib/math/NativeMath.clz32 (; 21 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.clz32 (; 21 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   local.get $0
   f64.sub
@@ -1586,14 +1586,14 @@
   i32.clz
   f64.convert_i32_s
  )
- (func $std/libm/clz32 (; 22 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/clz32 (; 22 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.clz32
  )
- (func $std/libm/cos (; 23 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/cos (; 23 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   unreachable
  )
- (func $~lib/math/NativeMath.expm1 (; 24 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.expm1 (; 24 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   (local $3 i32)
@@ -1872,7 +1872,7 @@
   local.get $5
   f64.mul
  )
- (func $~lib/math/NativeMath.scalbn (; 25 ;) (type $FiF) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/NativeMath.scalbn (; 25 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
   local.get $1
   i32.const 1023
   i32.gt_s
@@ -1949,7 +1949,7 @@
   f64.reinterpret_i64
   f64.mul
  )
- (func $~lib/math/NativeMath.exp (; 26 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.exp (; 26 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 f64)
   (local $3 i32)
@@ -2099,7 +2099,7 @@
   local.get $3
   call $~lib/math/NativeMath.scalbn
  )
- (func $~lib/math/NativeMath.cosh (; 27 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cosh (; 27 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i64)
   local.get $0
@@ -2163,27 +2163,27 @@
   f64.const 2247116418577894884661631e283
   f64.mul
  )
- (func $std/libm/cosh (; 28 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/cosh (; 28 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.cosh
  )
- (func $std/libm/exp (; 29 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/exp (; 29 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.exp
  )
- (func $std/libm/expm1 (; 30 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/expm1 (; 30 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.expm1
  )
- (func $std/libm/floor (; 31 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/floor (; 31 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   f64.floor
  )
- (func $std/libm/fround (; 32 ;) (type $Ff) (param $0 f64) (result f32)
+ (func $std/libm/fround (; 32 ;) (type $FUNCSIG$fd) (param $0 f64) (result f32)
   local.get $0
   f32.demote_f64
  )
- (func $~lib/math/NativeMath.hypot (; 33 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.hypot (; 33 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 i64)
   (local $4 f64)
@@ -2362,12 +2362,12 @@
   f64.sqrt
   f64.mul
  )
- (func $std/libm/hypot (; 34 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $std/libm/hypot (; 34 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.hypot
  )
- (func $~lib/math/NativeMath.imul (; 35 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.imul (; 35 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   local.get $0
   local.get $1
@@ -2404,16 +2404,16 @@
   i32.mul
   f64.convert_i32_s
  )
- (func $std/libm/imul (; 36 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $std/libm/imul (; 36 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.imul
  )
- (func $std/libm/log (; 37 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/log (; 37 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.log
  )
- (func $~lib/math/NativeMath.log10 (; 38 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log10 (; 38 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -2625,15 +2625,15 @@
   local.get $0
   f64.add
  )
- (func $std/libm/log10 (; 39 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/log10 (; 39 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.log10
  )
- (func $std/libm/log1p (; 40 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/log1p (; 40 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.log1p
  )
- (func $~lib/math/NativeMath.log2 (; 41 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log2 (; 41 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -2839,21 +2839,21 @@
   local.get $0
   f64.add
  )
- (func $std/libm/log2 (; 42 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/log2 (; 42 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.log2
  )
- (func $std/libm/max (; 43 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $std/libm/max (; 43 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   f64.max
  )
- (func $std/libm/min (; 44 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $std/libm/min (; 44 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   f64.min
  )
- (func $~lib/math/NativeMath.pow (; 45 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.pow (; 45 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 f64)
   (local $4 i32)
@@ -3803,12 +3803,12 @@
   f64.const 1e-300
   f64.mul
  )
- (func $std/libm/pow (; 46 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $std/libm/pow (; 46 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.pow
  )
- (func $std/libm/round (; 47 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/round (; 47 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   f64.const 0.5
   f64.add
@@ -3816,7 +3816,7 @@
   local.get $0
   f64.copysign
  )
- (func $std/libm/sign (; 48 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/sign (; 48 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   f64.const 0
   f64.gt
@@ -3834,7 +3834,7 @@
   end
   local.get $0
  )
- (func $~lib/math/NativeMath.sinh (; 49 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.sinh (; 49 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   (local $3 i32)
@@ -3911,15 +3911,15 @@
   f64.mul
   f64.mul
  )
- (func $std/libm/sinh (; 50 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/sinh (; 50 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.sinh
  )
- (func $std/libm/sqrt (; 51 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/sqrt (; 51 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   f64.sqrt
  )
- (func $~lib/math/NativeMath.tanh (; 52 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.tanh (; 52 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i64)
@@ -3998,15 +3998,15 @@
   local.get $0
   f64.copysign
  )
- (func $std/libm/tanh (; 53 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/tanh (; 53 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.tanh
  )
- (func $std/libm/trunc (; 54 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/trunc (; 54 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   f64.trunc
  )
- (func $null (; 55 ;) (type $_)
+ (func $null (; 55 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/libm.untouched.wat
+++ b/tests/compiler/std/libm.untouched.wat
@@ -1,10 +1,10 @@
 (module
- (type $FF (func (param f64) (result f64)))
- (type $Fi (func (param f64) (result i32)))
- (type $FFF (func (param f64 f64) (result f64)))
- (type $FiF (func (param f64 i32) (result f64)))
- (type $Ff (func (param f64) (result f32)))
- (type $_ (func))
+ (type $FUNCSIG$dd (func (param f64) (result f64)))
+ (type $FUNCSIG$id (func (param f64) (result i32)))
+ (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))
+ (type $FUNCSIG$ddi (func (param f64 i32) (result f64)))
+ (type $FUNCSIG$fd (func (param f64) (result f32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -70,14 +70,14 @@
  (export "tan" (func $std/libm/tan))
  (export "tanh" (func $std/libm/tanh))
  (export "trunc" (func $std/libm/trunc))
- (func $std/libm/abs (; 0 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/abs (; 0 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   local.get $0
   local.set $1
   local.get $1
   f64.abs
  )
- (func $~lib/math/R (; 1 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/R (; 1 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   local.get $0
@@ -126,7 +126,7 @@
   local.get $2
   f64.div
  )
- (func $~lib/math/NativeMath.acos (; 2 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.acos (; 2 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -278,11 +278,11 @@
   f64.add
   f64.mul
  )
- (func $std/libm/acos (; 3 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/acos (; 3 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.acos
  )
- (func $~lib/math/NativeMath.log1p (; 4 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log1p (; 4 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -527,7 +527,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.log (; 5 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log (; 5 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -740,7 +740,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.acosh (; 6 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.acosh (; 6 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   local.get $0
   i64.reinterpret_f64
@@ -804,11 +804,11 @@
   f64.const 0.6931471805599453
   f64.add
  )
- (func $std/libm/acosh (; 7 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/acosh (; 7 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.acosh
  )
- (func $~lib/math/NativeMath.asin (; 8 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.asin (; 8 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -968,11 +968,11 @@
   end
   local.get $0
  )
- (func $std/libm/asin (; 9 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/asin (; 9 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.asin
  )
- (func $~lib/math/NativeMath.asinh (; 10 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.asinh (; 10 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i64)
   (local $3 f64)
@@ -1054,16 +1054,16 @@
   local.get $0
   f64.copysign
  )
- (func $std/libm/asinh (; 11 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/asinh (; 11 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.asinh
  )
- (func $~lib/builtins/isNaN<f64> (; 12 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $~lib/builtins/isNaN<f64> (; 12 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   local.get $0
   f64.ne
  )
- (func $~lib/math/NativeMath.atan (; 13 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atan (; 13 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 f64)
   (local $3 f64)
@@ -1336,11 +1336,11 @@
   local.get $2
   f64.copysign
  )
- (func $std/libm/atan (; 14 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/atan (; 14 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.atan
  )
- (func $~lib/math/NativeMath.atanh (; 15 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atanh (; 15 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -1412,11 +1412,11 @@
   local.get $0
   f64.copysign
  )
- (func $std/libm/atanh (; 16 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/atanh (; 16 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.atanh
  )
- (func $~lib/math/NativeMath.atan2 (; 17 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.atan2 (; 17 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i32)
   (local $3 i64)
   (local $4 i32)
@@ -1763,12 +1763,12 @@
   unreachable
   f64.const 0
  )
- (func $std/libm/atan2 (; 18 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $std/libm/atan2 (; 18 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.atan2
  )
- (func $~lib/math/NativeMath.cbrt (; 19 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cbrt (; 19 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 f64)
@@ -1912,25 +1912,25 @@
   local.set $3
   local.get $3
  )
- (func $std/libm/cbrt (; 20 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/cbrt (; 20 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.cbrt
  )
- (func $std/libm/ceil (; 21 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/ceil (; 21 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   local.get $0
   local.set $1
   local.get $1
   f64.ceil
  )
- (func $~lib/builtins/isFinite<f64> (; 22 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $~lib/builtins/isFinite<f64> (; 22 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   local.get $0
   f64.sub
   f64.const 0
   f64.eq
  )
- (func $~lib/math/NativeMath.clz32 (; 23 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.clz32 (; 23 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/builtins/isFinite<f64>
   i32.eqz
@@ -1953,19 +1953,19 @@
   i32.clz
   f64.convert_i32_s
  )
- (func $std/libm/clz32 (; 24 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/clz32 (; 24 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.clz32
  )
- (func $~lib/math/NativeMath.cos (; 25 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cos (; 25 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   unreachable
   f64.const 0
  )
- (func $std/libm/cos (; 26 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/cos (; 26 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.cos
  )
- (func $~lib/math/NativeMath.expm1 (; 27 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.expm1 (; 27 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -2279,7 +2279,7 @@
   local.get $14
   f64.mul
  )
- (func $~lib/math/NativeMath.scalbn (; 28 ;) (type $FiF) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/NativeMath.scalbn (; 28 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
@@ -2370,7 +2370,7 @@
   f64.reinterpret_i64
   f64.mul
  )
- (func $~lib/math/NativeMath.exp (; 29 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.exp (; 29 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -2535,7 +2535,7 @@
   local.get $5
   call $~lib/math/NativeMath.scalbn
  )
- (func $~lib/math/NativeMath.cosh (; 30 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cosh (; 30 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 f64)
@@ -2630,33 +2630,33 @@
   local.set $3
   local.get $3
  )
- (func $std/libm/cosh (; 31 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/cosh (; 31 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.cosh
  )
- (func $std/libm/exp (; 32 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/exp (; 32 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.exp
  )
- (func $std/libm/expm1 (; 33 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/expm1 (; 33 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.expm1
  )
- (func $std/libm/floor (; 34 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/floor (; 34 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   local.get $0
   local.set $1
   local.get $1
   f64.floor
  )
- (func $std/libm/fround (; 35 ;) (type $Ff) (param $0 f64) (result f32)
+ (func $std/libm/fround (; 35 ;) (type $FUNCSIG$fd) (param $0 f64) (result f32)
   (local $1 f64)
   local.get $0
   local.set $1
   local.get $1
   f32.demote_f64
  )
- (func $~lib/math/NativeMath.hypot (; 36 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.hypot (; 36 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -2857,12 +2857,12 @@
   f64.sqrt
   f64.mul
  )
- (func $std/libm/hypot (; 37 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $std/libm/hypot (; 37 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.hypot
  )
- (func $~lib/math/NativeMath.imul (; 38 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.imul (; 38 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   f64.add
@@ -2895,16 +2895,16 @@
   i32.mul
   f64.convert_i32_s
  )
- (func $std/libm/imul (; 39 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $std/libm/imul (; 39 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.imul
  )
- (func $std/libm/log (; 40 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/log (; 40 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.log
  )
- (func $~lib/math/NativeMath.log10 (; 41 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log10 (; 41 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -3167,15 +3167,15 @@
   local.get $9
   f64.add
  )
- (func $std/libm/log10 (; 42 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/log10 (; 42 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.log10
  )
- (func $std/libm/log1p (; 43 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/log1p (; 43 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.log1p
  )
- (func $~lib/math/NativeMath.log2 (; 44 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log2 (; 44 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -3431,11 +3431,11 @@
   local.get $15
   f64.add
  )
- (func $std/libm/log2 (; 45 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/log2 (; 45 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.log2
  )
- (func $std/libm/max (; 46 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $std/libm/max (; 46 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 f64)
   local.get $0
@@ -3446,7 +3446,7 @@
   local.get $3
   f64.max
  )
- (func $std/libm/min (; 47 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $std/libm/min (; 47 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 f64)
   local.get $0
@@ -3457,7 +3457,7 @@
   local.get $3
   f64.min
  )
- (func $~lib/math/NativeMath.pow (; 48 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.pow (; 48 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -4545,12 +4545,12 @@
   local.get $16
   f64.mul
  )
- (func $std/libm/pow (; 49 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $std/libm/pow (; 49 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.pow
  )
- (func $std/libm/round (; 50 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/round (; 50 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   local.get $0
   local.set $1
@@ -4561,7 +4561,7 @@
   local.get $1
   f64.copysign
  )
- (func $std/libm/sign (; 51 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/sign (; 51 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   block $~lib/math/NativeMath.sign|inlined.0 (result f64)
    local.get $0
@@ -4584,15 +4584,15 @@
    br $~lib/math/NativeMath.sign|inlined.0
   end
  )
- (func $~lib/math/NativeMath.sin (; 52 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.sin (; 52 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   unreachable
   f64.const 0
  )
- (func $std/libm/sin (; 53 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/sin (; 53 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.sin
  )
- (func $~lib/math/NativeMath.sinh (; 54 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.sinh (; 54 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 f64)
   (local $3 i32)
@@ -4696,26 +4696,26 @@
   local.set $4
   local.get $4
  )
- (func $std/libm/sinh (; 55 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/sinh (; 55 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.sinh
  )
- (func $std/libm/sqrt (; 56 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/sqrt (; 56 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   local.get $0
   local.set $1
   local.get $1
   f64.sqrt
  )
- (func $~lib/math/NativeMath.tan (; 57 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.tan (; 57 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   unreachable
   f64.const 0
  )
- (func $std/libm/tan (; 58 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/tan (; 58 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.tan
  )
- (func $~lib/math/NativeMath.tanh (; 59 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.tanh (; 59 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 f64)
   (local $3 i32)
@@ -4807,17 +4807,17 @@
   local.get $0
   f64.copysign
  )
- (func $std/libm/tanh (; 60 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/tanh (; 60 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.tanh
  )
- (func $std/libm/trunc (; 61 ;) (type $FF) (param $0 f64) (result f64)
+ (func $std/libm/trunc (; 61 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   local.get $0
   local.set $1
   local.get $1
   f64.trunc
  )
- (func $null (; 62 ;) (type $_)
+ (func $null (; 62 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -1,24 +1,22 @@
 (module
- (type $_ (func))
- (type $ii (func (param i32) (result i32)))
- (type $i_ (func (param i32)))
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $iii_ (func (param i32 i32 i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $ii_ (func (param i32 i32)))
- (type $iIi (func (param i32 i64) (result i32)))
- (type $Ii (func (param i64) (result i32)))
- (type $iIii (func (param i32 i64 i32) (result i32)))
- (type $iIi_ (func (param i32 i64 i32)))
- (type $ifi (func (param i32 f32) (result i32)))
- (type $ifii (func (param i32 f32 i32) (result i32)))
- (type $ifi_ (func (param i32 f32 i32)))
- (type $iFi (func (param i32 f64) (result i32)))
- (type $iFii (func (param i32 f64 i32) (result i32)))
- (type $iFi_ (func (param i32 f64 i32)))
- (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$iij (func (param i32 i64) (result i32)))
+ (type $FUNCSIG$ij (func (param i64) (result i32)))
+ (type $FUNCSIG$iiji (func (param i32 i64 i32) (result i32)))
+ (type $FUNCSIG$viji (func (param i32 i64 i32)))
+ (type $FUNCSIG$iif (func (param i32 f32) (result i32)))
+ (type $FUNCSIG$iifi (func (param i32 f32 i32) (result i32)))
+ (type $FUNCSIG$vifi (func (param i32 f32 i32)))
+ (type $FUNCSIG$iid (func (param i32 f64) (result i32)))
+ (type $FUNCSIG$iidi (func (param i32 f64 i32) (result i32)))
+ (type $FUNCSIG$vidi (func (param i32 f64 i32)))
  (type $FUNCSIG$i (func (result i32)))
  (type $FUNCSIG$vij (func (param i32 i64)))
  (type $FUNCSIG$vif (func (param i32 f32)))
@@ -35,7 +33,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -97,7 +95,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/internal/arraybuffer/allocateUnsafe (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/allocateUnsafe (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 1073741816
@@ -370,7 +368,7 @@
   end
   local.get $2
  )
- (func $~lib/map/Map<i8,i32>#clear (; 5 ;) (type $i_) (param $0 i32)
+ (func $~lib/map/Map<i8,i32>#clear (; 5 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 16
   i32.const 0
@@ -420,7 +418,7 @@
   call $~lib/map/Map<i8,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<i8,i32>#find (; 7 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#find (; 7 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -465,7 +463,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i8,i32>#has (; 8 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#has (; 8 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -481,7 +479,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i8,i32>#rehash (; 9 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i8,i32>#rehash (; 9 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -591,7 +589,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<i8,i32>#set (; 10 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<i8,i32>#set (; 10 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -692,7 +690,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/map/Map<i8,i32>#get (; 11 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#get (; 11 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -780,7 +778,7 @@
    call $~lib/map/Map<i8,i32>#rehash
   end
  )
- (func $std/map/test<i8,i32> (; 13 ;) (type $_)
+ (func $std/map/test<i8,i32> (; 13 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   call $~lib/map/Map<i8,i32>#constructor
@@ -1124,7 +1122,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<u8,i32>#has (; 14 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#has (; 14 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -1138,7 +1136,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u8,i32>#rehash (; 15 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,i32>#rehash (; 15 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1248,7 +1246,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<u8,i32>#set (; 16 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<u8,i32>#set (; 16 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1347,7 +1345,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/map/Map<u8,i32>#get (; 17 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#get (; 17 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -1431,7 +1429,7 @@
    call $~lib/map/Map<u8,i32>#rehash
   end
  )
- (func $std/map/test<u8,i32> (; 19 ;) (type $_)
+ (func $std/map/test<u8,i32> (; 19 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   call $~lib/map/Map<i8,i32>#constructor
@@ -1761,7 +1759,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<i16,i32>#find (; 20 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#find (; 20 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -1806,7 +1804,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i16,i32>#has (; 21 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#has (; 21 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -1832,7 +1830,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i16,i32>#rehash (; 22 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i16,i32>#rehash (; 22 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1951,7 +1949,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<i16,i32>#set (; 23 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<i16,i32>#set (; 23 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2061,7 +2059,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/map/Map<i16,i32>#get (; 24 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#get (; 24 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -2167,7 +2165,7 @@
    call $~lib/map/Map<i16,i32>#rehash
   end
  )
- (func $std/map/test<i16,i32> (; 26 ;) (type $_)
+ (func $std/map/test<i16,i32> (; 26 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   call $~lib/map/Map<i8,i32>#constructor
@@ -2511,7 +2509,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<u16,i32>#has (; 27 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#has (; 27 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -2535,7 +2533,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u16,i32>#rehash (; 28 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,i32>#rehash (; 28 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2654,7 +2652,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<u16,i32>#set (; 29 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<u16,i32>#set (; 29 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2762,7 +2760,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/map/Map<u16,i32>#get (; 30 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#get (; 30 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -2864,7 +2862,7 @@
    call $~lib/map/Map<u16,i32>#rehash
   end
  )
- (func $std/map/test<u16,i32> (; 32 ;) (type $_)
+ (func $std/map/test<u16,i32> (; 32 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   call $~lib/map/Map<i8,i32>#constructor
@@ -3194,7 +3192,7 @@
    unreachable
   end
  )
- (func $~lib/internal/hash/hash32 (; 33 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/hash/hash32 (; 33 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -3225,7 +3223,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/map/Map<i32,i32>#find (; 34 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#find (; 34 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -3268,7 +3266,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i32,i32>#has (; 35 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#has (; 35 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -3277,7 +3275,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i32,i32>#rehash (; 36 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i32,i32>#rehash (; 36 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3384,7 +3382,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<i32,i32>#set (; 37 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<i32,i32>#set (; 37 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3476,7 +3474,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/map/Map<i32,i32>#get (; 38 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#get (; 38 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -3550,7 +3548,7 @@
    call $~lib/map/Map<i32,i32>#rehash
   end
  )
- (func $std/map/test<i32,i32> (; 40 ;) (type $_)
+ (func $std/map/test<i32,i32> (; 40 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   call $~lib/map/Map<i8,i32>#constructor
@@ -3866,7 +3864,7 @@
    unreachable
   end
  )
- (func $std/map/test<u32,i32> (; 41 ;) (type $_)
+ (func $std/map/test<u32,i32> (; 41 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   call $~lib/map/Map<i8,i32>#constructor
@@ -4182,7 +4180,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<i64,i32>#clear (; 42 ;) (type $i_) (param $0 i32)
+ (func $~lib/map/Map<i64,i32>#clear (; 42 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 16
   i32.const 0
@@ -4232,7 +4230,7 @@
   call $~lib/map/Map<i64,i32>#clear
   local.get $0
  )
- (func $~lib/internal/hash/hash64 (; 44 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/hash/hash64 (; 44 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   local.get $0
   i32.wrap_i64
@@ -4298,7 +4296,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/map/Map<i64,i32>#find (; 45 ;) (type $iIii) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#find (; 45 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -4341,7 +4339,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i64,i32>#has (; 46 ;) (type $iIi) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<i64,i32>#has (; 46 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -4350,7 +4348,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i64,i32>#rehash (; 47 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i64,i32>#rehash (; 47 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4457,7 +4455,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<i64,i32>#set (; 48 ;) (type $iIi_) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/map/Map<i64,i32>#set (; 48 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4549,7 +4547,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/map/Map<i64,i32>#get (; 49 ;) (type $iIi) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<i64,i32>#get (; 49 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -4624,7 +4622,7 @@
    call $~lib/map/Map<i64,i32>#rehash
   end
  )
- (func $std/map/test<i64,i32> (; 51 ;) (type $_)
+ (func $std/map/test<i64,i32> (; 51 ;) (type $FUNCSIG$v)
   (local $0 i64)
   (local $1 i32)
   call $~lib/map/Map<i64,i32>#constructor
@@ -4947,7 +4945,7 @@
    unreachable
   end
  )
- (func $std/map/test<u64,i32> (; 52 ;) (type $_)
+ (func $std/map/test<u64,i32> (; 52 ;) (type $FUNCSIG$v)
   (local $0 i64)
   (local $1 i32)
   call $~lib/map/Map<i64,i32>#constructor
@@ -5270,7 +5268,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<f32,i32>#find (; 53 ;) (type $ifii) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#find (; 53 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -5313,7 +5311,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f32,i32>#has (; 54 ;) (type $ifi) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/map/Map<f32,i32>#has (; 54 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -5323,7 +5321,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<f32,i32>#rehash (; 55 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f32,i32>#rehash (; 55 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5431,7 +5429,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<f32,i32>#set (; 56 ;) (type $ifi_) (param $0 i32) (param $1 f32) (param $2 i32)
+ (func $~lib/map/Map<f32,i32>#set (; 56 ;) (type $FUNCSIG$vifi) (param $0 i32) (param $1 f32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5524,7 +5522,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/map/Map<f32,i32>#get (; 57 ;) (type $ifi) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/map/Map<f32,i32>#get (; 57 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -5601,7 +5599,7 @@
    call $~lib/map/Map<f32,i32>#rehash
   end
  )
- (func $std/map/test<f32,i32> (; 59 ;) (type $_)
+ (func $std/map/test<f32,i32> (; 59 ;) (type $FUNCSIG$v)
   (local $0 f32)
   (local $1 i32)
   call $~lib/map/Map<i8,i32>#constructor
@@ -5924,7 +5922,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<f64,i32>#find (; 60 ;) (type $iFii) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#find (; 60 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -5967,7 +5965,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f64,i32>#has (; 61 ;) (type $iFi) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/map/Map<f64,i32>#has (; 61 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -5977,7 +5975,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<f64,i32>#rehash (; 62 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f64,i32>#rehash (; 62 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6085,7 +6083,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<f64,i32>#set (; 63 ;) (type $iFi_) (param $0 i32) (param $1 f64) (param $2 i32)
+ (func $~lib/map/Map<f64,i32>#set (; 63 ;) (type $FUNCSIG$vidi) (param $0 i32) (param $1 f64) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6178,7 +6176,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/map/Map<f64,i32>#get (; 64 ;) (type $iFi) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/map/Map<f64,i32>#get (; 64 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -6255,7 +6253,7 @@
    call $~lib/map/Map<f64,i32>#rehash
   end
  )
- (func $std/map/test<f64,i32> (; 66 ;) (type $_)
+ (func $std/map/test<f64,i32> (; 66 ;) (type $FUNCSIG$v)
   (local $0 f64)
   (local $1 i32)
   call $~lib/map/Map<i64,i32>#constructor
@@ -6578,7 +6576,7 @@
    unreachable
   end
  )
- (func $start (; 67 ;) (type $_)
+ (func $start (; 67 ;) (type $FUNCSIG$v)
   i32.const 144
   global.set $~lib/allocator/arena/startOffset
   global.get $~lib/allocator/arena/startOffset
@@ -6594,7 +6592,7 @@
   call $std/map/test<f32,i32>
   call $std/map/test<f64,i32>
  )
- (func $null (; 68 ;) (type $_)
+ (func $null (; 68 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -1,22 +1,22 @@
 (module
- (type $_ (func))
- (type $ii (func (param i32) (result i32)))
- (type $i_ (func (param i32)))
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $iii_ (func (param i32 i32 i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $ii_ (func (param i32 i32)))
- (type $iIi (func (param i32 i64) (result i32)))
- (type $Ii (func (param i64) (result i32)))
- (type $iIii (func (param i32 i64 i32) (result i32)))
- (type $iIi_ (func (param i32 i64 i32)))
- (type $ifi (func (param i32 f32) (result i32)))
- (type $ifii (func (param i32 f32 i32) (result i32)))
- (type $ifi_ (func (param i32 f32 i32)))
- (type $iFi (func (param i32 f64) (result i32)))
- (type $iFii (func (param i32 f64 i32) (result i32)))
- (type $iFi_ (func (param i32 f64 i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$iij (func (param i32 i64) (result i32)))
+ (type $FUNCSIG$ij (func (param i64) (result i32)))
+ (type $FUNCSIG$iiji (func (param i32 i64 i32) (result i32)))
+ (type $FUNCSIG$viji (func (param i32 i64 i32)))
+ (type $FUNCSIG$iif (func (param i32 f32) (result i32)))
+ (type $FUNCSIG$iifi (func (param i32 f32 i32) (result i32)))
+ (type $FUNCSIG$vifi (func (param i32 f32 i32)))
+ (type $FUNCSIG$iid (func (param i32 f64) (result i32)))
+ (type $FUNCSIG$iidi (func (param i32 f64 i32) (result i32)))
+ (type $FUNCSIG$vidi (func (param i32 f64 i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\13\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
@@ -30,7 +30,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:~lib/allocator/arena (; 1 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 1 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -42,7 +42,7 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -121,12 +121,12 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/memory/memory.allocate (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/memory/memory.allocate (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/allocator/arena/__memory_allocate
   return
  )
- (func $~lib/internal/arraybuffer/computeSize (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/computeSize (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   i32.const 32
   local.get $0
@@ -138,7 +138,7 @@
   i32.sub
   i32.shl
  )
- (func $~lib/internal/arraybuffer/allocateUnsafe (; 5 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/allocateUnsafe (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -167,7 +167,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memset (; 6 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 6 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -421,7 +421,7 @@
    end
   end
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (; 7 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (; 7 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -460,7 +460,7 @@
   end
   local.get $3
  )
- (func $~lib/map/Map<i8,i32>#clear (; 8 ;) (type $i_) (param $0 i32)
+ (func $~lib/map/Map<i8,i32>#clear (; 8 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -488,7 +488,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i8,i32>#constructor (; 9 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#constructor (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -520,14 +520,14 @@
   call $~lib/map/Map<i8,i32>#clear
   local.get $0
  )
- (func $~lib/internal/hash/hash8 (; 10 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/hash/hash8 (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const -2128831035
   local.get $0
   i32.xor
   i32.const 16777619
   i32.mul
  )
- (func $~lib/map/Map<i8,i32>#find (; 11 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#find (; 11 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -582,7 +582,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i8,i32>#has (; 12 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#has (; 12 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -601,7 +601,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i8,i32>#rehash (; 13 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i8,i32>#rehash (; 13 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -741,7 +741,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<i8,i32>#set (; 14 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<i8,i32>#set (; 14 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -851,7 +851,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/map/Map<i8,i32>#get (; 15 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#get (; 15 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -877,11 +877,11 @@
    unreachable
   end
  )
- (func $~lib/map/Map<i8,i32>#get:size (; 16 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#get:size (; 16 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<i8,i32>#delete (; 17 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#delete (; 17 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -958,7 +958,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<i8,i32> (; 18 ;) (type $_)
+ (func $std/map/test<i8,i32> (; 18 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -1342,7 +1342,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<u8,i32>#clear (; 19 ;) (type $i_) (param $0 i32)
+ (func $~lib/map/Map<u8,i32>#clear (; 19 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -1370,7 +1370,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u8,i32>#constructor (; 20 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#constructor (; 20 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -1402,7 +1402,7 @@
   call $~lib/map/Map<u8,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u8,i32>#find (; 21 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#find (; 21 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -1455,7 +1455,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u8,i32>#has (; 22 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#has (; 22 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -1472,7 +1472,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u8,i32>#rehash (; 23 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,i32>#rehash (; 23 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1612,7 +1612,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<u8,i32>#set (; 24 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<u8,i32>#set (; 24 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1720,7 +1720,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/map/Map<u8,i32>#get (; 25 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#get (; 25 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -1744,11 +1744,11 @@
    unreachable
   end
  )
- (func $~lib/map/Map<u8,i32>#get:size (; 26 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#get:size (; 26 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<u8,i32>#delete (; 27 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#delete (; 27 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1823,7 +1823,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<u8,i32> (; 28 ;) (type $_)
+ (func $std/map/test<u8,i32> (; 28 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -2193,7 +2193,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<i16,i32>#clear (; 29 ;) (type $i_) (param $0 i32)
+ (func $~lib/map/Map<i16,i32>#clear (; 29 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -2221,7 +2221,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i16,i32>#constructor (; 30 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#constructor (; 30 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -2253,7 +2253,7 @@
   call $~lib/map/Map<i16,i32>#clear
   local.get $0
  )
- (func $~lib/internal/hash/hash16 (; 31 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/hash/hash16 (; 31 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   i32.const -2128831035
   local.set $1
@@ -2275,7 +2275,7 @@
   local.set $1
   local.get $1
  )
- (func $~lib/map/Map<i16,i32>#find (; 32 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#find (; 32 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -2330,7 +2330,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i16,i32>#has (; 33 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#has (; 33 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -2349,7 +2349,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i16,i32>#rehash (; 34 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i16,i32>#rehash (; 34 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2489,7 +2489,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<i16,i32>#set (; 35 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<i16,i32>#set (; 35 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2599,7 +2599,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/map/Map<i16,i32>#get (; 36 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#get (; 36 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -2625,11 +2625,11 @@
    unreachable
   end
  )
- (func $~lib/map/Map<i16,i32>#get:size (; 37 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#get:size (; 37 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<i16,i32>#delete (; 38 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#delete (; 38 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2706,7 +2706,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<i16,i32> (; 39 ;) (type $_)
+ (func $std/map/test<i16,i32> (; 39 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -3090,7 +3090,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<u16,i32>#clear (; 40 ;) (type $i_) (param $0 i32)
+ (func $~lib/map/Map<u16,i32>#clear (; 40 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -3118,7 +3118,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u16,i32>#constructor (; 41 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#constructor (; 41 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -3150,7 +3150,7 @@
   call $~lib/map/Map<u16,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u16,i32>#find (; 42 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#find (; 42 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -3203,7 +3203,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u16,i32>#has (; 43 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#has (; 43 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -3220,7 +3220,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u16,i32>#rehash (; 44 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,i32>#rehash (; 44 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3360,7 +3360,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<u16,i32>#set (; 45 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<u16,i32>#set (; 45 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3468,7 +3468,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/map/Map<u16,i32>#get (; 46 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#get (; 46 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -3492,11 +3492,11 @@
    unreachable
   end
  )
- (func $~lib/map/Map<u16,i32>#get:size (; 47 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#get:size (; 47 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<u16,i32>#delete (; 48 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#delete (; 48 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3571,7 +3571,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<u16,i32> (; 49 ;) (type $_)
+ (func $std/map/test<u16,i32> (; 49 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -3941,7 +3941,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<i32,i32>#clear (; 50 ;) (type $i_) (param $0 i32)
+ (func $~lib/map/Map<i32,i32>#clear (; 50 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -3969,7 +3969,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i32,i32>#constructor (; 51 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#constructor (; 51 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -4001,7 +4001,7 @@
   call $~lib/map/Map<i32,i32>#clear
   local.get $0
  )
- (func $~lib/internal/hash/hash32 (; 52 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/hash/hash32 (; 52 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   i32.const -2128831035
   local.set $1
@@ -4043,7 +4043,7 @@
   local.set $1
   local.get $1
  )
- (func $~lib/map/Map<i32,i32>#find (; 53 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#find (; 53 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -4094,7 +4094,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i32,i32>#has (; 54 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#has (; 54 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -4109,7 +4109,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i32,i32>#rehash (; 55 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i32,i32>#rehash (; 55 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4249,7 +4249,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<i32,i32>#set (; 56 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<i32,i32>#set (; 56 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4355,7 +4355,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/map/Map<i32,i32>#get (; 57 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#get (; 57 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -4377,11 +4377,11 @@
    unreachable
   end
  )
- (func $~lib/map/Map<i32,i32>#get:size (; 58 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#get:size (; 58 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<i32,i32>#delete (; 59 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#delete (; 59 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4454,7 +4454,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<i32,i32> (; 60 ;) (type $_)
+ (func $std/map/test<i32,i32> (; 60 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4810,7 +4810,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<u32,i32>#clear (; 61 ;) (type $i_) (param $0 i32)
+ (func $~lib/map/Map<u32,i32>#clear (; 61 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -4838,7 +4838,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u32,i32>#constructor (; 62 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#constructor (; 62 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -4870,7 +4870,7 @@
   call $~lib/map/Map<u32,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u32,i32>#find (; 63 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#find (; 63 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -4921,7 +4921,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u32,i32>#has (; 64 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#has (; 64 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -4936,7 +4936,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u32,i32>#rehash (; 65 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u32,i32>#rehash (; 65 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5076,7 +5076,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<u32,i32>#set (; 66 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<u32,i32>#set (; 66 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5182,7 +5182,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/map/Map<u32,i32>#get (; 67 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#get (; 67 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -5204,11 +5204,11 @@
    unreachable
   end
  )
- (func $~lib/map/Map<u32,i32>#get:size (; 68 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#get:size (; 68 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<u32,i32>#delete (; 69 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#delete (; 69 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5281,7 +5281,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<u32,i32> (; 70 ;) (type $_)
+ (func $std/map/test<u32,i32> (; 70 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -5637,7 +5637,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<i64,i32>#clear (; 71 ;) (type $i_) (param $0 i32)
+ (func $~lib/map/Map<i64,i32>#clear (; 71 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -5665,7 +5665,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i64,i32>#constructor (; 72 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#constructor (; 72 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -5697,7 +5697,7 @@
   call $~lib/map/Map<i64,i32>#clear
   local.get $0
  )
- (func $~lib/internal/hash/hash64 (; 73 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/hash/hash64 (; 73 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5785,7 +5785,7 @@
   local.set $3
   local.get $3
  )
- (func $~lib/map/Map<i64,i32>#find (; 74 ;) (type $iIii) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#find (; 74 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -5836,7 +5836,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i64,i32>#has (; 75 ;) (type $iIi) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<i64,i32>#has (; 75 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   local.get $0
   local.get $1
@@ -5851,7 +5851,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i64,i32>#rehash (; 76 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i64,i32>#rehash (; 76 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5992,7 +5992,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<i64,i32>#set (; 77 ;) (type $iIi_) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/map/Map<i64,i32>#set (; 77 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -6099,7 +6099,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/map/Map<i64,i32>#get (; 78 ;) (type $iIi) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<i64,i32>#get (; 78 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   local.get $0
@@ -6121,11 +6121,11 @@
    unreachable
   end
  )
- (func $~lib/map/Map<i64,i32>#get:size (; 79 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#get:size (; 79 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<i64,i32>#delete (; 80 ;) (type $iIi) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<i64,i32>#delete (; 80 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -6199,7 +6199,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<i64,i32> (; 81 ;) (type $_)
+ (func $std/map/test<i64,i32> (; 81 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -6562,7 +6562,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<u64,i32>#clear (; 82 ;) (type $i_) (param $0 i32)
+ (func $~lib/map/Map<u64,i32>#clear (; 82 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -6590,7 +6590,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u64,i32>#constructor (; 83 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#constructor (; 83 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -6622,7 +6622,7 @@
   call $~lib/map/Map<u64,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u64,i32>#find (; 84 ;) (type $iIii) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#find (; 84 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -6673,7 +6673,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u64,i32>#has (; 85 ;) (type $iIi) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<u64,i32>#has (; 85 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   local.get $0
   local.get $1
@@ -6688,7 +6688,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u64,i32>#rehash (; 86 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u64,i32>#rehash (; 86 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6829,7 +6829,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<u64,i32>#set (; 87 ;) (type $iIi_) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/map/Map<u64,i32>#set (; 87 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -6936,7 +6936,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/map/Map<u64,i32>#get (; 88 ;) (type $iIi) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<u64,i32>#get (; 88 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   local.get $0
@@ -6958,11 +6958,11 @@
    unreachable
   end
  )
- (func $~lib/map/Map<u64,i32>#get:size (; 89 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#get:size (; 89 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<u64,i32>#delete (; 90 ;) (type $iIi) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<u64,i32>#delete (; 90 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -7036,7 +7036,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<u64,i32> (; 91 ;) (type $_)
+ (func $std/map/test<u64,i32> (; 91 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -7399,7 +7399,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<f32,i32>#clear (; 92 ;) (type $i_) (param $0 i32)
+ (func $~lib/map/Map<f32,i32>#clear (; 92 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -7427,7 +7427,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<f32,i32>#constructor (; 93 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#constructor (; 93 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -7459,7 +7459,7 @@
   call $~lib/map/Map<f32,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<f32,i32>#find (; 94 ;) (type $ifii) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#find (; 94 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -7510,7 +7510,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f32,i32>#has (; 95 ;) (type $ifi) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/map/Map<f32,i32>#has (; 95 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
   (local $2 f32)
   local.get $0
   local.get $1
@@ -7526,7 +7526,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<f32,i32>#rehash (; 96 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f32,i32>#rehash (; 96 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7668,7 +7668,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<f32,i32>#set (; 97 ;) (type $ifi_) (param $0 i32) (param $1 f32) (param $2 i32)
+ (func $~lib/map/Map<f32,i32>#set (; 97 ;) (type $FUNCSIG$vifi) (param $0 i32) (param $1 f32) (param $2 i32)
   (local $3 f32)
   (local $4 i32)
   (local $5 i32)
@@ -7776,7 +7776,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/map/Map<f32,i32>#get (; 98 ;) (type $ifi) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/map/Map<f32,i32>#get (; 98 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
   (local $2 f32)
   (local $3 i32)
   local.get $0
@@ -7799,11 +7799,11 @@
    unreachable
   end
  )
- (func $~lib/map/Map<f32,i32>#get:size (; 99 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#get:size (; 99 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<f32,i32>#delete (; 100 ;) (type $ifi) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/map/Map<f32,i32>#delete (; 100 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
   (local $2 f32)
   (local $3 i32)
   (local $4 i32)
@@ -7878,7 +7878,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<f32,i32> (; 101 ;) (type $_)
+ (func $std/map/test<f32,i32> (; 101 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f32)
   i32.const 0
@@ -8241,7 +8241,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<f64,i32>#clear (; 102 ;) (type $i_) (param $0 i32)
+ (func $~lib/map/Map<f64,i32>#clear (; 102 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -8269,7 +8269,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<f64,i32>#constructor (; 103 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#constructor (; 103 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -8301,7 +8301,7 @@
   call $~lib/map/Map<f64,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<f64,i32>#find (; 104 ;) (type $iFii) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#find (; 104 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -8352,7 +8352,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f64,i32>#has (; 105 ;) (type $iFi) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/map/Map<f64,i32>#has (; 105 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 f64)
   local.get $0
   local.get $1
@@ -8368,7 +8368,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<f64,i32>#rehash (; 106 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f64,i32>#rehash (; 106 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8510,7 +8510,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<f64,i32>#set (; 107 ;) (type $iFi_) (param $0 i32) (param $1 f64) (param $2 i32)
+ (func $~lib/map/Map<f64,i32>#set (; 107 ;) (type $FUNCSIG$vidi) (param $0 i32) (param $1 f64) (param $2 i32)
   (local $3 f64)
   (local $4 i32)
   (local $5 i32)
@@ -8618,7 +8618,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/map/Map<f64,i32>#get (; 108 ;) (type $iFi) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/map/Map<f64,i32>#get (; 108 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 f64)
   (local $3 i32)
   local.get $0
@@ -8641,11 +8641,11 @@
    unreachable
   end
  )
- (func $~lib/map/Map<f64,i32>#get:size (; 109 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#get:size (; 109 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<f64,i32>#delete (; 110 ;) (type $iFi) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/map/Map<f64,i32>#delete (; 110 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
@@ -8720,7 +8720,7 @@
   end
   i32.const 1
  )
- (func $std/map/test<f64,i32> (; 111 ;) (type $_)
+ (func $std/map/test<f64,i32> (; 111 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f64)
   i32.const 0
@@ -9083,7 +9083,7 @@
    unreachable
   end
  )
- (func $start:std/map (; 112 ;) (type $_)
+ (func $start:std/map (; 112 ;) (type $FUNCSIG$v)
   call $start:~lib/allocator/arena
   call $std/map/test<i8,i32>
   call $std/map/test<u8,i32>
@@ -9096,9 +9096,9 @@
   call $std/map/test<f32,i32>
   call $std/map/test<f64,i32>
  )
- (func $start (; 113 ;) (type $_)
+ (func $start (; 113 ;) (type $FUNCSIG$v)
   call $start:std/map
  )
- (func $null (; 114 ;) (type $_)
+ (func $null (; 114 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -1,19 +1,19 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $FFFF (func (param f64 f64 f64) (result f64)))
- (type $FiF (func (param f64 i32) (result f64)))
- (type $ffff (func (param f32 f32 f32) (result f32)))
- (type $fif (func (param f32 i32) (result f32)))
- (type $FF (func (param f64) (result f64)))
- (type $ff (func (param f32) (result f32)))
- (type $FFF (func (param f64 f64) (result f64)))
- (type $fff (func (param f32 f32) (result f32)))
- (type $F (func (result f64)))
- (type $I_ (func (param i64)))
- (type $ii (func (param i32) (result i32)))
- (type $f (func (result f32)))
- (type $IiI (func (param i64 i32) (result i64)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$dddd (func (param f64 f64 f64) (result f64)))
+ (type $FUNCSIG$ddi (func (param f64 i32) (result f64)))
+ (type $FUNCSIG$ffff (func (param f32 f32 f32) (result f32)))
+ (type $FUNCSIG$ffi (func (param f32 i32) (result f32)))
+ (type $FUNCSIG$dd (func (param f64) (result f64)))
+ (type $FUNCSIG$ff (func (param f32) (result f32)))
+ (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))
+ (type $FUNCSIG$fff (func (param f32 f32) (result f32)))
+ (type $FUNCSIG$d (func (result f64)))
+ (type $FUNCSIG$vj (func (param i64)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$f (func (result f32)))
+ (type $FUNCSIG$jji (func (param i64 i32) (result i64)))
+ (type $FUNCSIG$v (func))
  (type $FUNCSIG$iddd (func (param f64 f64 f64) (result i32)))
  (type $FUNCSIG$ifff (func (param f32 f32 f32) (result i32)))
  (type $FUNCSIG$idid (func (param f64 i32 f64) (result i32)))
@@ -72,7 +72,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $~lib/math/NativeMath.scalbn (; 30 ;) (type $FiF) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/NativeMath.scalbn (; 30 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
   local.get $1
   i32.const 1023
   i32.gt_s
@@ -149,7 +149,7 @@
   f64.reinterpret_i64
   f64.mul
  )
- (func $std/math/ulperr (; 31 ;) (type $FFFF) (param $0 f64) (param $1 f64) (param $2 f64) (result f64)
+ (func $std/math/ulperr (; 31 ;) (type $FUNCSIG$dddd) (param $0 f64) (param $1 f64) (param $2 f64) (result f64)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -275,7 +275,7 @@
   end
   i32.const 1
  )
- (func $~lib/math/NativeMathf.scalbn (; 33 ;) (type $fif) (param $0 f32) (param $1 i32) (result f32)
+ (func $~lib/math/NativeMathf.scalbn (; 33 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
   local.get $1
   i32.const 127
   i32.gt_s
@@ -351,7 +351,7 @@
   f32.reinterpret_i32
   f32.mul
  )
- (func $std/math/ulperrf (; 34 ;) (type $ffff) (param $0 f32) (param $1 f32) (param $2 f32) (result f32)
+ (func $std/math/ulperrf (; 34 ;) (type $FUNCSIG$ffff) (param $0 f32) (param $1 f32) (param $2 f32) (result f32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -515,7 +515,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/R (; 40 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/R (; 40 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   f64.const 0.16666666666666666
   local.get $0
@@ -558,7 +558,7 @@
   f64.add
   f64.div
  )
- (func $~lib/math/NativeMath.acos (; 41 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.acos (; 41 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -704,7 +704,7 @@
   end
   local.get $3
  )
- (func $~lib/math/NativeMathf.acos (; 43 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.acos (; 43 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 f32)
   (local $3 i32)
@@ -879,7 +879,7 @@
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log1p (; 45 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log1p (; 45 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -1081,7 +1081,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.log (; 46 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log (; 46 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1259,7 +1259,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.acosh (; 47 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.acosh (; 47 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   local.get $0
   i64.reinterpret_f64
@@ -1331,7 +1331,7 @@
   end
   local.get $3
  )
- (func $~lib/math/NativeMathf.log1p (; 49 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log1p (; 49 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -1504,7 +1504,7 @@
   f32.mul
   f32.add
  )
- (func $~lib/math/NativeMathf.log (; 50 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log (; 50 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 i32)
@@ -1643,7 +1643,7 @@
   f32.mul
   f32.add
  )
- (func $~lib/math/NativeMathf.acosh (; 51 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.acosh (; 51 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   local.get $0
   i32.reinterpret_f32
@@ -1700,7 +1700,7 @@
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.asin (; 53 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.asin (; 53 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -1859,7 +1859,7 @@
   end
   local.get $3
  )
- (func $~lib/math/NativeMathf.asin (; 55 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.asin (; 55 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 i32)
@@ -1984,7 +1984,7 @@
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.asinh (; 57 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.asinh (; 57 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i64)
   local.get $0
@@ -2072,7 +2072,7 @@
   end
   local.get $3
  )
- (func $~lib/math/NativeMathf.asinh (; 59 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.asinh (; 59 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   local.get $0
@@ -2144,7 +2144,7 @@
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atan (; 61 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atan (; 61 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -2385,7 +2385,7 @@
   end
   local.get $3
  )
- (func $~lib/math/NativeMathf.atan (; 63 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.atan (; 63 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -2588,7 +2588,7 @@
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atanh (; 65 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atanh (; 65 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i64)
   (local $3 i64)
@@ -2665,7 +2665,7 @@
   end
   local.get $3
  )
- (func $~lib/math/NativeMathf.atanh (; 67 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.atanh (; 67 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   local.get $0
@@ -2722,7 +2722,7 @@
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atan2 (; 69 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.atan2 (; 69 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2986,7 +2986,7 @@
   end
   local.get $4
  )
- (func $~lib/math/NativeMathf.atan2 (; 71 ;) (type $fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.atan2 (; 71 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3214,7 +3214,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.cbrt (; 73 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cbrt (; 73 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   (local $3 i32)
@@ -3353,7 +3353,7 @@
   end
   local.get $3
  )
- (func $~lib/math/NativeMathf.cbrt (; 75 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cbrt (; 75 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f64)
   (local $2 f64)
   (local $3 i32)
@@ -3482,7 +3482,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.expm1 (; 79 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.expm1 (; 79 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   (local $3 i32)
@@ -3761,7 +3761,7 @@
   local.get $5
   f64.mul
  )
- (func $~lib/math/NativeMath.exp (; 80 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.exp (; 80 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 f64)
   (local $3 i32)
@@ -3911,7 +3911,7 @@
   local.get $3
   call $~lib/math/NativeMath.scalbn
  )
- (func $~lib/math/NativeMath.cosh (; 81 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cosh (; 81 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i64)
   local.get $0
@@ -3993,7 +3993,7 @@
   end
   local.get $3
  )
- (func $~lib/math/NativeMathf.expm1 (; 83 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.expm1 (; 83 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 f32)
@@ -4252,7 +4252,7 @@
   local.get $5
   f32.mul
  )
- (func $~lib/math/NativeMathf.exp (; 84 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.exp (; 84 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -4380,7 +4380,7 @@
   local.get $1
   call $~lib/math/NativeMathf.scalbn
  )
- (func $~lib/math/NativeMathf.cosh (; 85 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cosh (; 85 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   local.get $0
   i32.reinterpret_f32
@@ -4521,7 +4521,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.hypot (; 93 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.hypot (; 93 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 i64)
   (local $4 f64)
@@ -4720,7 +4720,7 @@
   end
   local.get $4
  )
- (func $~lib/math/NativeMathf.hypot (; 95 ;) (type $fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.hypot (; 95 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4868,7 +4868,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log10 (; 99 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log10 (; 99 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -5098,7 +5098,7 @@
   end
   local.get $3
  )
- (func $~lib/math/NativeMathf.log10 (; 101 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log10 (; 101 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -5293,7 +5293,7 @@
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log2 (; 105 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log2 (; 105 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -5517,7 +5517,7 @@
   end
   local.get $3
  )
- (func $~lib/math/NativeMathf.log2 (; 107 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log2 (; 107 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -5735,7 +5735,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.mod (; 113 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (; 113 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -5963,7 +5963,7 @@
    local.get $3
   end
  )
- (func $~lib/math/NativeMathf.mod (; 115 ;) (type $fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (; 115 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6167,7 +6167,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.pow (; 117 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.pow (; 117 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 f64)
   (local $4 i32)
@@ -7137,7 +7137,7 @@
   end
   local.get $4
  )
- (func $~lib/math/NativeMathf.pow (; 119 ;) (type $fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.pow (; 119 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 f32)
   (local $3 f32)
   (local $4 i32)
@@ -7959,7 +7959,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/splitMix32 (; 121 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/math/splitMix32 (; 121 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 1831565813
   i32.add
@@ -7991,7 +7991,7 @@
   i32.shr_u
   i32.xor
  )
- (func $~lib/math/NativeMath.seedRandom (; 122 ;) (type $I_) (param $0 i64)
+ (func $~lib/math/NativeMath.seedRandom (; 122 ;) (type $FUNCSIG$vj) (param $0 i64)
   (local $1 i64)
   local.get $0
   i64.eqz
@@ -8056,7 +8056,7 @@
   call $~lib/math/splitMix32
   global.set $~lib/math/random_state1_32
  )
- (func $~lib/math/NativeMath.random (; 123 ;) (type $F) (result f64)
+ (func $~lib/math/NativeMath.random (; 123 ;) (type $FUNCSIG$d) (result f64)
   (local $0 i64)
   (local $1 i64)
   global.get $~lib/math/random_seeded
@@ -8103,7 +8103,7 @@
   f64.const 1
   f64.sub
  )
- (func $~lib/math/NativeMathf.random (; 124 ;) (type $f) (result f32)
+ (func $~lib/math/NativeMathf.random (; 124 ;) (type $FUNCSIG$f) (result f32)
   (local $0 i32)
   (local $1 i32)
   global.get $~lib/math/random_seeded
@@ -8217,7 +8217,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.rem (; 129 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.rem (; 129 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -8505,7 +8505,7 @@
   f64.const 0
   call $std/math/check<f64>
  )
- (func $~lib/math/NativeMathf.rem (; 131 ;) (type $fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.rem (; 131 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8781,7 +8781,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.sinh (; 133 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.sinh (; 133 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   (local $3 i32)
@@ -8876,7 +8876,7 @@
   end
   local.get $3
  )
- (func $~lib/math/NativeMathf.sinh (; 135 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.sinh (; 135 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 f32)
@@ -8980,7 +8980,7 @@
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.tanh (; 139 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.tanh (; 139 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i64)
@@ -9077,7 +9077,7 @@
   end
   local.get $3
  )
- (func $~lib/math/NativeMathf.tanh (; 141 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.tanh (; 141 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   local.get $0
@@ -9183,7 +9183,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.imul (; 145 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.imul (; 145 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   local.get $0
   local.get $1
@@ -9220,7 +9220,7 @@
   i32.mul
   f64.convert_i32_s
  )
- (func $~lib/math/NativeMath.clz32 (; 146 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.clz32 (; 146 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   local.get $0
   f64.sub
@@ -9243,7 +9243,7 @@
   i32.clz
   f64.convert_i32_s
  )
- (func $~lib/math/ipow64 (; 147 ;) (type $IiI) (param $0 i64) (param $1 i32) (result i64)
+ (func $~lib/math/ipow64 (; 147 ;) (type $FUNCSIG$jji) (param $0 i64) (param $1 i32) (result i64)
   (local $2 i64)
   (local $3 i32)
   i64.const 1
@@ -9439,7 +9439,7 @@
   end
   local.get $2
  )
- (func $~lib/math/ipow32f (; 148 ;) (type $fif) (param $0 f32) (param $1 i32) (result f32)
+ (func $~lib/math/ipow32f (; 148 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
   (local $2 f32)
   (local $3 i32)
   local.get $1
@@ -9485,7 +9485,7 @@
   end
   local.get $2
  )
- (func $~lib/math/ipow64f (; 149 ;) (type $FiF) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/ipow64f (; 149 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
   (local $2 f64)
   (local $3 i32)
   local.get $1
@@ -9531,7 +9531,7 @@
   end
   local.get $2
  )
- (func $start:std/math (; 150 ;) (type $_)
+ (func $start:std/math (; 150 ;) (type $FUNCSIG$v)
   (local $0 f64)
   (local $1 f32)
   (local $2 i32)
@@ -37158,10 +37158,10 @@
    unreachable
   end
  )
- (func $start (; 151 ;) (type $_)
+ (func $start (; 151 ;) (type $FUNCSIG$v)
   call $start:std/math
  )
- (func $null (; 152 ;) (type $_)
+ (func $null (; 152 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -1,28 +1,28 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $FFFii (func (param f64 f64 f64 i32) (result i32)))
- (type $Fi (func (param f64) (result i32)))
- (type $FFFF (func (param f64 f64 f64) (result f64)))
- (type $FiF (func (param f64 i32) (result f64)))
- (type $fffii (func (param f32 f32 f32 i32) (result i32)))
- (type $fi (func (param f32) (result i32)))
- (type $ffff (func (param f32 f32 f32) (result f32)))
- (type $fif (func (param f32 i32) (result f32)))
- (type $FiFFii (func (param f64 i32 f64 f64 i32) (result i32)))
- (type $fiffii (func (param f32 i32 f32 f32 i32) (result i32)))
- (type $FF (func (param f64) (result f64)))
- (type $ff (func (param f32) (result f32)))
- (type $FFFFii (func (param f64 f64 f64 f64 i32) (result i32)))
- (type $FFF (func (param f64 f64) (result f64)))
- (type $ffffii (func (param f32 f32 f32 f32 i32) (result i32)))
- (type $fff (func (param f32 f32) (result f32)))
- (type $F (func (result f64)))
- (type $I_ (func (param i64)))
- (type $II (func (param i64) (result i64)))
- (type $ii (func (param i32) (result i32)))
- (type $f (func (result f32)))
- (type $IiI (func (param i64 i32) (result i64)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$idddi (func (param f64 f64 f64 i32) (result i32)))
+ (type $FUNCSIG$id (func (param f64) (result i32)))
+ (type $FUNCSIG$dddd (func (param f64 f64 f64) (result f64)))
+ (type $FUNCSIG$ddi (func (param f64 i32) (result f64)))
+ (type $FUNCSIG$ifffi (func (param f32 f32 f32 i32) (result i32)))
+ (type $FUNCSIG$if (func (param f32) (result i32)))
+ (type $FUNCSIG$ffff (func (param f32 f32 f32) (result f32)))
+ (type $FUNCSIG$ffi (func (param f32 i32) (result f32)))
+ (type $FUNCSIG$ididdi (func (param f64 i32 f64 f64 i32) (result i32)))
+ (type $FUNCSIG$ififfi (func (param f32 i32 f32 f32 i32) (result i32)))
+ (type $FUNCSIG$dd (func (param f64) (result f64)))
+ (type $FUNCSIG$ff (func (param f32) (result f32)))
+ (type $FUNCSIG$iddddi (func (param f64 f64 f64 f64 i32) (result i32)))
+ (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))
+ (type $FUNCSIG$iffffi (func (param f32 f32 f32 f32 i32) (result i32)))
+ (type $FUNCSIG$fff (func (param f32 f32) (result f32)))
+ (type $FUNCSIG$d (func (result f64)))
+ (type $FUNCSIG$vj (func (param i64)))
+ (type $FUNCSIG$jj (func (param i64) (result i64)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$f (func (result f32)))
+ (type $FUNCSIG$jji (func (param i64 i32) (result i64)))
+ (type $FUNCSIG$v (func))
  (import "Math" "E" (global $~lib/bindings/Math/E f64))
  (import "Math" "LN2" (global $~lib/bindings/Math/LN2 f64))
  (import "Math" "LN10" (global $~lib/bindings/Math/LN10 f64))
@@ -101,19 +101,19 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $~lib/builtins/isNaN<f64> (; 30 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $~lib/builtins/isNaN<f64> (; 30 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   local.get $0
   f64.ne
  )
- (func $~lib/builtins/isFinite<f64> (; 31 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $~lib/builtins/isFinite<f64> (; 31 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   local.get $0
   f64.sub
   f64.const 0
   f64.eq
  )
- (func $std/math/eulp (; 32 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $std/math/eulp (; 32 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   (local $1 i64)
   (local $2 i32)
   local.get $0
@@ -140,7 +140,7 @@
   i32.const 52
   i32.sub
  )
- (func $~lib/math/NativeMath.scalbn (; 33 ;) (type $FiF) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/NativeMath.scalbn (; 33 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
@@ -231,7 +231,7 @@
   f64.reinterpret_i64
   f64.mul
  )
- (func $std/math/ulperr (; 34 ;) (type $FFFF) (param $0 f64) (param $1 f64) (param $2 f64) (result f64)
+ (func $std/math/ulperr (; 34 ;) (type $FUNCSIG$dddd) (param $0 f64) (param $1 f64) (param $2 f64) (result f64)
   (local $3 i32)
   (local $4 f64)
   local.get $0
@@ -313,7 +313,7 @@
   local.get $2
   f64.add
  )
- (func $std/math/check<f64> (; 35 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/check<f64> (; 35 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   local.get $0
   local.get $1
@@ -344,19 +344,19 @@
   end
   i32.const 1
  )
- (func $~lib/builtins/isNaN<f32> (; 36 ;) (type $fi) (param $0 f32) (result i32)
+ (func $~lib/builtins/isNaN<f32> (; 36 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
   local.get $0
   local.get $0
   f32.ne
  )
- (func $~lib/builtins/isFinite<f32> (; 37 ;) (type $fi) (param $0 f32) (result i32)
+ (func $~lib/builtins/isFinite<f32> (; 37 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
   local.get $0
   local.get $0
   f32.sub
   f32.const 0
   f32.eq
  )
- (func $std/math/eulpf (; 38 ;) (type $fi) (param $0 f32) (result i32)
+ (func $std/math/eulpf (; 38 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -382,7 +382,7 @@
   i32.const 23
   i32.sub
  )
- (func $~lib/math/NativeMathf.scalbn (; 39 ;) (type $fif) (param $0 f32) (param $1 i32) (result f32)
+ (func $~lib/math/NativeMathf.scalbn (; 39 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
   (local $2 f32)
   (local $3 i32)
   (local $4 i32)
@@ -472,7 +472,7 @@
   f32.reinterpret_i32
   f32.mul
  )
- (func $std/math/ulperrf (; 40 ;) (type $ffff) (param $0 f32) (param $1 f32) (param $2 f32) (result f32)
+ (func $std/math/ulperrf (; 40 ;) (type $FUNCSIG$ffff) (param $0 f32) (param $1 f32) (param $2 f32) (result f32)
   (local $3 i32)
   (local $4 f32)
   local.get $0
@@ -552,7 +552,7 @@
   local.get $2
   f32.add
  )
- (func $std/math/check<f32> (; 41 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/check<f32> (; 41 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   local.get $0
   local.get $1
@@ -583,7 +583,7 @@
   end
   i32.const 1
  )
- (func $std/math/test_scalbn (; 42 ;) (type $FiFFii) (param $0 f64) (param $1 i32) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_scalbn (; 42 ;) (type $FUNCSIG$ididdi) (param $0 f64) (param $1 i32) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.scalbn
@@ -592,7 +592,7 @@
   local.get $4
   call $std/math/check<f64>
  )
- (func $std/math/test_scalbnf (; 43 ;) (type $fiffii) (param $0 f32) (param $1 i32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_scalbnf (; 43 ;) (type $FUNCSIG$ififfi) (param $0 f32) (param $1 i32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.scalbn
@@ -601,7 +601,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $std/math/test_abs (; 44 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_abs (; 44 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   (local $5 i32)
   block $~lib/math/NativeMath.abs|inlined.0 (result f64)
@@ -633,7 +633,7 @@
    local.get $5
   end
  )
- (func $std/math/test_absf (; 45 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_absf (; 45 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   block $~lib/math/NativeMathf.abs|inlined.0 (result f32)
    local.get $0
@@ -646,7 +646,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/R (; 46 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/R (; 46 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   local.get $0
@@ -695,7 +695,7 @@
   local.get $2
   f64.div
  )
- (func $~lib/math/NativeMath.acos (; 47 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.acos (; 47 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -847,7 +847,7 @@
   f64.add
   f64.mul
  )
- (func $std/math/test_acos (; 48 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_acos (; 48 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $0
   call $~lib/math/NativeMath.acos
@@ -874,7 +874,7 @@
    local.get $4
   end
  )
- (func $~lib/math/Rf (; 49 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/Rf (; 49 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 f32)
   local.get $0
@@ -899,7 +899,7 @@
   local.get $2
   f32.div
  )
- (func $~lib/math/NativeMathf.acos (; 50 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.acos (; 50 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -1039,7 +1039,7 @@
   f32.add
   f32.mul
  )
- (func $std/math/test_acosf (; 51 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_acosf (; 51 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.acos
   local.get $1
@@ -1047,7 +1047,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log1p (; 52 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log1p (; 52 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -1292,7 +1292,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.log (; 53 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log (; 53 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -1505,7 +1505,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.acosh (; 54 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.acosh (; 54 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   local.get $0
   i64.reinterpret_f64
@@ -1569,7 +1569,7 @@
   f64.const 0.6931471805599453
   f64.add
  )
- (func $std/math/test_acosh (; 55 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_acosh (; 55 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $0
   call $~lib/math/NativeMath.acosh
@@ -1596,7 +1596,7 @@
    local.get $4
   end
  )
- (func $~lib/math/NativeMathf.log1p (; 56 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log1p (; 56 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -1808,7 +1808,7 @@
   f32.mul
   f32.add
  )
- (func $~lib/math/NativeMathf.log (; 57 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log (; 57 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1978,7 +1978,7 @@
   f32.mul
   f32.add
  )
- (func $~lib/math/NativeMathf.acosh (; 58 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.acosh (; 58 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -2042,7 +2042,7 @@
   f32.const 0.6931471824645996
   f32.add
  )
- (func $std/math/test_acoshf (; 59 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_acoshf (; 59 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.acosh
   local.get $1
@@ -2050,7 +2050,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.asin (; 60 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.asin (; 60 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2210,7 +2210,7 @@
   end
   local.get $0
  )
- (func $std/math/test_asin (; 61 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_asin (; 61 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $0
   call $~lib/math/NativeMath.asin
@@ -2237,7 +2237,7 @@
    local.get $4
   end
  )
- (func $~lib/math/NativeMathf.asin (; 62 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.asin (; 62 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -2331,7 +2331,7 @@
   local.get $1
   f32.copysign
  )
- (func $std/math/test_asinf (; 63 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_asinf (; 63 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.asin
   local.get $1
@@ -2339,7 +2339,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.asinh (; 64 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.asinh (; 64 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i64)
   (local $3 f64)
@@ -2421,7 +2421,7 @@
   local.get $0
   f64.copysign
  )
- (func $std/math/test_asinh (; 65 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_asinh (; 65 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $0
   call $~lib/math/NativeMath.asinh
@@ -2448,7 +2448,7 @@
    local.get $4
   end
  )
- (func $~lib/math/NativeMathf.asinh (; 66 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.asinh (; 66 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   local.get $0
@@ -2529,7 +2529,7 @@
   local.get $0
   f32.copysign
  )
- (func $std/math/test_asinhf (; 67 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_asinhf (; 67 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.asinh
   local.get $1
@@ -2537,7 +2537,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atan (; 68 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atan (; 68 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 f64)
   (local $3 f64)
@@ -2810,7 +2810,7 @@
   local.get $2
   f64.copysign
  )
- (func $std/math/test_atan (; 69 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_atan (; 69 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $0
   call $~lib/math/NativeMath.atan
@@ -2837,7 +2837,7 @@
    local.get $4
   end
  )
- (func $~lib/math/NativeMathf.atan (; 70 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.atan (; 70 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -3082,7 +3082,7 @@
   local.get $2
   f32.copysign
  )
- (func $std/math/test_atanf (; 71 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_atanf (; 71 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.atan
   local.get $1
@@ -3090,7 +3090,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atanh (; 72 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atanh (; 72 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -3162,7 +3162,7 @@
   local.get $0
   f64.copysign
  )
- (func $std/math/test_atanh (; 73 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_atanh (; 73 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $0
   call $~lib/math/NativeMath.atanh
@@ -3189,7 +3189,7 @@
    local.get $4
   end
  )
- (func $~lib/math/NativeMathf.atanh (; 74 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.atanh (; 74 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   local.get $0
@@ -3251,7 +3251,7 @@
   local.get $0
   f32.copysign
  )
- (func $std/math/test_atanhf (; 75 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_atanhf (; 75 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.atanh
   local.get $1
@@ -3259,7 +3259,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atan2 (; 76 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.atan2 (; 76 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i32)
   (local $3 i64)
   (local $4 i32)
@@ -3606,7 +3606,7 @@
   unreachable
   f64.const 0
  )
- (func $std/math/test_atan2 (; 77 ;) (type $FFFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_atan2 (; 77 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   (local $5 i32)
   local.get $0
   local.get $1
@@ -3635,7 +3635,7 @@
    local.get $5
   end
  )
- (func $~lib/math/NativeMathf.atan2 (; 78 ;) (type $fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.atan2 (; 78 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3955,7 +3955,7 @@
   unreachable
   f32.const 0
  )
- (func $std/math/test_atan2f (; 79 ;) (type $ffffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_atan2f (; 79 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.atan2
@@ -3964,7 +3964,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.cbrt (; 80 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cbrt (; 80 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 f64)
@@ -4108,7 +4108,7 @@
   local.set $3
   local.get $3
  )
- (func $std/math/test_cbrt (; 81 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_cbrt (; 81 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $0
   call $~lib/math/NativeMath.cbrt
@@ -4135,7 +4135,7 @@
    local.get $4
   end
  )
- (func $~lib/math/NativeMathf.cbrt (; 82 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cbrt (; 82 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -4251,7 +4251,7 @@
   local.get $3
   f32.demote_f64
  )
- (func $std/math/test_cbrtf (; 83 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_cbrtf (; 83 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.cbrt
   local.get $1
@@ -4259,7 +4259,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_ceil (; 84 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_ceil (; 84 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   (local $5 i32)
   block $~lib/math/NativeMath.ceil|inlined.0 (result f64)
@@ -4291,7 +4291,7 @@
    local.get $5
   end
  )
- (func $std/math/test_ceilf (; 85 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_ceilf (; 85 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   block $~lib/math/NativeMathf.ceil|inlined.0 (result f32)
    local.get $0
@@ -4304,7 +4304,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.expm1 (; 86 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.expm1 (; 86 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -4618,7 +4618,7 @@
   local.get $14
   f64.mul
  )
- (func $~lib/math/NativeMath.exp (; 87 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.exp (; 87 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -4783,7 +4783,7 @@
   local.get $5
   call $~lib/math/NativeMath.scalbn
  )
- (func $~lib/math/NativeMath.cosh (; 88 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cosh (; 88 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 f64)
@@ -4878,7 +4878,7 @@
   local.set $3
   local.get $3
  )
- (func $std/math/test_cosh (; 89 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_cosh (; 89 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $0
   call $~lib/math/NativeMath.cosh
@@ -4905,7 +4905,7 @@
    local.get $4
   end
  )
- (func $~lib/math/NativeMathf.expm1 (; 90 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.expm1 (; 90 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5200,7 +5200,7 @@
   local.get $13
   f32.mul
  )
- (func $~lib/math/NativeMathf.exp (; 91 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.exp (; 91 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -5344,7 +5344,7 @@
   local.get $5
   call $~lib/math/NativeMathf.scalbn
  )
- (func $~lib/math/NativeMathf.cosh (; 92 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cosh (; 92 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -5427,7 +5427,7 @@
    f32.mul
   end
  )
- (func $std/math/test_coshf (; 93 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_coshf (; 93 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.cosh
   local.get $1
@@ -5435,7 +5435,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_exp (; 94 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_exp (; 94 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $0
   call $~lib/math/NativeMath.exp
@@ -5462,7 +5462,7 @@
    local.get $4
   end
  )
- (func $std/math/test_expf (; 95 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_expf (; 95 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.exp
   local.get $1
@@ -5470,7 +5470,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_expm1 (; 96 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_expm1 (; 96 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $0
   call $~lib/math/NativeMath.expm1
@@ -5497,7 +5497,7 @@
    local.get $4
   end
  )
- (func $std/math/test_expm1f (; 97 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_expm1f (; 97 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.expm1
   local.get $1
@@ -5505,7 +5505,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_floor (; 98 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_floor (; 98 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   (local $5 i32)
   block $~lib/math/NativeMath.floor|inlined.0 (result f64)
@@ -5537,7 +5537,7 @@
    local.get $5
   end
  )
- (func $std/math/test_floorf (; 99 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_floorf (; 99 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   block $~lib/math/NativeMathf.floor|inlined.0 (result f32)
    local.get $0
@@ -5550,7 +5550,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.hypot (; 100 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.hypot (; 100 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -5751,7 +5751,7 @@
   f64.sqrt
   f64.mul
  )
- (func $std/math/test_hypot (; 101 ;) (type $FFFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_hypot (; 101 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   (local $5 i32)
   local.get $0
   local.get $1
@@ -5780,7 +5780,7 @@
    local.get $5
   end
  )
- (func $~lib/math/NativeMathf.hypot (; 102 ;) (type $fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.hypot (; 102 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5913,7 +5913,7 @@
   f32.sqrt
   f32.mul
  )
- (func $std/math/test_hypotf (; 103 ;) (type $ffffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_hypotf (; 103 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.hypot
@@ -5922,7 +5922,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $std/math/test_log (; 104 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_log (; 104 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $0
   call $~lib/math/NativeMath.log
@@ -5949,7 +5949,7 @@
    local.get $4
   end
  )
- (func $std/math/test_logf (; 105 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_logf (; 105 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log
   local.get $1
@@ -5957,7 +5957,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log10 (; 106 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log10 (; 106 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -6220,7 +6220,7 @@
   local.get $9
   f64.add
  )
- (func $std/math/test_log10 (; 107 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_log10 (; 107 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $0
   call $~lib/math/NativeMath.log10
@@ -6247,7 +6247,7 @@
    local.get $4
   end
  )
- (func $~lib/math/NativeMathf.log10 (; 108 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log10 (; 108 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6449,7 +6449,7 @@
   f32.mul
   f32.add
  )
- (func $std/math/test_log10f (; 109 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_log10f (; 109 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log10
   local.get $1
@@ -6457,7 +6457,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_log1p (; 110 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_log1p (; 110 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $0
   call $~lib/math/NativeMath.log1p
@@ -6484,7 +6484,7 @@
    local.get $4
   end
  )
- (func $std/math/test_log1pf (; 111 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_log1pf (; 111 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log1p
   local.get $1
@@ -6492,7 +6492,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log2 (; 112 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log2 (; 112 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -6748,7 +6748,7 @@
   local.get $15
   f64.add
  )
- (func $std/math/test_log2 (; 113 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_log2 (; 113 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $0
   call $~lib/math/NativeMath.log2
@@ -6775,7 +6775,7 @@
    local.get $4
   end
  )
- (func $~lib/math/NativeMathf.log2 (; 114 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log2 (; 114 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6972,7 +6972,7 @@
   local.get $15
   f32.add
  )
- (func $std/math/test_log2f (; 115 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_log2f (; 115 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log2
   local.get $1
@@ -6980,7 +6980,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_max (; 116 ;) (type $FFFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_max (; 116 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   (local $5 f64)
   (local $6 f64)
   (local $7 i32)
@@ -7017,7 +7017,7 @@
    local.get $7
   end
  )
- (func $std/math/test_maxf (; 117 ;) (type $ffffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_maxf (; 117 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   (local $5 f32)
   (local $6 f32)
   block $~lib/math/NativeMathf.max|inlined.0 (result f32)
@@ -7034,7 +7034,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $std/math/test_min (; 118 ;) (type $FFFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_min (; 118 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   (local $5 f64)
   (local $6 f64)
   (local $7 i32)
@@ -7071,7 +7071,7 @@
    local.get $7
   end
  )
- (func $std/math/test_minf (; 119 ;) (type $ffffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_minf (; 119 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   (local $5 f32)
   (local $6 f32)
   block $~lib/math/NativeMathf.min|inlined.0 (result f32)
@@ -7088,7 +7088,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.mod (; 120 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (; 120 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -7346,7 +7346,7 @@
   local.get $2
   f64.reinterpret_i64
  )
- (func $std/math/test_mod (; 121 ;) (type $FFFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_mod (; 121 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   (local $5 i32)
   local.get $0
   local.get $1
@@ -7375,7 +7375,7 @@
    local.get $5
   end
  )
- (func $~lib/math/NativeMathf.mod (; 122 ;) (type $fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (; 122 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7631,7 +7631,7 @@
   local.get $2
   f32.reinterpret_i32
  )
- (func $std/math/test_modf (; 123 ;) (type $ffffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_modf (; 123 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.mod
@@ -7640,7 +7640,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.pow (; 124 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.pow (; 124 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -8728,7 +8728,7 @@
   local.get $16
   f64.mul
  )
- (func $std/math/test_pow (; 125 ;) (type $FFFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_pow (; 125 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   (local $5 i32)
   local.get $0
   local.get $1
@@ -8757,7 +8757,7 @@
    local.get $5
   end
  )
- (func $~lib/math/NativeMathf.pow (; 126 ;) (type $fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.pow (; 126 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9695,7 +9695,7 @@
   local.get $11
   f32.mul
  )
- (func $std/math/test_powf (; 127 ;) (type $ffffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_powf (; 127 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.pow
@@ -9704,7 +9704,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $~lib/math/murmurHash3 (; 128 ;) (type $II) (param $0 i64) (result i64)
+ (func $~lib/math/murmurHash3 (; 128 ;) (type $FUNCSIG$jj) (param $0 i64) (result i64)
   local.get $0
   local.get $0
   i64.const 33
@@ -9733,7 +9733,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/math/splitMix32 (; 129 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/math/splitMix32 (; 129 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 1831565813
   i32.add
@@ -9768,7 +9768,7 @@
   i32.shr_u
   i32.xor
  )
- (func $~lib/math/NativeMath.seedRandom (; 130 ;) (type $I_) (param $0 i64)
+ (func $~lib/math/NativeMath.seedRandom (; 130 ;) (type $FUNCSIG$vj) (param $0 i64)
   local.get $0
   i64.eqz
   if
@@ -9797,7 +9797,7 @@
   call $~lib/math/splitMix32
   global.set $~lib/math/random_state1_32
  )
- (func $~lib/math/NativeMath.random (; 131 ;) (type $F) (result f64)
+ (func $~lib/math/NativeMath.random (; 131 ;) (type $FUNCSIG$d) (result f64)
   (local $0 i64)
   (local $1 i64)
   (local $2 i64)
@@ -9854,7 +9854,7 @@
   f64.const 1
   f64.sub
  )
- (func $~lib/math/NativeMathf.random (; 132 ;) (type $f) (result f32)
+ (func $~lib/math/NativeMathf.random (; 132 ;) (type $FUNCSIG$f) (result f32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9909,7 +9909,7 @@
   f32.const 1
   f32.sub
  )
- (func $std/math/test_round (; 133 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_round (; 133 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   block $~lib/math/NativeMath.round|inlined.0 (result f64)
    local.get $0
@@ -9926,7 +9926,7 @@
   local.get $3
   call $std/math/check<f64>
  )
- (func $std/math/test_roundf (; 134 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_roundf (; 134 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   block $~lib/math/NativeMathf.round|inlined.0 (result f32)
    local.get $0
@@ -9943,7 +9943,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_sign (; 135 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_sign (; 135 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   (local $5 i32)
   block $~lib/math/NativeMath.sign|inlined.0 (result f64)
@@ -9989,7 +9989,7 @@
    local.get $5
   end
  )
- (func $std/math/test_signf (; 136 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_signf (; 136 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   block $~lib/math/NativeMathf.sign|inlined.0 (result f32)
    local.get $0
@@ -10016,7 +10016,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.rem (; 137 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.rem (; 137 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -10339,7 +10339,7 @@
    local.get $0
   end
  )
- (func $std/math/test_rem (; 138 ;) (type $FFFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_rem (; 138 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.rem
@@ -10348,7 +10348,7 @@
   local.get $4
   call $std/math/check<f64>
  )
- (func $~lib/math/NativeMathf.rem (; 139 ;) (type $fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.rem (; 139 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10668,7 +10668,7 @@
    local.get $0
   end
  )
- (func $std/math/test_remf (; 140 ;) (type $ffffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_remf (; 140 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.rem
@@ -10677,7 +10677,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.sinh (; 141 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.sinh (; 141 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 f64)
   (local $3 i32)
@@ -10781,7 +10781,7 @@
   local.set $4
   local.get $4
  )
- (func $std/math/test_sinh (; 142 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_sinh (; 142 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $0
   call $~lib/math/NativeMath.sinh
@@ -10808,7 +10808,7 @@
    local.get $4
   end
  )
- (func $~lib/math/NativeMathf.sinh (; 143 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.sinh (; 143 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -10903,7 +10903,7 @@
   local.set $3
   local.get $3
  )
- (func $std/math/test_sinhf (; 144 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_sinhf (; 144 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.sinh
   local.get $1
@@ -10911,7 +10911,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_sqrt (; 145 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_sqrt (; 145 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   (local $5 i32)
   block $~lib/math/NativeMath.sqrt|inlined.0 (result f64)
@@ -10943,7 +10943,7 @@
    local.get $5
   end
  )
- (func $std/math/test_sqrtf (; 146 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_sqrtf (; 146 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   block $~lib/math/NativeMathf.sqrt|inlined.0 (result f32)
    local.get $0
@@ -10956,7 +10956,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.tanh (; 147 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.tanh (; 147 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 f64)
   (local $3 i32)
@@ -11048,7 +11048,7 @@
   local.get $0
   f64.copysign
  )
- (func $std/math/test_tanh (; 148 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_tanh (; 148 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $0
   call $~lib/math/NativeMath.tanh
@@ -11075,7 +11075,7 @@
    local.get $4
   end
  )
- (func $~lib/math/NativeMathf.tanh (; 149 ;) (type $ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.tanh (; 149 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -11161,7 +11161,7 @@
   local.get $0
   f32.copysign
  )
- (func $std/math/test_tanhf (; 150 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_tanhf (; 150 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.tanh
   local.get $1
@@ -11169,7 +11169,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_trunc (; 151 ;) (type $FFFii) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_trunc (; 151 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   (local $5 i32)
   block $~lib/math/NativeMath.trunc|inlined.0 (result f64)
@@ -11201,7 +11201,7 @@
    local.get $5
   end
  )
- (func $std/math/test_truncf (; 152 ;) (type $fffii) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_truncf (; 152 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   block $~lib/math/NativeMathf.trunc|inlined.0 (result f32)
    local.get $0
@@ -11214,7 +11214,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.imul (; 153 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.imul (; 153 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   f64.add
@@ -11247,7 +11247,7 @@
   i32.mul
   f64.convert_i32_s
  )
- (func $~lib/math/NativeMath.clz32 (; 154 ;) (type $FF) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.clz32 (; 154 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/builtins/isFinite<f64>
   i32.eqz
@@ -11270,7 +11270,7 @@
   i32.clz
   f64.convert_i32_s
  )
- (func $~lib/math/ipow64 (; 155 ;) (type $IiI) (param $0 i64) (param $1 i32) (result i64)
+ (func $~lib/math/ipow64 (; 155 ;) (type $FUNCSIG$jji) (param $0 i64) (param $1 i32) (result i64)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -11502,7 +11502,7 @@
   end
   local.get $2
  )
- (func $~lib/math/ipow32f (; 156 ;) (type $fif) (param $0 f32) (param $1 i32) (result f32)
+ (func $~lib/math/ipow32f (; 156 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
   (local $2 i32)
   (local $3 f32)
   local.get $1
@@ -11553,7 +11553,7 @@
    local.get $3
   end
  )
- (func $~lib/math/ipow64f (; 157 ;) (type $FiF) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/ipow64f (; 157 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
   (local $2 i32)
   (local $3 f64)
   local.get $1
@@ -11604,7 +11604,7 @@
    local.get $3
   end
  )
- (func $start:std/math (; 158 ;) (type $_)
+ (func $start:std/math (; 158 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f64)
   (local $2 i32)
@@ -43221,9 +43221,9 @@
    unreachable
   end
  )
- (func $start (; 159 ;) (type $_)
+ (func $start (; 159 ;) (type $FUNCSIG$v)
   call $start:std/math
  )
- (func $null (; 160 ;) (type $_)
+ (func $null (; 160 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/mod.optimized.wat
+++ b/tests/compiler/std/mod.optimized.wat
@@ -1,12 +1,12 @@
 (module
- (type $FFFi (func (param f64 f64 f64) (result i32)))
- (type $FFF (func (param f64 f64) (result f64)))
- (type $FFi (func (param f64 f64) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $fffi (func (param f32 f32 f32) (result i32)))
- (type $fff (func (param f32 f32) (result f32)))
- (type $ffi (func (param f32 f32) (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$iddd (func (param f64 f64 f64) (result i32)))
+ (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))
+ (type $FUNCSIG$idd (func (param f64 f64) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$ifff (func (param f32 f32 f32) (result i32)))
+ (type $FUNCSIG$fff (func (param f32 f32) (result f32)))
+ (type $FUNCSIG$iff (func (param f32 f32) (result i32)))
+ (type $FUNCSIG$v (func))
  (import "math" "mod" (func $std/mod/mod (param f64 f64) (result f64)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -17,7 +17,7 @@
  (export "table" (table $0))
  (export "mod" (func $std/mod/mod))
  (start $start)
- (func $~lib/math/NativeMath.mod (; 2 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (; 2 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -225,7 +225,7 @@
   local.get $0
   f64.mul
  )
- (func $std/mod/check<f64> (; 3 ;) (type $FFi) (param $0 f64) (param $1 f64) (result i32)
+ (func $std/mod/check<f64> (; 3 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
   local.get $1
   local.get $1
   f64.ne
@@ -252,7 +252,7 @@
   local.get $1
   f64.eq
  )
- (func $std/mod/test_fmod (; 4 ;) (type $FFFi) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/mod/test_fmod (; 4 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -270,7 +270,7 @@
   end
   local.get $3
  )
- (func $~lib/math/NativeMathf.mod (; 5 ;) (type $fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (; 5 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -466,7 +466,7 @@
   local.get $0
   f32.mul
  )
- (func $std/mod/check<f32> (; 6 ;) (type $ffi) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/mod/check<f32> (; 6 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
   local.get $1
   local.get $1
   f32.ne
@@ -493,14 +493,14 @@
   local.get $1
   f32.eq
  )
- (func $std/mod/test_fmodf (; 7 ;) (type $fffi) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/mod/test_fmodf (; 7 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.mod
   local.get $2
   call $std/mod/check<f32>
  )
- (func $start:std/mod (; 8 ;) (type $_)
+ (func $start:std/mod (; 8 ;) (type $FUNCSIG$v)
   f64.const 3
   f64.const 2
   f64.const 1
@@ -2257,10 +2257,10 @@
    unreachable
   end
  )
- (func $start (; 9 ;) (type $_)
+ (func $start (; 9 ;) (type $FUNCSIG$v)
   call $start:std/mod
  )
- (func $null (; 10 ;) (type $_)
+ (func $null (; 10 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/mod.untouched.wat
+++ b/tests/compiler/std/mod.untouched.wat
@@ -1,14 +1,14 @@
 (module
- (type $FFFi (func (param f64 f64 f64) (result i32)))
- (type $FFF (func (param f64 f64) (result f64)))
- (type $FFi (func (param f64 f64) (result i32)))
- (type $Fi (func (param f64) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $fffi (func (param f32 f32 f32) (result i32)))
- (type $fff (func (param f32 f32) (result f32)))
- (type $ffi (func (param f32 f32) (result i32)))
- (type $fi (func (param f32) (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$iddd (func (param f64 f64 f64) (result i32)))
+ (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))
+ (type $FUNCSIG$idd (func (param f64 f64) (result i32)))
+ (type $FUNCSIG$id (func (param f64) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$ifff (func (param f32 f32 f32) (result i32)))
+ (type $FUNCSIG$fff (func (param f32 f32) (result f32)))
+ (type $FUNCSIG$iff (func (param f32 f32) (result i32)))
+ (type $FUNCSIG$if (func (param f32) (result i32)))
+ (type $FUNCSIG$v (func))
  (import "math" "mod" (func $std/mod/mod (param f64 f64) (result f64)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -21,7 +21,7 @@
  (export "table" (table $0))
  (export "mod" (func $std/mod/mod))
  (start $start)
- (func $~lib/math/NativeMath.mod (; 2 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (; 2 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -279,12 +279,12 @@
   local.get $2
   f64.reinterpret_i64
  )
- (func $~lib/builtins/isNaN<f64> (; 3 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $~lib/builtins/isNaN<f64> (; 3 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   local.get $0
   f64.ne
  )
- (func $std/mod/check<f64> (; 4 ;) (type $FFi) (param $0 f64) (param $1 f64) (result i32)
+ (func $std/mod/check<f64> (; 4 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
   local.get $1
   call $~lib/builtins/isNaN<f64>
   if
@@ -310,7 +310,7 @@
   local.get $1
   f64.eq
  )
- (func $std/mod/test_fmod (; 5 ;) (type $FFFi) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/mod/test_fmod (; 5 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -335,7 +335,7 @@
    local.get $3
   end
  )
- (func $~lib/math/NativeMathf.mod (; 6 ;) (type $fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (; 6 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -591,12 +591,12 @@
   local.get $2
   f32.reinterpret_i32
  )
- (func $~lib/builtins/isNaN<f32> (; 7 ;) (type $fi) (param $0 f32) (result i32)
+ (func $~lib/builtins/isNaN<f32> (; 7 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
   local.get $0
   local.get $0
   f32.ne
  )
- (func $std/mod/check<f32> (; 8 ;) (type $ffi) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/mod/check<f32> (; 8 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
   local.get $1
   call $~lib/builtins/isNaN<f32>
   if
@@ -622,14 +622,14 @@
   local.get $1
   f32.eq
  )
- (func $std/mod/test_fmodf (; 9 ;) (type $fffi) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/mod/test_fmodf (; 9 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.mod
   local.get $2
   call $std/mod/check<f32>
  )
- (func $start:std/mod (; 10 ;) (type $_)
+ (func $start:std/mod (; 10 ;) (type $FUNCSIG$v)
   f64.const 3
   f64.const 2
   f64.const 1
@@ -2414,9 +2414,9 @@
    unreachable
   end
  )
- (func $start (; 11 ;) (type $_)
+ (func $start (; 11 ;) (type $FUNCSIG$v)
   call $start:std/mod
  )
- (func $null (; 12 ;) (type $_)
+ (func $null (; 12 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/new.optimized.wat
+++ b/tests/compiler/std/new.optimized.wat
@@ -1,5 +1,5 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (type $FUNCSIG$i (func (result i32)))
  (memory $0 0)
  (table $0 1 funcref)
@@ -80,7 +80,7 @@
   f32.store offset=4
   local.get $0
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   i32.const 8
   global.set $~lib/allocator/arena/startOffset
   global.get $~lib/allocator/arena/startOffset
@@ -88,7 +88,7 @@
   call $std/new/AClass#constructor
   global.set $std/new/aClass
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/new.untouched.wat
+++ b/tests/compiler/std/new.untouched.wat
@@ -1,7 +1,7 @@
 (module
- (type $_ (func))
- (type $ifi (func (param i32 f32) (result i32)))
- (type $ii (func (param i32) (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$iif (func (param i32 f32) (result i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -13,7 +13,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:~lib/allocator/arena (; 0 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 0 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -25,7 +25,7 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -104,12 +104,12 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/memory/memory.allocate (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/memory/memory.allocate (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/allocator/arena/__memory_allocate
   return
  )
- (func $std/new/AClass#constructor (; 3 ;) (type $ifi) (param $0 i32) (param $1 f32) (result i32)
+ (func $std/new/AClass#constructor (; 3 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
   local.get $0
   block (result i32)
    local.get $0
@@ -136,16 +136,16 @@
   f32.store offset=4
   local.get $0
  )
- (func $start:std/new (; 4 ;) (type $_)
+ (func $start:std/new (; 4 ;) (type $FUNCSIG$v)
   call $start:~lib/allocator/arena
   i32.const 0
   f32.const 3
   call $std/new/AClass#constructor
   global.set $std/new/aClass
  )
- (func $start (; 5 ;) (type $_)
+ (func $start (; 5 ;) (type $FUNCSIG$v)
   call $start:std/new
  )
- (func $null (; 6 ;) (type $_)
+ (func $null (; 6 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/operator-overloading.optimized.wat
+++ b/tests/compiler/std/operator-overloading.optimized.wat
@@ -1,11 +1,10 @@
 (module
- (type $_ (func))
- (type $iii (func (param i32 i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $FFF (func (param f64 f64) (result f64)))
- (type $FiF (func (param f64 i32) (result f64)))
- (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$v (func))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))
+ (type $FUNCSIG$ddi (func (param f64 i32) (result f64)))
+ (type $FUNCSIG$i (func (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\1b\00\00\00s\00t\00d\00/\00o\00p\00e\00r\00a\00t\00o\00r\00-\00o\00v\00e\00r\00l\00o\00a\00d\00i\00n\00g\00.\00t\00s")
@@ -143,7 +142,7 @@
   i32.store offset=4
   local.get $2
  )
- (func $~lib/math/NativeMath.scalbn (; 3 ;) (type $FiF) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/NativeMath.scalbn (; 3 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
   local.get $1
   i32.const 1023
   i32.gt_s
@@ -220,7 +219,7 @@
   f64.reinterpret_i64
   f64.mul
  )
- (func $~lib/math/NativeMath.pow (; 4 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.pow (; 4 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 f64)
   (local $4 i32)
@@ -1170,7 +1169,7 @@
   f64.const 1e-300
   f64.mul
  )
- (func $std/operator-overloading/Tester.pow (; 5 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.pow (; 5 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load
   f64.convert_i32_s
@@ -1189,7 +1188,7 @@
   i32.trunc_f64_s
   call $std/operator-overloading/Tester#constructor
  )
- (func $start:std/operator-overloading (; 6 ;) (type $_)
+ (func $start:std/operator-overloading (; 6 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2444,10 +2443,10 @@
    unreachable
   end
  )
- (func $start (; 7 ;) (type $_)
+ (func $start (; 7 ;) (type $FUNCSIG$v)
   call $start:std/operator-overloading
  )
- (func $null (; 8 ;) (type $_)
+ (func $null (; 8 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/operator-overloading.untouched.wat
+++ b/tests/compiler/std/operator-overloading.untouched.wat
@@ -1,11 +1,11 @@
 (module
- (type $_ (func))
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $ii (func (param i32) (result i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $FFF (func (param f64 f64) (result f64)))
- (type $FiF (func (param f64 i32) (result f64)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))
+ (type $FUNCSIG$ddi (func (param f64 i32) (result f64)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\1b\00\00\00s\00t\00d\00/\00o\00p\00e\00r\00a\00t\00o\00r\00-\00o\00v\00e\00r\00l\00o\00a\00d\00i\00n\00g\00.\00t\00s\00")
@@ -84,7 +84,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:~lib/allocator/arena (; 1 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 1 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -96,7 +96,7 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -175,12 +175,12 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/memory/memory.allocate (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/memory/memory.allocate (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/allocator/arena/__memory_allocate
   return
  )
- (func $std/operator-overloading/Tester#constructor (; 4 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/operator-overloading/Tester#constructor (; 4 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -196,7 +196,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $std/operator-overloading/Tester.add (; 5 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.add (; 5 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load
@@ -210,7 +210,7 @@
   i32.add
   call $std/operator-overloading/Tester#constructor
  )
- (func $std/operator-overloading/Tester.sub (; 6 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.sub (; 6 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load
@@ -224,7 +224,7 @@
   i32.sub
   call $std/operator-overloading/Tester#constructor
  )
- (func $std/operator-overloading/Tester.mul (; 7 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.mul (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load
@@ -238,7 +238,7 @@
   i32.mul
   call $std/operator-overloading/Tester#constructor
  )
- (func $std/operator-overloading/Tester.div (; 8 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.div (; 8 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load
@@ -252,7 +252,7 @@
   i32.div_s
   call $std/operator-overloading/Tester#constructor
  )
- (func $std/operator-overloading/Tester.mod (; 9 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.mod (; 9 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load
@@ -266,7 +266,7 @@
   i32.rem_s
   call $std/operator-overloading/Tester#constructor
  )
- (func $~lib/math/NativeMath.scalbn (; 10 ;) (type $FiF) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/NativeMath.scalbn (; 10 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
@@ -357,7 +357,7 @@
   f64.reinterpret_i64
   f64.mul
  )
- (func $~lib/math/NativeMath.pow (; 11 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.pow (; 11 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -1445,7 +1445,7 @@
   local.get $16
   f64.mul
  )
- (func $std/operator-overloading/Tester.pow (; 12 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.pow (; 12 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load
@@ -1465,7 +1465,7 @@
   i32.trunc_f64_s
   call $std/operator-overloading/Tester#constructor
  )
- (func $std/operator-overloading/Tester.and (; 13 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.and (; 13 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load
@@ -1479,7 +1479,7 @@
   i32.and
   call $std/operator-overloading/Tester#constructor
  )
- (func $std/operator-overloading/Tester.or (; 14 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.or (; 14 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load
@@ -1493,7 +1493,7 @@
   i32.or
   call $std/operator-overloading/Tester#constructor
  )
- (func $std/operator-overloading/Tester.xor (; 15 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.xor (; 15 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load
@@ -1507,7 +1507,7 @@
   i32.xor
   call $std/operator-overloading/Tester#constructor
  )
- (func $std/operator-overloading/Tester.equals (; 16 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.equals (; 16 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -1525,7 +1525,7 @@
    local.get $2
   end
  )
- (func $std/operator-overloading/Tester.notEquals (; 17 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.notEquals (; 17 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -1543,7 +1543,7 @@
    local.get $2
   end
  )
- (func $std/operator-overloading/Tester.greater (; 18 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.greater (; 18 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -1561,7 +1561,7 @@
    local.get $2
   end
  )
- (func $std/operator-overloading/Tester.greaterEquals (; 19 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.greaterEquals (; 19 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -1579,7 +1579,7 @@
    local.get $2
   end
  )
- (func $std/operator-overloading/Tester.less (; 20 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.less (; 20 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -1597,7 +1597,7 @@
    local.get $2
   end
  )
- (func $std/operator-overloading/Tester.lessEquals (; 21 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.lessEquals (; 21 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -1615,7 +1615,7 @@
    local.get $2
   end
  )
- (func $std/operator-overloading/Tester.shr (; 22 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.shr (; 22 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load
@@ -1627,7 +1627,7 @@
   i32.shr_s
   call $std/operator-overloading/Tester#constructor
  )
- (func $std/operator-overloading/Tester.shu (; 23 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.shu (; 23 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load
@@ -1639,7 +1639,7 @@
   i32.shr_u
   call $std/operator-overloading/Tester#constructor
  )
- (func $std/operator-overloading/Tester.shl (; 24 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.shl (; 24 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load
@@ -1651,7 +1651,7 @@
   i32.shl
   call $std/operator-overloading/Tester#constructor
  )
- (func $std/operator-overloading/Tester.pos (; 25 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/operator-overloading/Tester.pos (; 25 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load
@@ -1659,7 +1659,7 @@
   i32.load offset=4
   call $std/operator-overloading/Tester#constructor
  )
- (func $std/operator-overloading/Tester.neg (; 26 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/operator-overloading/Tester.neg (; 26 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   i32.const 0
   local.get $0
@@ -1671,7 +1671,7 @@
   i32.sub
   call $std/operator-overloading/Tester#constructor
  )
- (func $std/operator-overloading/Tester.not (; 27 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/operator-overloading/Tester.not (; 27 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load
@@ -1683,7 +1683,7 @@
   i32.xor
   call $std/operator-overloading/Tester#constructor
  )
- (func $std/operator-overloading/Tester.excl (; 28 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/operator-overloading/Tester.excl (; 28 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.load
@@ -1697,7 +1697,7 @@
    local.get $1
   end
  )
- (func $std/operator-overloading/Tester#inc (; 29 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/operator-overloading/Tester#inc (; 29 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   local.get $0
   i32.load
@@ -1712,7 +1712,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $std/operator-overloading/Tester#dec (; 30 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/operator-overloading/Tester#dec (; 30 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   local.get $0
   i32.load
@@ -1727,7 +1727,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $std/operator-overloading/Tester#postInc (; 31 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/operator-overloading/Tester#postInc (; 31 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load
@@ -1739,7 +1739,7 @@
   i32.add
   call $std/operator-overloading/Tester#constructor
  )
- (func $std/operator-overloading/Tester#postDec (; 32 ;) (type $ii) (param $0 i32) (result i32)
+ (func $std/operator-overloading/Tester#postDec (; 32 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load
@@ -1751,7 +1751,7 @@
   i32.sub
   call $std/operator-overloading/Tester#constructor
  )
- (func $std/operator-overloading/TesterInlineStatic#constructor (; 33 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/operator-overloading/TesterInlineStatic#constructor (; 33 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1767,7 +1767,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $std/operator-overloading/TesterInlineInstance#constructor (; 34 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/operator-overloading/TesterInlineInstance#constructor (; 34 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1783,7 +1783,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $start:std/operator-overloading (; 35 ;) (type $_)
+ (func $start:std/operator-overloading (; 35 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   call $start:~lib/allocator/arena
@@ -2835,9 +2835,9 @@
    unreachable
   end
  )
- (func $start (; 36 ;) (type $_)
+ (func $start (; 36 ;) (type $FUNCSIG$v)
   call $start:std/operator-overloading
  )
- (func $null (; 37 ;) (type $_)
+ (func $null (; 37 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/pointer.optimized.wat
+++ b/tests/compiler/std/pointer.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$vii (func (param i32 i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
@@ -1110,7 +1110,7 @@
    end
   end
  )
- (func $start:std/pointer (; 4 ;) (type $_)
+ (func $start:std/pointer (; 4 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 8
@@ -1499,10 +1499,10 @@
    unreachable
   end
  )
- (func $start (; 5 ;) (type $_)
+ (func $start (; 5 ;) (type $FUNCSIG$v)
   call $start:std/pointer
  )
- (func $null (; 6 ;) (type $_)
+ (func $null (; 6 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/pointer.untouched.wat
+++ b/tests/compiler/std/pointer.untouched.wat
@@ -1,10 +1,10 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $ii_ (func (param i32 i32)))
- (type $iii_ (func (param i32 i32 i32)))
- (type $iif_ (func (param i32 i32 f32)))
- (type $if_ (func (param i32 f32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$viif (func (param i32 i32 f32)))
+ (type $FUNCSIG$vif (func (param i32 f32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\0e\00\00\00s\00t\00d\00/\00p\00o\00i\00n\00t\00e\00r\00.\00t\00s\00")
@@ -20,7 +20,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $~lib/internal/memory/memset (; 1 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 1 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -274,7 +274,7 @@
    end
   end
  )
- (func $~lib/internal/memory/memcpy (; 2 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 2 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1475,7 +1475,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 3 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 3 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -1702,7 +1702,7 @@
    end
   end
  )
- (func $std/pointer/Pointer<Entry>#set:value (; 4 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $std/pointer/Pointer<Entry>#set:value (; 4 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1733,7 +1733,7 @@
    call $~lib/internal/memory/memmove
   end
  )
- (func $std/pointer/Pointer<f32>#set (; 5 ;) (type $iif_) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $std/pointer/Pointer<f32>#set (; 5 ;) (type $FUNCSIG$viif) (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $0
   local.get $1
   i32.const 4
@@ -1742,12 +1742,12 @@
   local.get $2
   f32.store
  )
- (func $std/pointer/Pointer<f32>#set:value (; 6 ;) (type $if_) (param $0 i32) (param $1 f32)
+ (func $std/pointer/Pointer<f32>#set:value (; 6 ;) (type $FUNCSIG$vif) (param $0 i32) (param $1 f32)
   local.get $0
   local.get $1
   f32.store
  )
- (func $start:std/pointer (; 7 ;) (type $_)
+ (func $start:std/pointer (; 7 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 f32)
@@ -2350,9 +2350,9 @@
    unreachable
   end
  )
- (func $start (; 8 ;) (type $_)
+ (func $start (; 8 ;) (type $FUNCSIG$v)
   call $start:std/pointer
  )
- (func $null (; 9 ;) (type $_)
+ (func $null (; 9 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/polyfills.optimized.wat
+++ b/tests/compiler/std/polyfills.optimized.wat
@@ -1,12 +1,12 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 1)
  (data (i32.const 8) "\10\00\00\00s\00t\00d\00/\00p\00o\00l\00y\00f\00i\00l\00l\00s\00.\00t\00s")
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $start (; 0 ;) (type $_)
+ (func $start (; 0 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/polyfills.untouched.wat
+++ b/tests/compiler/std/polyfills.untouched.wat
@@ -1,8 +1,8 @@
 (module
- (type $ii (func (param i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $II (func (param i64) (result i64)))
- (type $_ (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$jj (func (param i64) (result i64)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\10\00\00\00s\00t\00d\00/\00p\00o\00l\00y\00f\00i\00l\00l\00s\00.\00t\00s\00")
@@ -12,15 +12,15 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $~lib/polyfills/bswap<u8> (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<u8> (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   return
  )
- (func $~lib/polyfills/bswap<i8> (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<i8> (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   return
  )
- (func $~lib/polyfills/bswap<u16> (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<u16> (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 8
   i32.shl
@@ -34,7 +34,7 @@
   i32.or
   return
  )
- (func $~lib/polyfills/bswap<i16> (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<i16> (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 8
   i32.shl
@@ -50,7 +50,7 @@
   i32.or
   return
  )
- (func $~lib/polyfills/bswap<u32> (; 5 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<u32> (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const -16711936
   i32.and
@@ -64,7 +64,7 @@
   i32.or
   return
  )
- (func $~lib/polyfills/bswap<i32> (; 6 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<i32> (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const -16711936
   i32.and
@@ -78,7 +78,7 @@
   i32.or
   return
  )
- (func $~lib/polyfills/bswap<u64> (; 7 ;) (type $II) (param $0 i64) (result i64)
+ (func $~lib/polyfills/bswap<u64> (; 7 ;) (type $FUNCSIG$jj) (param $0 i64) (result i64)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -117,7 +117,7 @@
   i64.rotr
   return
  )
- (func $~lib/polyfills/bswap<i64> (; 8 ;) (type $II) (param $0 i64) (result i64)
+ (func $~lib/polyfills/bswap<i64> (; 8 ;) (type $FUNCSIG$jj) (param $0 i64) (result i64)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -156,7 +156,7 @@
   i64.rotr
   return
  )
- (func $~lib/polyfills/bswap<usize> (; 9 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<usize> (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const -16711936
   i32.and
@@ -170,7 +170,7 @@
   i32.or
   return
  )
- (func $~lib/polyfills/bswap<isize> (; 10 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<isize> (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const -16711936
   i32.and
@@ -184,7 +184,7 @@
   i32.or
   return
  )
- (func $start:std/polyfills (; 11 ;) (type $_)
+ (func $start:std/polyfills (; 11 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 170
   call $~lib/polyfills/bswap<u8>
@@ -507,9 +507,9 @@
    unreachable
   end
  )
- (func $start (; 12 ;) (type $_)
+ (func $start (; 12 ;) (type $FUNCSIG$v)
   call $start:std/polyfills
  )
- (func $null (; 13 ;) (type $_)
+ (func $null (; 13 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -1,29 +1,24 @@
 (module
- (type $_ (func))
- (type $ii (func (param i32) (result i32)))
- (type $i_ (func (param i32)))
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $ii_ (func (param i32 i32)))
- (type $iIi (func (param i32 i64) (result i32)))
- (type $Ii (func (param i64) (result i32)))
- (type $iIii (func (param i32 i64 i32) (result i32)))
- (type $iI_ (func (param i32 i64)))
- (type $ifi (func (param i32 f32) (result i32)))
- (type $fi (func (param f32) (result i32)))
- (type $ifii (func (param i32 f32 i32) (result i32)))
- (type $if_ (func (param i32 f32)))
- (type $iFi (func (param i32 f64) (result i32)))
- (type $Fi (func (param f64) (result i32)))
- (type $iFii (func (param i32 f64 i32) (result i32)))
- (type $iF_ (func (param i32 f64)))
- (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
- (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$iij (func (param i32 i64) (result i32)))
+ (type $FUNCSIG$ij (func (param i64) (result i32)))
+ (type $FUNCSIG$iiji (func (param i32 i64 i32) (result i32)))
  (type $FUNCSIG$vij (func (param i32 i64)))
+ (type $FUNCSIG$iif (func (param i32 f32) (result i32)))
+ (type $FUNCSIG$if (func (param f32) (result i32)))
+ (type $FUNCSIG$iifi (func (param i32 f32 i32) (result i32)))
  (type $FUNCSIG$vif (func (param i32 f32)))
+ (type $FUNCSIG$iid (func (param i32 f64) (result i32)))
+ (type $FUNCSIG$id (func (param f64) (result i32)))
+ (type $FUNCSIG$iidi (func (param i32 f64 i32) (result i32)))
  (type $FUNCSIG$vid (func (param i32 f64)))
+ (type $FUNCSIG$i (func (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\13\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s")
@@ -36,7 +31,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -98,7 +93,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/internal/arraybuffer/allocateUnsafe (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/allocateUnsafe (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 1073741816
@@ -371,7 +366,7 @@
   end
   local.get $2
  )
- (func $~lib/set/Set<i8>#clear (; 5 ;) (type $i_) (param $0 i32)
+ (func $~lib/set/Set<i8>#clear (; 5 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 16
   i32.const 0
@@ -421,7 +416,7 @@
   call $~lib/set/Set<i8>#clear
   local.get $0
  )
- (func $~lib/set/Set<i8>#find (; 7 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i8>#find (; 7 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -466,7 +461,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i8>#has (; 8 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i8>#has (; 8 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -482,7 +477,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i8>#rehash (; 9 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i8>#rehash (; 9 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -588,7 +583,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<i8>#add (; 10 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i8>#add (; 10 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -749,7 +744,7 @@
    call $~lib/set/Set<i8>#rehash
   end
  )
- (func $std/set/test<i8> (; 12 ;) (type $_)
+ (func $std/set/test<i8> (; 12 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   call $~lib/set/Set<i8>#constructor
@@ -994,7 +989,7 @@
    unreachable
   end
  )
- (func $~lib/set/Set<u8>#has (; 13 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u8>#has (; 13 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -1008,7 +1003,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u8>#rehash (; 14 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u8>#rehash (; 14 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1114,7 +1109,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<u8>#add (; 15 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u8>#add (; 15 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1271,7 +1266,7 @@
    call $~lib/set/Set<u8>#rehash
   end
  )
- (func $std/set/test<u8> (; 17 ;) (type $_)
+ (func $std/set/test<u8> (; 17 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   call $~lib/set/Set<i8>#constructor
@@ -1516,7 +1511,7 @@
    unreachable
   end
  )
- (func $~lib/set/Set<i16>#find (; 18 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i16>#find (; 18 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -1561,7 +1556,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i16>#has (; 19 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i16>#has (; 19 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -1587,7 +1582,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i16>#rehash (; 20 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i16>#rehash (; 20 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1702,7 +1697,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<i16>#add (; 21 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i16>#add (; 21 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1881,7 +1876,7 @@
    call $~lib/set/Set<i16>#rehash
   end
  )
- (func $std/set/test<i16> (; 23 ;) (type $_)
+ (func $std/set/test<i16> (; 23 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   call $~lib/set/Set<i8>#constructor
@@ -2126,7 +2121,7 @@
    unreachable
   end
  )
- (func $~lib/set/Set<u16>#has (; 24 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u16>#has (; 24 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -2150,7 +2145,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u16>#rehash (; 25 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u16>#rehash (; 25 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2265,7 +2260,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<u16>#add (; 26 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u16>#add (; 26 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2440,7 +2435,7 @@
    call $~lib/set/Set<u16>#rehash
   end
  )
- (func $std/set/test<u16> (; 28 ;) (type $_)
+ (func $std/set/test<u16> (; 28 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   call $~lib/set/Set<i8>#constructor
@@ -2685,7 +2680,7 @@
    unreachable
   end
  )
- (func $~lib/internal/hash/hash32 (; 29 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/hash/hash32 (; 29 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -2716,7 +2711,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/set/Set<i32>#find (; 30 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i32>#find (; 30 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -2759,7 +2754,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i32>#has (; 31 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i32>#has (; 31 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -2768,7 +2763,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i32>#rehash (; 32 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i32>#rehash (; 32 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2871,7 +2866,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<i32>#add (; 33 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i32>#add (; 33 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3018,7 +3013,7 @@
    call $~lib/set/Set<i32>#rehash
   end
  )
- (func $std/set/test<i32> (; 35 ;) (type $_)
+ (func $std/set/test<i32> (; 35 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   call $~lib/set/Set<i8>#constructor
@@ -3263,7 +3258,7 @@
    unreachable
   end
  )
- (func $std/set/test<u32> (; 36 ;) (type $_)
+ (func $std/set/test<u32> (; 36 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   call $~lib/set/Set<i8>#constructor
@@ -3508,7 +3503,7 @@
    unreachable
   end
  )
- (func $~lib/set/Set<i64>#clear (; 37 ;) (type $i_) (param $0 i32)
+ (func $~lib/set/Set<i64>#clear (; 37 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 16
   i32.const 0
@@ -3558,7 +3553,7 @@
   call $~lib/set/Set<i64>#clear
   local.get $0
  )
- (func $~lib/internal/hash/hash64 (; 39 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/hash/hash64 (; 39 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   local.get $0
   i32.wrap_i64
@@ -3624,7 +3619,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/set/Set<i64>#find (; 40 ;) (type $iIii) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i64>#find (; 40 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -3667,7 +3662,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i64>#has (; 41 ;) (type $iIi) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/set/Set<i64>#has (; 41 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -3676,7 +3671,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i64>#rehash (; 42 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i64>#rehash (; 42 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3779,7 +3774,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<i64>#add (; 43 ;) (type $iI_) (param $0 i32) (param $1 i64)
+ (func $~lib/set/Set<i64>#add (; 43 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3927,7 +3922,7 @@
    call $~lib/set/Set<i64>#rehash
   end
  )
- (func $std/set/test<i64> (; 45 ;) (type $_)
+ (func $std/set/test<i64> (; 45 ;) (type $FUNCSIG$v)
   (local $0 i64)
   (local $1 i32)
   call $~lib/set/Set<i64>#constructor
@@ -4172,7 +4167,7 @@
    unreachable
   end
  )
- (func $std/set/test<u64> (; 46 ;) (type $_)
+ (func $std/set/test<u64> (; 46 ;) (type $FUNCSIG$v)
   (local $0 i64)
   (local $1 i32)
   call $~lib/set/Set<i64>#constructor
@@ -4417,12 +4412,12 @@
    unreachable
   end
  )
- (func $~lib/internal/hash/HASH<f32> (; 47 ;) (type $fi) (param $0 f32) (result i32)
+ (func $~lib/internal/hash/HASH<f32> (; 47 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
   local.get $0
   i32.reinterpret_f32
   call $~lib/internal/hash/hash32
  )
- (func $~lib/set/Set<f32>#find (; 48 ;) (type $ifii) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<f32>#find (; 48 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -4465,7 +4460,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<f32>#has (; 49 ;) (type $ifi) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/set/Set<f32>#has (; 49 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -4474,7 +4469,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<f32>#rehash (; 50 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<f32>#rehash (; 50 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4578,7 +4573,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<f32>#add (; 51 ;) (type $if_) (param $0 i32) (param $1 f32)
+ (func $~lib/set/Set<f32>#add (; 51 ;) (type $FUNCSIG$vif) (param $0 i32) (param $1 f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4725,7 +4720,7 @@
    call $~lib/set/Set<f32>#rehash
   end
  )
- (func $std/set/test<f32> (; 53 ;) (type $_)
+ (func $std/set/test<f32> (; 53 ;) (type $FUNCSIG$v)
   (local $0 f32)
   (local $1 i32)
   call $~lib/set/Set<i8>#constructor
@@ -4970,12 +4965,12 @@
    unreachable
   end
  )
- (func $~lib/internal/hash/HASH<f64> (; 54 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $~lib/internal/hash/HASH<f64> (; 54 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   i64.reinterpret_f64
   call $~lib/internal/hash/hash64
  )
- (func $~lib/set/Set<f64>#find (; 55 ;) (type $iFii) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/set/Set<f64>#find (; 55 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -5018,7 +5013,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<f64>#has (; 56 ;) (type $iFi) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/set/Set<f64>#has (; 56 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -5027,7 +5022,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<f64>#rehash (; 57 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<f64>#rehash (; 57 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5131,7 +5126,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<f64>#add (; 58 ;) (type $iF_) (param $0 i32) (param $1 f64)
+ (func $~lib/set/Set<f64>#add (; 58 ;) (type $FUNCSIG$vid) (param $0 i32) (param $1 f64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5278,7 +5273,7 @@
    call $~lib/set/Set<f64>#rehash
   end
  )
- (func $std/set/test<f64> (; 60 ;) (type $_)
+ (func $std/set/test<f64> (; 60 ;) (type $FUNCSIG$v)
   (local $0 f64)
   (local $1 i32)
   call $~lib/set/Set<i64>#constructor
@@ -5523,7 +5518,7 @@
    unreachable
   end
  )
- (func $start (; 61 ;) (type $_)
+ (func $start (; 61 ;) (type $FUNCSIG$v)
   i32.const 144
   global.set $~lib/allocator/arena/startOffset
   global.get $~lib/allocator/arena/startOffset
@@ -5539,7 +5534,7 @@
   call $std/set/test<f32>
   call $std/set/test<f64>
  )
- (func $null (; 62 ;) (type $_)
+ (func $null (; 62 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -1,24 +1,24 @@
 (module
- (type $_ (func))
- (type $ii (func (param i32) (result i32)))
- (type $i_ (func (param i32)))
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $iii_ (func (param i32 i32 i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $ii_ (func (param i32 i32)))
- (type $iIi (func (param i32 i64) (result i32)))
- (type $Ii (func (param i64) (result i32)))
- (type $iIii (func (param i32 i64 i32) (result i32)))
- (type $iI_ (func (param i32 i64)))
- (type $ifi (func (param i32 f32) (result i32)))
- (type $fi (func (param f32) (result i32)))
- (type $ifii (func (param i32 f32 i32) (result i32)))
- (type $if_ (func (param i32 f32)))
- (type $iFi (func (param i32 f64) (result i32)))
- (type $Fi (func (param f64) (result i32)))
- (type $iFii (func (param i32 f64 i32) (result i32)))
- (type $iF_ (func (param i32 f64)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$iij (func (param i32 i64) (result i32)))
+ (type $FUNCSIG$ij (func (param i64) (result i32)))
+ (type $FUNCSIG$iiji (func (param i32 i64 i32) (result i32)))
+ (type $FUNCSIG$vij (func (param i32 i64)))
+ (type $FUNCSIG$iif (func (param i32 f32) (result i32)))
+ (type $FUNCSIG$if (func (param f32) (result i32)))
+ (type $FUNCSIG$iifi (func (param i32 f32 i32) (result i32)))
+ (type $FUNCSIG$vif (func (param i32 f32)))
+ (type $FUNCSIG$iid (func (param i32 f64) (result i32)))
+ (type $FUNCSIG$id (func (param f64) (result i32)))
+ (type $FUNCSIG$iidi (func (param i32 f64 i32) (result i32)))
+ (type $FUNCSIG$vid (func (param i32 f64)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\13\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
@@ -32,7 +32,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:~lib/allocator/arena (; 1 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 1 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -44,7 +44,7 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -123,12 +123,12 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/memory/memory.allocate (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/memory/memory.allocate (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/allocator/arena/__memory_allocate
   return
  )
- (func $~lib/internal/arraybuffer/computeSize (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/computeSize (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   i32.const 32
   local.get $0
@@ -140,7 +140,7 @@
   i32.sub
   i32.shl
  )
- (func $~lib/internal/arraybuffer/allocateUnsafe (; 5 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/allocateUnsafe (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -169,7 +169,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memset (; 6 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 6 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -423,7 +423,7 @@
    end
   end
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (; 7 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (; 7 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -462,7 +462,7 @@
   end
   local.get $3
  )
- (func $~lib/set/Set<i8>#clear (; 8 ;) (type $i_) (param $0 i32)
+ (func $~lib/set/Set<i8>#clear (; 8 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -490,7 +490,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<i8>#constructor (; 9 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i8>#constructor (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -522,14 +522,14 @@
   call $~lib/set/Set<i8>#clear
   local.get $0
  )
- (func $~lib/internal/hash/hash8 (; 10 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/hash/hash8 (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const -2128831035
   local.get $0
   i32.xor
   i32.const 16777619
   i32.mul
  )
- (func $~lib/internal/hash/HASH<i8> (; 11 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/hash/HASH<i8> (; 11 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -538,7 +538,7 @@
   call $~lib/internal/hash/hash8
   return
  )
- (func $~lib/set/Set<i8>#find (; 12 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i8>#find (; 12 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -593,7 +593,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i8>#has (; 13 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i8>#has (; 13 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -602,7 +602,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i8>#rehash (; 14 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i8>#rehash (; 14 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -738,7 +738,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<i8>#add (; 15 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i8>#add (; 15 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -833,11 +833,11 @@
    i32.store offset=8
   end
  )
- (func $~lib/set/Set<i8>#get:size (; 16 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i8>#get:size (; 16 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/set/Set<i8>#delete (; 17 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i8>#delete (; 17 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -914,7 +914,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<i8> (; 18 ;) (type $_)
+ (func $std/set/test<i8> (; 18 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -1197,7 +1197,7 @@
    unreachable
   end
  )
- (func $~lib/set/Set<u8>#clear (; 19 ;) (type $i_) (param $0 i32)
+ (func $~lib/set/Set<u8>#clear (; 19 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -1225,7 +1225,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<u8>#constructor (; 20 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u8>#constructor (; 20 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -1257,14 +1257,14 @@
   call $~lib/set/Set<u8>#clear
   local.get $0
  )
- (func $~lib/internal/hash/HASH<u8> (; 21 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/hash/HASH<u8> (; 21 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   call $~lib/internal/hash/hash8
   return
  )
- (func $~lib/set/Set<u8>#find (; 22 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<u8>#find (; 22 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -1317,7 +1317,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<u8>#has (; 23 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u8>#has (; 23 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -1326,7 +1326,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u8>#rehash (; 24 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u8>#rehash (; 24 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1462,7 +1462,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<u8>#add (; 25 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u8>#add (; 25 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1557,11 +1557,11 @@
    i32.store offset=8
   end
  )
- (func $~lib/set/Set<u8>#get:size (; 26 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u8>#get:size (; 26 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/set/Set<u8>#delete (; 27 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u8>#delete (; 27 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1636,7 +1636,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<u8> (; 28 ;) (type $_)
+ (func $std/set/test<u8> (; 28 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -1919,7 +1919,7 @@
    unreachable
   end
  )
- (func $~lib/set/Set<i16>#clear (; 29 ;) (type $i_) (param $0 i32)
+ (func $~lib/set/Set<i16>#clear (; 29 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -1947,7 +1947,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<i16>#constructor (; 30 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i16>#constructor (; 30 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -1979,7 +1979,7 @@
   call $~lib/set/Set<i16>#clear
   local.get $0
  )
- (func $~lib/internal/hash/hash16 (; 31 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/hash/hash16 (; 31 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   i32.const -2128831035
   local.set $1
@@ -2001,7 +2001,7 @@
   local.set $1
   local.get $1
  )
- (func $~lib/internal/hash/HASH<i16> (; 32 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/hash/HASH<i16> (; 32 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -2010,7 +2010,7 @@
   call $~lib/internal/hash/hash16
   return
  )
- (func $~lib/set/Set<i16>#find (; 33 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i16>#find (; 33 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -2065,7 +2065,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i16>#has (; 34 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i16>#has (; 34 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -2074,7 +2074,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i16>#rehash (; 35 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i16>#rehash (; 35 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2210,7 +2210,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<i16>#add (; 36 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i16>#add (; 36 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2305,11 +2305,11 @@
    i32.store offset=8
   end
  )
- (func $~lib/set/Set<i16>#get:size (; 37 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i16>#get:size (; 37 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/set/Set<i16>#delete (; 38 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i16>#delete (; 38 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2386,7 +2386,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<i16> (; 39 ;) (type $_)
+ (func $std/set/test<i16> (; 39 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -2669,7 +2669,7 @@
    unreachable
   end
  )
- (func $~lib/set/Set<u16>#clear (; 40 ;) (type $i_) (param $0 i32)
+ (func $~lib/set/Set<u16>#clear (; 40 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -2697,7 +2697,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<u16>#constructor (; 41 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u16>#constructor (; 41 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -2729,14 +2729,14 @@
   call $~lib/set/Set<u16>#clear
   local.get $0
  )
- (func $~lib/internal/hash/HASH<u16> (; 42 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/hash/HASH<u16> (; 42 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   call $~lib/internal/hash/hash16
   return
  )
- (func $~lib/set/Set<u16>#find (; 43 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<u16>#find (; 43 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -2789,7 +2789,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<u16>#has (; 44 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u16>#has (; 44 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -2798,7 +2798,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u16>#rehash (; 45 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u16>#rehash (; 45 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2934,7 +2934,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<u16>#add (; 46 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u16>#add (; 46 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3029,11 +3029,11 @@
    i32.store offset=8
   end
  )
- (func $~lib/set/Set<u16>#get:size (; 47 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u16>#get:size (; 47 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/set/Set<u16>#delete (; 48 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u16>#delete (; 48 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3108,7 +3108,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<u16> (; 49 ;) (type $_)
+ (func $std/set/test<u16> (; 49 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -3391,7 +3391,7 @@
    unreachable
   end
  )
- (func $~lib/set/Set<i32>#clear (; 50 ;) (type $i_) (param $0 i32)
+ (func $~lib/set/Set<i32>#clear (; 50 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -3419,7 +3419,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<i32>#constructor (; 51 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i32>#constructor (; 51 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -3451,7 +3451,7 @@
   call $~lib/set/Set<i32>#clear
   local.get $0
  )
- (func $~lib/internal/hash/hash32 (; 52 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/hash/hash32 (; 52 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   i32.const -2128831035
   local.set $1
@@ -3493,12 +3493,12 @@
   local.set $1
   local.get $1
  )
- (func $~lib/internal/hash/HASH<i32> (; 53 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/hash/HASH<i32> (; 53 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/internal/hash/hash32
   return
  )
- (func $~lib/set/Set<i32>#find (; 54 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i32>#find (; 54 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -3549,7 +3549,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i32>#has (; 55 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i32>#has (; 55 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -3558,7 +3558,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i32>#rehash (; 56 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i32>#rehash (; 56 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3694,7 +3694,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<i32>#add (; 57 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i32>#add (; 57 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3789,11 +3789,11 @@
    i32.store offset=8
   end
  )
- (func $~lib/set/Set<i32>#get:size (; 58 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i32>#get:size (; 58 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/set/Set<i32>#delete (; 59 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i32>#delete (; 59 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3866,7 +3866,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<i32> (; 60 ;) (type $_)
+ (func $std/set/test<i32> (; 60 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4149,7 +4149,7 @@
    unreachable
   end
  )
- (func $~lib/set/Set<u32>#clear (; 61 ;) (type $i_) (param $0 i32)
+ (func $~lib/set/Set<u32>#clear (; 61 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -4177,7 +4177,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<u32>#constructor (; 62 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u32>#constructor (; 62 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -4209,12 +4209,12 @@
   call $~lib/set/Set<u32>#clear
   local.get $0
  )
- (func $~lib/internal/hash/HASH<u32> (; 63 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/hash/HASH<u32> (; 63 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/internal/hash/hash32
   return
  )
- (func $~lib/set/Set<u32>#find (; 64 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<u32>#find (; 64 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -4265,7 +4265,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<u32>#has (; 65 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u32>#has (; 65 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -4274,7 +4274,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u32>#rehash (; 66 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u32>#rehash (; 66 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4410,7 +4410,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<u32>#add (; 67 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u32>#add (; 67 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4505,11 +4505,11 @@
    i32.store offset=8
   end
  )
- (func $~lib/set/Set<u32>#get:size (; 68 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u32>#get:size (; 68 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/set/Set<u32>#delete (; 69 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u32>#delete (; 69 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4582,7 +4582,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<u32> (; 70 ;) (type $_)
+ (func $std/set/test<u32> (; 70 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4865,7 +4865,7 @@
    unreachable
   end
  )
- (func $~lib/set/Set<i64>#clear (; 71 ;) (type $i_) (param $0 i32)
+ (func $~lib/set/Set<i64>#clear (; 71 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -4893,7 +4893,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<i64>#constructor (; 72 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i64>#constructor (; 72 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -4925,7 +4925,7 @@
   call $~lib/set/Set<i64>#clear
   local.get $0
  )
- (func $~lib/internal/hash/hash64 (; 73 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/hash/hash64 (; 73 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5013,12 +5013,12 @@
   local.set $3
   local.get $3
  )
- (func $~lib/internal/hash/HASH<i64> (; 74 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/hash/HASH<i64> (; 74 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   local.get $0
   call $~lib/internal/hash/hash64
   return
  )
- (func $~lib/set/Set<i64>#find (; 75 ;) (type $iIii) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i64>#find (; 75 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -5069,7 +5069,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i64>#has (; 76 ;) (type $iIi) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/set/Set<i64>#has (; 76 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -5078,7 +5078,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i64>#rehash (; 77 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i64>#rehash (; 77 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5215,7 +5215,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<i64>#add (; 78 ;) (type $iI_) (param $0 i32) (param $1 i64)
+ (func $~lib/set/Set<i64>#add (; 78 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5310,11 +5310,11 @@
    i32.store offset=8
   end
  )
- (func $~lib/set/Set<i64>#get:size (; 79 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i64>#get:size (; 79 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/set/Set<i64>#delete (; 80 ;) (type $iIi) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/set/Set<i64>#delete (; 80 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -5388,7 +5388,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<i64> (; 81 ;) (type $_)
+ (func $std/set/test<i64> (; 81 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -5671,7 +5671,7 @@
    unreachable
   end
  )
- (func $~lib/set/Set<u64>#clear (; 82 ;) (type $i_) (param $0 i32)
+ (func $~lib/set/Set<u64>#clear (; 82 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -5699,7 +5699,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<u64>#constructor (; 83 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u64>#constructor (; 83 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -5731,12 +5731,12 @@
   call $~lib/set/Set<u64>#clear
   local.get $0
  )
- (func $~lib/internal/hash/HASH<u64> (; 84 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/hash/HASH<u64> (; 84 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   local.get $0
   call $~lib/internal/hash/hash64
   return
  )
- (func $~lib/set/Set<u64>#find (; 85 ;) (type $iIii) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/set/Set<u64>#find (; 85 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -5787,7 +5787,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<u64>#has (; 86 ;) (type $iIi) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/set/Set<u64>#has (; 86 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -5796,7 +5796,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u64>#rehash (; 87 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u64>#rehash (; 87 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5933,7 +5933,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<u64>#add (; 88 ;) (type $iI_) (param $0 i32) (param $1 i64)
+ (func $~lib/set/Set<u64>#add (; 88 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6028,11 +6028,11 @@
    i32.store offset=8
   end
  )
- (func $~lib/set/Set<u64>#get:size (; 89 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u64>#get:size (; 89 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/set/Set<u64>#delete (; 90 ;) (type $iIi) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/set/Set<u64>#delete (; 90 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -6106,7 +6106,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<u64> (; 91 ;) (type $_)
+ (func $std/set/test<u64> (; 91 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -6389,7 +6389,7 @@
    unreachable
   end
  )
- (func $~lib/set/Set<f32>#clear (; 92 ;) (type $i_) (param $0 i32)
+ (func $~lib/set/Set<f32>#clear (; 92 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -6417,7 +6417,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<f32>#constructor (; 93 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<f32>#constructor (; 93 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -6449,13 +6449,13 @@
   call $~lib/set/Set<f32>#clear
   local.get $0
  )
- (func $~lib/internal/hash/HASH<f32> (; 94 ;) (type $fi) (param $0 f32) (result i32)
+ (func $~lib/internal/hash/HASH<f32> (; 94 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
   local.get $0
   i32.reinterpret_f32
   call $~lib/internal/hash/hash32
   return
  )
- (func $~lib/set/Set<f32>#find (; 95 ;) (type $ifii) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<f32>#find (; 95 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -6506,7 +6506,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<f32>#has (; 96 ;) (type $ifi) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/set/Set<f32>#has (; 96 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -6515,7 +6515,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<f32>#rehash (; 97 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<f32>#rehash (; 97 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6653,7 +6653,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<f32>#add (; 98 ;) (type $if_) (param $0 i32) (param $1 f32)
+ (func $~lib/set/Set<f32>#add (; 98 ;) (type $FUNCSIG$vif) (param $0 i32) (param $1 f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6748,11 +6748,11 @@
    i32.store offset=8
   end
  )
- (func $~lib/set/Set<f32>#get:size (; 99 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<f32>#get:size (; 99 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/set/Set<f32>#delete (; 100 ;) (type $ifi) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/set/Set<f32>#delete (; 100 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
   (local $2 f32)
   (local $3 i32)
   (local $4 i32)
@@ -6827,7 +6827,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<f32> (; 101 ;) (type $_)
+ (func $std/set/test<f32> (; 101 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f32)
   i32.const 0
@@ -7110,7 +7110,7 @@
    unreachable
   end
  )
- (func $~lib/set/Set<f64>#clear (; 102 ;) (type $i_) (param $0 i32)
+ (func $~lib/set/Set<f64>#clear (; 102 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -7138,7 +7138,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<f64>#constructor (; 103 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<f64>#constructor (; 103 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -7170,13 +7170,13 @@
   call $~lib/set/Set<f64>#clear
   local.get $0
  )
- (func $~lib/internal/hash/HASH<f64> (; 104 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $~lib/internal/hash/HASH<f64> (; 104 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   i64.reinterpret_f64
   call $~lib/internal/hash/hash64
   return
  )
- (func $~lib/set/Set<f64>#find (; 105 ;) (type $iFii) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/set/Set<f64>#find (; 105 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -7227,7 +7227,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<f64>#has (; 106 ;) (type $iFi) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/set/Set<f64>#has (; 106 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -7236,7 +7236,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<f64>#rehash (; 107 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<f64>#rehash (; 107 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7374,7 +7374,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/set/Set<f64>#add (; 108 ;) (type $iF_) (param $0 i32) (param $1 f64)
+ (func $~lib/set/Set<f64>#add (; 108 ;) (type $FUNCSIG$vid) (param $0 i32) (param $1 f64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7469,11 +7469,11 @@
    i32.store offset=8
   end
  )
- (func $~lib/set/Set<f64>#get:size (; 109 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<f64>#get:size (; 109 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/set/Set<f64>#delete (; 110 ;) (type $iFi) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/set/Set<f64>#delete (; 110 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
@@ -7548,7 +7548,7 @@
   end
   i32.const 1
  )
- (func $std/set/test<f64> (; 111 ;) (type $_)
+ (func $std/set/test<f64> (; 111 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f64)
   i32.const 0
@@ -7831,7 +7831,7 @@
    unreachable
   end
  )
- (func $start:std/set (; 112 ;) (type $_)
+ (func $start:std/set (; 112 ;) (type $FUNCSIG$v)
   call $start:~lib/allocator/arena
   call $std/set/test<i8>
   call $std/set/test<u8>
@@ -7844,9 +7844,9 @@
   call $std/set/test<f32>
   call $std/set/test<f64>
  )
- (func $start (; 113 ;) (type $_)
+ (func $start (; 113 ;) (type $FUNCSIG$v)
   call $start:std/set
  )
- (func $null (; 114 ;) (type $_)
+ (func $null (; 114 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/simd.optimized.wat
+++ b/tests/compiler/std/simd.optimized.wat
@@ -1,11 +1,11 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $null (; 0 ;) (type $_)
+ (func $null (; 0 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/simd.untouched.wat
+++ b/tests/compiler/std/simd.untouched.wat
@@ -1,5 +1,5 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -7,6 +7,6 @@
  (global $~lib/memory/HEAP_BASE i32 (i32.const 8))
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $null (; 0 ;) (type $_)
+ (func $null (; 0 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -1,11 +1,10 @@
 (module
- (type $_ (func))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $iii_ (func (param i32 i32 i32)))
- (type $ii (func (param i32) (result i32)))
- (type $FUNCSIG$vii (func (param i32 i32)))
  (type $FUNCSIG$v (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$vii (func (param i32 i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\08\00\00\00\00\00\00\00\01\00\00\00\02")
@@ -28,7 +27,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -90,7 +89,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/internal/arraybuffer/allocateUnsafe (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/allocateUnsafe (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 1073741816
@@ -117,7 +116,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memcpy (; 3 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 3 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1014,7 +1013,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 4 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 4 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -1431,7 +1430,7 @@
    end
   end
  )
- (func $~lib/internal/arraybuffer/reallocateUnsafe (; 6 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/arraybuffer/reallocateUnsafe (; 6 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -1613,7 +1612,7 @@
   f64.const 2.25
   f64.store offset=8
  )
- (func $start:std/static-array (; 11 ;) (type $_)
+ (func $start:std/static-array (; 11 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 280
   global.set $~lib/allocator/arena/startOffset
@@ -1968,10 +1967,10 @@
    unreachable
   end
  )
- (func $start (; 12 ;) (type $_)
+ (func $start (; 12 ;) (type $FUNCSIG$v)
   call $start:std/static-array
  )
- (func $null (; 13 ;) (type $_)
+ (func $null (; 13 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -1,16 +1,16 @@
 (module
- (type $_ (func))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $iii_ (func (param i32 i32 i32)))
- (type $ii (func (param i32) (result i32)))
- (type $i_ (func (param i32)))
- (type $iiI (func (param i32 i32) (result i64)))
- (type $iiI_ (func (param i32 i32 i64)))
- (type $iif (func (param i32 i32) (result f32)))
- (type $iif_ (func (param i32 i32 f32)))
- (type $iiF (func (param i32 i32) (result f64)))
- (type $iiF_ (func (param i32 i32 f64)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$jii (func (param i32 i32) (result i64)))
+ (type $FUNCSIG$viij (func (param i32 i32 i64)))
+ (type $FUNCSIG$fii (func (param i32 i32) (result f32)))
+ (type $FUNCSIG$viif (func (param i32 i32 f32)))
+ (type $FUNCSIG$dii (func (param i32 i32) (result f64)))
+ (type $FUNCSIG$viid (func (param i32 i32 f64)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\08\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00")
@@ -36,7 +36,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:~lib/allocator/arena (; 1 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 1 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -48,7 +48,7 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $~lib/array/Array<i32>#__get (; 2 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (; 2 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -81,7 +81,7 @@
    unreachable
   end
  )
- (func $~lib/internal/arraybuffer/computeSize (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/computeSize (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   i32.const 32
   local.get $0
@@ -93,7 +93,7 @@
   i32.sub
   i32.shl
  )
- (func $~lib/allocator/arena/__memory_allocate (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -172,7 +172,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/internal/arraybuffer/allocateUnsafe (; 5 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/allocateUnsafe (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -201,7 +201,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memcpy (; 6 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 6 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1402,7 +1402,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 7 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 7 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -1629,10 +1629,10 @@
    end
   end
  )
- (func $~lib/allocator/arena/__memory_free (; 8 ;) (type $i_) (param $0 i32)
+ (func $~lib/allocator/arena/__memory_free (; 8 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $~lib/internal/memory/memset (; 9 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 9 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -1886,7 +1886,7 @@
    end
   end
  )
- (func $~lib/internal/arraybuffer/reallocateUnsafe (; 10 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/arraybuffer/reallocateUnsafe (; 10 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1993,7 +1993,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<i32>#__set (; 11 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__set (; 11 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2060,7 +2060,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<i64>#__get (; 12 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<i64>#__get (; 12 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2093,7 +2093,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<i64>#__set (; 13 ;) (type $iiI_) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<i64>#__set (; 13 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2160,7 +2160,7 @@
    i64.store offset=8
   end
  )
- (func $~lib/array/Array<f32>#__get (; 14 ;) (type $iif) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__get (; 14 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2193,7 +2193,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<f32>#__set (; 15 ;) (type $iif_) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/array/Array<f32>#__set (; 15 ;) (type $FUNCSIG$viif) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2260,7 +2260,7 @@
    f32.store offset=8
   end
  )
- (func $~lib/array/Array<f64>#__get (; 16 ;) (type $iiF) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__get (; 16 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2293,7 +2293,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<f64>#__set (; 17 ;) (type $iiF_) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/array/Array<f64>#__set (; 17 ;) (type $FUNCSIG$viid) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2360,7 +2360,7 @@
    f64.store offset=8
   end
  )
- (func $start:std/static-array (; 18 ;) (type $_)
+ (func $start:std/static-array (; 18 ;) (type $FUNCSIG$v)
   (local $0 i32)
   call $start:~lib/allocator/arena
   block $~lib/array/Array<i32>#get:length|inlined.0 (result i32)
@@ -2616,9 +2616,9 @@
    unreachable
   end
  )
- (func $start (; 19 ;) (type $_)
+ (func $start (; 19 ;) (type $FUNCSIG$v)
   call $start:std/static-array
  )
- (func $null (; 20 ;) (type $_)
+ (func $null (; 20 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/string-utf8.optimized.wat
+++ b/tests/compiler/std/string-utf8.optimized.wat
@@ -1,9 +1,9 @@
 (module
- (type $_ (func))
- (type $ii (func (param i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $iii_ (func (param i32 i32 i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
  (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -25,7 +25,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $~lib/string/String#get:lengthUTF8 (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:lengthUTF8 (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -126,7 +126,7 @@
   end
   local.get $1
  )
- (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -188,7 +188,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/string/String#toUTF8 (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/string/String#toUTF8 (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -385,7 +385,7 @@
   i32.store8
   local.get $5
  )
- (func $~lib/internal/string/allocateUnsafe (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/string/allocateUnsafe (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 0
@@ -418,7 +418,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memcpy (; 5 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 5 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1315,7 +1315,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 6 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 6 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -1513,7 +1513,7 @@
    end
   end
  )
- (func $~lib/string/String.fromUTF8 (; 7 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.fromUTF8 (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1798,7 +1798,7 @@
   end
   local.get $3
  )
- (func $~lib/string/String.__eq (; 9 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 9 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -1837,7 +1837,7 @@
   call $~lib/internal/string/compareUnsafe
   i32.eqz
  )
- (func $start:std/string-utf8 (; 10 ;) (type $_)
+ (func $start:std/string-utf8 (; 10 ;) (type $FUNCSIG$v)
   i32.const 192
   global.set $~lib/allocator/arena/startOffset
   global.get $~lib/allocator/arena/startOffset
@@ -2082,10 +2082,10 @@
    unreachable
   end
  )
- (func $start (; 11 ;) (type $_)
+ (func $start (; 11 ;) (type $FUNCSIG$v)
   call $start:std/string-utf8
  )
- (func $null (; 12 ;) (type $_)
+ (func $null (; 12 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/string-utf8.untouched.wat
+++ b/tests/compiler/std/string-utf8.untouched.wat
@@ -1,11 +1,11 @@
 (module
- (type $_ (func))
- (type $ii (func (param i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $iii_ (func (param i32 i32 i32)))
- (type $i_ (func (param i32)))
- (type $iiiiii (func (param i32 i32 i32 i32 i32) (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$iiiiii (func (param i32 i32 i32 i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\06\00\00\00\01\d87\dch\00i\00R\d8b\df")
@@ -28,7 +28,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:~lib/allocator/arena (; 1 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 1 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -40,7 +40,7 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $~lib/string/String#get:lengthUTF8 (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:lengthUTF8 (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -153,7 +153,7 @@
   end
   local.get $1
  )
- (func $~lib/allocator/arena/__memory_allocate (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -232,7 +232,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/string/String#toUTF8 (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/string/String#toUTF8 (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -454,7 +454,7 @@
   i32.store8
   local.get $2
  )
- (func $~lib/internal/string/allocateUnsafe (; 5 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/string/allocateUnsafe (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -494,7 +494,7 @@
   i32.store
   local.get $2
  )
- (func $~lib/internal/memory/memcpy (; 6 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 6 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1695,7 +1695,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 7 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 7 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -1922,10 +1922,10 @@
    end
   end
  )
- (func $~lib/allocator/arena/__memory_free (; 8 ;) (type $i_) (param $0 i32)
+ (func $~lib/allocator/arena/__memory_free (; 8 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $~lib/string/String.fromUTF8 (; 9 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.fromUTF8 (; 9 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2253,7 +2253,7 @@
   end
   local.get $7
  )
- (func $~lib/internal/string/compareUnsafe (; 10 ;) (type $iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/internal/string/compareUnsafe (; 10 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -2306,7 +2306,7 @@
   end
   local.get $5
  )
- (func $~lib/string/String.__eq (; 11 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 11 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -2350,7 +2350,7 @@
   call $~lib/internal/string/compareUnsafe
   i32.eqz
  )
- (func $start:std/string-utf8 (; 12 ;) (type $_)
+ (func $start:std/string-utf8 (; 12 ;) (type $FUNCSIG$v)
   (local $0 i32)
   call $start:~lib/allocator/arena
   global.get $std/string-utf8/str
@@ -2614,9 +2614,9 @@
    br $~lib/memory/memory.free|inlined.1
   end
  )
- (func $start (; 13 ;) (type $_)
+ (func $start (; 13 ;) (type $FUNCSIG$v)
   call $start:std/string-utf8
  )
- (func $null (; 14 ;) (type $_)
+ (func $null (; 14 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -1,22 +1,19 @@
 (module
- (type $_ (func))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $ii (func (param i32) (result i32)))
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iii_ (func (param i32 i32 i32)))
- (type $iiiii_ (func (param i32 i32 i32 i32 i32)))
- (type $iF (func (param i32) (result f64)))
- (type $Ii (func (param i64) (result i32)))
- (type $iIi_ (func (param i32 i64 i32)))
- (type $Fi (func (param f64) (result i32)))
- (type $iFi (func (param i32 f64) (result i32)))
- (type $iIiIiIii (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
- (type $i (func (result i32)))
- (type $FUNCSIG$ii (func (param i32) (result i32)))
- (type $FUNCSIG$iiiii (func (param i32 i32 i32 i32) (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$viiiii (func (param i32 i32 i32 i32 i32)))
  (type $FUNCSIG$di (func (param i32) (result f64)))
+ (type $FUNCSIG$ij (func (param i64) (result i32)))
+ (type $FUNCSIG$viji (func (param i32 i64 i32)))
+ (type $FUNCSIG$id (func (param f64) (result i32)))
+ (type $FUNCSIG$iid (func (param i32 f64) (result i32)))
+ (type $FUNCSIG$iijijiji (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$iiiii (func (param i32 i32 i32 i32) (result i32)))
  (type $FUNCSIG$vii (func (param i32 i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -218,7 +215,7 @@
   local.get $0
   i32.load16_u offset=4
  )
- (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -280,7 +277,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/internal/string/allocateUnsafe (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/string/allocateUnsafe (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 0
@@ -313,7 +310,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/string/String.fromCharCode (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/string/String.fromCharCode (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   i32.const 1
   call $~lib/internal/string/allocateUnsafe
@@ -361,7 +358,7 @@
   end
   local.get $4
  )
- (func $~lib/string/String.__eq (; 6 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 6 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -401,7 +398,7 @@
   call $~lib/internal/string/compareUnsafe
   i32.eqz
  )
- (func $~lib/string/String.fromCodePoint (; 7 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/string/String.fromCodePoint (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -536,7 +533,7 @@
   call $~lib/internal/string/compareUnsafe
   i32.eqz
  )
- (func $~lib/string/String#indexOf (; 10 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#indexOf (; 10 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -612,7 +609,7 @@
   end
   i32.const -1
  )
- (func $~lib/internal/memory/memcpy (; 11 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 11 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1509,7 +1506,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 12 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 12 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -1707,7 +1704,7 @@
    end
   end
  )
- (func $~lib/internal/string/repeatUnsafe (; 13 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/string/repeatUnsafe (; 13 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -1912,7 +1909,7 @@
    end
   end
  )
- (func $~lib/internal/string/copyUnsafe (; 14 ;) (type $iiiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
+ (func $~lib/internal/string/copyUnsafe (; 14 ;) (type $FUNCSIG$viiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
   local.get $1
   i32.const 1
   i32.shl
@@ -1932,7 +1929,7 @@
   i32.shl
   call $~lib/internal/memory/memmove
  )
- (func $~lib/string/String#padStart (; 15 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#padStart (; 15 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2042,7 +2039,7 @@
   local.get $2
   call $~lib/string/String#padStart
  )
- (func $~lib/string/String#padEnd (; 17 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#padEnd (; 17 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2155,7 +2152,7 @@
   local.get $2
   call $~lib/string/String#padEnd
  )
- (func $~lib/string/String#lastIndexOf (; 19 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#lastIndexOf (; 19 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -2484,7 +2481,7 @@
   local.get $5
   f64.mul
  )
- (func $~lib/string/parseFloat (; 22 ;) (type $iF) (param $0 i32) (result f64)
+ (func $~lib/string/parseFloat (; 22 ;) (type $FUNCSIG$di) (param $0 i32) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2652,7 +2649,7 @@
   local.get $4
   f64.mul
  )
- (func $~lib/string/String#concat (; 23 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#concat (; 23 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2699,7 +2696,7 @@
   call $~lib/internal/string/copyUnsafe
   local.get $2
  )
- (func $~lib/string/String.__concat (; 24 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (; 24 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.const 200
   local.get $0
@@ -2707,13 +2704,13 @@
   local.get $1
   call $~lib/string/String#concat
  )
- (func $~lib/string/String.__ne (; 25 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__ne (; 25 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/string/String.__eq
   i32.eqz
  )
- (func $~lib/string/String.__gt (; 26 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__gt (; 26 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -2768,7 +2765,7 @@
   i32.const 0
   i32.gt_s
  )
- (func $~lib/string/String.__lt (; 27 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__lt (; 27 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -2823,7 +2820,7 @@
   i32.const 0
   i32.lt_s
  )
- (func $~lib/string/String.__gte (; 28 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__gte (; 28 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/string/String.__lt
@@ -2835,7 +2832,7 @@
   call $~lib/string/String.__gt
   i32.eqz
  )
- (func $~lib/string/String#repeat (; 30 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#repeat (; 30 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -2905,7 +2902,7 @@
   call $~lib/internal/string/repeatUnsafe
   local.get $2
  )
- (func $~lib/string/String#slice (; 31 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#slice (; 31 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -2994,7 +2991,7 @@
   local.get $2
   call $~lib/string/String#slice
  )
- (func $~lib/internal/arraybuffer/allocateUnsafe (; 33 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/allocateUnsafe (; 33 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 1073741816
@@ -3282,7 +3279,7 @@
   call $~lib/internal/memory/memset
   local.get $1
  )
- (func $~lib/internal/arraybuffer/reallocateUnsafe (; 36 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/arraybuffer/reallocateUnsafe (; 36 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -3414,7 +3411,7 @@
   local.get $1
   i32.store offset=8
  )
- (func $~lib/string/String#split (; 38 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#split (; 38 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3649,7 +3646,7 @@
   local.get $2
   call $~lib/string/String#split
  )
- (func $~lib/internal/number/decimalCount32 (; 40 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/decimalCount32 (; 40 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 100000
   i32.lt_u
@@ -3703,7 +3700,7 @@
    end
   end
  )
- (func $~lib/internal/number/utoa32_lut (; 41 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/number/utoa32_lut (; 41 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   i32.const 1816
@@ -3813,7 +3810,7 @@
    i32.store16 offset=4
   end
  )
- (func $~lib/internal/number/itoa32 (; 42 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/itoa32 (; 42 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3851,7 +3848,7 @@
   end
   local.get $2
  )
- (func $~lib/internal/number/utoa32 (; 43 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/utoa32 (; 43 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -3870,7 +3867,7 @@
   call $~lib/internal/number/utoa32_lut
   local.get $2
  )
- (func $~lib/internal/number/decimalCount64 (; 44 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/number/decimalCount64 (; 44 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   local.get $0
   i64.const 1000000000000000
   i64.lt_u
@@ -3924,7 +3921,7 @@
    end
   end
  )
- (func $~lib/internal/number/utoa64_lut (; 45 ;) (type $iIi_) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/internal/number/utoa64_lut (; 45 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4021,7 +4018,7 @@
   local.get $2
   call $~lib/internal/number/utoa32_lut
  )
- (func $~lib/internal/number/utoa64 (; 46 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/number/utoa64 (; 46 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4057,7 +4054,7 @@
   end
   local.get $2
  )
- (func $~lib/internal/number/itoa64 (; 47 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/number/itoa64 (; 47 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4116,7 +4113,7 @@
   end
   local.get $3
  )
- (func $~lib/internal/number/genDigits (; 48 ;) (type $iIiIiIii) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/internal/number/genDigits (; 48 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i32)
@@ -4530,7 +4527,7 @@
    local.get $10
   end
  )
- (func $~lib/internal/number/prettify (; 49 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/internal/number/prettify (; 49 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4804,7 +4801,7 @@
    end
   end
  )
- (func $~lib/internal/number/dtoa_core (; 50 ;) (type $iFi) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/internal/number/dtoa_core (; 50 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   (local $4 i32)
@@ -5201,7 +5198,7 @@
   call $~lib/internal/string/copyUnsafe
   local.get $2
  )
- (func $~lib/internal/number/dtoa (; 52 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $~lib/internal/number/dtoa (; 52 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -5254,7 +5251,7 @@
   end
   local.get $1
  )
- (func $start:std/string (; 53 ;) (type $_)
+ (func $start:std/string (; 53 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 5360
@@ -9030,13 +9027,13 @@
    unreachable
   end
  )
- (func $std/string/getString (; 54 ;) (type $i) (result i32)
+ (func $std/string/getString (; 54 ;) (type $FUNCSIG$i) (result i32)
   global.get $std/string/str
  )
- (func $start (; 55 ;) (type $_)
+ (func $start (; 55 ;) (type $FUNCSIG$v)
   call $start:std/string
  )
- (func $null (; 56 ;) (type $_)
+ (func $null (; 56 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -1,21 +1,21 @@
 (module
- (type $_ (func))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $ii (func (param i32) (result i32)))
- (type $iiiiii (func (param i32 i32 i32 i32 i32) (result i32)))
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iii_ (func (param i32 i32 i32)))
- (type $iiiii_ (func (param i32 i32 i32 i32 i32)))
- (type $iiF (func (param i32 i32) (result f64)))
- (type $iF (func (param i32) (result f64)))
- (type $i_ (func (param i32)))
- (type $Ii (func (param i64) (result i32)))
- (type $iIi_ (func (param i32 i64 i32)))
- (type $Fi (func (param f64) (result i32)))
- (type $iFi (func (param i32 f64) (result i32)))
- (type $iIiIiIii (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
- (type $i (func (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$iiiiii (func (param i32 i32 i32 i32 i32) (result i32)))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$viiiii (func (param i32 i32 i32 i32 i32)))
+ (type $FUNCSIG$dii (func (param i32 i32) (result f64)))
+ (type $FUNCSIG$di (func (param i32) (result f64)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$ij (func (param i64) (result i32)))
+ (type $FUNCSIG$viji (func (param i32 i64 i32)))
+ (type $FUNCSIG$id (func (param f64) (result i32)))
+ (type $FUNCSIG$iid (func (param i32 f64) (result i32)))
+ (type $FUNCSIG$iijijiji (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
+ (type $FUNCSIG$i (func (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\10\00\00\00h\00i\00,\00 \00I\00\'\00m\00 \00a\00 \00s\00t\00r\00i\00n\00g\00")
@@ -204,7 +204,7 @@
  (export "table" (table $0))
  (export "getString" (func $std/string/getString))
  (start $start)
- (func $start:~lib/allocator/arena (; 1 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 1 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -216,7 +216,7 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $~lib/string/String#charCodeAt (; 2 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#charCodeAt (; 2 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.const 0
   i32.ne
@@ -244,7 +244,7 @@
   i32.add
   i32.load16_u offset=4
  )
- (func $~lib/allocator/arena/__memory_allocate (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -323,7 +323,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/internal/string/allocateUnsafe (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/string/allocateUnsafe (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -363,7 +363,7 @@
   i32.store
   local.get $2
  )
- (func $~lib/string/String.fromCharCode (; 5 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/string/String.fromCharCode (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   i32.const 1
   call $~lib/internal/string/allocateUnsafe
@@ -373,7 +373,7 @@
   i32.store16 offset=4
   local.get $1
  )
- (func $~lib/internal/string/compareUnsafe (; 6 ;) (type $iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/internal/string/compareUnsafe (; 6 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -426,7 +426,7 @@
   end
   local.get $5
  )
- (func $~lib/string/String.__eq (; 7 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -470,7 +470,7 @@
   call $~lib/internal/string/compareUnsafe
   i32.eqz
  )
- (func $~lib/string/String.fromCodePoint (; 8 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/string/String.fromCodePoint (; 8 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -529,7 +529,7 @@
   end
   local.get $2
  )
- (func $~lib/string/String#startsWith (; 9 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#startsWith (; 9 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -596,7 +596,7 @@
   call $~lib/internal/string/compareUnsafe
   i32.eqz
  )
- (func $~lib/string/String#endsWith (; 10 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#endsWith (; 10 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -660,7 +660,7 @@
   call $~lib/internal/string/compareUnsafe
   i32.eqz
  )
- (func $~lib/string/String#endsWith|trampoline (; 11 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#endsWith|trampoline (; 11 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -679,7 +679,7 @@
   local.get $2
   call $~lib/string/String#endsWith
  )
- (func $~lib/string/String#indexOf (; 12 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#indexOf (; 12 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -773,7 +773,7 @@
   end
   i32.const -1
  )
- (func $~lib/internal/memory/memcpy (; 13 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 13 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1974,7 +1974,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 14 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 14 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -2201,7 +2201,7 @@
    end
   end
  )
- (func $~lib/internal/string/repeatUnsafe (; 15 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/string/repeatUnsafe (; 15 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -2481,7 +2481,7 @@
    unreachable
   end
  )
- (func $~lib/internal/string/copyUnsafe (; 16 ;) (type $iiiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
+ (func $~lib/internal/string/copyUnsafe (; 16 ;) (type $FUNCSIG$viiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -2510,7 +2510,7 @@
   local.get $7
   call $~lib/internal/memory/memmove
  )
- (func $~lib/string/String#padStart (; 17 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#padStart (; 17 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2608,7 +2608,7 @@
   end
   local.get $7
  )
- (func $~lib/string/String#padStart|trampoline (; 18 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#padStart|trampoline (; 18 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -2627,7 +2627,7 @@
   local.get $2
   call $~lib/string/String#padStart
  )
- (func $~lib/string/String#padEnd (; 19 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#padEnd (; 19 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2727,7 +2727,7 @@
   end
   local.get $7
  )
- (func $~lib/string/String#padEnd|trampoline (; 20 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#padEnd|trampoline (; 20 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -2746,7 +2746,7 @@
   local.get $2
   call $~lib/string/String#padEnd
  )
- (func $~lib/string/String#lastIndexOf (; 21 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#lastIndexOf (; 21 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2838,7 +2838,7 @@
   end
   i32.const -1
  )
- (func $~lib/string/String#lastIndexOf|trampoline (; 22 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#lastIndexOf|trampoline (; 22 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -2857,7 +2857,7 @@
   local.get $2
   call $~lib/string/String#lastIndexOf
  )
- (func $~lib/internal/string/parse<f64> (; 23 ;) (type $iiF) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/internal/string/parse<f64> (; 23 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3158,12 +3158,12 @@
   local.get $7
   f64.mul
  )
- (func $~lib/string/parseInt (; 24 ;) (type $iiF) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/string/parseInt (; 24 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
   local.get $0
   local.get $1
   call $~lib/internal/string/parse<f64>
  )
- (func $~lib/string/parseFloat (; 25 ;) (type $iF) (param $0 i32) (result f64)
+ (func $~lib/string/parseFloat (; 25 ;) (type $FUNCSIG$di) (param $0 i32) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3360,7 +3360,7 @@
   local.get $5
   f64.mul
  )
- (func $~lib/string/String#concat (; 26 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#concat (; 26 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3418,7 +3418,7 @@
   call $~lib/internal/string/copyUnsafe
   local.get $5
  )
- (func $~lib/string/String.__concat (; 27 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (; 27 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -3429,13 +3429,13 @@
   local.get $1
   call $~lib/string/String#concat
  )
- (func $~lib/string/String.__ne (; 28 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__ne (; 28 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/string/String.__eq
   i32.eqz
  )
- (func $~lib/string/String.__gt (; 29 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__gt (; 29 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3500,7 +3500,7 @@
   i32.const 0
   i32.gt_s
  )
- (func $~lib/string/String.__lt (; 30 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__lt (; 30 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3565,19 +3565,19 @@
   i32.const 0
   i32.lt_s
  )
- (func $~lib/string/String.__gte (; 31 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__gte (; 31 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/string/String.__lt
   i32.eqz
  )
- (func $~lib/string/String.__lte (; 32 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__lte (; 32 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/string/String.__gt
   i32.eqz
  )
- (func $~lib/string/String#repeat (; 33 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#repeat (; 33 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3652,7 +3652,7 @@
   call $~lib/internal/string/repeatUnsafe
   local.get $4
  )
- (func $~lib/string/String#slice (; 34 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#slice (; 34 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3734,7 +3734,7 @@
   call $~lib/internal/string/copyUnsafe
   local.get $8
  )
- (func $~lib/string/String#slice|trampoline (; 35 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#slice|trampoline (; 35 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -3753,7 +3753,7 @@
   local.get $2
   call $~lib/string/String#slice
  )
- (func $~lib/internal/arraybuffer/computeSize (; 36 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/computeSize (; 36 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   i32.const 32
   local.get $0
@@ -3765,7 +3765,7 @@
   i32.sub
   i32.shl
  )
- (func $~lib/internal/arraybuffer/allocateUnsafe (; 37 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/allocateUnsafe (; 37 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -3794,12 +3794,12 @@
   i32.store
   local.get $1
  )
- (func $~lib/memory/memory.allocate (; 38 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/memory/memory.allocate (; 38 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/allocator/arena/__memory_allocate
   return
  )
- (func $~lib/internal/memory/memset (; 39 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 39 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -4053,7 +4053,7 @@
    end
   end
  )
- (func $~lib/array/Array<String>#constructor (; 40 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<String>#constructor (; 40 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4114,7 +4114,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<String>#__unchecked_set (; 41 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<String>#__unchecked_set (; 41 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4138,7 +4138,7 @@
   local.get $5
   i32.store offset=8
  )
- (func $~lib/array/Array<String>#__unchecked_get (; 42 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<String>#__unchecked_get (; 42 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4158,10 +4158,10 @@
   i32.add
   i32.load offset=8
  )
- (func $~lib/allocator/arena/__memory_free (; 43 ;) (type $i_) (param $0 i32)
+ (func $~lib/allocator/arena/__memory_free (; 43 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $~lib/internal/arraybuffer/reallocateUnsafe (; 44 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/arraybuffer/reallocateUnsafe (; 44 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4268,7 +4268,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<String>#push (; 45 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<String>#push (; 45 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4341,7 +4341,7 @@
   end
   local.get $5
  )
- (func $~lib/string/String#split (; 46 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#split (; 46 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4628,7 +4628,7 @@
   end
   local.get $13
  )
- (func $~lib/string/String#split|trampoline (; 47 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#split|trampoline (; 47 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -4649,7 +4649,7 @@
   local.get $2
   call $~lib/string/String#split
  )
- (func $~lib/array/Array<String>#__get (; 48 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<String>#__get (; 48 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4682,7 +4682,7 @@
    unreachable
   end
  )
- (func $~lib/internal/number/decimalCount32 (; 49 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/decimalCount32 (; 49 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 100000
@@ -4751,7 +4751,7 @@
   unreachable
   unreachable
  )
- (func $~lib/internal/number/utoa32_lut (; 50 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/number/utoa32_lut (; 50 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4937,7 +4937,7 @@
    i32.store16 offset=4
   end
  )
- (func $~lib/internal/number/itoa32 (; 51 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/itoa32 (; 51 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4989,7 +4989,7 @@
   end
   local.get $3
  )
- (func $~lib/internal/number/utoa32 (; 52 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/number/utoa32 (; 52 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5021,7 +5021,7 @@
   end
   local.get $2
  )
- (func $~lib/internal/number/decimalCount64 (; 53 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/number/decimalCount64 (; 53 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   local.get $0
   i64.const 1000000000000000
@@ -5090,7 +5090,7 @@
   unreachable
   unreachable
  )
- (func $~lib/internal/number/utoa64_lut (; 54 ;) (type $iIi_) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/internal/number/utoa64_lut (; 54 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -5261,7 +5261,7 @@
   local.get $2
   call $~lib/internal/number/utoa32_lut
  )
- (func $~lib/internal/number/utoa64 (; 55 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/number/utoa64 (; 55 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5323,7 +5323,7 @@
   end
   local.get $1
  )
- (func $~lib/internal/number/itoa64 (; 56 ;) (type $Ii) (param $0 i64) (result i32)
+ (func $~lib/internal/number/itoa64 (; 56 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5407,19 +5407,19 @@
   end
   local.get $2
  )
- (func $~lib/builtins/isFinite<f64> (; 57 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $~lib/builtins/isFinite<f64> (; 57 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   local.get $0
   f64.sub
   f64.const 0
   f64.eq
  )
- (func $~lib/builtins/isNaN<f64> (; 58 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $~lib/builtins/isNaN<f64> (; 58 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   local.get $0
   f64.ne
  )
- (func $~lib/internal/number/genDigits (; 59 ;) (type $iIiIiIii) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/internal/number/genDigits (; 59 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -6010,7 +6010,7 @@
   end
   local.get $15
  )
- (func $~lib/internal/number/prettify (; 60 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/internal/number/prettify (; 60 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6379,7 +6379,7 @@
   unreachable
   unreachable
  )
- (func $~lib/internal/number/dtoa_core (; 61 ;) (type $iFi) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/internal/number/dtoa_core (; 61 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 f64)
   (local $4 i32)
@@ -6852,7 +6852,7 @@
   local.get $2
   i32.add
  )
- (func $~lib/string/String#substring (; 62 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substring (; 62 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6962,7 +6962,7 @@
   call $~lib/internal/string/copyUnsafe
   local.get $10
  )
- (func $~lib/internal/number/dtoa (; 63 ;) (type $Fi) (param $0 f64) (result i32)
+ (func $~lib/internal/number/dtoa (; 63 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7028,7 +7028,7 @@
   end
   local.get $3
  )
- (func $start:std/string (; 64 ;) (type $_)
+ (func $start:std/string (; 64 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10587,12 +10587,12 @@
    unreachable
   end
  )
- (func $std/string/getString (; 65 ;) (type $i) (result i32)
+ (func $std/string/getString (; 65 ;) (type $FUNCSIG$i) (result i32)
   global.get $std/string/str
  )
- (func $start (; 66 ;) (type $_)
+ (func $start (; 66 ;) (type $FUNCSIG$v)
   call $start:std/string
  )
- (func $null (; 67 ;) (type $_)
+ (func $null (; 67 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/symbol.optimized.wat
+++ b/tests/compiler/std/symbol.optimized.wat
@@ -1,17 +1,13 @@
 (module
- (type $_ (func))
- (type $ii (func (param i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $i_ (func (param i32)))
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iii_ (func (param i32 i32 i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $ii_ (func (param i32 i32)))
- (type $FUNCSIG$vii (func (param i32 i32)))
- (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
- (type $FUNCSIG$i (func (result i32)))
- (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$i (func (result i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\03\00\00\001\002\003")
@@ -58,7 +54,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -120,7 +116,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/internal/arraybuffer/allocateUnsafe (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/allocateUnsafe (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 1073741816
@@ -393,7 +389,7 @@
   end
   local.get $2
  )
- (func $~lib/map/Map<String,usize>#clear (; 5 ;) (type $i_) (param $0 i32)
+ (func $~lib/map/Map<String,usize>#clear (; 5 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 16
   i32.const 0
@@ -443,7 +439,7 @@
   call $~lib/map/Map<String,usize>#clear
   local.get $0
  )
- (func $~lib/internal/hash/hashStr (; 7 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/hash/hashStr (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -511,7 +507,7 @@
   end
   local.get $3
  )
- (func $~lib/string/String.__eq (; 9 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 9 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -593,7 +589,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<String,usize>#rehash (; 11 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<String,usize>#rehash (; 11 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -791,7 +787,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/internal/hash/hash32 (; 13 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/hash/hash32 (; 13 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -822,7 +818,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/map/Map<usize,String>#find (; 14 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<usize,String>#find (; 14 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -865,7 +861,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<usize,String>#rehash (; 15 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<usize,String>#rehash (; 15 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1110,7 +1106,7 @@
   call $~lib/map/Map<usize,String>#set
   local.get $0
  )
- (func $~lib/map/Map<usize,String>#has (; 18 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<usize,String>#has (; 18 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -1119,7 +1115,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<usize,String>#get (; 19 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<usize,String>#get (; 19 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -1133,7 +1129,7 @@
    unreachable
   end
  )
- (func $~lib/symbol/Symbol.keyFor (; 20 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/symbol/Symbol.keyFor (; 20 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   global.get $~lib/symbol/idToString
   i32.const 0
@@ -1154,7 +1150,7 @@
    i32.const 0
   end
  )
- (func $~lib/internal/string/allocateUnsafe (; 21 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/string/allocateUnsafe (; 21 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 0
@@ -1187,7 +1183,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memcpy (; 22 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 22 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2084,7 +2080,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 23 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 23 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -2298,7 +2294,7 @@
   i32.shl
   call $~lib/internal/memory/memmove
  )
- (func $~lib/string/String#concat (; 25 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#concat (; 25 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2343,7 +2339,7 @@
   call $~lib/internal/string/copyUnsafe
   local.get $2
  )
- (func $~lib/string/String.__concat (; 26 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (; 26 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.const 488
   local.get $0
@@ -2351,7 +2347,7 @@
   local.get $1
   call $~lib/string/String#concat
  )
- (func $~lib/symbol/symbol#toString (; 27 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/symbol/symbol#toString (; 27 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 168
@@ -2435,7 +2431,7 @@
   i32.const 592
   call $~lib/string/String.__concat
  )
- (func $start:std/symbol (; 28 ;) (type $_)
+ (func $start:std/symbol (; 28 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 760
   global.set $~lib/allocator/arena/startOffset
@@ -2612,10 +2608,10 @@
    unreachable
   end
  )
- (func $start (; 29 ;) (type $_)
+ (func $start (; 29 ;) (type $FUNCSIG$v)
   call $start:std/symbol
  )
- (func $null (; 30 ;) (type $_)
+ (func $null (; 30 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/symbol.untouched.wat
+++ b/tests/compiler/std/symbol.untouched.wat
@@ -1,14 +1,14 @@
 (module
- (type $_ (func))
- (type $ii (func (param i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $i_ (func (param i32)))
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iii_ (func (param i32 i32 i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $iiiiii (func (param i32 i32 i32 i32 i32) (result i32)))
- (type $ii_ (func (param i32 i32)))
- (type $iiiii_ (func (param i32 i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$iiiiii (func (param i32 i32 i32 i32 i32) (result i32)))
+ (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$viiiii (func (param i32 i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\03\00\00\001\002\003\00")
@@ -59,7 +59,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:~lib/allocator/arena (; 1 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 1 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -71,7 +71,7 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $~lib/symbol/Symbol (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/symbol/Symbol (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   block (result i32)
@@ -90,7 +90,7 @@
   end
   local.get $2
  )
- (func $~lib/allocator/arena/__memory_allocate (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -169,12 +169,12 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/memory/memory.allocate (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/memory/memory.allocate (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/allocator/arena/__memory_allocate
   return
  )
- (func $~lib/internal/arraybuffer/computeSize (; 5 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/computeSize (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   i32.const 32
   local.get $0
@@ -186,7 +186,7 @@
   i32.sub
   i32.shl
  )
- (func $~lib/internal/arraybuffer/allocateUnsafe (; 6 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/allocateUnsafe (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -215,7 +215,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memset (; 7 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 7 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -469,7 +469,7 @@
    end
   end
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (; 8 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (; 8 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -508,7 +508,7 @@
   end
   local.get $3
  )
- (func $~lib/map/Map<String,usize>#clear (; 9 ;) (type $i_) (param $0 i32)
+ (func $~lib/map/Map<String,usize>#clear (; 9 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -536,7 +536,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<String,usize>#constructor (; 10 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<String,usize>#constructor (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -568,7 +568,7 @@
   call $~lib/map/Map<String,usize>#clear
   local.get $0
  )
- (func $~lib/map/Map<usize,String>#clear (; 11 ;) (type $i_) (param $0 i32)
+ (func $~lib/map/Map<usize,String>#clear (; 11 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -596,7 +596,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<usize,String>#constructor (; 12 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<usize,String>#constructor (; 12 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -628,7 +628,7 @@
   call $~lib/map/Map<usize,String>#clear
   local.get $0
  )
- (func $~lib/internal/hash/hashStr (; 13 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/hash/hashStr (; 13 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -670,7 +670,7 @@
   end
   local.get $1
  )
- (func $~lib/internal/string/compareUnsafe (; 14 ;) (type $iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/internal/string/compareUnsafe (; 14 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -723,7 +723,7 @@
   end
   local.get $5
  )
- (func $~lib/string/String.__eq (; 15 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 15 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -767,7 +767,7 @@
   call $~lib/internal/string/compareUnsafe
   i32.eqz
  )
- (func $~lib/map/Map<String,usize>#find (; 16 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<String,usize>#find (; 16 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -818,7 +818,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<String,usize>#has (; 17 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<String,usize>#has (; 17 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -833,7 +833,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<String,usize>#get (; 18 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<String,usize>#get (; 18 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -855,7 +855,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<String,usize>#rehash (; 19 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<String,usize>#rehash (; 19 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -995,7 +995,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<String,usize>#set (; 20 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<String,usize>#set (; 20 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1101,7 +1101,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/internal/hash/hash32 (; 21 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/hash/hash32 (; 21 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   i32.const -2128831035
   local.set $1
@@ -1143,7 +1143,7 @@
   local.set $1
   local.get $1
  )
- (func $~lib/map/Map<usize,String>#find (; 22 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<usize,String>#find (; 22 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -1194,7 +1194,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<usize,String>#rehash (; 23 ;) (type $ii_) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<usize,String>#rehash (; 23 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1334,7 +1334,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<usize,String>#set (; 24 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<usize,String>#set (; 24 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1440,7 +1440,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/symbol/Symbol.for (; 25 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/symbol/Symbol.for (; 25 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   global.get $~lib/symbol/stringToId
@@ -1487,7 +1487,7 @@
   call $~lib/map/Map<usize,String>#set
   local.get $2
  )
- (func $~lib/map/Map<usize,String>#has (; 26 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<usize,String>#has (; 26 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -1502,7 +1502,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<usize,String>#get (; 27 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<usize,String>#get (; 27 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -1524,7 +1524,7 @@
    unreachable
   end
  )
- (func $~lib/symbol/Symbol.keyFor (; 28 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/symbol/Symbol.keyFor (; 28 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   global.get $~lib/symbol/idToString
   i32.const 0
@@ -1545,7 +1545,7 @@
    i32.const 0
   end
  )
- (func $~lib/internal/string/allocateUnsafe (; 29 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/string/allocateUnsafe (; 29 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1585,7 +1585,7 @@
   i32.store
   local.get $2
  )
- (func $~lib/internal/memory/memcpy (; 30 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memcpy (; 30 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2786,7 +2786,7 @@
    i32.store8
   end
  )
- (func $~lib/internal/memory/memmove (; 31 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memmove (; 31 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -3013,7 +3013,7 @@
    end
   end
  )
- (func $~lib/internal/string/copyUnsafe (; 32 ;) (type $iiiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
+ (func $~lib/internal/string/copyUnsafe (; 32 ;) (type $FUNCSIG$viiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -3042,7 +3042,7 @@
   local.get $7
   call $~lib/internal/memory/memmove
  )
- (func $~lib/string/String#concat (; 33 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#concat (; 33 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3100,7 +3100,7 @@
   call $~lib/internal/string/copyUnsafe
   local.get $5
  )
- (func $~lib/string/String.__concat (; 34 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (; 34 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -3111,7 +3111,7 @@
   local.get $1
   call $~lib/string/String#concat
  )
- (func $~lib/symbol/symbol#toString (; 35 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/symbol/symbol#toString (; 35 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3297,7 +3297,7 @@
   i32.const 592
   call $~lib/string/String.__concat
  )
- (func $start:std/symbol (; 36 ;) (type $_)
+ (func $start:std/symbol (; 36 ;) (type $FUNCSIG$v)
   call $start:~lib/allocator/arena
   i32.const 8
   call $~lib/symbol/Symbol
@@ -3457,9 +3457,9 @@
   global.get $~lib/symbol/Symbol.isConcatSpreadable
   drop
  )
- (func $start (; 37 ;) (type $_)
+ (func $start (; 37 ;) (type $FUNCSIG$v)
   call $start:std/symbol
  )
- (func $null (; 38 ;) (type $_)
+ (func $null (; 38 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/trace.optimized.wat
+++ b/tests/compiler/std/trace.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiFFFFF_ (func (param i32 i32 f64 f64 f64 f64 f64)))
- (type $_ (func))
+ (type $FUNCSIG$viiddddd (func (param i32 i32 f64 f64 f64 f64 f64)))
+ (type $FUNCSIG$v (func))
  (import "env" "trace" (func $~lib/env/trace (param i32 i32 f64 f64 f64 f64 f64)))
  (memory $0 1)
  (data (i32.const 8) "\0d\00\00\00z\00e\00r\00o\00_\00i\00m\00p\00l\00i\00c\00i\00t")
@@ -17,7 +17,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "main" (func $std/trace/main))
- (func $start:std/trace (; 1 ;) (type $_)
+ (func $start:std/trace (; 1 ;) (type $FUNCSIG$v)
   i32.const 8
   i32.const 0
   f64.const 0
@@ -83,7 +83,7 @@
   f64.const 5.5
   call $~lib/env/trace
  )
- (func $std/trace/main (; 2 ;) (type $_)
+ (func $std/trace/main (; 2 ;) (type $FUNCSIG$v)
   global.get $~lib/started
   i32.eqz
   if
@@ -92,7 +92,7 @@
    global.set $~lib/started
   end
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/trace.untouched.wat
+++ b/tests/compiler/std/trace.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiFFFFF_ (func (param i32 i32 f64 f64 f64 f64 f64)))
- (type $_ (func))
+ (type $FUNCSIG$viiddddd (func (param i32 i32 f64 f64 f64 f64 f64)))
+ (type $FUNCSIG$v (func))
  (import "env" "trace" (func $~lib/env/trace (param i32 i32 f64 f64 f64 f64 f64)))
  (memory $0 1)
  (data (i32.const 8) "\0d\00\00\00z\00e\00r\00o\00_\00i\00m\00p\00l\00i\00c\00i\00t\00")
@@ -18,7 +18,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "main" (func $std/trace/main))
- (func $start:std/trace (; 1 ;) (type $_)
+ (func $start:std/trace (; 1 ;) (type $FUNCSIG$v)
   i32.const 8
   i32.const 0
   f64.const 0
@@ -84,7 +84,7 @@
   f64.const 5.5
   call $~lib/env/trace
  )
- (func $std/trace/main (; 2 ;) (type $_)
+ (func $std/trace/main (; 2 ;) (type $FUNCSIG$v)
   global.get $~lib/started
   i32.eqz
   if
@@ -93,9 +93,9 @@
    global.set $~lib/started
   end
  )
- (func $start (; 3 ;) (type $_)
+ (func $start (; 3 ;) (type $FUNCSIG$v)
   call $start:std/trace
  )
- (func $null (; 4 ;) (type $_)
+ (func $null (; 4 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -1,34 +1,29 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
- (type $i_ (func (param i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $ii (func (param i32) (result i32)))
- (type $iii_ (func (param i32 i32 i32)))
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiF_ (func (param i32 i32 f64)))
- (type $FFi (func (param f64 f64) (result i32)))
- (type $iiF (func (param i32 i32) (result f64)))
- (type $iiiii (func (param i32 i32 i32 i32) (result i32)))
- (type $iiI_ (func (param i32 i32 i64)))
- (type $IIiiI (func (param i64 i64 i32 i32) (result i64)))
- (type $iif_ (func (param i32 i32 f32)))
- (type $ffiif (func (param f32 f32 i32 i32) (result f32)))
- (type $FFiiF (func (param f64 f64 i32 i32) (result f64)))
- (type $IiiI (func (param i64 i32 i32) (result i64)))
- (type $iiI (func (param i32 i32) (result i64)))
- (type $fiif (func (param f32 i32 i32) (result f32)))
- (type $iif (func (param i32 i32) (result f32)))
- (type $FiiF (func (param f64 i32 i32) (result f64)))
- (type $Iiii (func (param i64 i32 i32) (result i32)))
- (type $fiii (func (param f32 i32 i32) (result i32)))
- (type $Fiii (func (param f64 i32 i32) (result i32)))
- (type $FUNCSIG$ii (func (param i32) (result i32)))
- (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
- (type $FUNCSIG$vii (func (param i32 i32)))
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viid (func (param i32 i32 f64)))
+ (type $FUNCSIG$idd (func (param f64 f64) (result i32)))
+ (type $FUNCSIG$dii (func (param i32 i32) (result f64)))
+ (type $FUNCSIG$iiiii (func (param i32 i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viij (func (param i32 i32 i64)))
+ (type $FUNCSIG$jjjii (func (param i64 i64 i32 i32) (result i64)))
+ (type $FUNCSIG$viif (func (param i32 i32 f32)))
+ (type $FUNCSIG$fffii (func (param f32 f32 i32 i32) (result f32)))
+ (type $FUNCSIG$dddii (func (param f64 f64 i32 i32) (result f64)))
+ (type $FUNCSIG$jjii (func (param i64 i32 i32) (result i64)))
  (type $FUNCSIG$jii (func (param i32 i32) (result i64)))
+ (type $FUNCSIG$ffii (func (param f32 i32 i32) (result f32)))
+ (type $FUNCSIG$fii (func (param i32 i32) (result f32)))
+ (type $FUNCSIG$ddii (func (param f64 i32 i32) (result f64)))
+ (type $FUNCSIG$ijii (func (param i64 i32 i32) (result i32)))
+ (type $FUNCSIG$ifii (func (param f32 i32 i32) (result i32)))
+ (type $FUNCSIG$idii (func (param f64 i32 i32) (result i32)))
+ (type $FUNCSIG$vii (func (param i32 i32)))
  (type $FUNCSIG$fi (func (param i32) (result f32)))
  (type $FUNCSIG$di (func (param i32) (result f64)))
  (type $FUNCSIG$ff (func (param f32) (result f32)))
@@ -86,7 +81,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -148,7 +143,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/internal/arraybuffer/allocateUnsafe (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/allocateUnsafe (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 1073741816
@@ -175,7 +170,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memset (; 3 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 3 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i64)
   local.get $2
@@ -410,7 +405,7 @@
    end
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i8>#constructor (; 4 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<i8>#constructor (; 4 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 1073741816
@@ -458,7 +453,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/typedarray/Int8Array#constructor (; 5 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#constructor (; 5 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -475,7 +470,7 @@
   local.get $0
   call $~lib/typedarray/Int8Array#constructor
  )
- (func $~lib/internal/typedarray/TypedArray<i16>#constructor (; 7 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<i16>#constructor (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 536870908
@@ -532,7 +527,7 @@
   local.get $0
   call $~lib/internal/typedarray/TypedArray<i16>#constructor
  )
- (func $~lib/internal/typedarray/TypedArray<i32>#constructor (; 9 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<i32>#constructor (; 9 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 268435454
@@ -589,7 +584,7 @@
   local.get $0
   call $~lib/internal/typedarray/TypedArray<i32>#constructor
  )
- (func $~lib/internal/typedarray/TypedArray<i64>#constructor (; 11 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<i64>#constructor (; 11 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 134217727
@@ -646,7 +641,7 @@
   local.get $0
   call $~lib/internal/typedarray/TypedArray<i64>#constructor
  )
- (func $std/typedarray/testInstantiate (; 13 ;) (type $i_) (param $0 i32)
+ (func $std/typedarray/testInstantiate (; 13 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   i32.const 0
   local.get $0
@@ -1079,7 +1074,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i32>#__set (; 14 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<i32>#__set (; 14 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1106,7 +1101,7 @@
   local.get $2
   i32.store offset=8
  )
- (func $~lib/internal/typedarray/TypedArray<i32>#__get (; 15 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<i32>#__get (; 15 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1197,7 +1192,7 @@
   i32.store offset=8
   local.get $2
  )
- (func $~lib/internal/typedarray/TypedArray<f64>#__set (; 17 ;) (type $iiF_) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/internal/typedarray/TypedArray<f64>#__set (; 17 ;) (type $FUNCSIG$viid) (param $0 i32) (param $1 i32) (param $2 f64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1275,7 +1270,7 @@
   i32.store offset=8
   local.get $2
  )
- (func $~lib/internal/sort/insertionSort<f64> (; 19 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<f64> (; 19 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 f64)
@@ -1320,7 +1315,7 @@
        local.get $6
        local.get $7
        local.get $3
-       call_indirect (type $FFi)
+       call_indirect (type $FUNCSIG$idd)
        i32.const 0
        i32.ge_s
        br_if $break|1
@@ -1365,7 +1360,7 @@
    unreachable
   end
  )
- (func $~lib/internal/sort/weakHeapSort<f64> (; 20 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/weakHeapSort<f64> (; 20 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 f64)
@@ -1451,7 +1446,7 @@
     local.get $7
     local.get $6
     local.get $3
-    call_indirect (type $FFi)
+    call_indirect (type $FUNCSIG$idd)
     i32.const 0
     i32.lt_s
     if
@@ -1581,7 +1576,7 @@
       local.get $6
       local.get $7
       local.get $3
-      call_indirect (type $FFi)
+      call_indirect (type $FUNCSIG$idd)
       i32.const 0
       i32.lt_s
       if
@@ -1695,7 +1690,7 @@
     local.get $5
     local.get $6
     local.get $3
-    call_indirect (type $FFi)
+    call_indirect (type $FUNCSIG$idd)
     i32.const 0
     i32.lt_s
     if
@@ -1735,7 +1730,7 @@
    end
   end
  )
- (func $~lib/internal/sort/COMPARATOR<f64>~anonymous|0 (; 22 ;) (type $FFi) (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<f64>~anonymous|0 (; 22 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   local.get $0
@@ -1764,7 +1759,7 @@
   i64.lt_s
   i32.sub
  )
- (func $~lib/internal/typedarray/TypedArray<f64>#__get (; 23 ;) (type $iiF) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/internal/typedarray/TypedArray<f64>#__get (; 23 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1790,7 +1785,7 @@
   i32.add
   f64.load offset=8
  )
- (func $~lib/internal/typedarray/TypedArray<u8>#__set (; 24 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<u8>#__set (; 24 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1813,7 +1808,7 @@
   local.get $2
   i32.store8 offset=8
  )
- (func $~lib/typedarray/Uint8ClampedArray#__set (; 25 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#__set (; 25 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   local.get $1
   i32.const 255
@@ -1831,7 +1826,7 @@
   i32.and
   call $~lib/internal/typedarray/TypedArray<u8>#__set
  )
- (func $~lib/internal/typedarray/TypedArray<u8>#__get (; 26 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<u8>#__get (; 26 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1928,7 +1923,7 @@
    call $~lib/internal/memory/memset
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i8>#__get (; 28 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<i8>#__get (; 28 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1950,7 +1945,7 @@
   i32.add
   i32.load8_s offset=8
  )
- (func $std/typedarray/isInt8ArrayEqual (; 29 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/typedarray/isInt8ArrayEqual (; 29 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2177,7 +2172,7 @@
    end
   end
  )
- (func $std/typedarray/isInt32ArrayEqual (; 33 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/typedarray/isInt32ArrayEqual (; 33 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2264,7 +2259,7 @@
   local.get $3
   call $~lib/typedarray/Int32Array#fill
  )
- (func $std/typedarray/testReduce<Int8Array,i8>~anonymous|0 (; 35 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Int8Array,i8>~anonymous|0 (; 35 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
@@ -2301,7 +2296,7 @@
     local.get $1
     local.get $0
     i32.const 2
-    call_indirect (type $iiiii)
+    call_indirect (type $FUNCSIG$iiiii)
     local.set $2
     local.get $1
     i32.const 1
@@ -2312,7 +2307,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduce<Int8Array,i8> (; 37 ;) (type $_)
+ (func $std/typedarray/testReduce<Int8Array,i8> (; 37 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -2376,7 +2371,7 @@
     local.get $2
     local.get $0
     local.get $1
-    call_indirect (type $iiiii)
+    call_indirect (type $FUNCSIG$iiiii)
     local.set $3
     local.get $2
     i32.const 1
@@ -2387,7 +2382,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testReduce<Uint8Array,u8> (; 39 ;) (type $_)
+ (func $std/typedarray/testReduce<Uint8Array,u8> (; 39 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -2420,7 +2415,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Uint8ClampedArray,u8> (; 40 ;) (type $_)
+ (func $std/typedarray/testReduce<Uint8ClampedArray,u8> (; 40 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
@@ -2452,7 +2447,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i16>#__set (; 41 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<i16>#__set (; 41 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2515,7 +2510,7 @@
     local.get $1
     local.get $0
     i32.const 5
-    call_indirect (type $iiiii)
+    call_indirect (type $FUNCSIG$iiiii)
     local.set $2
     local.get $1
     i32.const 1
@@ -2526,7 +2521,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduce<Int16Array,i16> (; 43 ;) (type $_)
+ (func $std/typedarray/testReduce<Int16Array,i16> (; 43 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -2593,7 +2588,7 @@
     local.get $1
     local.get $0
     i32.const 6
-    call_indirect (type $iiiii)
+    call_indirect (type $FUNCSIG$iiiii)
     local.set $2
     local.get $1
     i32.const 1
@@ -2604,7 +2599,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduce<Uint16Array,u16> (; 45 ;) (type $_)
+ (func $std/typedarray/testReduce<Uint16Array,u16> (; 45 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -2671,7 +2666,7 @@
     local.get $2
     local.get $0
     local.get $1
-    call_indirect (type $iiiii)
+    call_indirect (type $FUNCSIG$iiiii)
     local.set $3
     local.get $2
     i32.const 1
@@ -2682,7 +2677,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testReduce<Int32Array,i32> (; 47 ;) (type $_)
+ (func $std/typedarray/testReduce<Int32Array,i32> (; 47 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -2712,7 +2707,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Uint32Array,u32> (; 48 ;) (type $_)
+ (func $std/typedarray/testReduce<Uint32Array,u32> (; 48 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -2742,7 +2737,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i64>#__set (; 49 ;) (type $iiI_) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/internal/typedarray/TypedArray<i64>#__set (; 49 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2769,7 +2764,7 @@
   local.get $2
   i64.store offset=8
  )
- (func $std/typedarray/testReduce<Int64Array,i64>~anonymous|0 (; 50 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduce<Int64Array,i64>~anonymous|0 (; 50 ;) (type $FUNCSIG$jjjii) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   local.get $0
   local.get $1
   i64.add
@@ -2810,7 +2805,7 @@
     local.get $2
     local.get $0
     local.get $1
-    call_indirect (type $IIiiI)
+    call_indirect (type $FUNCSIG$jjjii)
     local.set $3
     local.get $2
     i32.const 1
@@ -2821,7 +2816,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testReduce<Int64Array,i64> (; 52 ;) (type $_)
+ (func $std/typedarray/testReduce<Int64Array,i64> (; 52 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -2851,7 +2846,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Uint64Array,u64> (; 53 ;) (type $_)
+ (func $std/typedarray/testReduce<Uint64Array,u64> (; 53 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -2881,7 +2876,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<f32>#__set (; 54 ;) (type $iif_) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/internal/typedarray/TypedArray<f32>#__set (; 54 ;) (type $FUNCSIG$viif) (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2908,7 +2903,7 @@
   local.get $2
   f32.store offset=8
  )
- (func $std/typedarray/testReduce<Float32Array,f32>~anonymous|0 (; 55 ;) (type $ffiif) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
+ (func $std/typedarray/testReduce<Float32Array,f32>~anonymous|0 (; 55 ;) (type $FUNCSIG$fffii) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
   local.get $0
   local.get $1
   f32.add
@@ -2949,7 +2944,7 @@
     local.get $1
     local.get $0
     i32.const 11
-    call_indirect (type $ffiif)
+    call_indirect (type $FUNCSIG$fffii)
     local.set $2
     local.get $1
     i32.const 1
@@ -2960,7 +2955,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduce<Float32Array,f32> (; 57 ;) (type $_)
+ (func $std/typedarray/testReduce<Float32Array,f32> (; 57 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -2989,7 +2984,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Float64Array,f64>~anonymous|0 (; 58 ;) (type $FFiiF) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
+ (func $std/typedarray/testReduce<Float64Array,f64>~anonymous|0 (; 58 ;) (type $FUNCSIG$dddii) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
   local.get $0
   local.get $1
   f64.add
@@ -3030,7 +3025,7 @@
     local.get $1
     local.get $0
     i32.const 12
-    call_indirect (type $FFiiF)
+    call_indirect (type $FUNCSIG$dddii)
     local.set $2
     local.get $1
     i32.const 1
@@ -3041,7 +3036,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduce<Float64Array,f64> (; 60 ;) (type $_)
+ (func $std/typedarray/testReduce<Float64Array,f64> (; 60 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -3103,7 +3098,7 @@
     local.get $1
     local.get $0
     i32.const 13
-    call_indirect (type $iiiii)
+    call_indirect (type $FUNCSIG$iiiii)
     local.set $2
     local.get $1
     i32.const 1
@@ -3114,7 +3109,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduceRight<Int8Array,i8> (; 62 ;) (type $_)
+ (func $std/typedarray/testReduceRight<Int8Array,i8> (; 62 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -3179,7 +3174,7 @@
     local.get $2
     local.get $0
     local.get $1
-    call_indirect (type $iiiii)
+    call_indirect (type $FUNCSIG$iiiii)
     local.set $3
     local.get $2
     i32.const 1
@@ -3190,7 +3185,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testReduceRight<Uint8Array,u8> (; 64 ;) (type $_)
+ (func $std/typedarray/testReduceRight<Uint8Array,u8> (; 64 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -3223,7 +3218,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8> (; 65 ;) (type $_)
+ (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8> (; 65 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
@@ -3292,7 +3287,7 @@
     local.get $1
     local.get $0
     i32.const 16
-    call_indirect (type $iiiii)
+    call_indirect (type $FUNCSIG$iiiii)
     local.set $2
     local.get $1
     i32.const 1
@@ -3303,7 +3298,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduceRight<Int16Array,i16> (; 67 ;) (type $_)
+ (func $std/typedarray/testReduceRight<Int16Array,i16> (; 67 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -3371,7 +3366,7 @@
     local.get $1
     local.get $0
     i32.const 17
-    call_indirect (type $iiiii)
+    call_indirect (type $FUNCSIG$iiiii)
     local.set $2
     local.get $1
     i32.const 1
@@ -3382,7 +3377,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduceRight<Uint16Array,u16> (; 69 ;) (type $_)
+ (func $std/typedarray/testReduceRight<Uint16Array,u16> (; 69 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -3450,7 +3445,7 @@
     local.get $2
     local.get $0
     local.get $1
-    call_indirect (type $iiiii)
+    call_indirect (type $FUNCSIG$iiiii)
     local.set $3
     local.get $2
     i32.const 1
@@ -3461,7 +3456,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testReduceRight<Int32Array,i32> (; 71 ;) (type $_)
+ (func $std/typedarray/testReduceRight<Int32Array,i32> (; 71 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -3491,7 +3486,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint32Array,u32> (; 72 ;) (type $_)
+ (func $std/typedarray/testReduceRight<Uint32Array,u32> (; 72 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -3558,7 +3553,7 @@
     local.get $2
     local.get $0
     local.get $1
-    call_indirect (type $IIiiI)
+    call_indirect (type $FUNCSIG$jjjii)
     local.set $3
     local.get $2
     i32.const 1
@@ -3569,7 +3564,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testReduceRight<Int64Array,i64> (; 74 ;) (type $_)
+ (func $std/typedarray/testReduceRight<Int64Array,i64> (; 74 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -3599,7 +3594,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint64Array,u64> (; 75 ;) (type $_)
+ (func $std/typedarray/testReduceRight<Uint64Array,u64> (; 75 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -3666,7 +3661,7 @@
     local.get $1
     local.get $0
     i32.const 22
-    call_indirect (type $ffiif)
+    call_indirect (type $FUNCSIG$fffii)
     local.set $2
     local.get $1
     i32.const 1
@@ -3677,7 +3672,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduceRight<Float32Array,f32> (; 77 ;) (type $_)
+ (func $std/typedarray/testReduceRight<Float32Array,f32> (; 77 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -3743,7 +3738,7 @@
     local.get $1
     local.get $0
     i32.const 23
-    call_indirect (type $FFiiF)
+    call_indirect (type $FUNCSIG$dddii)
     local.set $2
     local.get $1
     i32.const 1
@@ -3754,7 +3749,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduceRight<Float64Array,f64> (; 79 ;) (type $_)
+ (func $std/typedarray/testReduceRight<Float64Array,f64> (; 79 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -3783,7 +3778,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|0 (; 80 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|0 (; 80 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $0
   i32.mul
@@ -3828,7 +3823,7 @@
     local.get $1
     local.get $0
     i32.const 24
-    call_indirect (type $iiii)
+    call_indirect (type $FUNCSIG$iiii)
     i32.store8 offset=8
     local.get $1
     i32.const 1
@@ -3839,7 +3834,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArrayMap<Int8Array,i8> (; 82 ;) (type $_)
+ (func $std/typedarray/testArrayMap<Int8Array,i8> (; 82 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -3944,7 +3939,7 @@
     local.get $1
     local.get $0
     i32.const 25
-    call_indirect (type $iiii)
+    call_indirect (type $FUNCSIG$iiii)
     i32.store8 offset=8
     local.get $1
     i32.const 1
@@ -3955,7 +3950,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArrayMap<Uint8Array,u8> (; 84 ;) (type $_)
+ (func $std/typedarray/testArrayMap<Uint8Array,u8> (; 84 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -4059,7 +4054,7 @@
     local.get $1
     local.get $0
     i32.const 26
-    call_indirect (type $iiii)
+    call_indirect (type $FUNCSIG$iiii)
     i32.store8 offset=8
     local.get $1
     i32.const 1
@@ -4070,7 +4065,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8> (; 86 ;) (type $_)
+ (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8> (; 86 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
@@ -4179,7 +4174,7 @@
     local.get $1
     local.get $0
     i32.const 27
-    call_indirect (type $iiii)
+    call_indirect (type $FUNCSIG$iiii)
     i32.store16 offset=8
     local.get $1
     i32.const 1
@@ -4190,7 +4185,7 @@
   end
   local.get $5
  )
- (func $~lib/internal/typedarray/TypedArray<i16>#__get (; 88 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<i16>#__get (; 88 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -4216,7 +4211,7 @@
   i32.add
   i32.load16_s offset=8
  )
- (func $std/typedarray/testArrayMap<Int16Array,i16> (; 89 ;) (type $_)
+ (func $std/typedarray/testArrayMap<Int16Array,i16> (; 89 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -4325,7 +4320,7 @@
     local.get $1
     local.get $0
     i32.const 28
-    call_indirect (type $iiii)
+    call_indirect (type $FUNCSIG$iiii)
     i32.store16 offset=8
     local.get $1
     i32.const 1
@@ -4336,7 +4331,7 @@
   end
   local.get $5
  )
- (func $~lib/internal/typedarray/TypedArray<u16>#__get (; 91 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<u16>#__get (; 91 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -4362,7 +4357,7 @@
   i32.add
   i32.load16_u offset=8
  )
- (func $std/typedarray/testArrayMap<Uint16Array,u16> (; 92 ;) (type $_)
+ (func $std/typedarray/testArrayMap<Uint16Array,u16> (; 92 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -4426,7 +4421,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Int32Array#map (; 93 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#map (; 93 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4472,7 +4467,7 @@
     local.get $2
     local.get $0
     local.get $1
-    call_indirect (type $iiii)
+    call_indirect (type $FUNCSIG$iiii)
     i32.store offset=8
     local.get $2
     i32.const 1
@@ -4483,7 +4478,7 @@
   end
   local.get $6
  )
- (func $std/typedarray/testArrayMap<Int32Array,i32> (; 94 ;) (type $_)
+ (func $std/typedarray/testArrayMap<Int32Array,i32> (; 94 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -4542,7 +4537,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint32Array,u32> (; 95 ;) (type $_)
+ (func $std/typedarray/testArrayMap<Uint32Array,u32> (; 95 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -4601,12 +4596,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|0 (; 96 ;) (type $IiiI) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+ (func $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|0 (; 96 ;) (type $FUNCSIG$jjii) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
   local.get $0
   local.get $0
   i64.mul
  )
- (func $~lib/typedarray/Int64Array#map (; 97 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#map (; 97 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4652,7 +4647,7 @@
     local.get $2
     local.get $0
     local.get $1
-    call_indirect (type $IiiI)
+    call_indirect (type $FUNCSIG$jjii)
     i64.store offset=8
     local.get $2
     i32.const 1
@@ -4663,7 +4658,7 @@
   end
   local.get $6
  )
- (func $~lib/internal/typedarray/TypedArray<i64>#__get (; 98 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/internal/typedarray/TypedArray<i64>#__get (; 98 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -4689,7 +4684,7 @@
   i32.add
   i64.load offset=8
  )
- (func $std/typedarray/testArrayMap<Int64Array,i64> (; 99 ;) (type $_)
+ (func $std/typedarray/testArrayMap<Int64Array,i64> (; 99 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -4748,7 +4743,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint64Array,u64> (; 100 ;) (type $_)
+ (func $std/typedarray/testArrayMap<Uint64Array,u64> (; 100 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -4807,7 +4802,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|0 (; 101 ;) (type $fiif) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
+ (func $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|0 (; 101 ;) (type $FUNCSIG$ffii) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
   local.get $0
   local.get $0
   f32.mul
@@ -4857,7 +4852,7 @@
     local.get $1
     local.get $0
     i32.const 33
-    call_indirect (type $fiif)
+    call_indirect (type $FUNCSIG$ffii)
     f32.store offset=8
     local.get $1
     i32.const 1
@@ -4868,7 +4863,7 @@
   end
   local.get $5
  )
- (func $~lib/internal/typedarray/TypedArray<f32>#__get (; 103 ;) (type $iif) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/internal/typedarray/TypedArray<f32>#__get (; 103 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -4894,7 +4889,7 @@
   i32.add
   f32.load offset=8
  )
- (func $std/typedarray/testArrayMap<Float32Array,f32> (; 104 ;) (type $_)
+ (func $std/typedarray/testArrayMap<Float32Array,f32> (; 104 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -4952,7 +4947,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|0 (; 105 ;) (type $FiiF) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
+ (func $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|0 (; 105 ;) (type $FUNCSIG$ddii) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
   local.get $0
   local.get $0
   f64.mul
@@ -5002,7 +4997,7 @@
     local.get $1
     local.get $0
     i32.const 34
-    call_indirect (type $FiiF)
+    call_indirect (type $FUNCSIG$ddii)
     f64.store offset=8
     local.get $1
     i32.const 1
@@ -5013,7 +5008,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArrayMap<Float64Array,f64> (; 107 ;) (type $_)
+ (func $std/typedarray/testArrayMap<Float64Array,f64> (; 107 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -5071,14 +5066,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Int8Array,i8>~anonymous|0 (; 108 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int8Array,i8>~anonymous|0 (; 108 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Int8Array#some (; 109 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#some (; 109 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5111,7 +5106,7 @@
      local.get $2
      local.get $0
      local.get $1
-     call_indirect (type $iiii)
+     call_indirect (type $FUNCSIG$iiii)
      br_if $~lib/internal/typedarray/SOME<Int8Array,i8>|inlined.0
      drop
      local.get $2
@@ -5124,13 +5119,13 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Int8Array,i8>~anonymous|1 (; 110 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int8Array,i8>~anonymous|1 (; 110 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.eqz
  )
- (func $std/typedarray/testArraySome<Int8Array,i8> (; 111 ;) (type $_)
+ (func $std/typedarray/testArraySome<Int8Array,i8> (; 111 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -5171,7 +5166,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Uint8Array#some (; 112 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#some (; 112 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5204,7 +5199,7 @@
      local.get $2
      local.get $0
      local.get $1
-     call_indirect (type $iiii)
+     call_indirect (type $FUNCSIG$iiii)
      br_if $~lib/internal/typedarray/SOME<Uint8Array,u8>|inlined.0
      drop
      local.get $2
@@ -5217,7 +5212,7 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Uint8Array,u8> (; 113 ;) (type $_)
+ (func $std/typedarray/testArraySome<Uint8Array,u8> (; 113 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -5258,7 +5253,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint8ClampedArray,u8> (; 114 ;) (type $_)
+ (func $std/typedarray/testArraySome<Uint8ClampedArray,u8> (; 114 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
@@ -5298,14 +5293,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Int16Array,i16>~anonymous|0 (; 115 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int16Array,i16>~anonymous|0 (; 115 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Int16Array#some (; 116 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#some (; 116 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5342,7 +5337,7 @@
      local.get $2
      local.get $0
      local.get $1
-     call_indirect (type $iiii)
+     call_indirect (type $FUNCSIG$iiii)
      br_if $~lib/internal/typedarray/SOME<Int16Array,i16>|inlined.0
      drop
      local.get $2
@@ -5355,13 +5350,13 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Int16Array,i16>~anonymous|1 (; 117 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int16Array,i16>~anonymous|1 (; 117 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   i32.eqz
  )
- (func $std/typedarray/testArraySome<Int16Array,i16> (; 118 ;) (type $_)
+ (func $std/typedarray/testArraySome<Int16Array,i16> (; 118 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -5401,7 +5396,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Uint16Array#some (; 119 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#some (; 119 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5438,7 +5433,7 @@
      local.get $2
      local.get $0
      local.get $1
-     call_indirect (type $iiii)
+     call_indirect (type $FUNCSIG$iiii)
      br_if $~lib/internal/typedarray/SOME<Uint16Array,u16>|inlined.0
      drop
      local.get $2
@@ -5451,7 +5446,7 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Uint16Array,u16> (; 120 ;) (type $_)
+ (func $std/typedarray/testArraySome<Uint16Array,u16> (; 120 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -5491,12 +5486,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Int32Array,i32>~anonymous|0 (; 121 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int32Array,i32>~anonymous|0 (; 121 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Int32Array#some (; 122 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#some (; 122 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5533,7 +5528,7 @@
      local.get $2
      local.get $0
      local.get $1
-     call_indirect (type $iiii)
+     call_indirect (type $FUNCSIG$iiii)
      br_if $~lib/internal/typedarray/SOME<Int32Array,i32>|inlined.0
      drop
      local.get $2
@@ -5546,11 +5541,11 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Int32Array,i32>~anonymous|1 (; 123 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int32Array,i32>~anonymous|1 (; 123 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.eqz
  )
- (func $std/typedarray/testArraySome<Int32Array,i32> (; 124 ;) (type $_)
+ (func $std/typedarray/testArraySome<Int32Array,i32> (; 124 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -5590,7 +5585,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint32Array,u32> (; 125 ;) (type $_)
+ (func $std/typedarray/testArraySome<Uint32Array,u32> (; 125 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -5630,12 +5625,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Int64Array,i64>~anonymous|0 (; 126 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int64Array,i64>~anonymous|0 (; 126 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.eq
  )
- (func $~lib/typedarray/Int64Array#some (; 127 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#some (; 127 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5672,7 +5667,7 @@
      local.get $2
      local.get $0
      local.get $1
-     call_indirect (type $Iiii)
+     call_indirect (type $FUNCSIG$ijii)
      br_if $~lib/internal/typedarray/SOME<Int64Array,i64>|inlined.0
      drop
      local.get $2
@@ -5685,12 +5680,12 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Int64Array,i64>~anonymous|1 (; 128 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int64Array,i64>~anonymous|1 (; 128 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 0
   i64.eq
  )
- (func $std/typedarray/testArraySome<Int64Array,i64> (; 129 ;) (type $_)
+ (func $std/typedarray/testArraySome<Int64Array,i64> (; 129 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -5730,7 +5725,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint64Array,u64> (; 130 ;) (type $_)
+ (func $std/typedarray/testArraySome<Uint64Array,u64> (; 130 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -5770,12 +5765,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Float32Array,f32>~anonymous|0 (; 131 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Float32Array,f32>~anonymous|0 (; 131 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 2
   f32.eq
  )
- (func $~lib/typedarray/Float32Array#some (; 132 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#some (; 132 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5812,7 +5807,7 @@
      local.get $2
      local.get $0
      local.get $1
-     call_indirect (type $fiii)
+     call_indirect (type $FUNCSIG$ifii)
      br_if $~lib/internal/typedarray/SOME<Float32Array,f32>|inlined.0
      drop
      local.get $2
@@ -5825,12 +5820,12 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Float32Array,f32>~anonymous|1 (; 133 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Float32Array,f32>~anonymous|1 (; 133 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 0
   f32.eq
  )
- (func $std/typedarray/testArraySome<Float32Array,f32> (; 134 ;) (type $_)
+ (func $std/typedarray/testArraySome<Float32Array,f32> (; 134 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -5870,12 +5865,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Float64Array,f64>~anonymous|0 (; 135 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Float64Array,f64>~anonymous|0 (; 135 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 2
   f64.eq
  )
- (func $~lib/typedarray/Float64Array#some (; 136 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#some (; 136 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5912,7 +5907,7 @@
      local.get $2
      local.get $0
      local.get $1
-     call_indirect (type $Fiii)
+     call_indirect (type $FUNCSIG$idii)
      br_if $~lib/internal/typedarray/SOME<Float64Array,f64>|inlined.0
      drop
      local.get $2
@@ -5925,12 +5920,12 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Float64Array,f64>~anonymous|1 (; 137 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Float64Array,f64>~anonymous|1 (; 137 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 0
   f64.eq
  )
- (func $std/typedarray/testArraySome<Float64Array,f64> (; 138 ;) (type $_)
+ (func $std/typedarray/testArraySome<Float64Array,f64> (; 138 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -5970,7 +5965,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Int8Array#findIndex (; 139 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#findIndex (; 139 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6005,7 +6000,7 @@
      local.get $0
      local.get $3
      local.get $1
-     call_indirect (type $iiii)
+     call_indirect (type $FUNCSIG$iiii)
      br_if $~lib/internal/typedarray/FIND_INDEX<Int8Array,i8>|inlined.0
      local.get $0
      i32.const 1
@@ -6019,14 +6014,14 @@
   end
   local.get $0
  )
- (func $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|1 (; 140 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|1 (; 140 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int8Array,i8> (; 141 ;) (type $_)
+ (func $std/typedarray/testArrayFindIndex<Int8Array,i8> (; 141 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -6070,7 +6065,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Uint8Array#findIndex (; 142 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#findIndex (; 142 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6105,7 +6100,7 @@
      local.get $0
      local.get $3
      local.get $1
-     call_indirect (type $iiii)
+     call_indirect (type $FUNCSIG$iiii)
      br_if $~lib/internal/typedarray/FIND_INDEX<Uint8Array,u8>|inlined.0
      local.get $0
      i32.const 1
@@ -6119,7 +6114,7 @@
   end
   local.get $0
  )
- (func $std/typedarray/testArrayFindIndex<Uint8Array,u8> (; 143 ;) (type $_)
+ (func $std/typedarray/testArrayFindIndex<Uint8Array,u8> (; 143 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -6163,7 +6158,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8> (; 144 ;) (type $_)
+ (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8> (; 144 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
@@ -6206,7 +6201,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Int16Array#findIndex (; 145 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#findIndex (; 145 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6245,7 +6240,7 @@
      local.get $0
      local.get $3
      local.get $1
-     call_indirect (type $iiii)
+     call_indirect (type $FUNCSIG$iiii)
      br_if $~lib/internal/typedarray/FIND_INDEX<Int16Array,i16>|inlined.0
      local.get $0
      i32.const 1
@@ -6259,14 +6254,14 @@
   end
   local.get $0
  )
- (func $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|1 (; 146 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|1 (; 146 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int16Array,i16> (; 147 ;) (type $_)
+ (func $std/typedarray/testArrayFindIndex<Int16Array,i16> (; 147 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -6309,7 +6304,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Uint16Array#findIndex (; 148 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#findIndex (; 148 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6348,7 +6343,7 @@
      local.get $0
      local.get $3
      local.get $1
-     call_indirect (type $iiii)
+     call_indirect (type $FUNCSIG$iiii)
      br_if $~lib/internal/typedarray/FIND_INDEX<Uint16Array,u16>|inlined.0
      local.get $0
      i32.const 1
@@ -6362,7 +6357,7 @@
   end
   local.get $0
  )
- (func $std/typedarray/testArrayFindIndex<Uint16Array,u16> (; 149 ;) (type $_)
+ (func $std/typedarray/testArrayFindIndex<Uint16Array,u16> (; 149 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -6405,7 +6400,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Int32Array#findIndex (; 150 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#findIndex (; 150 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6444,7 +6439,7 @@
      local.get $0
      local.get $3
      local.get $1
-     call_indirect (type $iiii)
+     call_indirect (type $FUNCSIG$iiii)
      br_if $~lib/internal/typedarray/FIND_INDEX<Int32Array,i32>|inlined.0
      local.get $0
      i32.const 1
@@ -6458,12 +6453,12 @@
   end
   local.get $0
  )
- (func $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|1 (; 151 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|1 (; 151 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int32Array,i32> (; 152 ;) (type $_)
+ (func $std/typedarray/testArrayFindIndex<Int32Array,i32> (; 152 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -6506,7 +6501,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint32Array,u32> (; 153 ;) (type $_)
+ (func $std/typedarray/testArrayFindIndex<Uint32Array,u32> (; 153 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -6549,7 +6544,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Int64Array#findIndex (; 154 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#findIndex (; 154 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6588,7 +6583,7 @@
      local.get $0
      local.get $3
      local.get $1
-     call_indirect (type $Iiii)
+     call_indirect (type $FUNCSIG$ijii)
      br_if $~lib/internal/typedarray/FIND_INDEX<Int64Array,i64>|inlined.0
      local.get $0
      i32.const 1
@@ -6602,12 +6597,12 @@
   end
   local.get $0
  )
- (func $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|1 (; 155 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|1 (; 155 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 4
   i64.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int64Array,i64> (; 156 ;) (type $_)
+ (func $std/typedarray/testArrayFindIndex<Int64Array,i64> (; 156 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -6650,7 +6645,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint64Array,u64> (; 157 ;) (type $_)
+ (func $std/typedarray/testArrayFindIndex<Uint64Array,u64> (; 157 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -6693,7 +6688,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Float32Array#findIndex (; 158 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#findIndex (; 158 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6732,7 +6727,7 @@
      local.get $0
      local.get $3
      local.get $1
-     call_indirect (type $fiii)
+     call_indirect (type $FUNCSIG$ifii)
      br_if $~lib/internal/typedarray/FIND_INDEX<Float32Array,f32>|inlined.0
      local.get $0
      i32.const 1
@@ -6746,12 +6741,12 @@
   end
   local.get $0
  )
- (func $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|1 (; 159 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|1 (; 159 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 4
   f32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Float32Array,f32> (; 160 ;) (type $_)
+ (func $std/typedarray/testArrayFindIndex<Float32Array,f32> (; 160 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -6794,7 +6789,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Float64Array#findIndex (; 161 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#findIndex (; 161 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6833,7 +6828,7 @@
      local.get $0
      local.get $3
      local.get $1
-     call_indirect (type $Fiii)
+     call_indirect (type $FUNCSIG$idii)
      br_if $~lib/internal/typedarray/FIND_INDEX<Float64Array,f64>|inlined.0
      local.get $0
      i32.const 1
@@ -6847,12 +6842,12 @@
   end
   local.get $0
  )
- (func $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|1 (; 162 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|1 (; 162 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 4
   f64.eq
  )
- (func $std/typedarray/testArrayFindIndex<Float64Array,f64> (; 163 ;) (type $_)
+ (func $std/typedarray/testArrayFindIndex<Float64Array,f64> (; 163 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -6895,7 +6890,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|0 (; 164 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|0 (; 164 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -6905,7 +6900,7 @@
   i32.rem_s
   i32.eqz
  )
- (func $~lib/typedarray/Int8Array#every (; 165 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#every (; 165 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6937,7 +6932,7 @@
      local.get $2
      local.get $0
      local.get $1
-     call_indirect (type $iiii)
+     call_indirect (type $FUNCSIG$iiii)
      i32.eqz
      if
       i32.const 0
@@ -6953,7 +6948,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int8Array,i8> (; 166 ;) (type $_)
+ (func $std/typedarray/testArrayEvery<Int8Array,i8> (; 166 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -6994,13 +6989,13 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|0 (; 167 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|0 (; 167 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 1
   i32.and
   i32.eqz
  )
- (func $~lib/typedarray/Uint8Array#every (; 168 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#every (; 168 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7032,7 +7027,7 @@
      local.get $2
      local.get $0
      local.get $1
-     call_indirect (type $iiii)
+     call_indirect (type $FUNCSIG$iiii)
      i32.eqz
      if
       i32.const 0
@@ -7048,7 +7043,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Uint8Array,u8> (; 169 ;) (type $_)
+ (func $std/typedarray/testArrayEvery<Uint8Array,u8> (; 169 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -7089,7 +7084,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8> (; 170 ;) (type $_)
+ (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8> (; 170 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
@@ -7129,7 +7124,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|0 (; 171 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|0 (; 171 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -7139,7 +7134,7 @@
   i32.rem_s
   i32.eqz
  )
- (func $~lib/typedarray/Int16Array#every (; 172 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#every (; 172 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7175,7 +7170,7 @@
      local.get $2
      local.get $0
      local.get $1
-     call_indirect (type $iiii)
+     call_indirect (type $FUNCSIG$iiii)
      i32.eqz
      if
       i32.const 0
@@ -7191,7 +7186,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int16Array,i16> (; 173 ;) (type $_)
+ (func $std/typedarray/testArrayEvery<Int16Array,i16> (; 173 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -7231,7 +7226,7 @@
    unreachable
   end
  )
- (func $~lib/typedarray/Uint16Array#every (; 174 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#every (; 174 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7267,7 +7262,7 @@
      local.get $2
      local.get $0
      local.get $1
-     call_indirect (type $iiii)
+     call_indirect (type $FUNCSIG$iiii)
      i32.eqz
      if
       i32.const 0
@@ -7283,7 +7278,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Uint16Array,u16> (; 175 ;) (type $_)
+ (func $std/typedarray/testArrayEvery<Uint16Array,u16> (; 175 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -7323,13 +7318,13 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|0 (; 176 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|0 (; 176 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.rem_s
   i32.eqz
  )
- (func $~lib/typedarray/Int32Array#every (; 177 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#every (; 177 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7365,7 +7360,7 @@
      local.get $2
      local.get $0
      local.get $1
-     call_indirect (type $iiii)
+     call_indirect (type $FUNCSIG$iiii)
      i32.eqz
      if
       i32.const 0
@@ -7381,7 +7376,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int32Array,i32> (; 178 ;) (type $_)
+ (func $std/typedarray/testArrayEvery<Int32Array,i32> (; 178 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -7421,7 +7416,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint32Array,u32> (; 179 ;) (type $_)
+ (func $std/typedarray/testArrayEvery<Uint32Array,u32> (; 179 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -7461,14 +7456,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|0 (; 180 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|0 (; 180 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.rem_s
   i64.const 0
   i64.eq
  )
- (func $~lib/typedarray/Int64Array#every (; 181 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#every (; 181 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7504,7 +7499,7 @@
      local.get $2
      local.get $0
      local.get $1
-     call_indirect (type $Iiii)
+     call_indirect (type $FUNCSIG$ijii)
      i32.eqz
      if
       i32.const 0
@@ -7520,7 +7515,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int64Array,i64> (; 182 ;) (type $_)
+ (func $std/typedarray/testArrayEvery<Int64Array,i64> (; 182 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -7560,14 +7555,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|0 (; 183 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|0 (; 183 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.rem_u
   i64.const 0
   i64.eq
  )
- (func $std/typedarray/testArrayEvery<Uint64Array,u64> (; 184 ;) (type $_)
+ (func $std/typedarray/testArrayEvery<Uint64Array,u64> (; 184 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -7758,13 +7753,13 @@
   local.get $0
   f32.mul
  )
- (func $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|0 (; 186 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|0 (; 186 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.mod
   f32.const 0
   f32.eq
  )
- (func $~lib/typedarray/Float32Array#every (; 187 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#every (; 187 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7800,7 +7795,7 @@
      local.get $2
      local.get $0
      local.get $1
-     call_indirect (type $fiii)
+     call_indirect (type $FUNCSIG$ifii)
      i32.eqz
      if
       i32.const 0
@@ -7816,7 +7811,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Float32Array,f32> (; 188 ;) (type $_)
+ (func $std/typedarray/testArrayEvery<Float32Array,f32> (; 188 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -8015,13 +8010,13 @@
   local.get $0
   f64.mul
  )
- (func $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|0 (; 190 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|0 (; 190 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.mod
   f64.const 0
   f64.eq
  )
- (func $~lib/typedarray/Float64Array#every (; 191 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#every (; 191 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8057,7 +8052,7 @@
      local.get $2
      local.get $0
      local.get $1
-     call_indirect (type $Fiii)
+     call_indirect (type $FUNCSIG$idii)
      i32.eqz
      if
       i32.const 0
@@ -8073,7 +8068,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Float64Array,f64> (; 192 ;) (type $_)
+ (func $std/typedarray/testArrayEvery<Float64Array,f64> (; 192 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -8113,7 +8108,7 @@
    unreachable
   end
  )
- (func $start:std/typedarray (; 193 ;) (type $_)
+ (func $start:std/typedarray (; 193 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 624
@@ -9093,10 +9088,10 @@
   call $std/typedarray/testArrayEvery<Float32Array,f32>
   call $std/typedarray/testArrayEvery<Float64Array,f64>
  )
- (func $start (; 194 ;) (type $_)
+ (func $start (; 194 ;) (type $FUNCSIG$v)
   call $start:std/typedarray
  )
- (func $null (; 195 ;) (type $_)
+ (func $null (; 195 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -1,33 +1,33 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
- (type $i_ (func (param i32)))
- (type $iii (func (param i32 i32) (result i32)))
- (type $ii (func (param i32) (result i32)))
- (type $iii_ (func (param i32 i32 i32)))
- (type $iiii (func (param i32 i32 i32) (result i32)))
- (type $iiF_ (func (param i32 i32 f64)))
- (type $FFi (func (param f64 f64) (result i32)))
- (type $iiF (func (param i32 i32) (result f64)))
- (type $iiiii (func (param i32 i32 i32 i32) (result i32)))
- (type $iiI_ (func (param i32 i32 i64)))
- (type $IIiiI (func (param i64 i64 i32 i32) (result i64)))
- (type $iiII (func (param i32 i32 i64) (result i64)))
- (type $iif_ (func (param i32 i32 f32)))
- (type $ffiif (func (param f32 f32 i32 i32) (result f32)))
- (type $iiff (func (param i32 i32 f32) (result f32)))
- (type $FFiiF (func (param f64 f64 i32 i32) (result f64)))
- (type $iiFF (func (param i32 i32 f64) (result f64)))
- (type $IiiI (func (param i64 i32 i32) (result i64)))
- (type $iiI (func (param i32 i32) (result i64)))
- (type $fiif (func (param f32 i32 i32) (result f32)))
- (type $iif (func (param i32 i32) (result f32)))
- (type $FiiF (func (param f64 i32 i32) (result f64)))
- (type $Iiii (func (param i64 i32 i32) (result i32)))
- (type $fiii (func (param f32 i32 i32) (result i32)))
- (type $Fiii (func (param f64 i32 i32) (result i32)))
- (type $fff (func (param f32 f32) (result f32)))
- (type $FFF (func (param f64 f64) (result f64)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viid (func (param i32 i32 f64)))
+ (type $FUNCSIG$idd (func (param f64 f64) (result i32)))
+ (type $FUNCSIG$dii (func (param i32 i32) (result f64)))
+ (type $FUNCSIG$iiiii (func (param i32 i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viij (func (param i32 i32 i64)))
+ (type $FUNCSIG$jjjii (func (param i64 i64 i32 i32) (result i64)))
+ (type $FUNCSIG$jiij (func (param i32 i32 i64) (result i64)))
+ (type $FUNCSIG$viif (func (param i32 i32 f32)))
+ (type $FUNCSIG$fffii (func (param f32 f32 i32 i32) (result f32)))
+ (type $FUNCSIG$fiif (func (param i32 i32 f32) (result f32)))
+ (type $FUNCSIG$dddii (func (param f64 f64 i32 i32) (result f64)))
+ (type $FUNCSIG$diid (func (param i32 i32 f64) (result f64)))
+ (type $FUNCSIG$jjii (func (param i64 i32 i32) (result i64)))
+ (type $FUNCSIG$jii (func (param i32 i32) (result i64)))
+ (type $FUNCSIG$ffii (func (param f32 i32 i32) (result f32)))
+ (type $FUNCSIG$fii (func (param i32 i32) (result f32)))
+ (type $FUNCSIG$ddii (func (param f64 i32 i32) (result f64)))
+ (type $FUNCSIG$ijii (func (param i64 i32 i32) (result i32)))
+ (type $FUNCSIG$ifii (func (param f32 i32 i32) (result i32)))
+ (type $FUNCSIG$idii (func (param f64 i32 i32) (result i32)))
+ (type $FUNCSIG$fff (func (param f32 f32) (result f32)))
+ (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\11\00\00\00s\00t\00d\00/\00t\00y\00p\00e\00d\00a\00r\00r\00a\00y\00.\00t\00s\00")
@@ -94,7 +94,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:~lib/allocator/arena (; 1 ;) (type $_)
+ (func $start:~lib/allocator/arena (; 1 ;) (type $FUNCSIG$v)
   global.get $~lib/memory/HEAP_BASE
   i32.const 7
   i32.add
@@ -106,7 +106,7 @@
   global.get $~lib/allocator/arena/startOffset
   global.set $~lib/allocator/arena/offset
  )
- (func $~lib/internal/arraybuffer/computeSize (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/computeSize (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   i32.const 32
   local.get $0
@@ -118,7 +118,7 @@
   i32.sub
   i32.shl
  )
- (func $~lib/allocator/arena/__memory_allocate (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/allocator/arena/__memory_allocate (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -197,7 +197,7 @@
   global.set $~lib/allocator/arena/offset
   local.get $1
  )
- (func $~lib/internal/arraybuffer/allocateUnsafe (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/internal/arraybuffer/allocateUnsafe (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -226,7 +226,7 @@
   i32.store
   local.get $1
  )
- (func $~lib/internal/memory/memset (; 5 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/memory/memset (; 5 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -480,12 +480,12 @@
    end
   end
  )
- (func $~lib/memory/memory.allocate (; 6 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/memory/memory.allocate (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/allocator/arena/__memory_allocate
   return
  )
- (func $~lib/internal/typedarray/TypedArray<i8>#constructor (; 7 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<i8>#constructor (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -552,7 +552,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/typedarray/Int8Array#constructor (; 8 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#constructor (; 8 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -566,7 +566,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/internal/typedarray/TypedArray<u8>#constructor (; 9 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<u8>#constructor (; 9 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -633,7 +633,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/typedarray/Uint8Array#constructor (; 10 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#constructor (; 10 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -647,7 +647,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/typedarray/Uint8ClampedArray#constructor (; 11 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#constructor (; 11 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -661,7 +661,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/internal/typedarray/TypedArray<i16>#constructor (; 12 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<i16>#constructor (; 12 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -728,7 +728,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/typedarray/Int16Array#constructor (; 13 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#constructor (; 13 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -742,7 +742,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/internal/typedarray/TypedArray<u16>#constructor (; 14 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<u16>#constructor (; 14 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -809,7 +809,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/typedarray/Uint16Array#constructor (; 15 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#constructor (; 15 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -823,7 +823,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/internal/typedarray/TypedArray<i32>#constructor (; 16 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<i32>#constructor (; 16 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -890,7 +890,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/typedarray/Int32Array#constructor (; 17 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#constructor (; 17 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -904,7 +904,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/internal/typedarray/TypedArray<u32>#constructor (; 18 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<u32>#constructor (; 18 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -971,7 +971,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/typedarray/Uint32Array#constructor (; 19 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#constructor (; 19 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -985,7 +985,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/internal/typedarray/TypedArray<i64>#constructor (; 20 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<i64>#constructor (; 20 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1052,7 +1052,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/typedarray/Int64Array#constructor (; 21 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#constructor (; 21 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1066,7 +1066,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/internal/typedarray/TypedArray<u64>#constructor (; 22 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<u64>#constructor (; 22 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1133,7 +1133,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/typedarray/Uint64Array#constructor (; 23 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#constructor (; 23 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1147,7 +1147,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/internal/typedarray/TypedArray<f32>#constructor (; 24 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<f32>#constructor (; 24 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1214,7 +1214,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/typedarray/Float32Array#constructor (; 25 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#constructor (; 25 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1228,7 +1228,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/internal/typedarray/TypedArray<f64>#constructor (; 26 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<f64>#constructor (; 26 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1295,7 +1295,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/typedarray/Float64Array#constructor (; 27 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#constructor (; 27 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -1309,7 +1309,7 @@
   local.set $0
   local.get $0
  )
- (func $std/typedarray/testInstantiate (; 28 ;) (type $i_) (param $0 i32)
+ (func $std/typedarray/testInstantiate (; 28 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1884,7 +1884,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i32>#__set (; 29 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<i32>#__set (; 29 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1925,7 +1925,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i32>#__get (; 30 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<i32>#__get (; 30 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1962,7 +1962,7 @@
    i32.load offset=8
   end
  )
- (func $~lib/typedarray/Int32Array#subarray (; 31 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#subarray (; 31 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2072,7 +2072,7 @@
   i32.store offset=8
   local.get $7
  )
- (func $~lib/internal/typedarray/TypedArray<f64>#__set (; 32 ;) (type $iiF_) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/internal/typedarray/TypedArray<f64>#__set (; 32 ;) (type $FUNCSIG$viid) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   (local $4 i32)
   (local $5 f64)
@@ -2113,7 +2113,7 @@
    f64.store offset=8
   end
  )
- (func $~lib/typedarray/Float64Array#subarray (; 33 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#subarray (; 33 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2223,7 +2223,7 @@
   i32.store offset=8
   local.get $7
  )
- (func $~lib/internal/sort/insertionSort<f64> (; 34 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<f64> (; 34 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -2293,7 +2293,7 @@
           local.get $8
           local.get $10
           local.get $3
-          call_indirect (type $FFi)
+          call_indirect (type $FUNCSIG$idd)
          end
          i32.const 0
          i32.lt_s
@@ -2364,10 +2364,10 @@
    unreachable
   end
  )
- (func $~lib/allocator/arena/__memory_free (; 35 ;) (type $i_) (param $0 i32)
+ (func $~lib/allocator/arena/__memory_free (; 35 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $~lib/internal/sort/weakHeapSort<f64> (; 36 ;) (type $iiii_) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/weakHeapSort<f64> (; 36 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -2497,7 +2497,7 @@
       local.get $12
       local.get $13
       local.get $3
-      call_indirect (type $FFi)
+      call_indirect (type $FUNCSIG$idd)
      end
      i32.const 0
      i32.lt_s
@@ -2734,7 +2734,7 @@
           local.get $13
           local.get $12
           local.get $3
-          call_indirect (type $FFi)
+          call_indirect (type $FUNCSIG$idd)
          end
          i32.const 0
          i32.lt_s
@@ -2897,7 +2897,7 @@
    f64.store offset=8
   end
  )
- (func $~lib/typedarray/Float64Array#sort (; 37 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#sort (; 37 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2981,7 +2981,7 @@
      local.get $10
      local.get $11
      local.get $3
-     call_indirect (type $FFi)
+     call_indirect (type $FUNCSIG$idd)
     end
     i32.const 0
     i32.lt_s
@@ -3057,7 +3057,7 @@
    local.get $2
   end
  )
- (func $~lib/internal/sort/COMPARATOR<f64>~anonymous|0 (; 38 ;) (type $FFi) (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<f64>~anonymous|0 (; 38 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   local.get $0
@@ -3090,7 +3090,7 @@
   i64.lt_s
   i32.sub
  )
- (func $~lib/typedarray/Float64Array#sort|trampoline (; 39 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#sort|trampoline (; 39 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -3109,7 +3109,7 @@
   local.get $1
   call $~lib/typedarray/Float64Array#sort
  )
- (func $~lib/internal/typedarray/TypedArray<f64>#__get (; 40 ;) (type $iiF) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/internal/typedarray/TypedArray<f64>#__get (; 40 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3146,7 +3146,7 @@
    f64.load offset=8
   end
  )
- (func $~lib/typedarray/clampToByte (; 41 ;) (type $ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/clampToByte (; 41 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 31
   i32.shr_s
@@ -3161,7 +3161,7 @@
   i32.or
   i32.and
  )
- (func $~lib/internal/typedarray/TypedArray<u8>#__set (; 42 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<u8>#__set (; 42 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3202,14 +3202,14 @@
    i32.store8 offset=8
   end
  )
- (func $~lib/typedarray/Uint8ClampedArray#__set (; 43 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#__set (; 43 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   local.get $1
   local.get $2
   call $~lib/typedarray/clampToByte
   call $~lib/internal/typedarray/TypedArray<u8>#__set
  )
- (func $~lib/internal/typedarray/TypedArray<u8>#__get (; 44 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<u8>#__get (; 44 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3246,7 +3246,7 @@
    i32.load8_u offset=8
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i8>#__set (; 45 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<i8>#__set (; 45 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3287,7 +3287,7 @@
    i32.store8 offset=8
   end
  )
- (func $~lib/typedarray/Int8Array#fill (; 46 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#fill (; 46 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3396,7 +3396,7 @@
   end
   local.get $4
  )
- (func $~lib/internal/typedarray/TypedArray<i8>#__get (; 47 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<i8>#__get (; 47 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3433,7 +3433,7 @@
    i32.load8_s offset=8
   end
  )
- (func $~lib/array/Array<i8>#__get (; 48 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__get (; 48 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3466,7 +3466,7 @@
    unreachable
   end
  )
- (func $std/typedarray/isInt8ArrayEqual (; 49 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/typedarray/isInt8ArrayEqual (; 49 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   block $~lib/internal/typedarray/TypedArray<i8>#get:length|inlined.3 (result i32)
@@ -3538,7 +3538,7 @@
   end
   i32.const 1
  )
- (func $~lib/typedarray/Int8Array#fill|trampoline (; 50 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#fill|trampoline (; 50 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -3562,7 +3562,7 @@
   local.get $3
   call $~lib/typedarray/Int8Array#fill
  )
- (func $~lib/typedarray/Int8Array#subarray (; 51 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#subarray (; 51 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3672,7 +3672,7 @@
   i32.store offset=8
   local.get $7
  )
- (func $~lib/typedarray/Int32Array#fill (; 52 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#fill (; 52 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3794,7 +3794,7 @@
   end
   local.get $4
  )
- (func $~lib/array/Array<i32>#__get (; 53 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (; 53 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3827,7 +3827,7 @@
    unreachable
   end
  )
- (func $std/typedarray/isInt32ArrayEqual (; 54 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/typedarray/isInt32ArrayEqual (; 54 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   block $~lib/internal/typedarray/TypedArray<i32>#get:length|inlined.6 (result i32)
@@ -3891,7 +3891,7 @@
   end
   i32.const 1
  )
- (func $~lib/typedarray/Int32Array#fill|trampoline (; 55 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#fill|trampoline (; 55 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -3915,12 +3915,12 @@
   local.get $3
   call $~lib/typedarray/Int32Array#fill
  )
- (func $std/typedarray/testReduce<Int8Array,i8>~anonymous|0 (; 56 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Int8Array,i8>~anonymous|0 (; 56 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $~lib/typedarray/Int8Array#reduce<i8> (; 57 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#reduce<i8> (; 57 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3984,7 +3984,7 @@
      local.get $9
      local.get $3
      local.get $4
-     call_indirect (type $iiiii)
+     call_indirect (type $FUNCSIG$iiiii)
     end
     local.set $5
     local.get $9
@@ -3998,7 +3998,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Int8Array,i8> (; 58 ;) (type $_)
+ (func $std/typedarray/testReduce<Int8Array,i8> (; 58 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4039,12 +4039,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Uint8Array,u8>~anonymous|0 (; 59 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Uint8Array,u8>~anonymous|0 (; 59 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $~lib/typedarray/Uint8Array#reduce<u8> (; 60 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#reduce<u8> (; 60 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4108,7 +4108,7 @@
      local.get $9
      local.get $3
      local.get $4
-     call_indirect (type $iiiii)
+     call_indirect (type $FUNCSIG$iiiii)
     end
     local.set $5
     local.get $9
@@ -4122,7 +4122,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Uint8Array,u8> (; 61 ;) (type $_)
+ (func $std/typedarray/testReduce<Uint8Array,u8> (; 61 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4161,12 +4161,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Uint8ClampedArray,u8>~anonymous|0 (; 62 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Uint8ClampedArray,u8>~anonymous|0 (; 62 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $~lib/typedarray/Uint8ClampedArray#reduce<u8> (; 63 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#reduce<u8> (; 63 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4230,7 +4230,7 @@
      local.get $9
      local.get $3
      local.get $4
-     call_indirect (type $iiiii)
+     call_indirect (type $FUNCSIG$iiiii)
     end
     local.set $5
     local.get $9
@@ -4244,7 +4244,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Uint8ClampedArray,u8> (; 64 ;) (type $_)
+ (func $std/typedarray/testReduce<Uint8ClampedArray,u8> (; 64 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4283,7 +4283,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i16>#__set (; 65 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<i16>#__set (; 65 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4324,12 +4324,12 @@
    i32.store16 offset=8
   end
  )
- (func $std/typedarray/testReduce<Int16Array,i16>~anonymous|0 (; 66 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Int16Array,i16>~anonymous|0 (; 66 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $~lib/typedarray/Int16Array#reduce<i16> (; 67 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#reduce<i16> (; 67 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4393,7 +4393,7 @@
      local.get $9
      local.get $3
      local.get $4
-     call_indirect (type $iiiii)
+     call_indirect (type $FUNCSIG$iiiii)
     end
     local.set $5
     local.get $9
@@ -4407,7 +4407,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Int16Array,i16> (; 68 ;) (type $_)
+ (func $std/typedarray/testReduce<Int16Array,i16> (; 68 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4448,7 +4448,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<u16>#__set (; 69 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<u16>#__set (; 69 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4489,12 +4489,12 @@
    i32.store16 offset=8
   end
  )
- (func $std/typedarray/testReduce<Uint16Array,u16>~anonymous|0 (; 70 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Uint16Array,u16>~anonymous|0 (; 70 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $~lib/typedarray/Uint16Array#reduce<u16> (; 71 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#reduce<u16> (; 71 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4558,7 +4558,7 @@
      local.get $9
      local.get $3
      local.get $4
-     call_indirect (type $iiiii)
+     call_indirect (type $FUNCSIG$iiiii)
     end
     local.set $5
     local.get $9
@@ -4572,7 +4572,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Uint16Array,u16> (; 72 ;) (type $_)
+ (func $std/typedarray/testReduce<Uint16Array,u16> (; 72 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4611,12 +4611,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Int32Array,i32>~anonymous|0 (; 73 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Int32Array,i32>~anonymous|0 (; 73 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $~lib/typedarray/Int32Array#reduce<i32> (; 74 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#reduce<i32> (; 74 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4680,7 +4680,7 @@
      local.get $9
      local.get $3
      local.get $4
-     call_indirect (type $iiiii)
+     call_indirect (type $FUNCSIG$iiiii)
     end
     local.set $5
     local.get $9
@@ -4694,7 +4694,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Int32Array,i32> (; 75 ;) (type $_)
+ (func $std/typedarray/testReduce<Int32Array,i32> (; 75 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4731,7 +4731,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<u32>#__set (; 76 ;) (type $iii_) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/internal/typedarray/TypedArray<u32>#__set (; 76 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4772,12 +4772,12 @@
    i32.store offset=8
   end
  )
- (func $std/typedarray/testReduce<Uint32Array,u32>~anonymous|0 (; 77 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<Uint32Array,u32>~anonymous|0 (; 77 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $~lib/typedarray/Uint32Array#reduce<u32> (; 78 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#reduce<u32> (; 78 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4841,7 +4841,7 @@
      local.get $9
      local.get $3
      local.get $4
-     call_indirect (type $iiiii)
+     call_indirect (type $FUNCSIG$iiiii)
     end
     local.set $5
     local.get $9
@@ -4855,7 +4855,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Uint32Array,u32> (; 79 ;) (type $_)
+ (func $std/typedarray/testReduce<Uint32Array,u32> (; 79 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4892,7 +4892,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<i64>#__set (; 80 ;) (type $iiI_) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/internal/typedarray/TypedArray<i64>#__set (; 80 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -4933,12 +4933,12 @@
    i64.store offset=8
   end
  )
- (func $std/typedarray/testReduce<Int64Array,i64>~anonymous|0 (; 81 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduce<Int64Array,i64>~anonymous|0 (; 81 ;) (type $FUNCSIG$jjjii) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   local.get $0
   local.get $1
   i64.add
  )
- (func $~lib/typedarray/Int64Array#reduce<i64> (; 82 ;) (type $iiII) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
+ (func $~lib/typedarray/Int64Array#reduce<i64> (; 82 ;) (type $FUNCSIG$jiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -5002,7 +5002,7 @@
      local.get $9
      local.get $3
      local.get $4
-     call_indirect (type $IIiiI)
+     call_indirect (type $FUNCSIG$jjjii)
     end
     local.set $5
     local.get $9
@@ -5016,7 +5016,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Int64Array,i64> (; 83 ;) (type $_)
+ (func $std/typedarray/testReduce<Int64Array,i64> (; 83 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -5053,7 +5053,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<u64>#__set (; 84 ;) (type $iiI_) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/internal/typedarray/TypedArray<u64>#__set (; 84 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -5094,12 +5094,12 @@
    i64.store offset=8
   end
  )
- (func $std/typedarray/testReduce<Uint64Array,u64>~anonymous|0 (; 85 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduce<Uint64Array,u64>~anonymous|0 (; 85 ;) (type $FUNCSIG$jjjii) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   local.get $0
   local.get $1
   i64.add
  )
- (func $~lib/typedarray/Uint64Array#reduce<u64> (; 86 ;) (type $iiII) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
+ (func $~lib/typedarray/Uint64Array#reduce<u64> (; 86 ;) (type $FUNCSIG$jiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -5163,7 +5163,7 @@
      local.get $9
      local.get $3
      local.get $4
-     call_indirect (type $IIiiI)
+     call_indirect (type $FUNCSIG$jjjii)
     end
     local.set $5
     local.get $9
@@ -5177,7 +5177,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Uint64Array,u64> (; 87 ;) (type $_)
+ (func $std/typedarray/testReduce<Uint64Array,u64> (; 87 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -5214,7 +5214,7 @@
    unreachable
   end
  )
- (func $~lib/internal/typedarray/TypedArray<f32>#__set (; 88 ;) (type $iif_) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/internal/typedarray/TypedArray<f32>#__set (; 88 ;) (type $FUNCSIG$viif) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   (local $4 i32)
   (local $5 f32)
@@ -5255,12 +5255,12 @@
    f32.store offset=8
   end
  )
- (func $std/typedarray/testReduce<Float32Array,f32>~anonymous|0 (; 89 ;) (type $ffiif) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
+ (func $std/typedarray/testReduce<Float32Array,f32>~anonymous|0 (; 89 ;) (type $FUNCSIG$fffii) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
   local.get $0
   local.get $1
   f32.add
  )
- (func $~lib/typedarray/Float32Array#reduce<f32> (; 90 ;) (type $iiff) (param $0 i32) (param $1 i32) (param $2 f32) (result f32)
+ (func $~lib/typedarray/Float32Array#reduce<f32> (; 90 ;) (type $FUNCSIG$fiif) (param $0 i32) (param $1 i32) (param $2 f32) (result f32)
   (local $3 i32)
   (local $4 i32)
   (local $5 f32)
@@ -5324,7 +5324,7 @@
      local.get $9
      local.get $3
      local.get $4
-     call_indirect (type $ffiif)
+     call_indirect (type $FUNCSIG$fffii)
     end
     local.set $5
     local.get $9
@@ -5338,7 +5338,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Float32Array,f32> (; 91 ;) (type $_)
+ (func $std/typedarray/testReduce<Float32Array,f32> (; 91 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f32)
   i32.const 0
@@ -5375,12 +5375,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Float64Array,f64>~anonymous|0 (; 92 ;) (type $FFiiF) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
+ (func $std/typedarray/testReduce<Float64Array,f64>~anonymous|0 (; 92 ;) (type $FUNCSIG$dddii) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
   local.get $0
   local.get $1
   f64.add
  )
- (func $~lib/typedarray/Float64Array#reduce<f64> (; 93 ;) (type $iiFF) (param $0 i32) (param $1 i32) (param $2 f64) (result f64)
+ (func $~lib/typedarray/Float64Array#reduce<f64> (; 93 ;) (type $FUNCSIG$diid) (param $0 i32) (param $1 i32) (param $2 f64) (result f64)
   (local $3 i32)
   (local $4 i32)
   (local $5 f64)
@@ -5444,7 +5444,7 @@
      local.get $9
      local.get $3
      local.get $4
-     call_indirect (type $FFiiF)
+     call_indirect (type $FUNCSIG$dddii)
     end
     local.set $5
     local.get $9
@@ -5458,7 +5458,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Float64Array,f64> (; 94 ;) (type $_)
+ (func $std/typedarray/testReduce<Float64Array,f64> (; 94 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f64)
   i32.const 0
@@ -5495,12 +5495,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Int8Array,i8>~anonymous|0 (; 95 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Int8Array,i8>~anonymous|0 (; 95 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $~lib/typedarray/Int8Array#reduceRight<i8> (; 96 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#reduceRight<i8> (; 96 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5563,7 +5563,7 @@
      local.get $8
      local.get $3
      local.get $4
-     call_indirect (type $iiiii)
+     call_indirect (type $FUNCSIG$iiiii)
     end
     local.set $5
     local.get $8
@@ -5577,7 +5577,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Int8Array,i8> (; 97 ;) (type $_)
+ (func $std/typedarray/testReduceRight<Int8Array,i8> (; 97 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -5618,12 +5618,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint8Array,u8>~anonymous|0 (; 98 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Uint8Array,u8>~anonymous|0 (; 98 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $~lib/typedarray/Uint8Array#reduceRight<u8> (; 99 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#reduceRight<u8> (; 99 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5686,7 +5686,7 @@
      local.get $8
      local.get $3
      local.get $4
-     call_indirect (type $iiiii)
+     call_indirect (type $FUNCSIG$iiiii)
     end
     local.set $5
     local.get $8
@@ -5700,7 +5700,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Uint8Array,u8> (; 100 ;) (type $_)
+ (func $std/typedarray/testReduceRight<Uint8Array,u8> (; 100 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -5739,12 +5739,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8>~anonymous|0 (; 101 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8>~anonymous|0 (; 101 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $~lib/typedarray/Uint8ClampedArray#reduceRight<u8> (; 102 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#reduceRight<u8> (; 102 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5807,7 +5807,7 @@
      local.get $8
      local.get $3
      local.get $4
-     call_indirect (type $iiiii)
+     call_indirect (type $FUNCSIG$iiiii)
     end
     local.set $5
     local.get $8
@@ -5821,7 +5821,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8> (; 103 ;) (type $_)
+ (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8> (; 103 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -5860,12 +5860,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Int16Array,i16>~anonymous|0 (; 104 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Int16Array,i16>~anonymous|0 (; 104 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $~lib/typedarray/Int16Array#reduceRight<i16> (; 105 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#reduceRight<i16> (; 105 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5928,7 +5928,7 @@
      local.get $8
      local.get $3
      local.get $4
-     call_indirect (type $iiiii)
+     call_indirect (type $FUNCSIG$iiiii)
     end
     local.set $5
     local.get $8
@@ -5942,7 +5942,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Int16Array,i16> (; 106 ;) (type $_)
+ (func $std/typedarray/testReduceRight<Int16Array,i16> (; 106 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -5983,12 +5983,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint16Array,u16>~anonymous|0 (; 107 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Uint16Array,u16>~anonymous|0 (; 107 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $~lib/typedarray/Uint16Array#reduceRight<u16> (; 108 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#reduceRight<u16> (; 108 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6051,7 +6051,7 @@
      local.get $8
      local.get $3
      local.get $4
-     call_indirect (type $iiiii)
+     call_indirect (type $FUNCSIG$iiiii)
     end
     local.set $5
     local.get $8
@@ -6065,7 +6065,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Uint16Array,u16> (; 109 ;) (type $_)
+ (func $std/typedarray/testReduceRight<Uint16Array,u16> (; 109 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -6104,12 +6104,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Int32Array,i32>~anonymous|0 (; 110 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Int32Array,i32>~anonymous|0 (; 110 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $~lib/typedarray/Int32Array#reduceRight<i32> (; 111 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#reduceRight<i32> (; 111 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6172,7 +6172,7 @@
      local.get $8
      local.get $3
      local.get $4
-     call_indirect (type $iiiii)
+     call_indirect (type $FUNCSIG$iiiii)
     end
     local.set $5
     local.get $8
@@ -6186,7 +6186,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Int32Array,i32> (; 112 ;) (type $_)
+ (func $std/typedarray/testReduceRight<Int32Array,i32> (; 112 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -6223,12 +6223,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint32Array,u32>~anonymous|0 (; 113 ;) (type $iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<Uint32Array,u32>~anonymous|0 (; 113 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $~lib/typedarray/Uint32Array#reduceRight<u32> (; 114 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#reduceRight<u32> (; 114 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6291,7 +6291,7 @@
      local.get $8
      local.get $3
      local.get $4
-     call_indirect (type $iiiii)
+     call_indirect (type $FUNCSIG$iiiii)
     end
     local.set $5
     local.get $8
@@ -6305,7 +6305,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Uint32Array,u32> (; 115 ;) (type $_)
+ (func $std/typedarray/testReduceRight<Uint32Array,u32> (; 115 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -6342,12 +6342,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Int64Array,i64>~anonymous|0 (; 116 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduceRight<Int64Array,i64>~anonymous|0 (; 116 ;) (type $FUNCSIG$jjjii) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   local.get $0
   local.get $1
   i64.add
  )
- (func $~lib/typedarray/Int64Array#reduceRight<i64> (; 117 ;) (type $iiII) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
+ (func $~lib/typedarray/Int64Array#reduceRight<i64> (; 117 ;) (type $FUNCSIG$jiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -6410,7 +6410,7 @@
      local.get $8
      local.get $3
      local.get $4
-     call_indirect (type $IIiiI)
+     call_indirect (type $FUNCSIG$jjjii)
     end
     local.set $5
     local.get $8
@@ -6424,7 +6424,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Int64Array,i64> (; 118 ;) (type $_)
+ (func $std/typedarray/testReduceRight<Int64Array,i64> (; 118 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -6461,12 +6461,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint64Array,u64>~anonymous|0 (; 119 ;) (type $IIiiI) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduceRight<Uint64Array,u64>~anonymous|0 (; 119 ;) (type $FUNCSIG$jjjii) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   local.get $0
   local.get $1
   i64.add
  )
- (func $~lib/typedarray/Uint64Array#reduceRight<u64> (; 120 ;) (type $iiII) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
+ (func $~lib/typedarray/Uint64Array#reduceRight<u64> (; 120 ;) (type $FUNCSIG$jiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
@@ -6529,7 +6529,7 @@
      local.get $8
      local.get $3
      local.get $4
-     call_indirect (type $IIiiI)
+     call_indirect (type $FUNCSIG$jjjii)
     end
     local.set $5
     local.get $8
@@ -6543,7 +6543,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Uint64Array,u64> (; 121 ;) (type $_)
+ (func $std/typedarray/testReduceRight<Uint64Array,u64> (; 121 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -6580,12 +6580,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Float32Array,f32>~anonymous|0 (; 122 ;) (type $ffiif) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
+ (func $std/typedarray/testReduceRight<Float32Array,f32>~anonymous|0 (; 122 ;) (type $FUNCSIG$fffii) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
   local.get $0
   local.get $1
   f32.add
  )
- (func $~lib/typedarray/Float32Array#reduceRight<f32> (; 123 ;) (type $iiff) (param $0 i32) (param $1 i32) (param $2 f32) (result f32)
+ (func $~lib/typedarray/Float32Array#reduceRight<f32> (; 123 ;) (type $FUNCSIG$fiif) (param $0 i32) (param $1 i32) (param $2 f32) (result f32)
   (local $3 i32)
   (local $4 i32)
   (local $5 f32)
@@ -6648,7 +6648,7 @@
      local.get $8
      local.get $3
      local.get $4
-     call_indirect (type $ffiif)
+     call_indirect (type $FUNCSIG$fffii)
     end
     local.set $5
     local.get $8
@@ -6662,7 +6662,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Float32Array,f32> (; 124 ;) (type $_)
+ (func $std/typedarray/testReduceRight<Float32Array,f32> (; 124 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f32)
   i32.const 0
@@ -6699,12 +6699,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Float64Array,f64>~anonymous|0 (; 125 ;) (type $FFiiF) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
+ (func $std/typedarray/testReduceRight<Float64Array,f64>~anonymous|0 (; 125 ;) (type $FUNCSIG$dddii) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
   local.get $0
   local.get $1
   f64.add
  )
- (func $~lib/typedarray/Float64Array#reduceRight<f64> (; 126 ;) (type $iiFF) (param $0 i32) (param $1 i32) (param $2 f64) (result f64)
+ (func $~lib/typedarray/Float64Array#reduceRight<f64> (; 126 ;) (type $FUNCSIG$diid) (param $0 i32) (param $1 i32) (param $2 f64) (result f64)
   (local $3 i32)
   (local $4 i32)
   (local $5 f64)
@@ -6767,7 +6767,7 @@
      local.get $8
      local.get $3
      local.get $4
-     call_indirect (type $FFiiF)
+     call_indirect (type $FUNCSIG$dddii)
     end
     local.set $5
     local.get $8
@@ -6781,7 +6781,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Float64Array,f64> (; 127 ;) (type $_)
+ (func $std/typedarray/testReduceRight<Float64Array,f64> (; 127 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f64)
   i32.const 0
@@ -6818,12 +6818,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|0 (; 128 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|0 (; 128 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $0
   i32.mul
  )
- (func $~lib/typedarray/Int8Array#map (; 129 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#map (; 129 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6899,7 +6899,7 @@
       local.get $9
       local.get $2
       local.get $3
-      call_indirect (type $iiii)
+      call_indirect (type $FUNCSIG$iiii)
      end
      i32.const 24
      i32.shl
@@ -6929,7 +6929,7 @@
   end
   local.get $7
  )
- (func $std/typedarray/testArrayMap<Int8Array,i8> (; 130 ;) (type $_)
+ (func $std/typedarray/testArrayMap<Int8Array,i8> (; 130 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -7007,12 +7007,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint8Array,u8>~anonymous|0 (; 131 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Uint8Array,u8>~anonymous|0 (; 131 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $0
   i32.mul
  )
- (func $~lib/typedarray/Uint8Array#map (; 132 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#map (; 132 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7088,7 +7088,7 @@
       local.get $9
       local.get $2
       local.get $3
-      call_indirect (type $iiii)
+      call_indirect (type $FUNCSIG$iiii)
      end
      i32.const 255
      i32.and
@@ -7116,7 +7116,7 @@
   end
   local.get $7
  )
- (func $std/typedarray/testArrayMap<Uint8Array,u8> (; 133 ;) (type $_)
+ (func $std/typedarray/testArrayMap<Uint8Array,u8> (; 133 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -7188,12 +7188,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8>~anonymous|0 (; 134 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8>~anonymous|0 (; 134 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $0
   i32.mul
  )
- (func $~lib/typedarray/Uint8ClampedArray#map (; 135 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#map (; 135 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7269,7 +7269,7 @@
       local.get $9
       local.get $2
       local.get $3
-      call_indirect (type $iiii)
+      call_indirect (type $FUNCSIG$iiii)
      end
      i32.const 255
      i32.and
@@ -7297,7 +7297,7 @@
   end
   local.get $7
  )
- (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8> (; 136 ;) (type $_)
+ (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8> (; 136 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -7369,12 +7369,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int16Array,i16>~anonymous|0 (; 137 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Int16Array,i16>~anonymous|0 (; 137 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $0
   i32.mul
  )
- (func $~lib/typedarray/Int16Array#map (; 138 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#map (; 138 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7450,7 +7450,7 @@
       local.get $9
       local.get $2
       local.get $3
-      call_indirect (type $iiii)
+      call_indirect (type $FUNCSIG$iiii)
      end
      i32.const 16
      i32.shl
@@ -7480,7 +7480,7 @@
   end
   local.get $7
  )
- (func $~lib/internal/typedarray/TypedArray<i16>#__get (; 139 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<i16>#__get (; 139 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7517,7 +7517,7 @@
    i32.load16_s offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Int16Array,i16> (; 140 ;) (type $_)
+ (func $std/typedarray/testArrayMap<Int16Array,i16> (; 140 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -7595,12 +7595,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint16Array,u16>~anonymous|0 (; 141 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Uint16Array,u16>~anonymous|0 (; 141 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $0
   i32.mul
  )
- (func $~lib/typedarray/Uint16Array#map (; 142 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#map (; 142 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7676,7 +7676,7 @@
       local.get $9
       local.get $2
       local.get $3
-      call_indirect (type $iiii)
+      call_indirect (type $FUNCSIG$iiii)
      end
      i32.const 65535
      i32.and
@@ -7704,7 +7704,7 @@
   end
   local.get $7
  )
- (func $~lib/internal/typedarray/TypedArray<u16>#__get (; 143 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<u16>#__get (; 143 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7741,7 +7741,7 @@
    i32.load16_u offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Uint16Array,u16> (; 144 ;) (type $_)
+ (func $std/typedarray/testArrayMap<Uint16Array,u16> (; 144 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -7813,12 +7813,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int32Array,i32>~anonymous|0 (; 145 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Int32Array,i32>~anonymous|0 (; 145 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $0
   i32.mul
  )
- (func $~lib/typedarray/Int32Array#map (; 146 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#map (; 146 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7894,7 +7894,7 @@
       local.get $9
       local.get $2
       local.get $3
-      call_indirect (type $iiii)
+      call_indirect (type $FUNCSIG$iiii)
      end
      local.set $14
      i32.const 0
@@ -7920,7 +7920,7 @@
   end
   local.get $7
  )
- (func $std/typedarray/testArrayMap<Int32Array,i32> (; 147 ;) (type $_)
+ (func $std/typedarray/testArrayMap<Int32Array,i32> (; 147 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -7986,12 +7986,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint32Array,u32>~anonymous|0 (; 148 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<Uint32Array,u32>~anonymous|0 (; 148 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $0
   i32.mul
  )
- (func $~lib/typedarray/Uint32Array#map (; 149 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#map (; 149 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8067,7 +8067,7 @@
       local.get $9
       local.get $2
       local.get $3
-      call_indirect (type $iiii)
+      call_indirect (type $FUNCSIG$iiii)
      end
      local.set $14
      i32.const 0
@@ -8093,7 +8093,7 @@
   end
   local.get $7
  )
- (func $~lib/internal/typedarray/TypedArray<u32>#__get (; 150 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/typedarray/TypedArray<u32>#__get (; 150 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8130,7 +8130,7 @@
    i32.load offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Uint32Array,u32> (; 151 ;) (type $_)
+ (func $std/typedarray/testArrayMap<Uint32Array,u32> (; 151 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -8196,12 +8196,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|0 (; 152 ;) (type $IiiI) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+ (func $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|0 (; 152 ;) (type $FUNCSIG$jjii) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
   local.get $0
   local.get $0
   i64.mul
  )
- (func $~lib/typedarray/Int64Array#map (; 153 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#map (; 153 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8278,7 +8278,7 @@
       local.get $9
       local.get $2
       local.get $3
-      call_indirect (type $IiiI)
+      call_indirect (type $FUNCSIG$jjii)
      end
      local.set $15
      i32.const 0
@@ -8304,7 +8304,7 @@
   end
   local.get $7
  )
- (func $~lib/internal/typedarray/TypedArray<i64>#__get (; 154 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/internal/typedarray/TypedArray<i64>#__get (; 154 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8341,7 +8341,7 @@
    i64.load offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Int64Array,i64> (; 155 ;) (type $_)
+ (func $std/typedarray/testArrayMap<Int64Array,i64> (; 155 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -8407,12 +8407,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint64Array,u64>~anonymous|0 (; 156 ;) (type $IiiI) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+ (func $std/typedarray/testArrayMap<Uint64Array,u64>~anonymous|0 (; 156 ;) (type $FUNCSIG$jjii) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
   local.get $0
   local.get $0
   i64.mul
  )
- (func $~lib/typedarray/Uint64Array#map (; 157 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#map (; 157 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8489,7 +8489,7 @@
       local.get $9
       local.get $2
       local.get $3
-      call_indirect (type $IiiI)
+      call_indirect (type $FUNCSIG$jjii)
      end
      local.set $15
      i32.const 0
@@ -8515,7 +8515,7 @@
   end
   local.get $7
  )
- (func $~lib/internal/typedarray/TypedArray<u64>#__get (; 158 ;) (type $iiI) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/internal/typedarray/TypedArray<u64>#__get (; 158 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8552,7 +8552,7 @@
    i64.load offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Uint64Array,u64> (; 159 ;) (type $_)
+ (func $std/typedarray/testArrayMap<Uint64Array,u64> (; 159 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -8618,12 +8618,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|0 (; 160 ;) (type $fiif) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
+ (func $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|0 (; 160 ;) (type $FUNCSIG$ffii) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
   local.get $0
   local.get $0
   f32.mul
  )
- (func $~lib/typedarray/Float32Array#map (; 161 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#map (; 161 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8700,7 +8700,7 @@
       local.get $9
       local.get $2
       local.get $3
-      call_indirect (type $fiif)
+      call_indirect (type $FUNCSIG$ffii)
      end
      local.set $15
      i32.const 0
@@ -8726,7 +8726,7 @@
   end
   local.get $7
  )
- (func $~lib/internal/typedarray/TypedArray<f32>#__get (; 162 ;) (type $iif) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/internal/typedarray/TypedArray<f32>#__get (; 162 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8763,7 +8763,7 @@
    f32.load offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Float32Array,f32> (; 163 ;) (type $_)
+ (func $std/typedarray/testArrayMap<Float32Array,f32> (; 163 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -8829,12 +8829,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|0 (; 164 ;) (type $FiiF) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
+ (func $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|0 (; 164 ;) (type $FUNCSIG$ddii) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
   local.get $0
   local.get $0
   f64.mul
  )
- (func $~lib/typedarray/Float64Array#map (; 165 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#map (; 165 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8911,7 +8911,7 @@
       local.get $9
       local.get $2
       local.get $3
-      call_indirect (type $FiiF)
+      call_indirect (type $FUNCSIG$ddii)
      end
      local.set $15
      i32.const 0
@@ -8937,7 +8937,7 @@
   end
   local.get $7
  )
- (func $std/typedarray/testArrayMap<Float64Array,f64> (; 166 ;) (type $_)
+ (func $std/typedarray/testArrayMap<Float64Array,f64> (; 166 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -9003,7 +9003,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Int8Array,i8>~anonymous|0 (; 167 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int8Array,i8>~anonymous|0 (; 167 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -9012,7 +9012,7 @@
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Int8Array#some (; 168 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#some (; 168 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9073,7 +9073,7 @@
       local.get $7
       local.get $2
       local.get $3
-      call_indirect (type $iiii)
+      call_indirect (type $FUNCSIG$iiii)
      end
      i32.const 0
      i32.ne
@@ -9093,7 +9093,7 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Int8Array,i8>~anonymous|1 (; 169 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int8Array,i8>~anonymous|1 (; 169 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -9102,7 +9102,7 @@
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Int8Array,i8> (; 170 ;) (type $_)
+ (func $std/typedarray/testArraySome<Int8Array,i8> (; 170 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9156,14 +9156,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint8Array,u8>~anonymous|0 (; 171 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Uint8Array,u8>~anonymous|0 (; 171 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Uint8Array#some (; 172 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#some (; 172 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9224,7 +9224,7 @@
       local.get $7
       local.get $2
       local.get $3
-      call_indirect (type $iiii)
+      call_indirect (type $FUNCSIG$iiii)
      end
      i32.const 0
      i32.ne
@@ -9244,14 +9244,14 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Uint8Array,u8>~anonymous|1 (; 173 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Uint8Array,u8>~anonymous|1 (; 173 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Uint8Array,u8> (; 174 ;) (type $_)
+ (func $std/typedarray/testArraySome<Uint8Array,u8> (; 174 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9305,14 +9305,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint8ClampedArray,u8>~anonymous|0 (; 175 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Uint8ClampedArray,u8>~anonymous|0 (; 175 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Uint8ClampedArray#some (; 176 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#some (; 176 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9373,7 +9373,7 @@
       local.get $7
       local.get $2
       local.get $3
-      call_indirect (type $iiii)
+      call_indirect (type $FUNCSIG$iiii)
      end
      i32.const 0
      i32.ne
@@ -9393,14 +9393,14 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Uint8ClampedArray,u8>~anonymous|1 (; 177 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Uint8ClampedArray,u8>~anonymous|1 (; 177 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Uint8ClampedArray,u8> (; 178 ;) (type $_)
+ (func $std/typedarray/testArraySome<Uint8ClampedArray,u8> (; 178 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9454,7 +9454,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Int16Array,i16>~anonymous|0 (; 179 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int16Array,i16>~anonymous|0 (; 179 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -9463,7 +9463,7 @@
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Int16Array#some (; 180 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#some (; 180 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9524,7 +9524,7 @@
       local.get $7
       local.get $2
       local.get $3
-      call_indirect (type $iiii)
+      call_indirect (type $FUNCSIG$iiii)
      end
      i32.const 0
      i32.ne
@@ -9544,7 +9544,7 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Int16Array,i16>~anonymous|1 (; 181 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int16Array,i16>~anonymous|1 (; 181 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -9553,7 +9553,7 @@
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Int16Array,i16> (; 182 ;) (type $_)
+ (func $std/typedarray/testArraySome<Int16Array,i16> (; 182 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9607,14 +9607,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint16Array,u16>~anonymous|0 (; 183 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Uint16Array,u16>~anonymous|0 (; 183 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Uint16Array#some (; 184 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#some (; 184 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9675,7 +9675,7 @@
       local.get $7
       local.get $2
       local.get $3
-      call_indirect (type $iiii)
+      call_indirect (type $FUNCSIG$iiii)
      end
      i32.const 0
      i32.ne
@@ -9695,14 +9695,14 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Uint16Array,u16>~anonymous|1 (; 185 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Uint16Array,u16>~anonymous|1 (; 185 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Uint16Array,u16> (; 186 ;) (type $_)
+ (func $std/typedarray/testArraySome<Uint16Array,u16> (; 186 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9756,12 +9756,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Int32Array,i32>~anonymous|0 (; 187 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int32Array,i32>~anonymous|0 (; 187 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Int32Array#some (; 188 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#some (; 188 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9822,7 +9822,7 @@
       local.get $7
       local.get $2
       local.get $3
-      call_indirect (type $iiii)
+      call_indirect (type $FUNCSIG$iiii)
      end
      i32.const 0
      i32.ne
@@ -9842,12 +9842,12 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Int32Array,i32>~anonymous|1 (; 189 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int32Array,i32>~anonymous|1 (; 189 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Int32Array,i32> (; 190 ;) (type $_)
+ (func $std/typedarray/testArraySome<Int32Array,i32> (; 190 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9901,12 +9901,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint32Array,u32>~anonymous|0 (; 191 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Uint32Array,u32>~anonymous|0 (; 191 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Uint32Array#some (; 192 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#some (; 192 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9967,7 +9967,7 @@
       local.get $7
       local.get $2
       local.get $3
-      call_indirect (type $iiii)
+      call_indirect (type $FUNCSIG$iiii)
      end
      i32.const 0
      i32.ne
@@ -9987,12 +9987,12 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Uint32Array,u32>~anonymous|1 (; 193 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Uint32Array,u32>~anonymous|1 (; 193 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Uint32Array,u32> (; 194 ;) (type $_)
+ (func $std/typedarray/testArraySome<Uint32Array,u32> (; 194 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10046,12 +10046,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Int64Array,i64>~anonymous|0 (; 195 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int64Array,i64>~anonymous|0 (; 195 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.eq
  )
- (func $~lib/typedarray/Int64Array#some (; 196 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#some (; 196 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10112,7 +10112,7 @@
       local.get $7
       local.get $2
       local.get $3
-      call_indirect (type $Iiii)
+      call_indirect (type $FUNCSIG$ijii)
      end
      i32.const 0
      i32.ne
@@ -10132,12 +10132,12 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Int64Array,i64>~anonymous|1 (; 197 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Int64Array,i64>~anonymous|1 (; 197 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 0
   i64.eq
  )
- (func $std/typedarray/testArraySome<Int64Array,i64> (; 198 ;) (type $_)
+ (func $std/typedarray/testArraySome<Int64Array,i64> (; 198 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10191,12 +10191,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint64Array,u64>~anonymous|0 (; 199 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Uint64Array,u64>~anonymous|0 (; 199 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.eq
  )
- (func $~lib/typedarray/Uint64Array#some (; 200 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#some (; 200 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10257,7 +10257,7 @@
       local.get $7
       local.get $2
       local.get $3
-      call_indirect (type $Iiii)
+      call_indirect (type $FUNCSIG$ijii)
      end
      i32.const 0
      i32.ne
@@ -10277,12 +10277,12 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Uint64Array,u64>~anonymous|1 (; 201 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Uint64Array,u64>~anonymous|1 (; 201 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 0
   i64.eq
  )
- (func $std/typedarray/testArraySome<Uint64Array,u64> (; 202 ;) (type $_)
+ (func $std/typedarray/testArraySome<Uint64Array,u64> (; 202 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10336,12 +10336,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Float32Array,f32>~anonymous|0 (; 203 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Float32Array,f32>~anonymous|0 (; 203 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 2
   f32.eq
  )
- (func $~lib/typedarray/Float32Array#some (; 204 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#some (; 204 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10402,7 +10402,7 @@
       local.get $7
       local.get $2
       local.get $3
-      call_indirect (type $fiii)
+      call_indirect (type $FUNCSIG$ifii)
      end
      i32.const 0
      i32.ne
@@ -10422,12 +10422,12 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Float32Array,f32>~anonymous|1 (; 205 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Float32Array,f32>~anonymous|1 (; 205 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 0
   f32.eq
  )
- (func $std/typedarray/testArraySome<Float32Array,f32> (; 206 ;) (type $_)
+ (func $std/typedarray/testArraySome<Float32Array,f32> (; 206 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10481,12 +10481,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Float64Array,f64>~anonymous|0 (; 207 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Float64Array,f64>~anonymous|0 (; 207 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 2
   f64.eq
  )
- (func $~lib/typedarray/Float64Array#some (; 208 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#some (; 208 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10547,7 +10547,7 @@
       local.get $7
       local.get $2
       local.get $3
-      call_indirect (type $Fiii)
+      call_indirect (type $FUNCSIG$idii)
      end
      i32.const 0
      i32.ne
@@ -10567,12 +10567,12 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Float64Array,f64>~anonymous|1 (; 209 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<Float64Array,f64>~anonymous|1 (; 209 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 0
   f64.eq
  )
- (func $std/typedarray/testArraySome<Float64Array,f64> (; 210 ;) (type $_)
+ (func $std/typedarray/testArraySome<Float64Array,f64> (; 210 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10626,7 +10626,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|0 (; 211 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|0 (; 211 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -10635,7 +10635,7 @@
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Int8Array#findIndex (; 212 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#findIndex (; 212 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10696,7 +10696,7 @@
       local.get $7
       local.get $2
       local.get $3
-      call_indirect (type $iiii)
+      call_indirect (type $FUNCSIG$iiii)
      end
      i32.const 0
      i32.ne
@@ -10716,7 +10716,7 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|1 (; 213 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|1 (; 213 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -10725,7 +10725,7 @@
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int8Array,i8> (; 214 ;) (type $_)
+ (func $std/typedarray/testArrayFindIndex<Int8Array,i8> (; 214 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10778,14 +10778,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint8Array,u8>~anonymous|0 (; 215 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Uint8Array,u8>~anonymous|0 (; 215 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Uint8Array#findIndex (; 216 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#findIndex (; 216 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10846,7 +10846,7 @@
       local.get $7
       local.get $2
       local.get $3
-      call_indirect (type $iiii)
+      call_indirect (type $FUNCSIG$iiii)
      end
      i32.const 0
      i32.ne
@@ -10866,14 +10866,14 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint8Array,u8>~anonymous|1 (; 217 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Uint8Array,u8>~anonymous|1 (; 217 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Uint8Array,u8> (; 218 ;) (type $_)
+ (func $std/typedarray/testArrayFindIndex<Uint8Array,u8> (; 218 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10926,14 +10926,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8>~anonymous|0 (; 219 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8>~anonymous|0 (; 219 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Uint8ClampedArray#findIndex (; 220 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#findIndex (; 220 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10994,7 +10994,7 @@
       local.get $7
       local.get $2
       local.get $3
-      call_indirect (type $iiii)
+      call_indirect (type $FUNCSIG$iiii)
      end
      i32.const 0
      i32.ne
@@ -11014,14 +11014,14 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8>~anonymous|1 (; 221 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8>~anonymous|1 (; 221 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8> (; 222 ;) (type $_)
+ (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8> (; 222 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11074,7 +11074,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|0 (; 223 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|0 (; 223 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -11083,7 +11083,7 @@
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Int16Array#findIndex (; 224 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#findIndex (; 224 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11144,7 +11144,7 @@
       local.get $7
       local.get $2
       local.get $3
-      call_indirect (type $iiii)
+      call_indirect (type $FUNCSIG$iiii)
      end
      i32.const 0
      i32.ne
@@ -11164,7 +11164,7 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|1 (; 225 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|1 (; 225 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -11173,7 +11173,7 @@
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int16Array,i16> (; 226 ;) (type $_)
+ (func $std/typedarray/testArrayFindIndex<Int16Array,i16> (; 226 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11226,14 +11226,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint16Array,u16>~anonymous|0 (; 227 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Uint16Array,u16>~anonymous|0 (; 227 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Uint16Array#findIndex (; 228 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#findIndex (; 228 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11294,7 +11294,7 @@
       local.get $7
       local.get $2
       local.get $3
-      call_indirect (type $iiii)
+      call_indirect (type $FUNCSIG$iiii)
      end
      i32.const 0
      i32.ne
@@ -11314,14 +11314,14 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint16Array,u16>~anonymous|1 (; 229 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Uint16Array,u16>~anonymous|1 (; 229 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Uint16Array,u16> (; 230 ;) (type $_)
+ (func $std/typedarray/testArrayFindIndex<Uint16Array,u16> (; 230 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11374,12 +11374,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|0 (; 231 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|0 (; 231 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Int32Array#findIndex (; 232 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#findIndex (; 232 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11440,7 +11440,7 @@
       local.get $7
       local.get $2
       local.get $3
-      call_indirect (type $iiii)
+      call_indirect (type $FUNCSIG$iiii)
      end
      i32.const 0
      i32.ne
@@ -11460,12 +11460,12 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|1 (; 233 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|1 (; 233 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int32Array,i32> (; 234 ;) (type $_)
+ (func $std/typedarray/testArrayFindIndex<Int32Array,i32> (; 234 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11518,12 +11518,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint32Array,u32>~anonymous|0 (; 235 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Uint32Array,u32>~anonymous|0 (; 235 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.eq
  )
- (func $~lib/typedarray/Uint32Array#findIndex (; 236 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#findIndex (; 236 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11584,7 +11584,7 @@
       local.get $7
       local.get $2
       local.get $3
-      call_indirect (type $iiii)
+      call_indirect (type $FUNCSIG$iiii)
      end
      i32.const 0
      i32.ne
@@ -11604,12 +11604,12 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint32Array,u32>~anonymous|1 (; 237 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Uint32Array,u32>~anonymous|1 (; 237 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Uint32Array,u32> (; 238 ;) (type $_)
+ (func $std/typedarray/testArrayFindIndex<Uint32Array,u32> (; 238 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11662,12 +11662,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|0 (; 239 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|0 (; 239 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.eq
  )
- (func $~lib/typedarray/Int64Array#findIndex (; 240 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#findIndex (; 240 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11728,7 +11728,7 @@
       local.get $7
       local.get $2
       local.get $3
-      call_indirect (type $Iiii)
+      call_indirect (type $FUNCSIG$ijii)
      end
      i32.const 0
      i32.ne
@@ -11748,12 +11748,12 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|1 (; 241 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|1 (; 241 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 4
   i64.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int64Array,i64> (; 242 ;) (type $_)
+ (func $std/typedarray/testArrayFindIndex<Int64Array,i64> (; 242 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11806,12 +11806,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint64Array,u64>~anonymous|0 (; 243 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Uint64Array,u64>~anonymous|0 (; 243 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.eq
  )
- (func $~lib/typedarray/Uint64Array#findIndex (; 244 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#findIndex (; 244 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11872,7 +11872,7 @@
       local.get $7
       local.get $2
       local.get $3
-      call_indirect (type $Iiii)
+      call_indirect (type $FUNCSIG$ijii)
      end
      i32.const 0
      i32.ne
@@ -11892,12 +11892,12 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint64Array,u64>~anonymous|1 (; 245 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Uint64Array,u64>~anonymous|1 (; 245 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 4
   i64.eq
  )
- (func $std/typedarray/testArrayFindIndex<Uint64Array,u64> (; 246 ;) (type $_)
+ (func $std/typedarray/testArrayFindIndex<Uint64Array,u64> (; 246 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11950,12 +11950,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|0 (; 247 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|0 (; 247 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 2
   f32.eq
  )
- (func $~lib/typedarray/Float32Array#findIndex (; 248 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#findIndex (; 248 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12016,7 +12016,7 @@
       local.get $7
       local.get $2
       local.get $3
-      call_indirect (type $fiii)
+      call_indirect (type $FUNCSIG$ifii)
      end
      i32.const 0
      i32.ne
@@ -12036,12 +12036,12 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|1 (; 249 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|1 (; 249 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 4
   f32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Float32Array,f32> (; 250 ;) (type $_)
+ (func $std/typedarray/testArrayFindIndex<Float32Array,f32> (; 250 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12094,12 +12094,12 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|0 (; 251 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|0 (; 251 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 2
   f64.eq
  )
- (func $~lib/typedarray/Float64Array#findIndex (; 252 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#findIndex (; 252 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12160,7 +12160,7 @@
       local.get $7
       local.get $2
       local.get $3
-      call_indirect (type $Fiii)
+      call_indirect (type $FUNCSIG$idii)
      end
      i32.const 0
      i32.ne
@@ -12180,12 +12180,12 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|1 (; 253 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|1 (; 253 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 4
   f64.eq
  )
- (func $std/typedarray/testArrayFindIndex<Float64Array,f64> (; 254 ;) (type $_)
+ (func $std/typedarray/testArrayFindIndex<Float64Array,f64> (; 254 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12238,7 +12238,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|0 (; 255 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|0 (; 255 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -12249,7 +12249,7 @@
   i32.const 0
   i32.eq
  )
- (func $~lib/typedarray/Int8Array#every (; 256 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#every (; 256 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12312,7 +12312,7 @@
         local.get $7
         local.get $2
         local.get $3
-        call_indirect (type $iiii)
+        call_indirect (type $FUNCSIG$iiii)
        end
        i32.const 0
        i32.ne
@@ -12337,7 +12337,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|1 (; 257 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|1 (; 257 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -12346,7 +12346,7 @@
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Int8Array,i8> (; 258 ;) (type $_)
+ (func $std/typedarray/testArrayEvery<Int8Array,i8> (; 258 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12400,7 +12400,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|0 (; 259 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|0 (; 259 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -12409,7 +12409,7 @@
   i32.const 0
   i32.eq
  )
- (func $~lib/typedarray/Uint8Array#every (; 260 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#every (; 260 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12472,7 +12472,7 @@
         local.get $7
         local.get $2
         local.get $3
-        call_indirect (type $iiii)
+        call_indirect (type $FUNCSIG$iiii)
        end
        i32.const 0
        i32.ne
@@ -12497,14 +12497,14 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|1 (; 261 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|1 (; 261 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Uint8Array,u8> (; 262 ;) (type $_)
+ (func $std/typedarray/testArrayEvery<Uint8Array,u8> (; 262 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12558,7 +12558,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8>~anonymous|0 (; 263 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8>~anonymous|0 (; 263 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -12567,7 +12567,7 @@
   i32.const 0
   i32.eq
  )
- (func $~lib/typedarray/Uint8ClampedArray#every (; 264 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#every (; 264 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12630,7 +12630,7 @@
         local.get $7
         local.get $2
         local.get $3
-        call_indirect (type $iiii)
+        call_indirect (type $FUNCSIG$iiii)
        end
        i32.const 0
        i32.ne
@@ -12655,14 +12655,14 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8>~anonymous|1 (; 265 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8>~anonymous|1 (; 265 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8> (; 266 ;) (type $_)
+ (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8> (; 266 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12716,7 +12716,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|0 (; 267 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|0 (; 267 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -12727,7 +12727,7 @@
   i32.const 0
   i32.eq
  )
- (func $~lib/typedarray/Int16Array#every (; 268 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#every (; 268 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12790,7 +12790,7 @@
         local.get $7
         local.get $2
         local.get $3
-        call_indirect (type $iiii)
+        call_indirect (type $FUNCSIG$iiii)
        end
        i32.const 0
        i32.ne
@@ -12815,7 +12815,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|1 (; 269 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|1 (; 269 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -12824,7 +12824,7 @@
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Int16Array,i16> (; 270 ;) (type $_)
+ (func $std/typedarray/testArrayEvery<Int16Array,i16> (; 270 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12878,7 +12878,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint16Array,u16>~anonymous|0 (; 271 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Uint16Array,u16>~anonymous|0 (; 271 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
@@ -12887,7 +12887,7 @@
   i32.const 0
   i32.eq
  )
- (func $~lib/typedarray/Uint16Array#every (; 272 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#every (; 272 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12950,7 +12950,7 @@
         local.get $7
         local.get $2
         local.get $3
-        call_indirect (type $iiii)
+        call_indirect (type $FUNCSIG$iiii)
        end
        i32.const 0
        i32.ne
@@ -12975,14 +12975,14 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Uint16Array,u16>~anonymous|1 (; 273 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Uint16Array,u16>~anonymous|1 (; 273 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Uint16Array,u16> (; 274 ;) (type $_)
+ (func $std/typedarray/testArrayEvery<Uint16Array,u16> (; 274 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13036,14 +13036,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|0 (; 275 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|0 (; 275 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.rem_s
   i32.const 0
   i32.eq
  )
- (func $~lib/typedarray/Int32Array#every (; 276 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#every (; 276 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13106,7 +13106,7 @@
         local.get $7
         local.get $2
         local.get $3
-        call_indirect (type $iiii)
+        call_indirect (type $FUNCSIG$iiii)
        end
        i32.const 0
        i32.ne
@@ -13131,12 +13131,12 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|1 (; 277 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|1 (; 277 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Int32Array,i32> (; 278 ;) (type $_)
+ (func $std/typedarray/testArrayEvery<Int32Array,i32> (; 278 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13190,14 +13190,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint32Array,u32>~anonymous|0 (; 279 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Uint32Array,u32>~anonymous|0 (; 279 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.rem_u
   i32.const 0
   i32.eq
  )
- (func $~lib/typedarray/Uint32Array#every (; 280 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#every (; 280 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13260,7 +13260,7 @@
         local.get $7
         local.get $2
         local.get $3
-        call_indirect (type $iiii)
+        call_indirect (type $FUNCSIG$iiii)
        end
        i32.const 0
        i32.ne
@@ -13285,12 +13285,12 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Uint32Array,u32>~anonymous|1 (; 281 ;) (type $iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Uint32Array,u32>~anonymous|1 (; 281 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Uint32Array,u32> (; 282 ;) (type $_)
+ (func $std/typedarray/testArrayEvery<Uint32Array,u32> (; 282 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13344,14 +13344,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|0 (; 283 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|0 (; 283 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.rem_s
   i64.const 0
   i64.eq
  )
- (func $~lib/typedarray/Int64Array#every (; 284 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#every (; 284 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13414,7 +13414,7 @@
         local.get $7
         local.get $2
         local.get $3
-        call_indirect (type $Iiii)
+        call_indirect (type $FUNCSIG$ijii)
        end
        i32.const 0
        i32.ne
@@ -13439,12 +13439,12 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|1 (; 285 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|1 (; 285 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.eq
  )
- (func $std/typedarray/testArrayEvery<Int64Array,i64> (; 286 ;) (type $_)
+ (func $std/typedarray/testArrayEvery<Int64Array,i64> (; 286 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13498,14 +13498,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|0 (; 287 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|0 (; 287 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.rem_u
   i64.const 0
   i64.eq
  )
- (func $~lib/typedarray/Uint64Array#every (; 288 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#every (; 288 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13568,7 +13568,7 @@
         local.get $7
         local.get $2
         local.get $3
-        call_indirect (type $Iiii)
+        call_indirect (type $FUNCSIG$ijii)
        end
        i32.const 0
        i32.ne
@@ -13593,12 +13593,12 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|1 (; 289 ;) (type $Iiii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|1 (; 289 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.eq
  )
- (func $std/typedarray/testArrayEvery<Uint64Array,u64> (; 290 ;) (type $_)
+ (func $std/typedarray/testArrayEvery<Uint64Array,u64> (; 290 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13652,7 +13652,7 @@
    unreachable
   end
  )
- (func $~lib/math/NativeMathf.mod (; 291 ;) (type $fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (; 291 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13908,14 +13908,14 @@
   local.get $2
   f32.reinterpret_i32
  )
- (func $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|0 (; 292 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|0 (; 292 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 2
   call $~lib/math/NativeMathf.mod
   f32.const 0
   f32.eq
  )
- (func $~lib/typedarray/Float32Array#every (; 293 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#every (; 293 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13978,7 +13978,7 @@
         local.get $7
         local.get $2
         local.get $3
-        call_indirect (type $fiii)
+        call_indirect (type $FUNCSIG$ifii)
        end
        i32.const 0
        i32.ne
@@ -14003,12 +14003,12 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|1 (; 294 ;) (type $fiii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|1 (; 294 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 2
   f32.eq
  )
- (func $std/typedarray/testArrayEvery<Float32Array,f32> (; 295 ;) (type $_)
+ (func $std/typedarray/testArrayEvery<Float32Array,f32> (; 295 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14062,7 +14062,7 @@
    unreachable
   end
  )
- (func $~lib/math/NativeMath.mod (; 296 ;) (type $FFF) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (; 296 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -14320,14 +14320,14 @@
   local.get $2
   f64.reinterpret_i64
  )
- (func $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|0 (; 297 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|0 (; 297 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 2
   call $~lib/math/NativeMath.mod
   f64.const 0
   f64.eq
  )
- (func $~lib/typedarray/Float64Array#every (; 298 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#every (; 298 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14390,7 +14390,7 @@
         local.get $7
         local.get $2
         local.get $3
-        call_indirect (type $Fiii)
+        call_indirect (type $FUNCSIG$idii)
        end
        i32.const 0
        i32.ne
@@ -14415,12 +14415,12 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|1 (; 299 ;) (type $Fiii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|1 (; 299 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 2
   f64.eq
  )
- (func $std/typedarray/testArrayEvery<Float64Array,f64> (; 300 ;) (type $_)
+ (func $std/typedarray/testArrayEvery<Float64Array,f64> (; 300 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14474,7 +14474,7 @@
    unreachable
   end
  )
- (func $start:std/typedarray (; 301 ;) (type $_)
+ (func $start:std/typedarray (; 301 ;) (type $FUNCSIG$v)
   (local $0 i32)
   global.get $~lib/typedarray/Int8Array.BYTES_PER_ELEMENT
   i32.const 1
@@ -15711,9 +15711,9 @@
   call $std/typedarray/testArrayEvery<Float32Array,f32>
   call $std/typedarray/testArrayEvery<Float64Array,f64>
  )
- (func $start (; 302 ;) (type $_)
+ (func $start (; 302 ;) (type $FUNCSIG$v)
   call $start:std/typedarray
  )
- (func $null (; 303 ;) (type $_)
+ (func $null (; 303 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/switch.optimized.wat
+++ b/tests/compiler/switch.optimized.wat
@@ -1,7 +1,7 @@
 (module
- (type $ii (func (param i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\t\00\00\00s\00w\00i\00t\00c\00h\00.\00t\00s")
@@ -10,7 +10,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $switch/doSwitch (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $switch/doSwitch (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   block $case4|0
    block $case2|0
@@ -40,7 +40,7 @@
   end
   i32.const 23
  )
- (func $switch/doSwitchDefaultOmitted (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $switch/doSwitchDefaultOmitted (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   block $break|0
    block $case2|0
@@ -67,7 +67,7 @@
   end
   i32.const 0
  )
- (func $start:switch (; 3 ;) (type $_)
+ (func $start:switch (; 3 ;) (type $FUNCSIG$v)
   i32.const 0
   call $switch/doSwitch
   if
@@ -237,10 +237,10 @@
    unreachable
   end
  )
- (func $start (; 4 ;) (type $_)
+ (func $start (; 4 ;) (type $FUNCSIG$v)
   call $start:switch
  )
- (func $null (; 5 ;) (type $_)
+ (func $null (; 5 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/switch.untouched.wat
+++ b/tests/compiler/switch.untouched.wat
@@ -1,7 +1,7 @@
 (module
- (type $ii (func (param i32) (result i32)))
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\t\00\00\00s\00w\00i\00t\00c\00h\00.\00t\00s\00")
@@ -11,7 +11,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $switch/doSwitch (; 1 ;) (type $ii) (param $0 i32) (result i32)
+ (func $switch/doSwitch (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   block $break|0
    block $case4|0
@@ -54,7 +54,7 @@
   unreachable
   unreachable
  )
- (func $switch/doSwitchDefaultOmitted (; 2 ;) (type $ii) (param $0 i32) (result i32)
+ (func $switch/doSwitchDefaultOmitted (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   block $break|0
    block $case2|0
@@ -85,7 +85,7 @@
   end
   i32.const 0
  )
- (func $switch/doSwitchBreakCase (; 3 ;) (type $ii) (param $0 i32) (result i32)
+ (func $switch/doSwitchBreakCase (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   block $break|0
    block $case1|0
@@ -105,7 +105,7 @@
   end
   i32.const 1
  )
- (func $switch/doSwitchBreakDefault (; 4 ;) (type $ii) (param $0 i32) (result i32)
+ (func $switch/doSwitchBreakDefault (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   block $break|0
    block $case1|0
@@ -125,7 +125,7 @@
   end
   i32.const 2
  )
- (func $switch/doSwitchFallThroughCase (; 5 ;) (type $ii) (param $0 i32) (result i32)
+ (func $switch/doSwitchFallThroughCase (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   block $break|0
    block $case1|0
@@ -144,7 +144,7 @@
   end
   i32.const 1
  )
- (func $switch/doSwitchFallThroughDefault (; 6 ;) (type $ii) (param $0 i32) (result i32)
+ (func $switch/doSwitchFallThroughDefault (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   block $break|0
    block $case1|0
@@ -163,12 +163,12 @@
   end
   i32.const 2
  )
- (func $switch/doSwitchEmpty (; 7 ;) (type $ii) (param $0 i32) (result i32)
+ (func $switch/doSwitchEmpty (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   drop
   i32.const 2
  )
- (func $start:switch (; 8 ;) (type $_)
+ (func $start:switch (; 8 ;) (type $FUNCSIG$v)
   i32.const 0
   call $switch/doSwitch
   i32.const 0
@@ -560,9 +560,9 @@
    unreachable
   end
  )
- (func $start (; 9 ;) (type $_)
+ (func $start (; 9 ;) (type $FUNCSIG$v)
   call $start:switch
  )
- (func $null (; 10 ;) (type $_)
+ (func $null (; 10 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/ternary.optimized.wat
+++ b/tests/compiler/ternary.optimized.wat
@@ -1,5 +1,5 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -7,7 +7,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start (; 0 ;) (type $_)
+ (func $start (; 0 ;) (type $FUNCSIG$v)
   i32.const 1
   global.set $ternary/a
   i32.const 1
@@ -15,7 +15,7 @@
   i32.const 1
   global.set $ternary/a
  )
- (func $null (; 1 ;) (type $_)
+ (func $null (; 1 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/ternary.untouched.wat
+++ b/tests/compiler/ternary.untouched.wat
@@ -1,5 +1,5 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -8,7 +8,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:ternary (; 0 ;) (type $_)
+ (func $start:ternary (; 0 ;) (type $FUNCSIG$v)
   i32.const 1
   drop
   i32.const 1
@@ -22,9 +22,9 @@
   i32.const 1
   global.set $ternary/a
  )
- (func $start (; 1 ;) (type $_)
+ (func $start (; 1 ;) (type $FUNCSIG$v)
   call $start:ternary
  )
- (func $null (; 2 ;) (type $_)
+ (func $null (; 2 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/typealias.optimized.wat
+++ b/tests/compiler/typealias.optimized.wat
@@ -1,16 +1,16 @@
 (module
- (type $ii (func (param i32) (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "alias" (func $typealias/alias))
- (func $typealias/alias (; 0 ;) (type $ii) (param $0 i32) (result i32)
+ (func $typealias/alias (; 0 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $null (; 1 ;) (type $_)
+ (func $null (; 1 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/typealias.untouched.wat
+++ b/tests/compiler/typealias.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $ii (func (param i32) (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -8,9 +8,9 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (export "alias" (func $typealias/alias))
- (func $typealias/alias (; 0 ;) (type $ii) (param $0 i32) (result i32)
+ (func $typealias/alias (; 0 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $null (; 1 ;) (type $_)
+ (func $null (; 1 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/unary.optimized.wat
+++ b/tests/compiler/unary.optimized.wat
@@ -1,5 +1,5 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -10,7 +10,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:unary (; 0 ;) (type $_)
+ (func $start:unary (; 0 ;) (type $FUNCSIG$v)
   (local $0 f32)
   (local $1 f64)
   (local $2 i32)
@@ -236,10 +236,10 @@
   local.get $1
   global.set $unary/F
  )
- (func $start (; 1 ;) (type $_)
+ (func $start (; 1 ;) (type $FUNCSIG$v)
   call $start:unary
  )
- (func $null (; 2 ;) (type $_)
+ (func $null (; 2 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/unary.untouched.wat
+++ b/tests/compiler/unary.untouched.wat
@@ -1,5 +1,5 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -11,7 +11,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:unary (; 0 ;) (type $_)
+ (func $start:unary (; 0 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i64)
   (local $2 f32)
@@ -366,9 +366,9 @@
   end
   global.set $unary/F
  )
- (func $start (; 1 ;) (type $_)
+ (func $start (; 1 ;) (type $FUNCSIG$v)
   call $start:unary
  )
- (func $null (; 2 ;) (type $_)
+ (func $null (; 2 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/void.optimized.wat
+++ b/tests/compiler/void.optimized.wat
@@ -1,11 +1,11 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
  (export "memory" (memory $0))
  (export "table" (table $0))
- (func $start (; 0 ;) (type $_)
+ (func $start (; 0 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/void.untouched.wat
+++ b/tests/compiler/void.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $i (func (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -10,10 +10,10 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $void/anInt (; 0 ;) (type $i) (result i32)
+ (func $void/anInt (; 0 ;) (type $FUNCSIG$i) (result i32)
   i32.const 2
  )
- (func $start:void (; 1 ;) (type $_)
+ (func $start:void (; 1 ;) (type $FUNCSIG$v)
   i32.const 1
   drop
   call $void/anInt
@@ -23,9 +23,9 @@
   i32.add
   drop
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   call $start:void
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/while.optimized.wat
+++ b/tests/compiler/while.optimized.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\08\00\00\00w\00h\00i\00l\00e\00.\00t\00s")
@@ -12,7 +12,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:while (; 1 ;) (type $_)
+ (func $start:while (; 1 ;) (type $FUNCSIG$v)
   (local $0 i32)
   loop $continue|0
    global.get $while/n
@@ -176,10 +176,10 @@
    unreachable
   end
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   call $start:while
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/while.untouched.wat
+++ b/tests/compiler/while.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iiii_ (func (param i32 i32 i32 i32)))
- (type $_ (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/env/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\08\00\00\00w\00h\00i\00l\00e\00.\00t\00s\00")
@@ -13,7 +13,7 @@
  (export "memory" (memory $0))
  (export "table" (table $0))
  (start $start)
- (func $start:while (; 1 ;) (type $_)
+ (func $start:while (; 1 ;) (type $FUNCSIG$v)
   (local $0 i32)
   block $break|0
    loop $continue|0
@@ -212,9 +212,9 @@
    unreachable
   end
  )
- (func $start (; 2 ;) (type $_)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   call $start:while
  )
- (func $null (; 3 ;) (type $_)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/wildcard-export.optimized.wat
+++ b/tests/compiler/wildcard-export.optimized.wat
@@ -1,5 +1,5 @@
 (module
- (type $_ (func))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $start)
@@ -11,7 +11,7 @@
  (export "renamed_a" (global $export/a))
  (export "renamed_b" (global $export/b))
  (export "renamed_renamed_b" (global $export/b))
- (func $start (; 0 ;) (type $_)
+ (func $start (; 0 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/wildcard-export.untouched.wat
+++ b/tests/compiler/wildcard-export.untouched.wat
@@ -1,6 +1,6 @@
 (module
- (type $iii (func (param i32 i32) (result i32)))
- (type $_ (func))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
@@ -15,17 +15,17 @@
  (export "renamed_b" (global $export/b))
  (export "renamed_renamed_b" (global $export/b))
  (start $start)
- (func $export/add (; 0 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/add (; 0 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
  )
- (func $export/mul (; 1 ;) (type $iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $export/mul (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.mul
  )
- (func $start:reexport (; 2 ;) (type $_)
+ (func $start:reexport (; 2 ;) (type $FUNCSIG$v)
   i32.const 1
   i32.const 2
   call $export/add
@@ -35,15 +35,15 @@
   i32.add
   drop
  )
- (func $start:rereexport (; 3 ;) (type $_)
+ (func $start:rereexport (; 3 ;) (type $FUNCSIG$v)
   call $start:reexport
  )
- (func $start:wildcard-export (; 4 ;) (type $_)
+ (func $start:wildcard-export (; 4 ;) (type $FUNCSIG$v)
   call $start:rereexport
  )
- (func $start (; 5 ;) (type $_)
+ (func $start (; 5 ;) (type $FUNCSIG$v)
   call $start:wildcard-export
  )
- (func $null (; 6 ;) (type $_)
+ (func $null (; 6 ;) (type $FUNCSIG$v)
  )
 )


### PR DESCRIPTION
Recently, dead return value elimination landed in Binaryen which results in generated names for amended function types that differ from our naming scheme. So this PR makes the compiler adopt Binaryen's naming scheme, mostly for the looks.