### PR TITLE
Use fully qualified names in generic types

### DIFF
--- a/bin/asc
+++ b/bin/asc
@@ -1,4 +1,22 @@
 #!/usr/bin/env node
+
+/* tslint:disable */
+
+const tailArgs = process.argv.indexOf("--");
+if (~tailArgs) {
+  require("child_process").spawnSync(
+    process.argv[0],
+    process.argv.slice(tailArgs + 1).concat(
+      process.argv.slice(1, tailArgs)
+    ),
+    { stdio: "inherit" }
+  );
+  return;
+}
+
 require("source-map-support").install();
+
 const asc = module.exports = require("../cli/asc.js");
-if (/\basc$/.test(process.argv[1])) process.exitCode = asc.main(process.argv.slice(2));
+if (/\basc$/.test(process.argv[1])) {
+  process.exitCode = asc.main(process.argv.slice(2));
+}

--- a/bin/asinit
+++ b/bin/asinit
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+
+/* tslint:disable */
+
 const fs = require("fs");
 const path = require("path");
 const colors = require("../cli/util/colors");

--- a/cli/asc.json
+++ b/cli/asc.json
@@ -182,6 +182,9 @@
     "type": "b",
     "default": false
   },
+  " ...": {
+    "description": "Specifies node.js options (CLI only). See: node --help"
+  },
   "-Os": { "value": { "optimize": true, "shrinkLevel": 1 } },
   "-Oz": { "value": { "optimize": true, "shrinkLevel": 2 } },
   "-O0": { "value": { "optimizeLevel": 0, "shrinkLevel": 0 } },

--- a/cli/util/options.js
+++ b/cli/util/options.js
@@ -18,6 +18,7 @@ function parse(argv, config) {
   // make an alias map and initialize defaults
   var aliases = {};
   Object.keys(config).forEach(key => {
+    if (key.startsWith(" ")) return;
     var option = config[key];
     if (option.alias != null) {
       if (typeof option.alias === "string") aliases[option.alias] = key;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1570,6 +1570,16 @@ export class Parser extends DiagnosticEmitter {
       do {
         let member = this.parseClassMember(tn, declaration);
         if (member) members.push(<DeclarationStatement>member);
+        else {
+          this.skipStatement(tn);
+          if (tn.skip(Token.ENDOFFILE)) {
+            this.error(
+              DiagnosticCode._0_expected,
+              tn.range(), "}"
+            );
+            return null;
+          }
+        }
       } while (!tn.skip(Token.CLOSEBRACE));
     }
     return declaration;
@@ -1611,6 +1621,16 @@ export class Parser extends DiagnosticEmitter {
       do {
         let member = this.parseClassMember(tn, declaration);
         if (member) members.push(<DeclarationStatement>member);
+        else {
+          this.skipStatement(tn);
+          if (tn.skip(Token.ENDOFFILE)) {
+            this.error(
+              DiagnosticCode._0_expected,
+              tn.range(), "}"
+            );
+            return null;
+          }
+        }
       } while (!tn.skip(Token.CLOSEBRACE));
     }
     return Node.createClassExpression(declaration);
@@ -2145,6 +2165,16 @@ export class Parser extends DiagnosticEmitter {
         while (!tn.skip(Token.CLOSEBRACE)) {
           let member = this.parseTopLevelStatement(tn, ns);
           if (member) members.push(member);
+          else {
+            this.skipStatement(tn);
+            if (tn.skip(Token.ENDOFFILE)) {
+              this.error(
+                DiagnosticCode._0_expected,
+                tn.range(), "}"
+              );
+              return null;
+            }
+          }
         }
         tn.skip(Token.SEMICOLON);
         return ns;
@@ -2175,9 +2205,9 @@ export class Parser extends DiagnosticEmitter {
     if (tn.skip(Token.OPENBRACE)) {
       let members = new Array<ExportMember>();
       while (!tn.skip(Token.CLOSEBRACE)) {
-          let member = this.parseExportMember(tn);
-          if (!member) return null;
-          members.push(member);
+        let member = this.parseExportMember(tn);
+        if (!member) return null;
+        members.push(member);
         if (!tn.skip(Token.COMMA)) {
           if (tn.skip(Token.CLOSEBRACE)) {
             break;
@@ -3710,6 +3740,10 @@ export class Parser extends DiagnosticEmitter {
         }
         case Token.FLOATLITERAL: {
           tn.readFloat();
+          break;
+        }
+        case Token.OPENBRACE: {
+          this.skipBlock(tn);
           break;
         }
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -266,20 +266,20 @@ export class Type {
     return null;
   }
 
-  /** Converts this type to its TypeScript representation. */
-  toString(kindOnly: bool = false): string {
-    if (!kindOnly && this.is(TypeFlags.REFERENCE)) {
+  /** Converts this type to a string. */
+  toString(): string {
+    if (this.is(TypeFlags.REFERENCE)) {
       let classReference = this.classReference;
       if (classReference) {
         return this.is(TypeFlags.NULLABLE)
-          ? classReference.name + " | null"
-          : classReference.name;
+          ? classReference.internalName + " | null"
+          : classReference.internalName;
       }
       let signatureReference = this.signatureReference;
       if (signatureReference) {
         return this.is(TypeFlags.NULLABLE)
-          ? "(" + signatureReference.toString(true) + ") | null"
-          : signatureReference.toString(true);
+          ? "(" + signatureReference.toString() + ") | null"
+          : signatureReference.toString();
       }
       assert(false);
     }
@@ -637,17 +637,15 @@ export class Signature {
   }
 
   /** Converts this signature to a string. */
-  toString(includeThis: bool = false): string {
+  toString(): string {
     var sb = new Array<string>();
     sb.push("(");
     var index = 0;
     var thisType = this.thisType;
     if (thisType) {
-      if (includeThis) {
-        sb.push("this: ");
-        sb.push(thisType.toString());
-        index = 1;
-      }
+      sb.push("this: ");
+      sb.push(thisType.toString());
+      index = 1;
     }
     var parameters = this.parameterTypes;
     var numParameters = parameters.length;

--- a/src/types.ts
+++ b/src/types.ts
@@ -644,6 +644,7 @@ export class Signature {
     var thisType = this.thisType;
     if (thisType) {
       sb.push("this: ");
+      assert(!thisType.signatureReference);
       sb.push(thisType.toString());
       index = 1;
     }

--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -223,8 +223,12 @@ tests.forEach(filename => {
       stderr: stderr
     }, err => {
       console.log();
-      if (err)
+      if (err) {
         stderr.write(err.stack + os.EOL);
+        failedMessages.set(basename, err.message);
+        failedTests.push(basename);
+        return 1;
+      }
 
       // Instantiate
       try {
@@ -308,6 +312,7 @@ tests.forEach(filename => {
       if (failed) failedTests.push(basename);
       console.log();
     });
+    if (failed) return 1;
   });
   if (v8_no_flags) v8.setFlagsFromString(v8_no_flags);
 });

--- a/tests/compiler/nonNullAssertion.untouched.wat
+++ b/tests/compiler/nonNullAssertion.untouched.wat
@@ -51,7 +51,7 @@
   local.get $0
   i32.load
  )
- (func $~lib/array/Array<Foo>#__get (; 5 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<nonNullAssertion/Foo>#__get (; 5 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -87,9 +87,9 @@
  (func $nonNullAssertion/testArr (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
-  call $~lib/array/Array<Foo>#__get
+  call $~lib/array/Array<nonNullAssertion/Foo>#__get
  )
- (func $~lib/array/Array<Foo | null>#__get (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<nonNullAssertion/Foo | null>#__get (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -125,18 +125,18 @@
  (func $nonNullAssertion/testElem (; 8 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
-  call $~lib/array/Array<Foo | null>#__get
+  call $~lib/array/Array<nonNullAssertion/Foo | null>#__get
  )
  (func $nonNullAssertion/testAll (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
-  call $~lib/array/Array<Foo | null>#__get
+  call $~lib/array/Array<nonNullAssertion/Foo | null>#__get
   i32.load
  )
  (func $nonNullAssertion/testAll2 (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
-  call $~lib/array/Array<Foo | null>#__get
+  call $~lib/array/Array<nonNullAssertion/Foo | null>#__get
   i32.load
  )
  (func $nonNullAssertion/testFn (; 11 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)

--- a/tests/compiler/std/array-access.untouched.wat
+++ b/tests/compiler/std/array-access.untouched.wat
@@ -20,7 +20,7 @@
  (export "stringArrayMethodCall" (func $std/array-access/stringArrayMethodCall))
  (export "stringArrayArrayPropertyAccess" (func $std/array-access/stringArrayArrayPropertyAccess))
  (export "stringArrayArrayMethodCall" (func $std/array-access/stringArrayArrayMethodCall))
- (func $~lib/array/Array<Array<i32>>#__get (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__get (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -89,11 +89,11 @@
  (func $std/array-access/i32ArrayArrayElementAccess (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
-  call $~lib/array/Array<Array<i32>>#__get
+  call $~lib/array/Array<~lib/array/Array<i32>>#__get
   i32.const 1
   call $~lib/array/Array<i32>#__get
  )
- (func $~lib/array/Array<String>#__get (; 4 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#__get (; 4 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -129,7 +129,7 @@
  (func $std/array-access/stringArrayPropertyAccess (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
-  call $~lib/array/Array<String>#__get
+  call $~lib/array/Array<~lib/string/String>#__get
   i32.load
  )
  (func $~lib/internal/string/compareUnsafe (; 6 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
@@ -255,12 +255,12 @@
  (func $std/array-access/stringArrayMethodCall (; 8 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
-  call $~lib/array/Array<String>#__get
+  call $~lib/array/Array<~lib/string/String>#__get
   i32.const 8
   i32.const 0
   call $~lib/string/String#startsWith
  )
- (func $~lib/array/Array<Array<String>>#__get (; 9 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/string/String>>#__get (; 9 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -296,17 +296,17 @@
  (func $std/array-access/stringArrayArrayPropertyAccess (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
-  call $~lib/array/Array<Array<String>>#__get
+  call $~lib/array/Array<~lib/array/Array<~lib/string/String>>#__get
   i32.const 1
-  call $~lib/array/Array<String>#__get
+  call $~lib/array/Array<~lib/string/String>#__get
   i32.load
  )
  (func $std/array-access/stringArrayArrayMethodCall (; 11 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
-  call $~lib/array/Array<Array<String>>#__get
+  call $~lib/array/Array<~lib/array/Array<~lib/string/String>>#__get
   i32.const 1
-  call $~lib/array/Array<String>#__get
+  call $~lib/array/Array<~lib/string/String>#__get
   i32.const 8
   i32.const 0
   call $~lib/string/String#startsWith

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -668,7 +668,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<Ref>#constructor (; 14 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array-literal/Ref>#constructor (; 14 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -729,7 +729,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<Ref>#__unchecked_set (; 15 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<std/array-literal/Ref>#__unchecked_set (; 15 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -763,7 +763,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<RefWithCtor>#constructor (; 17 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array-literal/RefWithCtor>#constructor (; 17 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -824,7 +824,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<RefWithCtor>#__unchecked_set (; 18 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<std/array-literal/RefWithCtor>#__unchecked_set (; 18 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1201,27 +1201,27 @@
   block (result i32)
    i32.const 0
    i32.const 3
-   call $~lib/array/Array<Ref>#constructor
+   call $~lib/array/Array<std/array-literal/Ref>#constructor
    local.set $3
    local.get $3
    i32.const 0
    i32.const 0
    call $std/array-literal/Ref#constructor
-   call $~lib/array/Array<Ref>#__unchecked_set
+   call $~lib/array/Array<std/array-literal/Ref>#__unchecked_set
    local.get $3
    i32.const 1
    i32.const 0
    call $std/array-literal/Ref#constructor
-   call $~lib/array/Array<Ref>#__unchecked_set
+   call $~lib/array/Array<std/array-literal/Ref>#__unchecked_set
    local.get $3
    i32.const 2
    i32.const 0
    call $std/array-literal/Ref#constructor
-   call $~lib/array/Array<Ref>#__unchecked_set
+   call $~lib/array/Array<std/array-literal/Ref>#__unchecked_set
    local.get $3
   end
   global.set $std/array-literal/dynamicArrayRef
-  block $~lib/array/Array<Ref>#get:length|inlined.0 (result i32)
+  block $~lib/array/Array<std/array-literal/Ref>#get:length|inlined.0 (result i32)
    global.get $std/array-literal/dynamicArrayRef
    local.set $3
    local.get $3
@@ -1241,27 +1241,27 @@
   block (result i32)
    i32.const 0
    i32.const 3
-   call $~lib/array/Array<RefWithCtor>#constructor
+   call $~lib/array/Array<std/array-literal/RefWithCtor>#constructor
    local.set $4
    local.get $4
    i32.const 0
    i32.const 0
    call $std/array-literal/RefWithCtor#constructor
-   call $~lib/array/Array<RefWithCtor>#__unchecked_set
+   call $~lib/array/Array<std/array-literal/RefWithCtor>#__unchecked_set
    local.get $4
    i32.const 1
    i32.const 0
    call $std/array-literal/RefWithCtor#constructor
-   call $~lib/array/Array<RefWithCtor>#__unchecked_set
+   call $~lib/array/Array<std/array-literal/RefWithCtor>#__unchecked_set
    local.get $4
    i32.const 2
    i32.const 0
    call $std/array-literal/RefWithCtor#constructor
-   call $~lib/array/Array<RefWithCtor>#__unchecked_set
+   call $~lib/array/Array<std/array-literal/RefWithCtor>#__unchecked_set
    local.get $4
   end
   global.set $std/array-literal/dynamicArrayRefWithCtor
-  block $~lib/array/Array<RefWithCtor>#get:length|inlined.0 (result i32)
+  block $~lib/array/Array<std/array-literal/RefWithCtor>#get:length|inlined.0 (result i32)
    global.get $std/array-literal/dynamicArrayRefWithCtor
    local.set $4
    local.get $4

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -332,7 +332,7 @@
  (data (i32.const 7888) "\04\00\00\00\00\00\00\00\c8\1e")
  (data (i32.const 7904) "\d0\1e\00\00\01")
  (table $0 56 funcref)
- (elem (i32.const 0) $null $start:std/array~anonymous|0 $start:std/array~anonymous|1 $start:std/array~anonymous|2 $start:std/array~anonymous|3 $start:std/array~anonymous|2 $start:std/array~anonymous|5 $start:std/array~anonymous|6 $start:std/array~anonymous|7 $start:std/array~anonymous|8 $start:std/array~anonymous|9 $start:std/array~anonymous|10 $start:std/array~anonymous|11 $start:std/array~anonymous|12 $start:std/array~anonymous|13 $start:std/array~anonymous|14 $start:std/array~anonymous|15 $start:std/array~anonymous|16 $start:std/array~anonymous|17 $start:std/array~anonymous|16 $start:std/array~anonymous|19 $start:std/array~anonymous|20 $start:std/array~anonymous|21 $start:std/array~anonymous|22 $start:std/array~anonymous|23 $start:std/array~anonymous|24 $start:std/array~anonymous|25 $start:std/array~anonymous|26 $start:std/array~anonymous|27 $start:std/array~anonymous|28 $start:std/array~anonymous|29 $start:std/array~anonymous|29 $start:std/array~anonymous|31 $start:std/array~anonymous|32 $start:std/array~anonymous|33 $start:std/array~anonymous|29 $start:std/array~anonymous|35 $start:std/array~anonymous|29 $start:std/array~anonymous|29 $start:std/array~anonymous|31 $start:std/array~anonymous|32 $start:std/array~anonymous|33 $start:std/array~anonymous|29 $start:std/array~anonymous|35 $~lib/internal/sort/COMPARATOR<f32>~anonymous|0 $~lib/internal/sort/COMPARATOR<f64>~anonymous|0 $~lib/internal/sort/COMPARATOR<i32>~anonymous|0 $~lib/internal/sort/COMPARATOR<u32>~anonymous|0 $~lib/internal/sort/COMPARATOR<i32>~anonymous|0 $~lib/internal/sort/COMPARATOR<i32>~anonymous|0 $start:std/array~anonymous|44 $~lib/internal/sort/COMPARATOR<i32>~anonymous|0 $start:std/array~anonymous|44 $start:std/array~anonymous|47 $start:std/array~anonymous|48 $~lib/internal/sort/COMPARATOR<String>~anonymous|0)
+ (elem (i32.const 0) $null $start:std/array~anonymous|0 $start:std/array~anonymous|1 $start:std/array~anonymous|2 $start:std/array~anonymous|3 $start:std/array~anonymous|2 $start:std/array~anonymous|5 $start:std/array~anonymous|6 $start:std/array~anonymous|7 $start:std/array~anonymous|8 $start:std/array~anonymous|9 $start:std/array~anonymous|10 $start:std/array~anonymous|11 $start:std/array~anonymous|12 $start:std/array~anonymous|13 $start:std/array~anonymous|14 $start:std/array~anonymous|15 $start:std/array~anonymous|16 $start:std/array~anonymous|17 $start:std/array~anonymous|16 $start:std/array~anonymous|19 $start:std/array~anonymous|20 $start:std/array~anonymous|21 $start:std/array~anonymous|22 $start:std/array~anonymous|23 $start:std/array~anonymous|24 $start:std/array~anonymous|25 $start:std/array~anonymous|26 $start:std/array~anonymous|27 $start:std/array~anonymous|28 $start:std/array~anonymous|29 $start:std/array~anonymous|29 $start:std/array~anonymous|31 $start:std/array~anonymous|32 $start:std/array~anonymous|33 $start:std/array~anonymous|29 $start:std/array~anonymous|35 $start:std/array~anonymous|29 $start:std/array~anonymous|29 $start:std/array~anonymous|31 $start:std/array~anonymous|32 $start:std/array~anonymous|33 $start:std/array~anonymous|29 $start:std/array~anonymous|35 $~lib/internal/sort/COMPARATOR<f32>~anonymous|0 $~lib/internal/sort/COMPARATOR<f64>~anonymous|0 $~lib/internal/sort/COMPARATOR<i32>~anonymous|0 $~lib/internal/sort/COMPARATOR<u32>~anonymous|0 $~lib/internal/sort/COMPARATOR<i32>~anonymous|0 $~lib/internal/sort/COMPARATOR<i32>~anonymous|0 $start:std/array~anonymous|44 $~lib/internal/sort/COMPARATOR<i32>~anonymous|0 $start:std/array~anonymous|44 $start:std/array~anonymous|47 $start:std/array~anonymous|48 $~lib/internal/sort/COMPARATOR<~lib/string/String>~anonymous|0)
  (global $~lib/allocator/arena/startOffset (mut i32) (i32.const 0))
  (global $~lib/allocator/arena/offset (mut i32) (i32.const 0))
  (global $std/array/arr (mut i32) (i32.const 0))
@@ -5755,7 +5755,7 @@
   end
   i32.sub
  )
- (func $~lib/array/Array<Array<i32>>#sort (; 95 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#sort (; 95 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5820,10 +5820,10 @@
   call $~lib/internal/sort/insertionSort<i32>
   local.get $0
  )
- (func $std/array/assertSorted<Array<i32>> (; 96 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/array/Array<i32>> (; 96 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
-  call $~lib/array/Array<Array<i32>>#sort
+  call $~lib/array/Array<~lib/array/Array<i32>>#sort
   local.get $1
   call $std/array/isSorted<i32>
   i32.eqz
@@ -5915,7 +5915,7 @@
   end
   local.get $3
  )
- (func $~lib/internal/sort/COMPARATOR<String>~anonymous|0 (; 100 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<~lib/string/String>~anonymous|0 (; 100 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5982,7 +5982,7 @@
   select
   call $~lib/internal/string/compareUnsafe
  )
- (func $std/array/assertSorted<String>|trampoline (; 101 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $std/array/assertSorted<~lib/string/String>|trampoline (; 101 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   block $1of1
    block $0of1
@@ -5999,7 +5999,7 @@
   end
   local.get $0
   local.get $1
-  call $std/array/assertSorted<Array<i32>>
+  call $std/array/assertSorted<~lib/array/Array<i32>>
  )
  (func $~lib/string/String.__eq (; 102 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -6040,7 +6040,7 @@
   call $~lib/internal/string/compareUnsafe
   i32.eqz
  )
- (func $std/array/isArraysEqual<String> (; 103 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isArraysEqual<~lib/string/String> (; 103 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8313,7 +8313,7 @@
   end
   local.get $1
  )
- (func $~lib/array/Array<String>#join (; 127 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#join (; 127 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8449,7 +8449,7 @@
   end
   local.get $4
  )
- (func $~lib/array/Array<Ref>#join (; 128 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#join (; 128 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9477,7 +9477,7 @@
   end
   local.get $1
  )
- (func $~lib/array/Array<Array<i32>>#join (; 141 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#join (; 141 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9716,7 +9716,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<Array<u8>>#join (; 144 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u8>>#join (; 144 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9808,7 +9808,7 @@
   end
   local.get $1
  )
- (func $~lib/array/Array<Array<u32>>#join (; 145 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u32>>#join (; 145 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9903,7 +9903,7 @@
   end
   local.get $1
  )
- (func $~lib/array/Array<Array<Array<u32>>>#join (; 146 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#join (; 146 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9938,7 +9938,7 @@
    local.tee $2
    if (result i32)
     local.get $2
-    call $~lib/array/Array<Array<u32>>#join
+    call $~lib/array/Array<~lib/array/Array<u32>>#join
    else    
     i32.const 3904
    end
@@ -9961,7 +9961,7 @@
     if
      local.get $1
      local.get $2
-     call $~lib/array/Array<Array<u32>>#join
+     call $~lib/array/Array<~lib/array/Array<u32>>#join
      call $~lib/string/String.__concat
      local.set $1
     end
@@ -9989,7 +9989,7 @@
   if
    local.get $1
    local.get $2
-   call $~lib/array/Array<Array<u32>>#join
+   call $~lib/array/Array<~lib/array/Array<u32>>#join
    call $~lib/string/String.__concat
    local.set $1
   end
@@ -14081,19 +14081,19 @@
   global.set $std/array/reversedNested512
   global.get $std/array/reversedNested512
   i32.const 53
-  call $std/array/assertSorted<Array<i32>>
+  call $std/array/assertSorted<~lib/array/Array<i32>>
   call $std/array/createReverseOrderedElementsArray
   global.set $std/array/reversedElements512
   global.get $std/array/reversedElements512
   i32.const 54
-  call $std/array/assertSorted<Array<i32>>
+  call $std/array/assertSorted<~lib/array/Array<i32>>
   i32.const 1
   global.set $~lib/argc
   global.get $std/array/randomStringsActual
-  call $std/array/assertSorted<String>|trampoline
+  call $std/array/assertSorted<~lib/string/String>|trampoline
   global.get $std/array/randomStringsActual
   global.get $std/array/randomStringsExpected
-  call $std/array/isArraysEqual<String>
+  call $std/array/isArraysEqual<~lib/string/String>
   i32.eqz
   if
    i32.const 0
@@ -14108,7 +14108,7 @@
   i32.const 1
   global.set $~lib/argc
   global.get $std/array/randomStrings400
-  call $std/array/assertSorted<String>|trampoline
+  call $std/array/assertSorted<~lib/string/String>|trampoline
   call $~lib/array/Array<bool>#join
   i32.const 4248
   call $~lib/string/String.__eq
@@ -14177,7 +14177,7 @@
   end
   i32.const 6864
   i32.const 3904
-  call $~lib/array/Array<String>#join
+  call $~lib/array/Array<~lib/string/String>#join
   i32.const 6784
   call $~lib/string/String.__eq
   i32.eqz
@@ -14217,7 +14217,7 @@
   local.get $1
   global.set $std/array/refArr
   global.get $std/array/refArr
-  call $~lib/array/Array<Ref>#join
+  call $~lib/array/Array<std/array/Ref>#join
   i32.const 6912
   call $~lib/string/String.__eq
   i32.eqz
@@ -14335,7 +14335,7 @@
   end
   global.get $std/array/randomStringsExpected
   i32.const 4216
-  call $~lib/array/Array<String>#join
+  call $~lib/array/Array<~lib/string/String>#join
   i32.const 7528
   call $~lib/string/String.__eq
   i32.eqz
@@ -14349,7 +14349,7 @@
   end
   i32.const 7648
   i32.const 4216
-  call $~lib/array/Array<String>#join
+  call $~lib/array/Array<~lib/string/String>#join
   i32.const 7656
   call $~lib/string/String.__eq
   i32.eqz
@@ -14362,7 +14362,7 @@
    unreachable
   end
   global.get $std/array/subarr32
-  call $~lib/array/Array<Array<i32>>#join
+  call $~lib/array/Array<~lib/array/Array<i32>>#join
   i32.const 7744
   call $~lib/string/String.__eq
   i32.eqz
@@ -14375,7 +14375,7 @@
    unreachable
   end
   global.get $std/array/subarr8
-  call $~lib/array/Array<Array<u8>>#join
+  call $~lib/array/Array<~lib/array/Array<u8>>#join
   i32.const 7744
   call $~lib/string/String.__eq
   i32.eqz
@@ -14388,7 +14388,7 @@
    unreachable
   end
   global.get $std/array/subarrU32
-  call $~lib/array/Array<Array<Array<u32>>>#join
+  call $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#join
   i32.const 6784
   call $~lib/string/String.__eq
   i32.eqz

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -332,7 +332,7 @@
  (data (i32.const 7888) "\04\00\00\00\00\00\00\00\c8\1e\00\00\00\00\00\00")
  (data (i32.const 7904) "\d0\1e\00\00\01\00\00\00")
  (table $0 56 funcref)
- (elem (i32.const 0) $null $start:std/array~anonymous|0 $start:std/array~anonymous|1 $start:std/array~anonymous|2 $start:std/array~anonymous|3 $start:std/array~anonymous|4 $start:std/array~anonymous|5 $start:std/array~anonymous|6 $start:std/array~anonymous|7 $start:std/array~anonymous|8 $start:std/array~anonymous|9 $start:std/array~anonymous|10 $start:std/array~anonymous|11 $start:std/array~anonymous|12 $start:std/array~anonymous|13 $start:std/array~anonymous|14 $start:std/array~anonymous|15 $start:std/array~anonymous|16 $start:std/array~anonymous|17 $start:std/array~anonymous|18 $start:std/array~anonymous|19 $start:std/array~anonymous|20 $start:std/array~anonymous|21 $start:std/array~anonymous|22 $start:std/array~anonymous|23 $start:std/array~anonymous|24 $start:std/array~anonymous|25 $start:std/array~anonymous|26 $start:std/array~anonymous|27 $start:std/array~anonymous|28 $start:std/array~anonymous|29 $start:std/array~anonymous|30 $start:std/array~anonymous|31 $start:std/array~anonymous|32 $start:std/array~anonymous|33 $start:std/array~anonymous|34 $start:std/array~anonymous|35 $start:std/array~anonymous|36 $start:std/array~anonymous|37 $start:std/array~anonymous|38 $start:std/array~anonymous|39 $start:std/array~anonymous|40 $start:std/array~anonymous|41 $start:std/array~anonymous|42 $~lib/internal/sort/COMPARATOR<f32>~anonymous|0 $~lib/internal/sort/COMPARATOR<f64>~anonymous|0 $~lib/internal/sort/COMPARATOR<i32>~anonymous|0 $~lib/internal/sort/COMPARATOR<u32>~anonymous|0 $~lib/internal/sort/COMPARATOR<i32>~anonymous|1 $start:std/array~anonymous|43 $start:std/array~anonymous|44 $start:std/array~anonymous|45 $start:std/array~anonymous|46 $start:std/array~anonymous|47 $start:std/array~anonymous|48 $~lib/internal/sort/COMPARATOR<String>~anonymous|0)
+ (elem (i32.const 0) $null $start:std/array~anonymous|0 $start:std/array~anonymous|1 $start:std/array~anonymous|2 $start:std/array~anonymous|3 $start:std/array~anonymous|4 $start:std/array~anonymous|5 $start:std/array~anonymous|6 $start:std/array~anonymous|7 $start:std/array~anonymous|8 $start:std/array~anonymous|9 $start:std/array~anonymous|10 $start:std/array~anonymous|11 $start:std/array~anonymous|12 $start:std/array~anonymous|13 $start:std/array~anonymous|14 $start:std/array~anonymous|15 $start:std/array~anonymous|16 $start:std/array~anonymous|17 $start:std/array~anonymous|18 $start:std/array~anonymous|19 $start:std/array~anonymous|20 $start:std/array~anonymous|21 $start:std/array~anonymous|22 $start:std/array~anonymous|23 $start:std/array~anonymous|24 $start:std/array~anonymous|25 $start:std/array~anonymous|26 $start:std/array~anonymous|27 $start:std/array~anonymous|28 $start:std/array~anonymous|29 $start:std/array~anonymous|30 $start:std/array~anonymous|31 $start:std/array~anonymous|32 $start:std/array~anonymous|33 $start:std/array~anonymous|34 $start:std/array~anonymous|35 $start:std/array~anonymous|36 $start:std/array~anonymous|37 $start:std/array~anonymous|38 $start:std/array~anonymous|39 $start:std/array~anonymous|40 $start:std/array~anonymous|41 $start:std/array~anonymous|42 $~lib/internal/sort/COMPARATOR<f32>~anonymous|0 $~lib/internal/sort/COMPARATOR<f64>~anonymous|0 $~lib/internal/sort/COMPARATOR<i32>~anonymous|0 $~lib/internal/sort/COMPARATOR<u32>~anonymous|0 $~lib/internal/sort/COMPARATOR<i32>~anonymous|1 $start:std/array~anonymous|43 $start:std/array~anonymous|44 $start:std/array~anonymous|45 $start:std/array~anonymous|46 $start:std/array~anonymous|47 $start:std/array~anonymous|48 $~lib/internal/sort/COMPARATOR<~lib/string/String>~anonymous|0)
  (global $~lib/allocator/arena/startOffset (mut i32) (i32.const 0))
  (global $~lib/allocator/arena/offset (mut i32) (i32.const 0))
  (global $std/array/arr (mut i32) (i32.const 0))
@@ -852,7 +852,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array.isArray<Array<i32> | null> (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array.isArray<~lib/array/Array<i32> | null> (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   if (result i32)
    local.get $0
@@ -862,7 +862,7 @@
    i32.const 1
   end
  )
- (func $~lib/array/Array.isArray<Array<i32>> (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array.isArray<~lib/array/Array<i32>> (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   if (result i32)
    local.get $0
@@ -882,7 +882,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array.isArray<P> (; 12 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array.isArray<std/array/P> (; 12 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   if (result i32)
    local.get $0
@@ -973,7 +973,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/array/Array.isArray<Uint8Array> (; 15 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array.isArray<~lib/typedarray/Uint8Array> (; 15 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   if (result i32)
    local.get $0
@@ -993,7 +993,7 @@
    i32.const 0
   end
  )
- (func $~lib/array/Array.isArray<String> (; 17 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array.isArray<~lib/string/String> (; 17 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   if (result i32)
    local.get $0
@@ -9422,7 +9422,7 @@
   local.get $0
   i32.sub
  )
- (func $~lib/array/Array<Array<i32>>#constructor (; 140 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#constructor (; 140 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9483,7 +9483,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<Array<i32>>#__set (; 141 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__set (; 141 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9530,7 +9530,7 @@
    i32.add
    i32.store offset=4
   end
-  block $~lib/internal/arraybuffer/STORE<Array<i32>,Array<i32>>|inlined.0
+  block $~lib/internal/arraybuffer/STORE<~lib/array/Array<i32>,~lib/array/Array<i32>>|inlined.0
    local.get $3
    local.set $5
    local.get $1
@@ -9550,7 +9550,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<Array<i32>>#__get (; 142 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__get (; 142 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9589,14 +9589,14 @@
   (local $3 i32)
   i32.const 0
   local.get $0
-  call $~lib/array/Array<Array<i32>>#constructor
+  call $~lib/array/Array<~lib/array/Array<i32>>#constructor
   local.set $1
   block $break|0
    i32.const 0
    local.set $2
    loop $repeat|0
     local.get $2
-    block $~lib/array/Array<Array<i32>>#get:length|inlined.1 (result i32)
+    block $~lib/array/Array<~lib/array/Array<i32>>#get:length|inlined.1 (result i32)
      local.get $1
      local.set $3
      local.get $3
@@ -9611,12 +9611,12 @@
      i32.const 0
      i32.const 1
      call $~lib/array/Array<i32>#constructor
-     call $~lib/array/Array<Array<i32>>#__set
+     call $~lib/array/Array<~lib/array/Array<i32>>#__set
      local.get $1
      local.get $2
-     call $~lib/array/Array<Array<i32>>#__get
+     call $~lib/array/Array<~lib/array/Array<i32>>#__get
      i32.const 0
-     block $~lib/array/Array<Array<i32>>#get:length|inlined.2 (result i32)
+     block $~lib/array/Array<~lib/array/Array<i32>>#get:length|inlined.2 (result i32)
       local.get $1
       local.set $3
       local.get $3
@@ -9648,7 +9648,7 @@
   call $~lib/array/Array<i32>#__get
   i32.sub
  )
- (func $~lib/internal/sort/insertionSort<Array<i32>> (; 145 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<~lib/array/Array<i32>> (; 145 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -9667,7 +9667,7 @@
     i32.eqz
     br_if $break|0
     block
-     block $~lib/internal/arraybuffer/LOAD<Array<i32>,Array<i32>>|inlined.3 (result i32)
+     block $~lib/internal/arraybuffer/LOAD<~lib/array/Array<i32>,~lib/array/Array<i32>>|inlined.3 (result i32)
       local.get $0
       local.set $5
       local.get $4
@@ -9695,7 +9695,7 @@
        i32.ge_s
        if
         block
-         block $~lib/internal/arraybuffer/LOAD<Array<i32>,Array<i32>>|inlined.4 (result i32)
+         block $~lib/internal/arraybuffer/LOAD<~lib/array/Array<i32>,~lib/array/Array<i32>>|inlined.4 (result i32)
           local.get $0
           local.set $5
           local.get $6
@@ -9757,7 +9757,7 @@
        end
       end
      end
-     block $~lib/internal/arraybuffer/STORE<Array<i32>,Array<i32>>|inlined.4
+     block $~lib/internal/arraybuffer/STORE<~lib/array/Array<i32>,~lib/array/Array<i32>>|inlined.4
       local.get $0
       local.set $9
       local.get $6
@@ -9789,7 +9789,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<Array<i32>>#sort (; 146 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#sort (; 146 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9825,7 +9825,7 @@
   i32.const 2
   i32.eq
   if
-   block $~lib/internal/arraybuffer/LOAD<Array<i32>,Array<i32>>|inlined.1 (result i32)
+   block $~lib/internal/arraybuffer/LOAD<~lib/array/Array<i32>,~lib/array/Array<i32>>|inlined.1 (result i32)
     local.get $3
     local.set $4
     i32.const 1
@@ -9842,7 +9842,7 @@
     i32.load offset=8
    end
    local.set $6
-   block $~lib/internal/arraybuffer/LOAD<Array<i32>,Array<i32>>|inlined.2 (result i32)
+   block $~lib/internal/arraybuffer/LOAD<~lib/array/Array<i32>,~lib/array/Array<i32>>|inlined.2 (result i32)
     local.get $3
     local.set $5
     i32.const 0
@@ -9870,7 +9870,7 @@
    i32.const 0
    i32.lt_s
    if
-    block $~lib/internal/arraybuffer/STORE<Array<i32>,Array<i32>>|inlined.1
+    block $~lib/internal/arraybuffer/STORE<~lib/array/Array<i32>,~lib/array/Array<i32>>|inlined.1
      local.get $3
      local.set $4
      i32.const 1
@@ -9889,7 +9889,7 @@
      local.get $8
      i32.store offset=8
     end
-    block $~lib/internal/arraybuffer/STORE<Array<i32>,Array<i32>>|inlined.2
+    block $~lib/internal/arraybuffer/STORE<~lib/array/Array<i32>,~lib/array/Array<i32>>|inlined.2
      local.get $3
      local.set $9
      i32.const 0
@@ -9912,7 +9912,7 @@
    local.get $0
    return
   end
-  block $~lib/internal/sort/SORT<Array<i32>>|inlined.0
+  block $~lib/internal/sort/SORT<~lib/array/Array<i32>>|inlined.0
    local.get $3
    local.set $7
    i32.const 0
@@ -9925,18 +9925,18 @@
    local.get $6
    local.get $4
    local.get $5
-   call $~lib/internal/sort/insertionSort<Array<i32>>
+   call $~lib/internal/sort/insertionSort<~lib/array/Array<i32>>
   end
   local.get $0
  )
- (func $std/array/isSorted<Array<i32>> (; 147 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<~lib/array/Array<i32>> (; 147 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   block $break|0
    block
     i32.const 1
     local.set $2
-    block $~lib/array/Array<Array<i32>>#get:length|inlined.3 (result i32)
+    block $~lib/array/Array<~lib/array/Array<i32>>#get:length|inlined.3 (result i32)
      local.get $0
      local.set $3
      local.get $3
@@ -9957,10 +9957,10 @@
      local.get $2
      i32.const 1
      i32.sub
-     call $~lib/array/Array<Array<i32>>#__get
+     call $~lib/array/Array<~lib/array/Array<i32>>#__get
      local.get $0
      local.get $2
-     call $~lib/array/Array<Array<i32>>#__get
+     call $~lib/array/Array<~lib/array/Array<i32>>#__get
      local.get $1
      call_indirect (type $FUNCSIG$iii)
     end
@@ -9981,12 +9981,12 @@
   end
   i32.const 1
  )
- (func $std/array/assertSorted<Array<i32>> (; 148 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/array/Array<i32>> (; 148 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
-  call $~lib/array/Array<Array<i32>>#sort
+  call $~lib/array/Array<~lib/array/Array<i32>>#sort
   local.get $1
-  call $std/array/isSorted<Array<i32>>
+  call $std/array/isSorted<~lib/array/Array<i32>>
   i32.eqz
   if
    i32.const 0
@@ -9997,7 +9997,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<Proxy<i32>>#constructor (; 149 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#constructor (; 149 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10071,7 +10071,7 @@
   i32.store
   local.get $0
  )
- (func $~lib/array/Array<Proxy<i32>>#__set (; 151 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#__set (; 151 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -10118,7 +10118,7 @@
    i32.add
    i32.store offset=4
   end
-  block $~lib/internal/arraybuffer/STORE<Proxy<i32>,Proxy<i32>>|inlined.0
+  block $~lib/internal/arraybuffer/STORE<std/array/Proxy<i32>,std/array/Proxy<i32>>|inlined.0
    local.get $3
    local.set $5
    local.get $1
@@ -10144,14 +10144,14 @@
   (local $3 i32)
   i32.const 0
   local.get $0
-  call $~lib/array/Array<Proxy<i32>>#constructor
+  call $~lib/array/Array<std/array/Proxy<i32>>#constructor
   local.set $1
   block $break|0
    i32.const 0
    local.set $2
    loop $repeat|0
     local.get $2
-    block $~lib/array/Array<Proxy<i32>>#get:length|inlined.1 (result i32)
+    block $~lib/array/Array<std/array/Proxy<i32>>#get:length|inlined.1 (result i32)
      local.get $1
      local.set $3
      local.get $3
@@ -10163,7 +10163,7 @@
     local.get $1
     local.get $2
     i32.const 0
-    block $~lib/array/Array<Proxy<i32>>#get:length|inlined.2 (result i32)
+    block $~lib/array/Array<std/array/Proxy<i32>>#get:length|inlined.2 (result i32)
      local.get $1
      local.set $3
      local.get $3
@@ -10174,7 +10174,7 @@
     local.get $2
     i32.sub
     call $std/array/Proxy<i32>#constructor
-    call $~lib/array/Array<Proxy<i32>>#__set
+    call $~lib/array/Array<std/array/Proxy<i32>>#__set
     local.get $2
     i32.const 1
     i32.add
@@ -10193,7 +10193,7 @@
   i32.load
   i32.sub
  )
- (func $~lib/internal/sort/insertionSort<Proxy<i32>> (; 154 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<std/array/Proxy<i32>> (; 154 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -10212,7 +10212,7 @@
     i32.eqz
     br_if $break|0
     block
-     block $~lib/internal/arraybuffer/LOAD<Proxy<i32>,Proxy<i32>>|inlined.2 (result i32)
+     block $~lib/internal/arraybuffer/LOAD<std/array/Proxy<i32>,std/array/Proxy<i32>>|inlined.2 (result i32)
       local.get $0
       local.set $5
       local.get $4
@@ -10240,7 +10240,7 @@
        i32.ge_s
        if
         block
-         block $~lib/internal/arraybuffer/LOAD<Proxy<i32>,Proxy<i32>>|inlined.3 (result i32)
+         block $~lib/internal/arraybuffer/LOAD<std/array/Proxy<i32>,std/array/Proxy<i32>>|inlined.3 (result i32)
           local.get $0
           local.set $5
           local.get $6
@@ -10302,7 +10302,7 @@
        end
       end
      end
-     block $~lib/internal/arraybuffer/STORE<Proxy<i32>,Proxy<i32>>|inlined.4
+     block $~lib/internal/arraybuffer/STORE<std/array/Proxy<i32>,std/array/Proxy<i32>>|inlined.4
       local.get $0
       local.set $9
       local.get $6
@@ -10334,7 +10334,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<Proxy<i32>>#sort (; 155 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#sort (; 155 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10370,7 +10370,7 @@
   i32.const 2
   i32.eq
   if
-   block $~lib/internal/arraybuffer/LOAD<Proxy<i32>,Proxy<i32>>|inlined.0 (result i32)
+   block $~lib/internal/arraybuffer/LOAD<std/array/Proxy<i32>,std/array/Proxy<i32>>|inlined.0 (result i32)
     local.get $3
     local.set $4
     i32.const 1
@@ -10387,7 +10387,7 @@
     i32.load offset=8
    end
    local.set $6
-   block $~lib/internal/arraybuffer/LOAD<Proxy<i32>,Proxy<i32>>|inlined.1 (result i32)
+   block $~lib/internal/arraybuffer/LOAD<std/array/Proxy<i32>,std/array/Proxy<i32>>|inlined.1 (result i32)
     local.get $3
     local.set $5
     i32.const 0
@@ -10415,7 +10415,7 @@
    i32.const 0
    i32.lt_s
    if
-    block $~lib/internal/arraybuffer/STORE<Proxy<i32>,Proxy<i32>>|inlined.1
+    block $~lib/internal/arraybuffer/STORE<std/array/Proxy<i32>,std/array/Proxy<i32>>|inlined.1
      local.get $3
      local.set $4
      i32.const 1
@@ -10434,7 +10434,7 @@
      local.get $8
      i32.store offset=8
     end
-    block $~lib/internal/arraybuffer/STORE<Proxy<i32>,Proxy<i32>>|inlined.2
+    block $~lib/internal/arraybuffer/STORE<std/array/Proxy<i32>,std/array/Proxy<i32>>|inlined.2
      local.get $3
      local.set $9
      i32.const 0
@@ -10457,7 +10457,7 @@
    local.get $0
    return
   end
-  block $~lib/internal/sort/SORT<Proxy<i32>>|inlined.0
+  block $~lib/internal/sort/SORT<std/array/Proxy<i32>>|inlined.0
    local.get $3
    local.set $7
    i32.const 0
@@ -10470,11 +10470,11 @@
    local.get $6
    local.get $4
    local.get $5
-   call $~lib/internal/sort/insertionSort<Proxy<i32>>
+   call $~lib/internal/sort/insertionSort<std/array/Proxy<i32>>
   end
   local.get $0
  )
- (func $~lib/array/Array<Proxy<i32>>#__get (; 156 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#__get (; 156 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10507,14 +10507,14 @@
    unreachable
   end
  )
- (func $std/array/isSorted<Proxy<i32>> (; 157 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<std/array/Proxy<i32>> (; 157 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   block $break|0
    block
     i32.const 1
     local.set $2
-    block $~lib/array/Array<Proxy<i32>>#get:length|inlined.3 (result i32)
+    block $~lib/array/Array<std/array/Proxy<i32>>#get:length|inlined.3 (result i32)
      local.get $0
      local.set $3
      local.get $3
@@ -10535,10 +10535,10 @@
      local.get $2
      i32.const 1
      i32.sub
-     call $~lib/array/Array<Proxy<i32>>#__get
+     call $~lib/array/Array<std/array/Proxy<i32>>#__get
      local.get $0
      local.get $2
-     call $~lib/array/Array<Proxy<i32>>#__get
+     call $~lib/array/Array<std/array/Proxy<i32>>#__get
      local.get $1
      call_indirect (type $FUNCSIG$iii)
     end
@@ -10559,12 +10559,12 @@
   end
   i32.const 1
  )
- (func $std/array/assertSorted<Proxy<i32>> (; 158 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<std/array/Proxy<i32>> (; 158 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
-  call $~lib/array/Array<Proxy<i32>>#sort
+  call $~lib/array/Array<std/array/Proxy<i32>>#sort
   local.get $1
-  call $std/array/isSorted<Proxy<i32>>
+  call $std/array/isSorted<std/array/Proxy<i32>>
   i32.eqz
   if
    i32.const 0
@@ -10575,7 +10575,7 @@
    unreachable
   end
  )
- (func $~lib/internal/sort/insertionSort<String> (; 159 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $~lib/internal/sort/insertionSort<~lib/string/String> (; 159 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -10594,7 +10594,7 @@
     i32.eqz
     br_if $break|0
     block
-     block $~lib/internal/arraybuffer/LOAD<String,String>|inlined.2 (result i32)
+     block $~lib/internal/arraybuffer/LOAD<~lib/string/String,~lib/string/String>|inlined.2 (result i32)
       local.get $0
       local.set $5
       local.get $4
@@ -10622,7 +10622,7 @@
        i32.ge_s
        if
         block
-         block $~lib/internal/arraybuffer/LOAD<String,String>|inlined.3 (result i32)
+         block $~lib/internal/arraybuffer/LOAD<~lib/string/String,~lib/string/String>|inlined.3 (result i32)
           local.get $0
           local.set $5
           local.get $6
@@ -10684,7 +10684,7 @@
        end
       end
      end
-     block $~lib/internal/arraybuffer/STORE<String,String>|inlined.3
+     block $~lib/internal/arraybuffer/STORE<~lib/string/String,~lib/string/String>|inlined.3
       local.get $0
       local.set $9
       local.get $6
@@ -10716,7 +10716,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<String>#sort (; 160 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#sort (; 160 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10752,7 +10752,7 @@
   i32.const 2
   i32.eq
   if
-   block $~lib/internal/arraybuffer/LOAD<String,String>|inlined.0 (result i32)
+   block $~lib/internal/arraybuffer/LOAD<~lib/string/String,~lib/string/String>|inlined.0 (result i32)
     local.get $3
     local.set $4
     i32.const 1
@@ -10769,7 +10769,7 @@
     i32.load offset=8
    end
    local.set $6
-   block $~lib/internal/arraybuffer/LOAD<String,String>|inlined.1 (result i32)
+   block $~lib/internal/arraybuffer/LOAD<~lib/string/String,~lib/string/String>|inlined.1 (result i32)
     local.get $3
     local.set $5
     i32.const 0
@@ -10797,7 +10797,7 @@
    i32.const 0
    i32.lt_s
    if
-    block $~lib/internal/arraybuffer/STORE<String,String>|inlined.0
+    block $~lib/internal/arraybuffer/STORE<~lib/string/String,~lib/string/String>|inlined.0
      local.get $3
      local.set $4
      i32.const 1
@@ -10816,7 +10816,7 @@
      local.get $8
      i32.store offset=8
     end
-    block $~lib/internal/arraybuffer/STORE<String,String>|inlined.1
+    block $~lib/internal/arraybuffer/STORE<~lib/string/String,~lib/string/String>|inlined.1
      local.get $3
      local.set $9
      i32.const 0
@@ -10839,7 +10839,7 @@
    local.get $0
    return
   end
-  block $~lib/internal/sort/SORT<String>|inlined.0
+  block $~lib/internal/sort/SORT<~lib/string/String>|inlined.0
    local.get $3
    local.set $7
    i32.const 0
@@ -10852,11 +10852,11 @@
    local.get $6
    local.get $4
    local.get $5
-   call $~lib/internal/sort/insertionSort<String>
+   call $~lib/internal/sort/insertionSort<~lib/string/String>
   end
   local.get $0
  )
- (func $~lib/array/Array<String>#__get (; 161 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#__get (; 161 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10889,14 +10889,14 @@
    unreachable
   end
  )
- (func $std/array/isSorted<String> (; 162 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<~lib/string/String> (; 162 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   block $break|0
    block
     i32.const 1
     local.set $2
-    block $~lib/array/Array<String>#get:length|inlined.0 (result i32)
+    block $~lib/array/Array<~lib/string/String>#get:length|inlined.0 (result i32)
      local.get $0
      local.set $3
      local.get $3
@@ -10917,10 +10917,10 @@
      local.get $2
      i32.const 1
      i32.sub
-     call $~lib/array/Array<String>#__get
+     call $~lib/array/Array<~lib/string/String>#__get
      local.get $0
      local.get $2
-     call $~lib/array/Array<String>#__get
+     call $~lib/array/Array<~lib/string/String>#__get
      local.get $1
      call_indirect (type $FUNCSIG$iii)
     end
@@ -10941,12 +10941,12 @@
   end
   i32.const 1
  )
- (func $std/array/assertSorted<String> (; 163 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/string/String> (; 163 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
-  call $~lib/array/Array<String>#sort
+  call $~lib/array/Array<~lib/string/String>#sort
   local.get $1
-  call $std/array/isSorted<String>
+  call $std/array/isSorted<~lib/string/String>
   i32.eqz
   if
    i32.const 0
@@ -11010,7 +11010,7 @@
   end
   local.get $5
  )
- (func $~lib/internal/sort/COMPARATOR<String>~anonymous|0 (; 165 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/internal/sort/COMPARATOR<~lib/string/String>~anonymous|0 (; 165 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11083,7 +11083,7 @@
   select
   call $~lib/internal/string/compareUnsafe
  )
- (func $std/array/assertSorted<String>|trampoline (; 166 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/string/String>|trampoline (; 166 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -11094,15 +11094,15 @@
     end
     unreachable
    end
-   block $~lib/internal/sort/COMPARATOR<String>|inlined.0 (result i32)
+   block $~lib/internal/sort/COMPARATOR<~lib/string/String>|inlined.0 (result i32)
     i32.const 55
-    br $~lib/internal/sort/COMPARATOR<String>|inlined.0
+    br $~lib/internal/sort/COMPARATOR<~lib/string/String>|inlined.0
    end
    local.set $1
   end
   local.get $0
   local.get $1
-  call $std/array/assertSorted<String>
+  call $std/array/assertSorted<~lib/string/String>
  )
  (func $~lib/string/String.__eq (; 167 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -11154,12 +11154,12 @@
   call $~lib/string/String.__eq
   i32.eqz
  )
- (func $std/array/isArraysEqual<String> (; 169 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<~lib/string/String> (; 169 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
   if
-   block $~lib/array/Array<String>#get:length|inlined.1 (result i32)
+   block $~lib/array/Array<~lib/string/String>#get:length|inlined.1 (result i32)
     local.get $0
     local.set $3
     local.get $3
@@ -11167,7 +11167,7 @@
    end
    local.set $2
    local.get $2
-   block $~lib/array/Array<String>#get:length|inlined.3 (result i32)
+   block $~lib/array/Array<~lib/string/String>#get:length|inlined.3 (result i32)
     local.get $1
     local.set $3
     local.get $3
@@ -11197,10 +11197,10 @@
     br_if $break|0
     local.get $0
     local.get $3
-    call $~lib/array/Array<String>#__get
+    call $~lib/array/Array<~lib/string/String>#__get
     local.get $1
     local.get $3
-    call $~lib/array/Array<String>#__get
+    call $~lib/array/Array<~lib/string/String>#__get
     call $~lib/string/String.__ne
     if
      i32.const 0
@@ -11217,7 +11217,7 @@
   end
   i32.const 1
  )
- (func $~lib/array/Array<String>#constructor (; 170 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#constructor (; 170 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11493,7 +11493,7 @@
   end
   local.get $1
  )
- (func $~lib/array/Array<String>#__set (; 177 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<~lib/string/String>#__set (; 177 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -11540,7 +11540,7 @@
    i32.add
    i32.store offset=4
   end
-  block $~lib/internal/arraybuffer/STORE<String,String>|inlined.4
+  block $~lib/internal/arraybuffer/STORE<~lib/string/String,~lib/string/String>|inlined.4
    local.get $3
    local.set $5
    local.get $1
@@ -11566,14 +11566,14 @@
   (local $3 i32)
   i32.const 0
   local.get $0
-  call $~lib/array/Array<String>#constructor
+  call $~lib/array/Array<~lib/string/String>#constructor
   local.set $1
   block $break|0
    i32.const 0
    local.set $2
    loop $repeat|0
     local.get $2
-    block $~lib/array/Array<String>#get:length|inlined.5 (result i32)
+    block $~lib/array/Array<~lib/string/String>#get:length|inlined.5 (result i32)
      local.get $1
      local.set $3
      local.get $3
@@ -11589,7 +11589,7 @@
     f64.mul
     i32.trunc_f64_s
     call $std/array/createRandomString
-    call $~lib/array/Array<String>#__set
+    call $~lib/array/Array<~lib/string/String>#__set
     local.get $2
     i32.const 1
     i32.add
@@ -14550,7 +14550,7 @@
   local.get $13
   return
  )
- (func $~lib/array/Array<String>#join (; 198 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#join (; 198 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14591,7 +14591,7 @@
   local.get $2
   i32.eqz
   if
-   block $~lib/internal/arraybuffer/LOAD<String,String>|inlined.5 (result i32)
+   block $~lib/internal/arraybuffer/LOAD<~lib/string/String,~lib/string/String>|inlined.5 (result i32)
     local.get $5
     local.set $8
     i32.const 0
@@ -14627,7 +14627,7 @@
     i32.eqz
     br_if $break|0
     local.get $10
-    block $~lib/internal/arraybuffer/LOAD<String,String>|inlined.6 (result i32)
+    block $~lib/internal/arraybuffer/LOAD<~lib/string/String,~lib/string/String>|inlined.6 (result i32)
      local.get $5
      local.set $11
      local.get $9
@@ -14674,7 +14674,7 @@
     i32.eqz
     br_if $break|1
     block
-     block $~lib/internal/arraybuffer/LOAD<String,String>|inlined.7 (result i32)
+     block $~lib/internal/arraybuffer/LOAD<~lib/string/String,~lib/string/String>|inlined.7 (result i32)
       local.get $5
       local.set $12
       local.get $13
@@ -14730,7 +14730,7 @@
    end
    unreachable
   end
-  block $~lib/internal/arraybuffer/LOAD<String,String>|inlined.8 (result i32)
+  block $~lib/internal/arraybuffer/LOAD<~lib/string/String,~lib/string/String>|inlined.8 (result i32)
    local.get $5
    local.set $13
    local.get $2
@@ -14772,7 +14772,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<Ref>#constructor (; 200 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#constructor (; 200 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14833,7 +14833,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<Ref>#__unchecked_set (; 201 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<std/array/Ref>#__unchecked_set (; 201 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -14857,7 +14857,7 @@
   local.get $5
   i32.store offset=8
  )
- (func $~lib/array/Array<Ref>#join (; 202 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#join (; 202 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14924,7 +14924,7 @@
     i32.eqz
     br_if $break|0
     block
-     block $~lib/internal/arraybuffer/LOAD<Ref,Ref>|inlined.0 (result i32)
+     block $~lib/internal/arraybuffer/LOAD<std/array/Ref,std/array/Ref>|inlined.0 (result i32)
       local.get $5
       local.set $12
       local.get $11
@@ -14977,7 +14977,7 @@
    end
    unreachable
   end
-  block $~lib/internal/arraybuffer/LOAD<Ref,Ref>|inlined.2 (result i32)
+  block $~lib/internal/arraybuffer/LOAD<std/array/Ref,std/array/Ref>|inlined.2 (result i32)
    local.get $5
    local.set $13
    local.get $2
@@ -16487,7 +16487,7 @@
   local.get $13
   return
  )
- (func $~lib/array/Array<Array<i32>>#join (; 219 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#join (; 219 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16525,7 +16525,7 @@
   local.get $2
   i32.eqz
   if
-   block $~lib/internal/arraybuffer/LOAD<Array<i32>,Array<i32>>|inlined.5 (result i32)
+   block $~lib/internal/arraybuffer/LOAD<~lib/array/Array<i32>,~lib/array/Array<i32>>|inlined.5 (result i32)
     local.get $5
     local.set $8
     i32.const 0
@@ -16562,7 +16562,7 @@
     i32.eqz
     br_if $break|0
     block
-     block $~lib/internal/arraybuffer/LOAD<Array<i32>,Array<i32>>|inlined.6 (result i32)
+     block $~lib/internal/arraybuffer/LOAD<~lib/array/Array<i32>,~lib/array/Array<i32>>|inlined.6 (result i32)
       local.get $5
       local.set $9
       local.get $10
@@ -16605,7 +16605,7 @@
    end
    unreachable
   end
-  block $~lib/internal/arraybuffer/LOAD<Array<i32>,Array<i32>>|inlined.7 (result i32)
+  block $~lib/internal/arraybuffer/LOAD<~lib/array/Array<i32>,~lib/array/Array<i32>>|inlined.7 (result i32)
    local.get $5
    local.set $10
    local.get $2
@@ -16876,7 +16876,7 @@
   local.get $13
   return
  )
- (func $~lib/array/Array<Array<u8>>#join (; 223 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u8>>#join (; 223 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16914,7 +16914,7 @@
   local.get $2
   i32.eqz
   if
-   block $~lib/internal/arraybuffer/LOAD<Array<u8>,Array<u8>>|inlined.0 (result i32)
+   block $~lib/internal/arraybuffer/LOAD<~lib/array/Array<u8>,~lib/array/Array<u8>>|inlined.0 (result i32)
     local.get $5
     local.set $8
     i32.const 0
@@ -16951,7 +16951,7 @@
     i32.eqz
     br_if $break|0
     block
-     block $~lib/internal/arraybuffer/LOAD<Array<u8>,Array<u8>>|inlined.1 (result i32)
+     block $~lib/internal/arraybuffer/LOAD<~lib/array/Array<u8>,~lib/array/Array<u8>>|inlined.1 (result i32)
       local.get $5
       local.set $9
       local.get $10
@@ -16994,7 +16994,7 @@
    end
    unreachable
   end
-  block $~lib/internal/arraybuffer/LOAD<Array<u8>,Array<u8>>|inlined.2 (result i32)
+  block $~lib/internal/arraybuffer/LOAD<~lib/array/Array<u8>,~lib/array/Array<u8>>|inlined.2 (result i32)
    local.get $5
    local.set $10
    local.get $2
@@ -17023,7 +17023,7 @@
   local.get $3
   return
  )
- (func $~lib/array/Array<Array<u32>>#join (; 224 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u32>>#join (; 224 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17061,7 +17061,7 @@
   local.get $2
   i32.eqz
   if
-   block $~lib/internal/arraybuffer/LOAD<Array<u32>,Array<u32>>|inlined.0 (result i32)
+   block $~lib/internal/arraybuffer/LOAD<~lib/array/Array<u32>,~lib/array/Array<u32>>|inlined.0 (result i32)
     local.get $5
     local.set $8
     i32.const 0
@@ -17098,7 +17098,7 @@
     i32.eqz
     br_if $break|0
     block
-     block $~lib/internal/arraybuffer/LOAD<Array<u32>,Array<u32>>|inlined.1 (result i32)
+     block $~lib/internal/arraybuffer/LOAD<~lib/array/Array<u32>,~lib/array/Array<u32>>|inlined.1 (result i32)
       local.get $5
       local.set $9
       local.get $10
@@ -17141,7 +17141,7 @@
    end
    unreachable
   end
-  block $~lib/internal/arraybuffer/LOAD<Array<u32>,Array<u32>>|inlined.2 (result i32)
+  block $~lib/internal/arraybuffer/LOAD<~lib/array/Array<u32>,~lib/array/Array<u32>>|inlined.2 (result i32)
    local.get $5
    local.set $10
    local.get $2
@@ -17170,7 +17170,7 @@
   local.get $3
   return
  )
- (func $~lib/array/Array<Array<Array<u32>>>#join (; 225 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#join (; 225 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17208,7 +17208,7 @@
   local.get $2
   i32.eqz
   if
-   block $~lib/internal/arraybuffer/LOAD<Array<Array<u32>>,Array<Array<u32>>>|inlined.0 (result i32)
+   block $~lib/internal/arraybuffer/LOAD<~lib/array/Array<~lib/array/Array<u32>>,~lib/array/Array<~lib/array/Array<u32>>>|inlined.0 (result i32)
     local.get $5
     local.set $8
     i32.const 0
@@ -17229,7 +17229,7 @@
    if (result i32)
     local.get $4
     local.get $1
-    call $~lib/array/Array<Array<u32>>#join
+    call $~lib/array/Array<~lib/array/Array<u32>>#join
    else    
     i32.const 3904
    end
@@ -17245,7 +17245,7 @@
     i32.eqz
     br_if $break|0
     block
-     block $~lib/internal/arraybuffer/LOAD<Array<Array<u32>>,Array<Array<u32>>>|inlined.1 (result i32)
+     block $~lib/internal/arraybuffer/LOAD<~lib/array/Array<~lib/array/Array<u32>>,~lib/array/Array<~lib/array/Array<u32>>>|inlined.1 (result i32)
       local.get $5
       local.set $9
       local.get $10
@@ -17267,7 +17267,7 @@
       local.get $3
       local.get $4
       local.get $1
-      call $~lib/array/Array<Array<u32>>#join
+      call $~lib/array/Array<~lib/array/Array<u32>>#join
       call $~lib/string/String.__concat
       local.set $3
      end
@@ -17288,7 +17288,7 @@
    end
    unreachable
   end
-  block $~lib/internal/arraybuffer/LOAD<Array<Array<u32>>,Array<Array<u32>>>|inlined.2 (result i32)
+  block $~lib/internal/arraybuffer/LOAD<~lib/array/Array<~lib/array/Array<u32>>,~lib/array/Array<~lib/array/Array<u32>>>|inlined.2 (result i32)
    local.get $5
    local.set $10
    local.get $2
@@ -17310,7 +17310,7 @@
    local.get $3
    local.get $4
    local.get $1
-   call $~lib/array/Array<Array<u32>>#join
+   call $~lib/array/Array<~lib/array/Array<u32>>#join
    call $~lib/string/String.__concat
    local.set $3
   end
@@ -17328,7 +17328,7 @@
   call $~lib/array/Array<i32>#constructor
   global.set $std/array/arr
   global.get $std/array/Null
-  call $~lib/array/Array.isArray<Array<i32> | null>
+  call $~lib/array/Array.isArray<~lib/array/Array<i32> | null>
   i32.const 0
   i32.eq
   i32.eqz
@@ -17341,7 +17341,7 @@
    unreachable
   end
   global.get $std/array/arr
-  call $~lib/array/Array.isArray<Array<i32>>
+  call $~lib/array/Array.isArray<~lib/array/Array<i32>>
   i32.const 1
   i32.eq
   i32.eqz
@@ -17355,7 +17355,7 @@
   end
   i32.const 0
   call $std/array/P#constructor
-  call $~lib/array/Array.isArray<P>
+  call $~lib/array/Array.isArray<std/array/P>
   i32.const 0
   i32.eq
   i32.eqz
@@ -17370,7 +17370,7 @@
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint8Array#constructor
-  call $~lib/array/Array.isArray<Uint8Array>
+  call $~lib/array/Array.isArray<~lib/typedarray/Uint8Array>
   i32.const 0
   i32.eq
   i32.eqz
@@ -17396,7 +17396,7 @@
    unreachable
   end
   global.get $std/array/str
-  call $~lib/array/Array.isArray<String>
+  call $~lib/array/Array.isArray<~lib/string/String>
   i32.const 0
   i32.eq
   i32.eqz
@@ -21417,24 +21417,24 @@
   global.set $std/array/reversedNested512
   global.get $std/array/reversedNested512
   i32.const 53
-  call $std/array/assertSorted<Array<i32>>
+  call $std/array/assertSorted<~lib/array/Array<i32>>
   i32.const 512
   call $std/array/createReverseOrderedElementsArray
   global.set $std/array/reversedElements512
   global.get $std/array/reversedElements512
   i32.const 54
-  call $std/array/assertSorted<Proxy<i32>>
+  call $std/array/assertSorted<std/array/Proxy<i32>>
   block
    i32.const 1
    global.set $~lib/argc
    global.get $std/array/randomStringsActual
    i32.const 0
-   call $std/array/assertSorted<String>|trampoline
+   call $std/array/assertSorted<~lib/string/String>|trampoline
   end
   global.get $std/array/randomStringsActual
   global.get $std/array/randomStringsExpected
   i32.const 0
-  call $std/array/isArraysEqual<String>
+  call $std/array/isArraysEqual<~lib/string/String>
   i32.eqz
   if
    i32.const 0
@@ -21452,7 +21452,7 @@
    global.set $~lib/argc
    global.get $std/array/randomStrings400
    i32.const 0
-   call $std/array/assertSorted<String>|trampoline
+   call $std/array/assertSorted<~lib/string/String>|trampoline
   end
   i32.const 4240
   i32.const 4216
@@ -21526,7 +21526,7 @@
   end
   i32.const 6864
   i32.const 3904
-  call $~lib/array/Array<String>#join
+  call $~lib/array/Array<~lib/string/String>#join
   i32.const 6784
   call $~lib/string/String.__eq
   i32.eqz
@@ -21541,28 +21541,28 @@
   block (result i32)
    i32.const 0
    i32.const 3
-   call $~lib/array/Array<Ref>#constructor
+   call $~lib/array/Array<std/array/Ref>#constructor
    local.set $3
    local.get $3
    i32.const 0
    i32.const 0
    call $std/array/Ref#constructor
-   call $~lib/array/Array<Ref>#__unchecked_set
+   call $~lib/array/Array<std/array/Ref>#__unchecked_set
    local.get $3
    i32.const 1
    i32.const 0
-   call $~lib/array/Array<Ref>#__unchecked_set
+   call $~lib/array/Array<std/array/Ref>#__unchecked_set
    local.get $3
    i32.const 2
    i32.const 0
    call $std/array/Ref#constructor
-   call $~lib/array/Array<Ref>#__unchecked_set
+   call $~lib/array/Array<std/array/Ref>#__unchecked_set
    local.get $3
   end
   global.set $std/array/refArr
   global.get $std/array/refArr
   i32.const 4216
-  call $~lib/array/Array<Ref>#join
+  call $~lib/array/Array<std/array/Ref>#join
   i32.const 6912
   call $~lib/string/String.__eq
   i32.eqz
@@ -21718,12 +21718,12 @@
    call $~lib/env/abort
    unreachable
   end
-  block $~lib/array/Array<String>#toString|inlined.1 (result i32)
+  block $~lib/array/Array<~lib/string/String>#toString|inlined.1 (result i32)
    global.get $std/array/randomStringsExpected
    local.set $3
    local.get $3
    i32.const 4216
-   call $~lib/array/Array<String>#join
+   call $~lib/array/Array<~lib/string/String>#join
   end
   i32.const 7528
   call $~lib/string/String.__eq
@@ -21736,12 +21736,12 @@
    call $~lib/env/abort
    unreachable
   end
-  block $~lib/array/Array<String>#toString|inlined.3 (result i32)
+  block $~lib/array/Array<~lib/string/String>#toString|inlined.3 (result i32)
    i32.const 7648
    local.set $3
    local.get $3
    i32.const 4216
-   call $~lib/array/Array<String>#join
+   call $~lib/array/Array<~lib/string/String>#join
   end
   i32.const 7656
   call $~lib/string/String.__eq
@@ -21754,12 +21754,12 @@
    call $~lib/env/abort
    unreachable
   end
-  block $~lib/array/Array<Array<i32>>#toString|inlined.1 (result i32)
+  block $~lib/array/Array<~lib/array/Array<i32>>#toString|inlined.1 (result i32)
    global.get $std/array/subarr32
    local.set $3
    local.get $3
    i32.const 4216
-   call $~lib/array/Array<Array<i32>>#join
+   call $~lib/array/Array<~lib/array/Array<i32>>#join
   end
   i32.const 7744
   call $~lib/string/String.__eq
@@ -21772,12 +21772,12 @@
    call $~lib/env/abort
    unreachable
   end
-  block $~lib/array/Array<Array<u8>>#toString|inlined.1 (result i32)
+  block $~lib/array/Array<~lib/array/Array<u8>>#toString|inlined.1 (result i32)
    global.get $std/array/subarr8
    local.set $3
    local.get $3
    i32.const 4216
-   call $~lib/array/Array<Array<u8>>#join
+   call $~lib/array/Array<~lib/array/Array<u8>>#join
   end
   i32.const 7744
   call $~lib/string/String.__eq
@@ -21790,12 +21790,12 @@
    call $~lib/env/abort
    unreachable
   end
-  block $~lib/array/Array<Array<Array<u32>>>#toString|inlined.1 (result i32)
+  block $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#toString|inlined.1 (result i32)
    global.get $std/array/subarrU32
    local.set $3
    local.get $3
    i32.const 4216
-   call $~lib/array/Array<Array<Array<u32>>>#join
+   call $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#join
   end
   i32.const 6784
   call $~lib/string/String.__eq

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -1857,13 +1857,13 @@
    call $~lib/env/abort
    unreachable
   end
-  block $__inlined_func$~lib/arraybuffer/ArrayBuffer.isView<Uint8Array>5 (result i32)
+  block $__inlined_func$~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Uint8Array>5 (result i32)
    i32.const 0
    i32.const 12
    call $~lib/allocator/arena/__memory_allocate
    call $~lib/internal/typedarray/TypedArray<i32>#constructor
    i32.eqz
-   br_if $__inlined_func$~lib/arraybuffer/ArrayBuffer.isView<Uint8Array>5
+   br_if $__inlined_func$~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Uint8Array>5
    drop
    i32.const 1
   end
@@ -1878,7 +1878,7 @@
   end
   i32.const 1
   global.set $~lib/argc
-  block $__inlined_func$~lib/arraybuffer/ArrayBuffer.isView<Uint8Array>6 (result i32)
+  block $__inlined_func$~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Uint8Array>6 (result i32)
    global.get $std/arraybuffer/arr8
    i32.load
    local.set $1
@@ -1902,7 +1902,7 @@
    local.get $0
    call $~lib/dataview/DataView#constructor
    i32.eqz
-   br_if $__inlined_func$~lib/arraybuffer/ArrayBuffer.isView<Uint8Array>6
+   br_if $__inlined_func$~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Uint8Array>6
    drop
    i32.const 1
   end

--- a/tests/compiler/std/arraybuffer.untouched.wat
+++ b/tests/compiler/std/arraybuffer.untouched.wat
@@ -1995,7 +1995,7 @@
   local.get $2
   call $~lib/arraybuffer/ArrayBuffer#slice
  )
- (func $~lib/arraybuffer/ArrayBuffer.isView<Array<i32>> (; 11 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/array/Array<i32>> (; 11 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
   i32.eq
@@ -2015,7 +2015,7 @@
   end
   i32.const 0
  )
- (func $~lib/arraybuffer/ArrayBuffer.isView<Uint8Array> (; 13 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Uint8Array> (; 13 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
   i32.eq
@@ -2026,7 +2026,7 @@
   i32.const 1
   return
  )
- (func $~lib/arraybuffer/ArrayBuffer.isView<Int32Array> (; 14 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Int32Array> (; 14 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
   i32.eq
@@ -2037,7 +2037,7 @@
   i32.const 1
   return
  )
- (func $~lib/arraybuffer/ArrayBuffer.isView<DataView> (; 15 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer.isView<~lib/dataview/DataView> (; 15 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 0
   i32.eq
@@ -2534,7 +2534,7 @@
    unreachable
   end
   i32.const 0
-  call $~lib/arraybuffer/ArrayBuffer.isView<Array<i32>>
+  call $~lib/arraybuffer/ArrayBuffer.isView<~lib/array/Array<i32>>
   i32.eqz
   i32.eqz
   if
@@ -2558,7 +2558,7 @@
    unreachable
   end
   i32.const 0
-  call $~lib/arraybuffer/ArrayBuffer.isView<Uint8Array>
+  call $~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Uint8Array>
   i32.eqz
   i32.eqz
   if
@@ -2570,7 +2570,7 @@
    unreachable
   end
   i32.const 0
-  call $~lib/arraybuffer/ArrayBuffer.isView<Int32Array>
+  call $~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Int32Array>
   i32.eqz
   i32.eqz
   if
@@ -2582,7 +2582,7 @@
    unreachable
   end
   i32.const 0
-  call $~lib/arraybuffer/ArrayBuffer.isView<DataView>
+  call $~lib/arraybuffer/ArrayBuffer.isView<~lib/dataview/DataView>
   i32.eqz
   i32.eqz
   if
@@ -2598,7 +2598,7 @@
   call $~lib/typedarray/Uint8Array#constructor
   global.set $std/arraybuffer/arr8
   i32.const 240
-  call $~lib/arraybuffer/ArrayBuffer.isView<Array<i32>>
+  call $~lib/arraybuffer/ArrayBuffer.isView<~lib/array/Array<i32>>
   i32.eqz
   i32.eqz
   if
@@ -2610,7 +2610,7 @@
    unreachable
   end
   global.get $std/arraybuffer/arr8
-  call $~lib/arraybuffer/ArrayBuffer.isView<Uint8Array>
+  call $~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Uint8Array>
   i32.eqz
   if
    i32.const 0
@@ -2623,7 +2623,7 @@
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Int32Array#constructor
-  call $~lib/arraybuffer/ArrayBuffer.isView<Int32Array>
+  call $~lib/arraybuffer/ArrayBuffer.isView<~lib/typedarray/Int32Array>
   i32.eqz
   if
    i32.const 0
@@ -2643,7 +2643,7 @@
    i32.const 0
    call $~lib/dataview/DataView#constructor|trampoline
   end
-  call $~lib/arraybuffer/ArrayBuffer.isView<DataView>
+  call $~lib/arraybuffer/ArrayBuffer.isView<~lib/dataview/DataView>
   i32.eqz
   if
    i32.const 0

--- a/tests/compiler/std/gc-array.optimized.wat
+++ b/tests/compiler/std/gc-array.optimized.wat
@@ -14,7 +14,7 @@
  (data (i32.const 64) "\05\00\00\00\00\00\00\00\0d\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s")
  (data (i32.const 112) "\05\00\00\00\00\00\00\00\1c\00\00\00~\00l\00i\00b\00/\00i\00n\00t\00e\00r\00n\00a\00l\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s")
  (table $0 7 funcref)
- (elem (i32.const 0) $null $~lib/arraybuffer/ArrayBuffer~gc $~lib/array/Array<Foo>~gc $~lib/collector/itcm/__gc_mark $~lib/arraybuffer/ArrayBuffer~gc $~lib/arraybuffer/ArrayBuffer~gc $~lib/allocator/arena/__memory_free)
+ (elem (i32.const 0) $null $~lib/arraybuffer/ArrayBuffer~gc $~lib/array/Array<std/gc-array/Foo>~gc $~lib/collector/itcm/__gc_mark $~lib/arraybuffer/ArrayBuffer~gc $~lib/arraybuffer/ArrayBuffer~gc $~lib/allocator/arena/__memory_free)
  (global $~lib/allocator/arena/startOffset (mut i32) (i32.const 0))
  (global $~lib/allocator/arena/offset (mut i32) (i32.const 0))
  (global $~lib/collector/itcm/state (mut i32) (i32.const 0))
@@ -123,7 +123,7 @@
    end
   end
  )
- (func $~lib/array/Array<Foo>~gc (; 5 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/array/Array<std/gc-array/Foo>~gc (; 5 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1861,7 +1861,7 @@
    call $~lib/collector/itcm/ManagedObject#makeGray
   end
  )
- (func $~lib/array/Array<Foo>#__set (; 17 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<std/gc-array/Foo>#__set (; 17 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -1921,21 +1921,21 @@
   i32.const 0
   i32.const 4
   call $~lib/collector/itcm/__gc_allocate
-  call $~lib/array/Array<Foo>#__set
+  call $~lib/array/Array<std/gc-array/Foo>#__set
   call $~lib/collector/itcm/__gc_collect
   global.get $std/gc-array/arr
   i32.const 1
   i32.const 0
   i32.const 4
   call $~lib/collector/itcm/__gc_allocate
-  call $~lib/array/Array<Foo>#__set
+  call $~lib/array/Array<std/gc-array/Foo>#__set
   call $~lib/collector/itcm/__gc_collect
   global.get $std/gc-array/arr
   i32.const 0
   i32.const 0
   i32.const 4
   call $~lib/collector/itcm/__gc_allocate
-  call $~lib/array/Array<Foo>#__set
+  call $~lib/array/Array<std/gc-array/Foo>#__set
   call $~lib/collector/itcm/__gc_collect
  )
  (func $std/gc-array/main (; 19 ;) (type $FUNCSIG$i) (result i32)

--- a/tests/compiler/std/gc-array.untouched.wat
+++ b/tests/compiler/std/gc-array.untouched.wat
@@ -14,7 +14,7 @@
  (data (i32.const 56) "\00\00\00\00\00\00\00\00\05\00\00\00\00\00\00\00\0d\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s\00")
  (data (i32.const 104) "\00\00\00\00\00\00\00\00\05\00\00\00\00\00\00\00\1c\00\00\00~\00l\00i\00b\00/\00i\00n\00t\00e\00r\00n\00a\00l\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
  (table $0 7 funcref)
- (elem (i32.const 0) $null $~lib/arraybuffer/ArrayBuffer~gc $~lib/array/Array<Foo>~gc $~lib/collector/itcm/__gc_mark $std/gc-array/Foo~gc $~lib/string/String~gc $~lib/internal/arraybuffer/__gc)
+ (elem (i32.const 0) $null $~lib/arraybuffer/ArrayBuffer~gc $~lib/array/Array<std/gc-array/Foo>~gc $~lib/collector/itcm/__gc_mark $std/gc-array/Foo~gc $~lib/string/String~gc $~lib/internal/arraybuffer/__gc)
  (global $~lib/allocator/arena/startOffset (mut i32) (i32.const 0))
  (global $~lib/allocator/arena/offset (mut i32) (i32.const 0))
  (global $~lib/collector/itcm/state (mut i32) (i32.const 0))
@@ -155,7 +155,7 @@
    end
   end
  )
- (func $~lib/array/Array<Foo>~gc (; 10 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/array/Array<std/gc-array/Foo>~gc (; 10 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2407,7 +2407,7 @@
    call $~lib/collector/itcm/ManagedObject#makeGray
   end
  )
- (func $~lib/array/Array<Foo>#__set (; 29 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<std/gc-array/Foo>#__set (; 29 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2454,7 +2454,7 @@
    i32.add
    i32.store offset=4
   end
-  block $~lib/internal/arraybuffer/STORE<Foo,Foo>|inlined.0
+  block $~lib/internal/arraybuffer/STORE<std/gc-array/Foo,std/gc-array/Foo>|inlined.0
    local.get $3
    local.set $5
    local.get $1
@@ -2492,7 +2492,7 @@
    local.set $0
    local.get $0
   end
-  call $~lib/array/Array<Foo>#__set
+  call $~lib/array/Array<std/gc-array/Foo>#__set
   call $~lib/gc/gc.collect
   global.get $std/gc-array/arr
   i32.const 1
@@ -2503,7 +2503,7 @@
    local.set $1
    local.get $1
   end
-  call $~lib/array/Array<Foo>#__set
+  call $~lib/array/Array<std/gc-array/Foo>#__set
   call $~lib/gc/gc.collect
   global.get $std/gc-array/arr
   i32.const 0
@@ -2514,7 +2514,7 @@
    local.set $2
    local.get $2
   end
-  call $~lib/array/Array<Foo>#__set
+  call $~lib/array/Array<std/gc-array/Foo>#__set
   call $~lib/gc/gc.collect
  )
  (func $std/gc-array/main (; 31 ;) (type $FUNCSIG$i) (result i32)

--- a/tests/compiler/std/hash.untouched.wat
+++ b/tests/compiler/std/hash.untouched.wat
@@ -192,48 +192,48 @@
   (local $0 i32)
   (local $1 f32)
   (local $2 f64)
-  block $~lib/internal/hash/HASH<String>|inlined.0 (result i32)
+  block $~lib/internal/hash/HASH<~lib/string/String>|inlined.0 (result i32)
    i32.const 0
    local.set $0
    local.get $0
    call $~lib/internal/hash/hashStr
-   br $~lib/internal/hash/HASH<String>|inlined.0
+   br $~lib/internal/hash/HASH<~lib/string/String>|inlined.0
   end
   call $std/hash/check
   drop
-  block $~lib/internal/hash/HASH<String>|inlined.1 (result i32)
+  block $~lib/internal/hash/HASH<~lib/string/String>|inlined.1 (result i32)
    i32.const 8
    local.set $0
    local.get $0
    call $~lib/internal/hash/hashStr
-   br $~lib/internal/hash/HASH<String>|inlined.1
+   br $~lib/internal/hash/HASH<~lib/string/String>|inlined.1
   end
   call $std/hash/check
   drop
-  block $~lib/internal/hash/HASH<String>|inlined.2 (result i32)
+  block $~lib/internal/hash/HASH<~lib/string/String>|inlined.2 (result i32)
    i32.const 16
    local.set $0
    local.get $0
    call $~lib/internal/hash/hashStr
-   br $~lib/internal/hash/HASH<String>|inlined.2
+   br $~lib/internal/hash/HASH<~lib/string/String>|inlined.2
   end
   call $std/hash/check
   drop
-  block $~lib/internal/hash/HASH<String>|inlined.3 (result i32)
+  block $~lib/internal/hash/HASH<~lib/string/String>|inlined.3 (result i32)
    i32.const 24
    local.set $0
    local.get $0
    call $~lib/internal/hash/hashStr
-   br $~lib/internal/hash/HASH<String>|inlined.3
+   br $~lib/internal/hash/HASH<~lib/string/String>|inlined.3
   end
   call $std/hash/check
   drop
-  block $~lib/internal/hash/HASH<String>|inlined.4 (result i32)
+  block $~lib/internal/hash/HASH<~lib/string/String>|inlined.4 (result i32)
    i32.const 32
    local.set $0
    local.get $0
    call $~lib/internal/hash/hashStr
-   br $~lib/internal/hash/HASH<String>|inlined.4
+   br $~lib/internal/hash/HASH<~lib/string/String>|inlined.4
   end
   call $std/hash/check
   drop

--- a/tests/compiler/std/pointer.untouched.wat
+++ b/tests/compiler/std/pointer.untouched.wat
@@ -1702,7 +1702,7 @@
    end
   end
  )
- (func $std/pointer/Pointer<Entry>#set:value (; 4 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/pointer/Pointer<std/pointer/Entry>#set:value (; 4 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1751,7 +1751,7 @@
   (local $0 i32)
   (local $1 i32)
   (local $2 f32)
-  block $std/pointer/Pointer<Entry>#constructor|inlined.0 (result i32)
+  block $std/pointer/Pointer<std/pointer/Entry>#constructor|inlined.0 (result i32)
    i32.const 0
    local.set $0
    i32.const 8
@@ -1759,7 +1759,7 @@
    local.get $1
   end
   global.set $std/pointer/one
-  block $std/pointer/Pointer<Entry>#constructor|inlined.1 (result i32)
+  block $std/pointer/Pointer<std/pointer/Entry>#constructor|inlined.1 (result i32)
    i32.const 0
    local.set $1
    i32.const 24
@@ -1767,7 +1767,7 @@
    local.get $0
   end
   global.set $std/pointer/two
-  block $std/pointer/Pointer<Entry>#get:offset|inlined.0 (result i32)
+  block $std/pointer/Pointer<std/pointer/Entry>#get:offset|inlined.0 (result i32)
    global.get $std/pointer/one
    local.set $0
    local.get $0
@@ -1783,7 +1783,7 @@
    call $~lib/env/abort
    unreachable
   end
-  block $std/pointer/Pointer<Entry>#get:offset|inlined.1 (result i32)
+  block $std/pointer/Pointer<std/pointer/Entry>#get:offset|inlined.1 (result i32)
    global.get $std/pointer/two
    local.set $0
    local.get $0
@@ -1799,27 +1799,27 @@
    call $~lib/env/abort
    unreachable
   end
-  block $std/pointer/Pointer<Entry>#get:value|inlined.0 (result i32)
+  block $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.0 (result i32)
    global.get $std/pointer/one
    local.set $0
    local.get $0
-   br $std/pointer/Pointer<Entry>#get:value|inlined.0
+   br $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.0
   end
   i32.const 1
   i32.store
-  block $std/pointer/Pointer<Entry>#get:value|inlined.1 (result i32)
+  block $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.1 (result i32)
    global.get $std/pointer/one
    local.set $0
    local.get $0
-   br $std/pointer/Pointer<Entry>#get:value|inlined.1
+   br $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.1
   end
   i32.const 2
   i32.store offset=4
-  block $std/pointer/Pointer<Entry>#get:value|inlined.2 (result i32)
+  block $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.2 (result i32)
    global.get $std/pointer/one
    local.set $0
    local.get $0
-   br $std/pointer/Pointer<Entry>#get:value|inlined.2
+   br $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.2
   end
   i32.load
   i32.const 1
@@ -1833,11 +1833,11 @@
    call $~lib/env/abort
    unreachable
   end
-  block $std/pointer/Pointer<Entry>#get:value|inlined.3 (result i32)
+  block $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.3 (result i32)
    global.get $std/pointer/one
    local.set $0
    local.get $0
-   br $std/pointer/Pointer<Entry>#get:value|inlined.3
+   br $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.3
   end
   i32.load offset=4
   i32.const 2
@@ -1851,7 +1851,7 @@
    call $~lib/env/abort
    unreachable
   end
-  block $std/pointer/Pointer<Entry>#add|inlined.0 (result i32)
+  block $std/pointer/Pointer<std/pointer/Entry>#add|inlined.0 (result i32)
    global.get $std/pointer/one
    local.set $0
    global.get $std/pointer/two
@@ -1861,7 +1861,7 @@
    i32.add
   end
   global.set $std/pointer/add
-  block $std/pointer/Pointer<Entry>#get:offset|inlined.2 (result i32)
+  block $std/pointer/Pointer<std/pointer/Entry>#get:offset|inlined.2 (result i32)
    global.get $std/pointer/add
    local.set $1
    local.get $1
@@ -1877,7 +1877,7 @@
    call $~lib/env/abort
    unreachable
   end
-  block $std/pointer/Pointer<Entry>#sub|inlined.0 (result i32)
+  block $std/pointer/Pointer<std/pointer/Entry>#sub|inlined.0 (result i32)
    global.get $std/pointer/two
    local.set $1
    global.get $std/pointer/one
@@ -1887,7 +1887,7 @@
    i32.sub
   end
   global.set $std/pointer/sub
-  block $std/pointer/Pointer<Entry>#get:offset|inlined.3 (result i32)
+  block $std/pointer/Pointer<std/pointer/Entry>#get:offset|inlined.3 (result i32)
    global.get $std/pointer/sub
    local.set $0
    local.get $0
@@ -1903,7 +1903,7 @@
    call $~lib/env/abort
    unreachable
   end
-  block $std/pointer/Pointer<Entry>#get:offset|inlined.4 (result i32)
+  block $std/pointer/Pointer<std/pointer/Entry>#get:offset|inlined.4 (result i32)
    global.get $std/pointer/one
    local.set $0
    local.get $0
@@ -1920,7 +1920,7 @@
    unreachable
   end
   block (result i32)
-   block $std/pointer/Pointer<Entry>#inc|inlined.0 (result i32)
+   block $std/pointer/Pointer<std/pointer/Entry>#inc|inlined.0 (result i32)
     global.get $std/pointer/one
     local.set $0
     local.get $0
@@ -1943,7 +1943,7 @@
    call $~lib/env/abort
    unreachable
   end
-  block $std/pointer/Pointer<Entry>#get:offset|inlined.5 (result i32)
+  block $std/pointer/Pointer<std/pointer/Entry>#get:offset|inlined.5 (result i32)
    global.get $std/pointer/one
    local.set $0
    local.get $0
@@ -1959,7 +1959,7 @@
    call $~lib/env/abort
    unreachable
   end
-  block $std/pointer/Pointer<Entry>#get:offset|inlined.6 (result i32)
+  block $std/pointer/Pointer<std/pointer/Entry>#get:offset|inlined.6 (result i32)
    global.get $std/pointer/two
    local.set $0
    local.get $0
@@ -1975,7 +1975,7 @@
    call $~lib/env/abort
    unreachable
   end
-  block $std/pointer/Pointer<Entry>#dec|inlined.0 (result i32)
+  block $std/pointer/Pointer<std/pointer/Entry>#dec|inlined.0 (result i32)
    global.get $std/pointer/two
    local.set $0
    local.get $0
@@ -1983,7 +1983,7 @@
    i32.sub
   end
   global.set $std/pointer/two
-  block $std/pointer/Pointer<Entry>#dec|inlined.1 (result i32)
+  block $std/pointer/Pointer<std/pointer/Entry>#dec|inlined.1 (result i32)
    global.get $std/pointer/two
    local.set $0
    local.get $0
@@ -1991,7 +1991,7 @@
    i32.sub
   end
   global.set $std/pointer/two
-  block $std/pointer/Pointer<Entry>#get:offset|inlined.7 (result i32)
+  block $std/pointer/Pointer<std/pointer/Entry>#get:offset|inlined.7 (result i32)
    global.get $std/pointer/two
    local.set $0
    local.get $0
@@ -2007,11 +2007,11 @@
    call $~lib/env/abort
    unreachable
   end
-  block $std/pointer/Pointer<Entry>#get:value|inlined.4 (result i32)
+  block $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.4 (result i32)
    global.get $std/pointer/two
    local.set $0
    local.get $0
-   br $std/pointer/Pointer<Entry>#get:value|inlined.4
+   br $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.4
   end
   i32.load
   i32.const 1
@@ -2025,11 +2025,11 @@
    call $~lib/env/abort
    unreachable
   end
-  block $std/pointer/Pointer<Entry>#get:value|inlined.5 (result i32)
+  block $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.5 (result i32)
    global.get $std/pointer/two
    local.set $0
    local.get $0
-   br $std/pointer/Pointer<Entry>#get:value|inlined.5
+   br $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.5
   end
   i32.load offset=4
   i32.const 2
@@ -2044,19 +2044,19 @@
    unreachable
   end
   global.get $std/pointer/one
-  block $std/pointer/Pointer<Entry>#get:value|inlined.6 (result i32)
+  block $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.6 (result i32)
    global.get $std/pointer/two
    local.set $0
    local.get $0
-   br $std/pointer/Pointer<Entry>#get:value|inlined.6
+   br $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.6
   end
-  call $std/pointer/Pointer<Entry>#set:value
-  block $std/pointer/Pointer<Entry>#get:offset|inlined.8 (result i32)
+  call $std/pointer/Pointer<std/pointer/Entry>#set:value
+  block $std/pointer/Pointer<std/pointer/Entry>#get:offset|inlined.8 (result i32)
    global.get $std/pointer/one
    local.set $0
    local.get $0
   end
-  block $std/pointer/Pointer<Entry>#get:offset|inlined.9 (result i32)
+  block $std/pointer/Pointer<std/pointer/Entry>#get:offset|inlined.9 (result i32)
    global.get $std/pointer/two
    local.set $0
    local.get $0
@@ -2071,11 +2071,11 @@
    call $~lib/env/abort
    unreachable
   end
-  block $std/pointer/Pointer<Entry>#get:value|inlined.7 (result i32)
+  block $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.7 (result i32)
    global.get $std/pointer/one
    local.set $0
    local.get $0
-   br $std/pointer/Pointer<Entry>#get:value|inlined.7
+   br $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.7
   end
   i32.load
   i32.const 1
@@ -2089,11 +2089,11 @@
    call $~lib/env/abort
    unreachable
   end
-  block $std/pointer/Pointer<Entry>#get:value|inlined.8 (result i32)
+  block $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.8 (result i32)
    global.get $std/pointer/one
    local.set $0
    local.get $0
-   br $std/pointer/Pointer<Entry>#get:value|inlined.8
+   br $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.8
   end
   i32.load offset=4
   i32.const 2

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -3237,7 +3237,7 @@
    end
   end
  )
- (func $~lib/array/Array<String>#constructor (; 35 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#constructor (; 35 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3361,7 +3361,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<String>#push (; 37 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/string/String>#push (; 37 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3434,14 +3434,14 @@
   i32.eqz
   if
    i32.const 0
-   call $~lib/array/Array<String>#constructor
+   call $~lib/array/Array<~lib/string/String>#constructor
    return
   end
   local.get $1
   i32.eqz
   if
    i32.const 1
-   call $~lib/array/Array<String>#constructor
+   call $~lib/array/Array<~lib/string/String>#constructor
    local.tee $3
    i32.load
    local.get $0
@@ -3468,7 +3468,7 @@
     i32.eqz
     if
      i32.const 1
-     call $~lib/array/Array<String>#constructor
+     call $~lib/array/Array<~lib/string/String>#constructor
      local.tee $3
      i32.load
      i32.const 256
@@ -3480,7 +3480,7 @@
     i32.eqz
     if
      i32.const 0
-     call $~lib/array/Array<String>#constructor
+     call $~lib/array/Array<~lib/string/String>#constructor
      return
     end
     local.get $4
@@ -3491,7 +3491,7 @@
     i32.lt_s
     select
     local.tee $4
-    call $~lib/array/Array<String>#constructor
+    call $~lib/array/Array<~lib/string/String>#constructor
     local.tee $3
     i32.load
     local.set $5
@@ -3530,7 +3530,7 @@
     return
    end
    i32.const 0
-   call $~lib/array/Array<String>#constructor
+   call $~lib/array/Array<~lib/string/String>#constructor
    local.set $6
    loop $continue|1
     local.get $0
@@ -3558,11 +3558,11 @@
       call $~lib/internal/string/copyUnsafe
       local.get $6
       local.get $3
-      call $~lib/array/Array<String>#push
+      call $~lib/array/Array<~lib/string/String>#push
      else      
       local.get $6
       i32.const 256
-      call $~lib/array/Array<String>#push
+      call $~lib/array/Array<~lib/string/String>#push
      end
      local.get $10
      i32.const 1
@@ -3585,7 +3585,7 @@
    i32.eqz
    if
     i32.const 1
-    call $~lib/array/Array<String>#constructor
+    call $~lib/array/Array<~lib/string/String>#constructor
     local.tee $3
     i32.load
     local.get $0
@@ -3609,11 +3609,11 @@
     call $~lib/internal/string/copyUnsafe
     local.get $6
     local.get $5
-    call $~lib/array/Array<String>#push
+    call $~lib/array/Array<~lib/string/String>#push
    else    
     local.get $6
     i32.const 256
-    call $~lib/array/Array<String>#push
+    call $~lib/array/Array<~lib/string/String>#push
    end
    local.get $6
    return

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -4053,7 +4053,7 @@
    end
   end
  )
- (func $~lib/array/Array<String>#constructor (; 40 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#constructor (; 40 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4114,7 +4114,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<String>#__unchecked_set (; 41 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<~lib/string/String>#__unchecked_set (; 41 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4138,7 +4138,7 @@
   local.get $5
   i32.store offset=8
  )
- (func $~lib/array/Array<String>#__unchecked_get (; 42 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#__unchecked_get (; 42 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4268,7 +4268,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<String>#push (; 45 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#push (; 45 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4320,7 +4320,7 @@
   local.get $0
   local.get $5
   i32.store offset=4
-  block $~lib/internal/arraybuffer/STORE<String,String>|inlined.2
+  block $~lib/internal/arraybuffer/STORE<~lib/string/String,~lib/string/String>|inlined.2
    local.get $3
    local.set $6
    local.get $2
@@ -4374,7 +4374,7 @@
   if
    i32.const 0
    i32.const 0
-   call $~lib/array/Array<String>#constructor
+   call $~lib/array/Array<~lib/string/String>#constructor
    return
   end
   local.get $1
@@ -4384,12 +4384,12 @@
    block (result i32)
     i32.const 0
     i32.const 1
-    call $~lib/array/Array<String>#constructor
+    call $~lib/array/Array<~lib/string/String>#constructor
     local.set $3
     local.get $3
     i32.const 0
     local.get $0
-    call $~lib/array/Array<String>#__unchecked_set
+    call $~lib/array/Array<~lib/string/String>#__unchecked_set
     local.get $3
    end
    return
@@ -4415,7 +4415,7 @@
    if
     i32.const 0
     i32.const 0
-    call $~lib/array/Array<String>#constructor
+    call $~lib/array/Array<~lib/string/String>#constructor
     return
    end
    local.get $4
@@ -4429,7 +4429,7 @@
    local.set $4
    i32.const 0
    local.get $4
-   call $~lib/array/Array<String>#constructor
+   call $~lib/array/Array<~lib/string/String>#constructor
    local.set $3
    local.get $3
    i32.load
@@ -4455,7 +4455,7 @@
       i32.add
       i32.load16_u offset=4
       i32.store16 offset=4
-      block $~lib/internal/arraybuffer/STORE<String,String>|inlined.1
+      block $~lib/internal/arraybuffer/STORE<~lib/string/String,~lib/string/String>|inlined.1
        local.get $6
        local.set $9
        local.get $7
@@ -4492,7 +4492,7 @@
    if
     i32.const 0
     i32.const 1
-    call $~lib/array/Array<String>#constructor
+    call $~lib/array/Array<~lib/string/String>#constructor
     local.set $6
     block (result i32)
      local.get $6
@@ -4500,10 +4500,10 @@
      i32.const 0
      local.tee $7
      i32.const 256
-     call $~lib/array/Array<String>#__unchecked_set
+     call $~lib/array/Array<~lib/string/String>#__unchecked_set
      local.get $3
      local.get $7
-     call $~lib/array/Array<String>#__unchecked_get
+     call $~lib/array/Array<~lib/string/String>#__unchecked_get
     end
     drop
     local.get $6
@@ -4512,7 +4512,7 @@
   end
   i32.const 0
   i32.const 0
-  call $~lib/array/Array<String>#constructor
+  call $~lib/array/Array<~lib/string/String>#constructor
   local.set $13
   i32.const 0
   local.set $14
@@ -4550,12 +4550,12 @@
        call $~lib/internal/string/copyUnsafe
        local.get $13
        local.get $3
-       call $~lib/array/Array<String>#push
+       call $~lib/array/Array<~lib/string/String>#push
        drop
       else       
        local.get $13
        i32.const 256
-       call $~lib/array/Array<String>#push
+       call $~lib/array/Array<~lib/string/String>#push
        drop
       end
       local.get $16
@@ -4582,7 +4582,7 @@
   if
    i32.const 0
    i32.const 1
-   call $~lib/array/Array<String>#constructor
+   call $~lib/array/Array<~lib/string/String>#constructor
    local.set $6
    block (result i32)
     local.get $6
@@ -4590,10 +4590,10 @@
     i32.const 0
     local.tee $7
     local.get $0
-    call $~lib/array/Array<String>#__unchecked_set
+    call $~lib/array/Array<~lib/string/String>#__unchecked_set
     local.get $3
     local.get $7
-    call $~lib/array/Array<String>#__unchecked_get
+    call $~lib/array/Array<~lib/string/String>#__unchecked_get
    end
    drop
    local.get $6
@@ -4618,12 +4618,12 @@
    call $~lib/internal/string/copyUnsafe
    local.get $13
    local.get $6
-   call $~lib/array/Array<String>#push
+   call $~lib/array/Array<~lib/string/String>#push
    drop
   else   
    local.get $13
    i32.const 256
-   call $~lib/array/Array<String>#push
+   call $~lib/array/Array<~lib/string/String>#push
    drop
   end
   local.get $13
@@ -4649,7 +4649,7 @@
   local.get $2
   call $~lib/string/String#split
  )
- (func $~lib/array/Array<String>#__get (; 48 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#__get (; 48 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8665,7 +8665,7 @@
    call $~lib/string/String#split|trampoline
   end
   global.set $std/string/sa
-  block $~lib/array/Array<String>#get:length|inlined.0 (result i32)
+  block $~lib/array/Array<~lib/string/String>#get:length|inlined.0 (result i32)
    global.get $std/string/sa
    local.set $2
    local.get $2
@@ -8677,7 +8677,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 0
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 256
    call $~lib/string/String.__eq
   else   
@@ -8701,7 +8701,7 @@
    call $~lib/string/String#split|trampoline
   end
   global.set $std/string/sa
-  block $~lib/array/Array<String>#get:length|inlined.1 (result i32)
+  block $~lib/array/Array<~lib/string/String>#get:length|inlined.1 (result i32)
    global.get $std/string/sa
    local.set $2
    local.get $2
@@ -8727,7 +8727,7 @@
    call $~lib/string/String#split|trampoline
   end
   global.set $std/string/sa
-  block $~lib/array/Array<String>#get:length|inlined.2 (result i32)
+  block $~lib/array/Array<~lib/string/String>#get:length|inlined.2 (result i32)
    global.get $std/string/sa
    local.set $2
    local.get $2
@@ -8739,7 +8739,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 0
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 256
    call $~lib/string/String.__eq
   else   
@@ -8763,7 +8763,7 @@
    call $~lib/string/String#split|trampoline
   end
   global.set $std/string/sa
-  block $~lib/array/Array<String>#get:length|inlined.3 (result i32)
+  block $~lib/array/Array<~lib/string/String>#get:length|inlined.3 (result i32)
    global.get $std/string/sa
    local.set $2
    local.get $2
@@ -8775,7 +8775,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 0
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 1192
    call $~lib/string/String.__eq
   else   
@@ -8799,7 +8799,7 @@
    call $~lib/string/String#split|trampoline
   end
   global.set $std/string/sa
-  block $~lib/array/Array<String>#get:length|inlined.4 (result i32)
+  block $~lib/array/Array<~lib/string/String>#get:length|inlined.4 (result i32)
    global.get $std/string/sa
    local.set $2
    local.get $2
@@ -8811,7 +8811,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 0
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 280
    call $~lib/string/String.__eq
   else   
@@ -8821,7 +8821,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 1
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 648
    call $~lib/string/String.__eq
   else   
@@ -8831,7 +8831,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 2
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 1216
    call $~lib/string/String.__eq
   else   
@@ -8855,7 +8855,7 @@
    call $~lib/string/String#split|trampoline
   end
   global.set $std/string/sa
-  block $~lib/array/Array<String>#get:length|inlined.5 (result i32)
+  block $~lib/array/Array<~lib/string/String>#get:length|inlined.5 (result i32)
    global.get $std/string/sa
    local.set $2
    local.get $2
@@ -8867,7 +8867,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 0
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 280
    call $~lib/string/String.__eq
   else   
@@ -8877,7 +8877,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 1
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 648
    call $~lib/string/String.__eq
   else   
@@ -8887,7 +8887,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 2
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 1216
    call $~lib/string/String.__eq
   else   
@@ -8911,7 +8911,7 @@
    call $~lib/string/String#split|trampoline
   end
   global.set $std/string/sa
-  block $~lib/array/Array<String>#get:length|inlined.6 (result i32)
+  block $~lib/array/Array<~lib/string/String>#get:length|inlined.6 (result i32)
    global.get $std/string/sa
    local.set $2
    local.get $2
@@ -8923,7 +8923,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 0
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 280
    call $~lib/string/String.__eq
   else   
@@ -8933,7 +8933,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 1
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 648
    call $~lib/string/String.__eq
   else   
@@ -8943,7 +8943,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 2
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 256
    call $~lib/string/String.__eq
   else   
@@ -8953,7 +8953,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 3
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 1216
    call $~lib/string/String.__eq
   else   
@@ -8977,7 +8977,7 @@
    call $~lib/string/String#split|trampoline
   end
   global.set $std/string/sa
-  block $~lib/array/Array<String>#get:length|inlined.7 (result i32)
+  block $~lib/array/Array<~lib/string/String>#get:length|inlined.7 (result i32)
    global.get $std/string/sa
    local.set $2
    local.get $2
@@ -8989,7 +8989,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 0
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 256
    call $~lib/string/String.__eq
   else   
@@ -8999,7 +8999,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 1
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 280
    call $~lib/string/String.__eq
   else   
@@ -9009,7 +9009,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 2
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 648
    call $~lib/string/String.__eq
   else   
@@ -9019,7 +9019,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 3
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 1216
    call $~lib/string/String.__eq
   else   
@@ -9043,7 +9043,7 @@
    call $~lib/string/String#split|trampoline
   end
   global.set $std/string/sa
-  block $~lib/array/Array<String>#get:length|inlined.8 (result i32)
+  block $~lib/array/Array<~lib/string/String>#get:length|inlined.8 (result i32)
    global.get $std/string/sa
    local.set $2
    local.get $2
@@ -9055,7 +9055,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 0
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 280
    call $~lib/string/String.__eq
   else   
@@ -9065,7 +9065,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 1
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 648
    call $~lib/string/String.__eq
   else   
@@ -9075,7 +9075,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 2
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 1216
    call $~lib/string/String.__eq
   else   
@@ -9085,7 +9085,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 3
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 256
    call $~lib/string/String.__eq
   else   
@@ -9109,7 +9109,7 @@
    call $~lib/string/String#split|trampoline
   end
   global.set $std/string/sa
-  block $~lib/array/Array<String>#get:length|inlined.9 (result i32)
+  block $~lib/array/Array<~lib/string/String>#get:length|inlined.9 (result i32)
    global.get $std/string/sa
    local.set $2
    local.get $2
@@ -9121,7 +9121,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 0
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 280
    call $~lib/string/String.__eq
   else   
@@ -9131,7 +9131,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 1
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 648
    call $~lib/string/String.__eq
   else   
@@ -9141,7 +9141,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 2
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 1216
    call $~lib/string/String.__eq
   else   
@@ -9161,7 +9161,7 @@
   i32.const 0
   call $~lib/string/String#split
   global.set $std/string/sa
-  block $~lib/array/Array<String>#get:length|inlined.10 (result i32)
+  block $~lib/array/Array<~lib/string/String>#get:length|inlined.10 (result i32)
    global.get $std/string/sa
    local.set $2
    local.get $2
@@ -9183,7 +9183,7 @@
   i32.const 1
   call $~lib/string/String#split
   global.set $std/string/sa
-  block $~lib/array/Array<String>#get:length|inlined.11 (result i32)
+  block $~lib/array/Array<~lib/string/String>#get:length|inlined.11 (result i32)
    global.get $std/string/sa
    local.set $2
    local.get $2
@@ -9195,7 +9195,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 0
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 280
    call $~lib/string/String.__eq
   else   
@@ -9215,7 +9215,7 @@
   i32.const 1
   call $~lib/string/String#split
   global.set $std/string/sa
-  block $~lib/array/Array<String>#get:length|inlined.12 (result i32)
+  block $~lib/array/Array<~lib/string/String>#get:length|inlined.12 (result i32)
    global.get $std/string/sa
    local.set $2
    local.get $2
@@ -9227,7 +9227,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 0
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 280
    call $~lib/string/String.__eq
   else   
@@ -9247,7 +9247,7 @@
   i32.const 4
   call $~lib/string/String#split
   global.set $std/string/sa
-  block $~lib/array/Array<String>#get:length|inlined.13 (result i32)
+  block $~lib/array/Array<~lib/string/String>#get:length|inlined.13 (result i32)
    global.get $std/string/sa
    local.set $2
    local.get $2
@@ -9259,7 +9259,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 0
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 280
    call $~lib/string/String.__eq
   else   
@@ -9269,7 +9269,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 1
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 648
    call $~lib/string/String.__eq
   else   
@@ -9279,7 +9279,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 2
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 1216
    call $~lib/string/String.__eq
   else   
@@ -9299,7 +9299,7 @@
   i32.const -1
   call $~lib/string/String#split
   global.set $std/string/sa
-  block $~lib/array/Array<String>#get:length|inlined.14 (result i32)
+  block $~lib/array/Array<~lib/string/String>#get:length|inlined.14 (result i32)
    global.get $std/string/sa
    local.set $2
    local.get $2
@@ -9311,7 +9311,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 0
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 280
    call $~lib/string/String.__eq
   else   
@@ -9321,7 +9321,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 1
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 648
    call $~lib/string/String.__eq
   else   
@@ -9331,7 +9331,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 2
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 1216
    call $~lib/string/String.__eq
   else   
@@ -9351,7 +9351,7 @@
   i32.const -1
   call $~lib/string/String#split
   global.set $std/string/sa
-  block $~lib/array/Array<String>#get:length|inlined.15 (result i32)
+  block $~lib/array/Array<~lib/string/String>#get:length|inlined.15 (result i32)
    global.get $std/string/sa
    local.set $2
    local.get $2
@@ -9363,7 +9363,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 0
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 280
    call $~lib/string/String.__eq
   else   
@@ -9373,7 +9373,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 1
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 648
    call $~lib/string/String.__eq
   else   
@@ -9383,7 +9383,7 @@
   if (result i32)
    global.get $std/string/sa
    i32.const 2
-   call $~lib/array/Array<String>#__get
+   call $~lib/array/Array<~lib/string/String>#__get
    i32.const 1216
    call $~lib/string/String.__eq
   else   

--- a/tests/compiler/std/symbol.optimized.wat
+++ b/tests/compiler/std/symbol.optimized.wat
@@ -389,7 +389,7 @@
   end
   local.get $2
  )
- (func $~lib/map/Map<String,usize>#clear (; 5 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#clear (; 5 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 16
   i32.const 0
@@ -413,7 +413,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<String,usize>#constructor (; 6 ;) (type $FUNCSIG$i) (result i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#constructor (; 6 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   i32.const 24
   call $~lib/allocator/arena/__memory_allocate
@@ -436,7 +436,7 @@
   i32.const 0
   i32.store offset=20
   local.get $0
-  call $~lib/map/Map<String,usize>#clear
+  call $~lib/map/Map<~lib/string/String,usize>#clear
   local.get $0
  )
  (func $~lib/internal/hash/hashStr (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
@@ -546,7 +546,7 @@
   call $~lib/internal/string/compareUnsafe
   i32.eqz
  )
- (func $~lib/map/Map<String,usize>#find (; 10 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#find (; 10 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -589,7 +589,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<String,usize>#rehash (; 11 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#rehash (; 11 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -696,7 +696,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<String,usize>#set (; 12 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#set (; 12 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -704,7 +704,7 @@
   i32.const 8
   call $~lib/internal/hash/hashStr
   local.tee $4
-  call $~lib/map/Map<String,usize>#find
+  call $~lib/map/Map<~lib/string/String,usize>#find
   local.tee $2
   if
    local.get $2
@@ -738,7 +738,7 @@
      i32.const 1
      i32.or
     end
-    call $~lib/map/Map<String,usize>#rehash
+    call $~lib/map/Map<~lib/string/String,usize>#rehash
    end
    local.get $0
    i32.load offset=8
@@ -818,7 +818,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/map/Map<usize,String>#find (; 14 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#find (; 14 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -861,7 +861,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<usize,String>#rehash (; 15 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#rehash (; 15 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -968,7 +968,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<usize,String>#set (; 16 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#set (; 16 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -977,7 +977,7 @@
   local.get $1
   call $~lib/internal/hash/hash32
   local.tee $4
-  call $~lib/map/Map<usize,String>#find
+  call $~lib/map/Map<usize,~lib/string/String>#find
   local.tee $2
   if
    local.get $2
@@ -1011,7 +1011,7 @@
      i32.const 1
      i32.or
     end
-    call $~lib/map/Map<usize,String>#rehash
+    call $~lib/map/Map<usize,~lib/string/String>#rehash
    end
    local.get $0
    i32.load offset=8
@@ -1067,12 +1067,12 @@
    global.get $~lib/symbol/stringToId
    i32.const 8
    call $~lib/internal/hash/hashStr
-   call $~lib/map/Map<String,usize>#find
+   call $~lib/map/Map<~lib/string/String,usize>#find
    if
     global.get $~lib/symbol/stringToId
     i32.const 8
     call $~lib/internal/hash/hashStr
-    call $~lib/map/Map<String,usize>#find
+    call $~lib/map/Map<~lib/string/String,usize>#find
     local.tee $0
     if (result i32)
      local.get $0
@@ -1083,9 +1083,9 @@
     return
    end
   else   
-   call $~lib/map/Map<String,usize>#constructor
+   call $~lib/map/Map<~lib/string/String,usize>#constructor
    global.set $~lib/symbol/stringToId
-   call $~lib/map/Map<String,usize>#constructor
+   call $~lib/map/Map<~lib/string/String,usize>#constructor
    global.set $~lib/symbol/idToString
   end
   global.get $~lib/symbol/nextId
@@ -1100,27 +1100,27 @@
   end
   global.get $~lib/symbol/stringToId
   local.get $0
-  call $~lib/map/Map<String,usize>#set
+  call $~lib/map/Map<~lib/string/String,usize>#set
   global.get $~lib/symbol/idToString
   local.get $0
-  call $~lib/map/Map<usize,String>#set
+  call $~lib/map/Map<usize,~lib/string/String>#set
   local.get $0
  )
- (func $~lib/map/Map<usize,String>#has (; 18 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#has (; 18 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
   call $~lib/internal/hash/hash32
-  call $~lib/map/Map<usize,String>#find
+  call $~lib/map/Map<usize,~lib/string/String>#find
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<usize,String>#get (; 19 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#get (; 19 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
   call $~lib/internal/hash/hash32
-  call $~lib/map/Map<usize,String>#find
+  call $~lib/map/Map<usize,~lib/string/String>#find
   local.tee $0
   if (result i32)
    local.get $0
@@ -1138,14 +1138,14 @@
   if
    global.get $~lib/symbol/idToString
    local.get $0
-   call $~lib/map/Map<usize,String>#has
+   call $~lib/map/Map<usize,~lib/string/String>#has
    local.set $1
   end
   local.get $1
   if (result i32)
    global.get $~lib/symbol/idToString
    local.get $0
-   call $~lib/map/Map<usize,String>#get
+   call $~lib/map/Map<usize,~lib/string/String>#get
   else   
    i32.const 0
   end
@@ -2415,14 +2415,14 @@
    if
     global.get $~lib/symbol/idToString
     local.get $1
-    call $~lib/map/Map<usize,String>#has
+    call $~lib/map/Map<usize,~lib/string/String>#has
     local.set $0
    end
    local.get $0
    if (result i32)
     global.get $~lib/symbol/idToString
     local.get $1
-    call $~lib/map/Map<usize,String>#get
+    call $~lib/map/Map<usize,~lib/string/String>#get
    else    
     i32.const 168
    end

--- a/tests/compiler/std/symbol.untouched.wat
+++ b/tests/compiler/std/symbol.untouched.wat
@@ -508,7 +508,7 @@
   end
   local.get $3
  )
- (func $~lib/map/Map<String,usize>#clear (; 9 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#clear (; 9 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -536,7 +536,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<String,usize>#constructor (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#constructor (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -565,10 +565,10 @@
    i32.store offset=20
    local.get $0
   end
-  call $~lib/map/Map<String,usize>#clear
+  call $~lib/map/Map<~lib/string/String,usize>#clear
   local.get $0
  )
- (func $~lib/map/Map<usize,String>#clear (; 11 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#clear (; 11 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.const 0
   i32.const 16
@@ -596,7 +596,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<usize,String>#constructor (; 12 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#constructor (; 12 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   block (result i32)
    local.get $0
    i32.eqz
@@ -625,7 +625,7 @@
    i32.store offset=20
    local.get $0
   end
-  call $~lib/map/Map<usize,String>#clear
+  call $~lib/map/Map<usize,~lib/string/String>#clear
   local.get $0
  )
  (func $~lib/internal/hash/hashStr (; 13 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
@@ -767,7 +767,7 @@
   call $~lib/internal/string/compareUnsafe
   i32.eqz
  )
- (func $~lib/map/Map<String,usize>#find (; 16 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#find (; 16 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -818,34 +818,34 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<String,usize>#has (; 17 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#has (; 17 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
-  block $~lib/internal/hash/HASH<String>|inlined.0 (result i32)
+  block $~lib/internal/hash/HASH<~lib/string/String>|inlined.0 (result i32)
    local.get $1
    local.set $2
    local.get $2
    call $~lib/internal/hash/hashStr
-   br $~lib/internal/hash/HASH<String>|inlined.0
+   br $~lib/internal/hash/HASH<~lib/string/String>|inlined.0
   end
-  call $~lib/map/Map<String,usize>#find
+  call $~lib/map/Map<~lib/string/String,usize>#find
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<String,usize>#get (; 18 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#get (; 18 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
   local.get $1
-  block $~lib/internal/hash/HASH<String>|inlined.1 (result i32)
+  block $~lib/internal/hash/HASH<~lib/string/String>|inlined.1 (result i32)
    local.get $1
    local.set $2
    local.get $2
    call $~lib/internal/hash/hashStr
-   br $~lib/internal/hash/HASH<String>|inlined.1
+   br $~lib/internal/hash/HASH<~lib/string/String>|inlined.1
   end
-  call $~lib/map/Map<String,usize>#find
+  call $~lib/map/Map<~lib/string/String,usize>#find
   local.set $3
   local.get $3
   if (result i32)
@@ -855,7 +855,7 @@
    unreachable
   end
  )
- (func $~lib/map/Map<String,usize>#rehash (; 19 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#rehash (; 19 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -886,7 +886,7 @@
   local.set $4
   i32.const 0
   local.get $4
-  block $~lib/map/ENTRY_SIZE<String,usize>|inlined.1 (result i32)
+  block $~lib/map/ENTRY_SIZE<~lib/string/String,usize>|inlined.1 (result i32)
    i32.const 12
   end
   i32.mul
@@ -901,7 +901,7 @@
   local.get $6
   local.get $0
   i32.load offset=16
-  block $~lib/map/ENTRY_SIZE<String,usize>|inlined.2 (result i32)
+  block $~lib/map/ENTRY_SIZE<~lib/string/String,usize>|inlined.2 (result i32)
    i32.const 12
   end
   i32.mul
@@ -936,13 +936,13 @@
        local.get $9
        i32.load offset=4
        i32.store offset=4
-       block $~lib/internal/hash/HASH<String>|inlined.3 (result i32)
+       block $~lib/internal/hash/HASH<~lib/string/String>|inlined.3 (result i32)
         local.get $9
         i32.load
         local.set $11
         local.get $11
         call $~lib/internal/hash/hashStr
-        br $~lib/internal/hash/HASH<String>|inlined.3
+        br $~lib/internal/hash/HASH<~lib/string/String>|inlined.3
        end
        local.get $1
        i32.and
@@ -961,14 +961,14 @@
        local.get $8
        i32.store offset=8
        local.get $8
-       block $~lib/map/ENTRY_SIZE<String,usize>|inlined.3 (result i32)
+       block $~lib/map/ENTRY_SIZE<~lib/string/String,usize>|inlined.3 (result i32)
         i32.const 12
        end
        i32.add
        local.set $8
       end
       local.get $6
-      block $~lib/map/ENTRY_SIZE<String,usize>|inlined.4 (result i32)
+      block $~lib/map/ENTRY_SIZE<~lib/string/String,usize>|inlined.4 (result i32)
        i32.const 12
       end
       i32.add
@@ -995,23 +995,23 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<String,usize>#set (; 20 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#set (; 20 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  block $~lib/internal/hash/HASH<String>|inlined.2 (result i32)
+  block $~lib/internal/hash/HASH<~lib/string/String>|inlined.2 (result i32)
    local.get $1
    local.set $3
    local.get $3
    call $~lib/internal/hash/hashStr
-   br $~lib/internal/hash/HASH<String>|inlined.2
+   br $~lib/internal/hash/HASH<~lib/string/String>|inlined.2
   end
   local.set $4
   local.get $0
   local.get $1
   local.get $4
-  call $~lib/map/Map<String,usize>#find
+  call $~lib/map/Map<~lib/string/String,usize>#find
   local.set $5
   local.get $5
   if
@@ -1046,7 +1046,7 @@
      i32.const 1
      i32.or
     end
-    call $~lib/map/Map<String,usize>#rehash
+    call $~lib/map/Map<~lib/string/String,usize>#rehash
    end
    local.get $0
    i32.load offset=8
@@ -1064,7 +1064,7 @@
     i32.store offset=16
     local.get $6
    end
-   block $~lib/map/ENTRY_SIZE<String,usize>|inlined.5 (result i32)
+   block $~lib/map/ENTRY_SIZE<~lib/string/String,usize>|inlined.5 (result i32)
     i32.const 12
    end
    i32.mul
@@ -1143,7 +1143,7 @@
   local.set $1
   local.get $1
  )
- (func $~lib/map/Map<usize,String>#find (; 22 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#find (; 22 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -1194,7 +1194,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<usize,String>#rehash (; 23 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#rehash (; 23 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1225,7 +1225,7 @@
   local.set $4
   i32.const 0
   local.get $4
-  block $~lib/map/ENTRY_SIZE<usize,String>|inlined.1 (result i32)
+  block $~lib/map/ENTRY_SIZE<usize,~lib/string/String>|inlined.1 (result i32)
    i32.const 12
   end
   i32.mul
@@ -1240,7 +1240,7 @@
   local.get $6
   local.get $0
   i32.load offset=16
-  block $~lib/map/ENTRY_SIZE<usize,String>|inlined.2 (result i32)
+  block $~lib/map/ENTRY_SIZE<usize,~lib/string/String>|inlined.2 (result i32)
    i32.const 12
   end
   i32.mul
@@ -1300,14 +1300,14 @@
        local.get $8
        i32.store offset=8
        local.get $8
-       block $~lib/map/ENTRY_SIZE<usize,String>|inlined.3 (result i32)
+       block $~lib/map/ENTRY_SIZE<usize,~lib/string/String>|inlined.3 (result i32)
         i32.const 12
        end
        i32.add
        local.set $8
       end
       local.get $6
-      block $~lib/map/ENTRY_SIZE<usize,String>|inlined.4 (result i32)
+      block $~lib/map/ENTRY_SIZE<usize,~lib/string/String>|inlined.4 (result i32)
        i32.const 12
       end
       i32.add
@@ -1334,7 +1334,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<usize,String>#set (; 24 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#set (; 24 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1350,7 +1350,7 @@
   local.get $0
   local.get $1
   local.get $4
-  call $~lib/map/Map<usize,String>#find
+  call $~lib/map/Map<usize,~lib/string/String>#find
   local.set $5
   local.get $5
   if
@@ -1385,7 +1385,7 @@
      i32.const 1
      i32.or
     end
-    call $~lib/map/Map<usize,String>#rehash
+    call $~lib/map/Map<usize,~lib/string/String>#rehash
    end
    local.get $0
    i32.load offset=8
@@ -1403,7 +1403,7 @@
     i32.store offset=16
     local.get $6
    end
-   block $~lib/map/ENTRY_SIZE<usize,String>|inlined.5 (result i32)
+   block $~lib/map/ENTRY_SIZE<usize,~lib/string/String>|inlined.5 (result i32)
     i32.const 12
    end
    i32.mul
@@ -1447,19 +1447,19 @@
   i32.eqz
   if
    i32.const 0
-   call $~lib/map/Map<String,usize>#constructor
+   call $~lib/map/Map<~lib/string/String,usize>#constructor
    global.set $~lib/symbol/stringToId
    i32.const 0
-   call $~lib/map/Map<usize,String>#constructor
+   call $~lib/map/Map<usize,~lib/string/String>#constructor
    global.set $~lib/symbol/idToString
   else   
    global.get $~lib/symbol/stringToId
    local.get $0
-   call $~lib/map/Map<String,usize>#has
+   call $~lib/map/Map<~lib/string/String,usize>#has
    if
     global.get $~lib/symbol/stringToId
     local.get $0
-    call $~lib/map/Map<String,usize>#get
+    call $~lib/map/Map<~lib/string/String,usize>#get
     return
    end
   end
@@ -1480,14 +1480,14 @@
   global.get $~lib/symbol/stringToId
   local.get $0
   local.get $2
-  call $~lib/map/Map<String,usize>#set
+  call $~lib/map/Map<~lib/string/String,usize>#set
   global.get $~lib/symbol/idToString
   local.get $2
   local.get $0
-  call $~lib/map/Map<usize,String>#set
+  call $~lib/map/Map<usize,~lib/string/String>#set
   local.get $2
  )
- (func $~lib/map/Map<usize,String>#has (; 26 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#has (; 26 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -1498,11 +1498,11 @@
    call $~lib/internal/hash/hash32
    br $~lib/internal/hash/HASH<usize>|inlined.2
   end
-  call $~lib/map/Map<usize,String>#find
+  call $~lib/map/Map<usize,~lib/string/String>#find
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<usize,String>#get (; 27 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#get (; 27 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -1514,7 +1514,7 @@
    call $~lib/internal/hash/hash32
    br $~lib/internal/hash/HASH<usize>|inlined.3
   end
-  call $~lib/map/Map<usize,String>#find
+  call $~lib/map/Map<usize,~lib/string/String>#find
   local.set $3
   local.get $3
   if (result i32)
@@ -1533,14 +1533,14 @@
   if (result i32)
    global.get $~lib/symbol/idToString
    local.get $0
-   call $~lib/map/Map<usize,String>#has
+   call $~lib/map/Map<usize,~lib/string/String>#has
   else   
    local.get $1
   end
   if (result i32)
    global.get $~lib/symbol/idToString
    local.get $0
-   call $~lib/map/Map<usize,String>#get
+   call $~lib/map/Map<usize,~lib/string/String>#get
   else   
    i32.const 0
   end
@@ -3276,14 +3276,14 @@
     if (result i32)
      global.get $~lib/symbol/idToString
      local.get $1
-     call $~lib/map/Map<usize,String>#has
+     call $~lib/map/Map<usize,~lib/string/String>#has
     else     
      local.get $3
     end
     if
      global.get $~lib/symbol/idToString
      local.get $1
-     call $~lib/map/Map<usize,String>#get
+     call $~lib/map/Map<usize,~lib/string/String>#get
      local.set $2
     end
     br $break|0

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -78,7 +78,7 @@
  (data (i32.const 1056) "!\00\00\00T\00y\00p\00e\00d\00A\00r\00r\00a\00y\00 \00r\00e\00v\00e\00r\00s\00e\00 \00v\00a\00l\00u\00e\00 \00m\00i\00s\00m\00a\00t\00c\00h")
  (data (i32.const 1128) "+\00\00\00T\00y\00p\00e\00d\00A\00r\00r\00a\00y\00 \00r\00e\00v\00e\00r\00s\00e\00 \00w\00i\00t\00h\00 \00b\00y\00t\00e\00O\00f\00f\00s\00e\00t\00 \00m\00i\00s\00m\00a\00t\00c\00h")
  (table $0 112 funcref)
- (elem (i32.const 0) $null $~lib/internal/sort/COMPARATOR<f64>~anonymous|0 $std/typedarray/testReduce<Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<Int64Array,i64>~anonymous|0 $std/typedarray/testReduce<Int64Array,i64>~anonymous|0 $std/typedarray/testReduce<Float32Array,f32>~anonymous|0 $std/typedarray/testReduce<Float64Array,f64>~anonymous|0 $std/typedarray/testReduce<Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<Int64Array,i64>~anonymous|0 $std/typedarray/testReduce<Int64Array,i64>~anonymous|0 $std/typedarray/testReduce<Float32Array,f32>~anonymous|0 $std/typedarray/testReduce<Float64Array,f64>~anonymous|0 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|0 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|0 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|0 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|0 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|0 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|0 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|0 $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|0 $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|0 $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|0 $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|0 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|0 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|1 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|0 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|1 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|0 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|1 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|0 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|1 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|0 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|1 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|0 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|1 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|0 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|1 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|0 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|1 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|0 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|1 $std/typedarray/testArraySome<Float32Array,f32>~anonymous|0 $std/typedarray/testArraySome<Float32Array,f32>~anonymous|1 $std/typedarray/testArraySome<Float64Array,f64>~anonymous|0 $std/typedarray/testArraySome<Float64Array,f64>~anonymous|1 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|0 $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|1 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|0 $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|1 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|0 $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|1 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|0 $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|1 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|0 $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|1 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|0 $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|1 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|0 $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|1 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|0 $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|1 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|0 $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|1 $std/typedarray/testArraySome<Float32Array,f32>~anonymous|0 $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|1 $std/typedarray/testArraySome<Float64Array,f64>~anonymous|0 $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|1 $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|0 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|0 $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|0 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|0 $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|0 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|0 $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|0 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|0 $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|0 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|0 $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|0 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|0 $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|0 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|0 $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|0 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|0 $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|0 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|0 $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|0 $std/typedarray/testArraySome<Float32Array,f32>~anonymous|0 $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|0 $std/typedarray/testArraySome<Float64Array,f64>~anonymous|0 $std/typedarray/testArrayForEach<Int8Array,i8>~anonymous|0 $std/typedarray/testArrayForEach<Int8Array,i8>~anonymous|0 $std/typedarray/testArrayForEach<Int8Array,i8>~anonymous|0 $std/typedarray/testArrayForEach<Int16Array,i16>~anonymous|0 $std/typedarray/testArrayForEach<Int16Array,i16>~anonymous|0 $std/typedarray/testArrayForEach<Int32Array,i32>~anonymous|0 $std/typedarray/testArrayForEach<Int32Array,i32>~anonymous|0 $std/typedarray/testArrayForEach<Int64Array,i64>~anonymous|0 $std/typedarray/testArrayForEach<Int64Array,i64>~anonymous|0 $std/typedarray/testArrayForEach<Float32Array,f32>~anonymous|0 $std/typedarray/testArrayForEach<Float64Array,f64>~anonymous|0)
+ (elem (i32.const 0) $null $~lib/internal/sort/COMPARATOR<f64>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|1 $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0)
  (global $~lib/allocator/arena/startOffset (mut i32) (i32.const 0))
  (global $~lib/allocator/arena/offset (mut i32) (i32.const 0))
  (global $std/typedarray/arr (mut i32) (i32.const 0))
@@ -1722,7 +1722,7 @@
   local.get $0
   i32.load offset=4
   local.set $2
-  block $~lib/internal/typedarray/SORT<Float64Array,f64>|inlined.0
+  block $~lib/internal/typedarray/SORT<~lib/typedarray/Float64Array,f64>|inlined.0
    local.get $0
    i32.load offset=8
    i32.const 3
@@ -1730,7 +1730,7 @@
    local.tee $4
    i32.const 1
    i32.le_s
-   br_if $~lib/internal/typedarray/SORT<Float64Array,f64>|inlined.0
+   br_if $~lib/internal/typedarray/SORT<~lib/typedarray/Float64Array,f64>|inlined.0
    local.get $0
    i32.load
    local.set $1
@@ -1773,7 +1773,7 @@
      local.get $5
      f64.store offset=8
     end
-    br $~lib/internal/typedarray/SORT<Float64Array,f64>|inlined.0
+    br $~lib/internal/typedarray/SORT<~lib/typedarray/Float64Array,f64>|inlined.0
    end
    local.get $1
    local.set $0
@@ -2341,7 +2341,7 @@
   local.get $3
   call $~lib/typedarray/Int32Array#fill
  )
- (func $std/typedarray/testReduce<Int8Array,i8>~anonymous|0 (; 35 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 35 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
@@ -2389,7 +2389,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduce<Int8Array,i8> (; 37 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8> (; 37 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -2464,7 +2464,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testReduce<Uint8Array,u8> (; 39 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint8Array,u8> (; 39 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -2497,7 +2497,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Uint8ClampedArray,u8> (; 40 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint8ClampedArray,u8> (; 40 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
@@ -2603,7 +2603,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduce<Int16Array,i16> (; 43 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int16Array,i16> (; 43 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -2681,7 +2681,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduce<Uint16Array,u16> (; 45 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint16Array,u16> (; 45 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -2759,7 +2759,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testReduce<Int32Array,i32> (; 47 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int32Array,i32> (; 47 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -2789,7 +2789,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Uint32Array,u32> (; 48 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint32Array,u32> (; 48 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -2846,7 +2846,7 @@
   local.get $2
   i64.store offset=8
  )
- (func $std/typedarray/testReduce<Int64Array,i64>~anonymous|0 (; 50 ;) (type $FUNCSIG$jjjii) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 50 ;) (type $FUNCSIG$jjjii) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   local.get $0
   local.get $1
   i64.add
@@ -2898,7 +2898,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testReduce<Int64Array,i64> (; 52 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64> (; 52 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -2928,7 +2928,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Uint64Array,u64> (; 53 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint64Array,u64> (; 53 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -2985,7 +2985,7 @@
   local.get $2
   f32.store offset=8
  )
- (func $std/typedarray/testReduce<Float32Array,f32>~anonymous|0 (; 55 ;) (type $FUNCSIG$fffii) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 55 ;) (type $FUNCSIG$fffii) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
   local.get $0
   local.get $1
   f32.add
@@ -3037,7 +3037,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduce<Float32Array,f32> (; 57 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32> (; 57 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -3066,7 +3066,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Float64Array,f64>~anonymous|0 (; 58 ;) (type $FUNCSIG$dddii) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 58 ;) (type $FUNCSIG$dddii) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
   local.get $0
   local.get $1
   f64.add
@@ -3118,7 +3118,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduce<Float64Array,f64> (; 60 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64> (; 60 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -3191,7 +3191,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduceRight<Int8Array,i8> (; 62 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int8Array,i8> (; 62 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -3267,7 +3267,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testReduceRight<Uint8Array,u8> (; 64 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8Array,u8> (; 64 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -3300,7 +3300,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8> (; 65 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8ClampedArray,u8> (; 65 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
@@ -3380,7 +3380,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduceRight<Int16Array,i16> (; 67 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int16Array,i16> (; 67 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -3459,7 +3459,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduceRight<Uint16Array,u16> (; 69 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint16Array,u16> (; 69 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -3538,7 +3538,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testReduceRight<Int32Array,i32> (; 71 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int32Array,i32> (; 71 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -3568,7 +3568,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint32Array,u32> (; 72 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint32Array,u32> (; 72 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -3646,7 +3646,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testReduceRight<Int64Array,i64> (; 74 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int64Array,i64> (; 74 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -3676,7 +3676,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint64Array,u64> (; 75 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint64Array,u64> (; 75 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -3754,7 +3754,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduceRight<Float32Array,f32> (; 77 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Float32Array,f32> (; 77 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -3831,7 +3831,7 @@
   end
   local.get $2
  )
- (func $std/typedarray/testReduceRight<Float64Array,f64> (; 79 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Float64Array,f64> (; 79 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -3860,7 +3860,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|0 (; 80 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 80 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $0
   i32.mul
@@ -3916,7 +3916,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArrayMap<Int8Array,i8> (; 82 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8> (; 82 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -4032,7 +4032,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArrayMap<Uint8Array,u8> (; 84 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8Array,u8> (; 84 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -4147,7 +4147,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8> (; 86 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8ClampedArray,u8> (; 86 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
@@ -4293,7 +4293,7 @@
   i32.add
   i32.load16_s offset=8
  )
- (func $std/typedarray/testArrayMap<Int16Array,i16> (; 89 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int16Array,i16> (; 89 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -4439,7 +4439,7 @@
   i32.add
   i32.load16_u offset=8
  )
- (func $std/typedarray/testArrayMap<Uint16Array,u16> (; 92 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint16Array,u16> (; 92 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -4560,7 +4560,7 @@
   end
   local.get $6
  )
- (func $std/typedarray/testArrayMap<Int32Array,i32> (; 94 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int32Array,i32> (; 94 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -4619,7 +4619,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint32Array,u32> (; 95 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint32Array,u32> (; 95 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -4678,7 +4678,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|0 (; 96 ;) (type $FUNCSIG$jjii) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 96 ;) (type $FUNCSIG$jjii) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
   local.get $0
   local.get $0
   i64.mul
@@ -4766,7 +4766,7 @@
   i32.add
   i64.load offset=8
  )
- (func $std/typedarray/testArrayMap<Int64Array,i64> (; 99 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64> (; 99 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -4825,7 +4825,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint64Array,u64> (; 100 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint64Array,u64> (; 100 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -4884,7 +4884,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|0 (; 101 ;) (type $FUNCSIG$ffii) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 101 ;) (type $FUNCSIG$ffii) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
   local.get $0
   local.get $0
   f32.mul
@@ -4971,7 +4971,7 @@
   i32.add
   f32.load offset=8
  )
- (func $std/typedarray/testArrayMap<Float32Array,f32> (; 104 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32> (; 104 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -5029,7 +5029,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|0 (; 105 ;) (type $FUNCSIG$ddii) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 105 ;) (type $FUNCSIG$ddii) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
   local.get $0
   local.get $0
   f64.mul
@@ -5090,7 +5090,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testArrayMap<Float64Array,f64> (; 107 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64> (; 107 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -5148,7 +5148,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Int8Array,i8>~anonymous|0 (; 108 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 108 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -5160,7 +5160,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  block $~lib/internal/typedarray/SOME<Int8Array,i8>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/SOME<~lib/typedarray/Int8Array,i8>|inlined.0 (result i32)
    local.get $0
    i32.load offset=8
    local.set $3
@@ -5189,7 +5189,7 @@
      local.get $0
      local.get $1
      call_indirect (type $FUNCSIG$iiii)
-     br_if $~lib/internal/typedarray/SOME<Int8Array,i8>|inlined.0
+     br_if $~lib/internal/typedarray/SOME<~lib/typedarray/Int8Array,i8>|inlined.0
      drop
      local.get $2
      i32.const 1
@@ -5201,13 +5201,13 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Int8Array,i8>~anonymous|1 (; 110 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1 (; 110 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.eqz
  )
- (func $std/typedarray/testArraySome<Int8Array,i8> (; 111 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8> (; 111 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -5253,7 +5253,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  block $~lib/internal/typedarray/SOME<Uint8Array,u8>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/SOME<~lib/typedarray/Uint8Array,u8>|inlined.0 (result i32)
    local.get $0
    i32.load offset=8
    local.set $3
@@ -5282,7 +5282,7 @@
      local.get $0
      local.get $1
      call_indirect (type $FUNCSIG$iiii)
-     br_if $~lib/internal/typedarray/SOME<Uint8Array,u8>|inlined.0
+     br_if $~lib/internal/typedarray/SOME<~lib/typedarray/Uint8Array,u8>|inlined.0
      drop
      local.get $2
      i32.const 1
@@ -5294,7 +5294,7 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Uint8Array,u8> (; 113 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8> (; 113 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -5335,7 +5335,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint8ClampedArray,u8> (; 114 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8> (; 114 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
@@ -5375,7 +5375,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Int16Array,i16>~anonymous|0 (; 115 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 115 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
@@ -5387,7 +5387,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  block $~lib/internal/typedarray/SOME<Int16Array,i16>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/SOME<~lib/typedarray/Int16Array,i16>|inlined.0 (result i32)
    local.get $0
    i32.load offset=8
    i32.const 1
@@ -5420,7 +5420,7 @@
      local.get $0
      local.get $1
      call_indirect (type $FUNCSIG$iiii)
-     br_if $~lib/internal/typedarray/SOME<Int16Array,i16>|inlined.0
+     br_if $~lib/internal/typedarray/SOME<~lib/typedarray/Int16Array,i16>|inlined.0
      drop
      local.get $2
      i32.const 1
@@ -5432,13 +5432,13 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Int16Array,i16>~anonymous|1 (; 117 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|1 (; 117 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   i32.eqz
  )
- (func $std/typedarray/testArraySome<Int16Array,i16> (; 118 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16> (; 118 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -5483,7 +5483,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  block $~lib/internal/typedarray/SOME<Uint16Array,u16>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/SOME<~lib/typedarray/Uint16Array,u16>|inlined.0 (result i32)
    local.get $0
    i32.load offset=8
    i32.const 1
@@ -5516,7 +5516,7 @@
      local.get $0
      local.get $1
      call_indirect (type $FUNCSIG$iiii)
-     br_if $~lib/internal/typedarray/SOME<Uint16Array,u16>|inlined.0
+     br_if $~lib/internal/typedarray/SOME<~lib/typedarray/Uint16Array,u16>|inlined.0
      drop
      local.get $2
      i32.const 1
@@ -5528,7 +5528,7 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Uint16Array,u16> (; 120 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16> (; 120 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -5568,7 +5568,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Int32Array,i32>~anonymous|0 (; 121 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 121 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.eq
@@ -5578,7 +5578,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  block $~lib/internal/typedarray/SOME<Int32Array,i32>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/SOME<~lib/typedarray/Int32Array,i32>|inlined.0 (result i32)
    local.get $0
    i32.load offset=8
    i32.const 2
@@ -5611,7 +5611,7 @@
      local.get $0
      local.get $1
      call_indirect (type $FUNCSIG$iiii)
-     br_if $~lib/internal/typedarray/SOME<Int32Array,i32>|inlined.0
+     br_if $~lib/internal/typedarray/SOME<~lib/typedarray/Int32Array,i32>|inlined.0
      drop
      local.get $2
      i32.const 1
@@ -5623,11 +5623,11 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Int32Array,i32>~anonymous|1 (; 123 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|1 (; 123 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.eqz
  )
- (func $std/typedarray/testArraySome<Int32Array,i32> (; 124 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32> (; 124 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -5667,7 +5667,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint32Array,u32> (; 125 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32> (; 125 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -5707,7 +5707,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Int64Array,i64>~anonymous|0 (; 126 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 126 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.eq
@@ -5717,7 +5717,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  block $~lib/internal/typedarray/SOME<Int64Array,i64>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/SOME<~lib/typedarray/Int64Array,i64>|inlined.0 (result i32)
    local.get $0
    i32.load offset=8
    i32.const 3
@@ -5750,7 +5750,7 @@
      local.get $0
      local.get $1
      call_indirect (type $FUNCSIG$ijii)
-     br_if $~lib/internal/typedarray/SOME<Int64Array,i64>|inlined.0
+     br_if $~lib/internal/typedarray/SOME<~lib/typedarray/Int64Array,i64>|inlined.0
      drop
      local.get $2
      i32.const 1
@@ -5762,12 +5762,12 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Int64Array,i64>~anonymous|1 (; 128 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|1 (; 128 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 0
   i64.eq
  )
- (func $std/typedarray/testArraySome<Int64Array,i64> (; 129 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64> (; 129 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -5807,7 +5807,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint64Array,u64> (; 130 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64> (; 130 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -5847,7 +5847,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Float32Array,f32>~anonymous|0 (; 131 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 131 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 2
   f32.eq
@@ -5857,7 +5857,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  block $~lib/internal/typedarray/SOME<Float32Array,f32>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/SOME<~lib/typedarray/Float32Array,f32>|inlined.0 (result i32)
    local.get $0
    i32.load offset=8
    i32.const 2
@@ -5890,7 +5890,7 @@
      local.get $0
      local.get $1
      call_indirect (type $FUNCSIG$ifii)
-     br_if $~lib/internal/typedarray/SOME<Float32Array,f32>|inlined.0
+     br_if $~lib/internal/typedarray/SOME<~lib/typedarray/Float32Array,f32>|inlined.0
      drop
      local.get $2
      i32.const 1
@@ -5902,12 +5902,12 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Float32Array,f32>~anonymous|1 (; 133 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|1 (; 133 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 0
   f32.eq
  )
- (func $std/typedarray/testArraySome<Float32Array,f32> (; 134 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32> (; 134 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -5947,7 +5947,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Float64Array,f64>~anonymous|0 (; 135 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 135 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 2
   f64.eq
@@ -5957,7 +5957,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  block $~lib/internal/typedarray/SOME<Float64Array,f64>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/SOME<~lib/typedarray/Float64Array,f64>|inlined.0 (result i32)
    local.get $0
    i32.load offset=8
    i32.const 3
@@ -5990,7 +5990,7 @@
      local.get $0
      local.get $1
      call_indirect (type $FUNCSIG$idii)
-     br_if $~lib/internal/typedarray/SOME<Float64Array,f64>|inlined.0
+     br_if $~lib/internal/typedarray/SOME<~lib/typedarray/Float64Array,f64>|inlined.0
      drop
      local.get $2
      i32.const 1
@@ -6002,12 +6002,12 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Float64Array,f64>~anonymous|1 (; 137 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|1 (; 137 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 0
   f64.eq
  )
- (func $std/typedarray/testArraySome<Float64Array,f64> (; 138 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64> (; 138 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -6064,7 +6064,7 @@
   local.set $5
   i32.const 0
   local.set $0
-  block $~lib/internal/typedarray/FIND_INDEX<Int8Array,i8>|inlined.0
+  block $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Int8Array,i8>|inlined.0
    loop $repeat|0
     block $break|0
      local.get $0
@@ -6083,7 +6083,7 @@
      local.get $3
      local.get $1
      call_indirect (type $FUNCSIG$iiii)
-     br_if $~lib/internal/typedarray/FIND_INDEX<Int8Array,i8>|inlined.0
+     br_if $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Int8Array,i8>|inlined.0
      local.get $0
      i32.const 1
      i32.add
@@ -6096,14 +6096,14 @@
   end
   local.get $0
  )
- (func $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|1 (; 140 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1 (; 140 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int8Array,i8> (; 141 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8> (; 141 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -6164,7 +6164,7 @@
   local.set $5
   i32.const 0
   local.set $0
-  block $~lib/internal/typedarray/FIND_INDEX<Uint8Array,u8>|inlined.0
+  block $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.0
    loop $repeat|0
     block $break|0
      local.get $0
@@ -6183,7 +6183,7 @@
      local.get $3
      local.get $1
      call_indirect (type $FUNCSIG$iiii)
-     br_if $~lib/internal/typedarray/FIND_INDEX<Uint8Array,u8>|inlined.0
+     br_if $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.0
      local.get $0
      i32.const 1
      i32.add
@@ -6196,7 +6196,7 @@
   end
   local.get $0
  )
- (func $std/typedarray/testArrayFindIndex<Uint8Array,u8> (; 143 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8> (; 143 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -6240,7 +6240,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8> (; 144 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8> (; 144 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
@@ -6302,7 +6302,7 @@
   local.set $5
   i32.const 0
   local.set $0
-  block $~lib/internal/typedarray/FIND_INDEX<Int16Array,i16>|inlined.0
+  block $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Int16Array,i16>|inlined.0
    loop $repeat|0
     block $break|0
      local.get $0
@@ -6323,7 +6323,7 @@
      local.get $3
      local.get $1
      call_indirect (type $FUNCSIG$iiii)
-     br_if $~lib/internal/typedarray/FIND_INDEX<Int16Array,i16>|inlined.0
+     br_if $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Int16Array,i16>|inlined.0
      local.get $0
      i32.const 1
      i32.add
@@ -6336,14 +6336,14 @@
   end
   local.get $0
  )
- (func $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|1 (; 146 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|1 (; 146 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int16Array,i16> (; 147 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16> (; 147 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -6405,7 +6405,7 @@
   local.set $5
   i32.const 0
   local.set $0
-  block $~lib/internal/typedarray/FIND_INDEX<Uint16Array,u16>|inlined.0
+  block $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Uint16Array,u16>|inlined.0
    loop $repeat|0
     block $break|0
      local.get $0
@@ -6426,7 +6426,7 @@
      local.get $3
      local.get $1
      call_indirect (type $FUNCSIG$iiii)
-     br_if $~lib/internal/typedarray/FIND_INDEX<Uint16Array,u16>|inlined.0
+     br_if $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Uint16Array,u16>|inlined.0
      local.get $0
      i32.const 1
      i32.add
@@ -6439,7 +6439,7 @@
   end
   local.get $0
  )
- (func $std/typedarray/testArrayFindIndex<Uint16Array,u16> (; 149 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16> (; 149 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -6501,7 +6501,7 @@
   local.set $5
   i32.const 0
   local.set $0
-  block $~lib/internal/typedarray/FIND_INDEX<Int32Array,i32>|inlined.0
+  block $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Int32Array,i32>|inlined.0
    loop $repeat|0
     block $break|0
      local.get $0
@@ -6522,7 +6522,7 @@
      local.get $3
      local.get $1
      call_indirect (type $FUNCSIG$iiii)
-     br_if $~lib/internal/typedarray/FIND_INDEX<Int32Array,i32>|inlined.0
+     br_if $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Int32Array,i32>|inlined.0
      local.get $0
      i32.const 1
      i32.add
@@ -6535,12 +6535,12 @@
   end
   local.get $0
  )
- (func $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|1 (; 151 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|1 (; 151 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int32Array,i32> (; 152 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32> (; 152 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -6583,7 +6583,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint32Array,u32> (; 153 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32> (; 153 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -6645,7 +6645,7 @@
   local.set $5
   i32.const 0
   local.set $0
-  block $~lib/internal/typedarray/FIND_INDEX<Int64Array,i64>|inlined.0
+  block $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Int64Array,i64>|inlined.0
    loop $repeat|0
     block $break|0
      local.get $0
@@ -6666,7 +6666,7 @@
      local.get $3
      local.get $1
      call_indirect (type $FUNCSIG$ijii)
-     br_if $~lib/internal/typedarray/FIND_INDEX<Int64Array,i64>|inlined.0
+     br_if $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Int64Array,i64>|inlined.0
      local.get $0
      i32.const 1
      i32.add
@@ -6679,12 +6679,12 @@
   end
   local.get $0
  )
- (func $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|1 (; 155 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|1 (; 155 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 4
   i64.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int64Array,i64> (; 156 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64> (; 156 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -6727,7 +6727,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint64Array,u64> (; 157 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64> (; 157 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -6789,7 +6789,7 @@
   local.set $5
   i32.const 0
   local.set $0
-  block $~lib/internal/typedarray/FIND_INDEX<Float32Array,f32>|inlined.0
+  block $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Float32Array,f32>|inlined.0
    loop $repeat|0
     block $break|0
      local.get $0
@@ -6810,7 +6810,7 @@
      local.get $3
      local.get $1
      call_indirect (type $FUNCSIG$ifii)
-     br_if $~lib/internal/typedarray/FIND_INDEX<Float32Array,f32>|inlined.0
+     br_if $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Float32Array,f32>|inlined.0
      local.get $0
      i32.const 1
      i32.add
@@ -6823,12 +6823,12 @@
   end
   local.get $0
  )
- (func $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|1 (; 159 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|1 (; 159 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 4
   f32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Float32Array,f32> (; 160 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32> (; 160 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -6890,7 +6890,7 @@
   local.set $5
   i32.const 0
   local.set $0
-  block $~lib/internal/typedarray/FIND_INDEX<Float64Array,f64>|inlined.0
+  block $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Float64Array,f64>|inlined.0
    loop $repeat|0
     block $break|0
      local.get $0
@@ -6911,7 +6911,7 @@
      local.get $3
      local.get $1
      call_indirect (type $FUNCSIG$idii)
-     br_if $~lib/internal/typedarray/FIND_INDEX<Float64Array,f64>|inlined.0
+     br_if $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Float64Array,f64>|inlined.0
      local.get $0
      i32.const 1
      i32.add
@@ -6924,12 +6924,12 @@
   end
   local.get $0
  )
- (func $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|1 (; 162 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|1 (; 162 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 4
   f64.eq
  )
- (func $std/typedarray/testArrayFindIndex<Float64Array,f64> (; 163 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64> (; 163 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -6972,7 +6972,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|0 (; 164 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 164 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -6987,7 +6987,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  block $~lib/internal/typedarray/EVERY<Int8Array,i8>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/EVERY<~lib/typedarray/Int8Array,i8>|inlined.0 (result i32)
    local.get $0
    i32.load offset=8
    local.set $3
@@ -7018,7 +7018,7 @@
      i32.eqz
      if
       i32.const 0
-      br $~lib/internal/typedarray/EVERY<Int8Array,i8>|inlined.0
+      br $~lib/internal/typedarray/EVERY<~lib/typedarray/Int8Array,i8>|inlined.0
      end
      local.get $2
      i32.const 1
@@ -7030,7 +7030,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int8Array,i8> (; 166 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8> (; 166 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -7071,7 +7071,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|0 (; 167 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 167 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 1
   i32.and
@@ -7082,7 +7082,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  block $~lib/internal/typedarray/EVERY<Uint8Array,u8>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/EVERY<~lib/typedarray/Uint8Array,u8>|inlined.0 (result i32)
    local.get $0
    i32.load offset=8
    local.set $3
@@ -7113,7 +7113,7 @@
      i32.eqz
      if
       i32.const 0
-      br $~lib/internal/typedarray/EVERY<Uint8Array,u8>|inlined.0
+      br $~lib/internal/typedarray/EVERY<~lib/typedarray/Uint8Array,u8>|inlined.0
      end
      local.get $2
      i32.const 1
@@ -7125,7 +7125,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Uint8Array,u8> (; 169 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8> (; 169 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   i32.const 3
@@ -7166,7 +7166,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8> (; 170 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8> (; 170 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Uint8ClampedArray#constructor
@@ -7206,7 +7206,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|0 (; 171 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 171 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -7221,7 +7221,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  block $~lib/internal/typedarray/EVERY<Int16Array,i16>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/EVERY<~lib/typedarray/Int16Array,i16>|inlined.0 (result i32)
    local.get $0
    i32.load offset=8
    i32.const 1
@@ -7256,7 +7256,7 @@
      i32.eqz
      if
       i32.const 0
-      br $~lib/internal/typedarray/EVERY<Int16Array,i16>|inlined.0
+      br $~lib/internal/typedarray/EVERY<~lib/typedarray/Int16Array,i16>|inlined.0
      end
      local.get $2
      i32.const 1
@@ -7268,7 +7268,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int16Array,i16> (; 173 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16> (; 173 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -7313,7 +7313,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  block $~lib/internal/typedarray/EVERY<Uint16Array,u16>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/EVERY<~lib/typedarray/Uint16Array,u16>|inlined.0 (result i32)
    local.get $0
    i32.load offset=8
    i32.const 1
@@ -7348,7 +7348,7 @@
      i32.eqz
      if
       i32.const 0
-      br $~lib/internal/typedarray/EVERY<Uint16Array,u16>|inlined.0
+      br $~lib/internal/typedarray/EVERY<~lib/typedarray/Uint16Array,u16>|inlined.0
      end
      local.get $2
      i32.const 1
@@ -7360,7 +7360,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Uint16Array,u16> (; 175 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16> (; 175 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int16Array#constructor
@@ -7400,7 +7400,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|0 (; 176 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 176 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.rem_s
@@ -7411,7 +7411,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  block $~lib/internal/typedarray/EVERY<Int32Array,i32>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/EVERY<~lib/typedarray/Int32Array,i32>|inlined.0 (result i32)
    local.get $0
    i32.load offset=8
    i32.const 2
@@ -7446,7 +7446,7 @@
      i32.eqz
      if
       i32.const 0
-      br $~lib/internal/typedarray/EVERY<Int32Array,i32>|inlined.0
+      br $~lib/internal/typedarray/EVERY<~lib/typedarray/Int32Array,i32>|inlined.0
      end
      local.get $2
      i32.const 1
@@ -7458,7 +7458,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int32Array,i32> (; 178 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32> (; 178 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -7498,7 +7498,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint32Array,u32> (; 179 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32> (; 179 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -7538,7 +7538,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|0 (; 180 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 180 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.rem_s
@@ -7550,7 +7550,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  block $~lib/internal/typedarray/EVERY<Int64Array,i64>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/EVERY<~lib/typedarray/Int64Array,i64>|inlined.0 (result i32)
    local.get $0
    i32.load offset=8
    i32.const 3
@@ -7585,7 +7585,7 @@
      i32.eqz
      if
       i32.const 0
-      br $~lib/internal/typedarray/EVERY<Int64Array,i64>|inlined.0
+      br $~lib/internal/typedarray/EVERY<~lib/typedarray/Int64Array,i64>|inlined.0
      end
      local.get $2
      i32.const 1
@@ -7597,7 +7597,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int64Array,i64> (; 182 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64> (; 182 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -7637,14 +7637,14 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|0 (; 183 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 183 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.rem_u
   i64.const 0
   i64.eq
  )
- (func $std/typedarray/testArrayEvery<Uint64Array,u64> (; 184 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64> (; 184 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -7835,7 +7835,7 @@
   local.get $0
   f32.mul
  )
- (func $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|0 (; 186 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 186 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.mod
   f32.const 0
@@ -7846,7 +7846,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  block $~lib/internal/typedarray/EVERY<Float32Array,f32>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/EVERY<~lib/typedarray/Float32Array,f32>|inlined.0 (result i32)
    local.get $0
    i32.load offset=8
    i32.const 2
@@ -7881,7 +7881,7 @@
      i32.eqz
      if
       i32.const 0
-      br $~lib/internal/typedarray/EVERY<Float32Array,f32>|inlined.0
+      br $~lib/internal/typedarray/EVERY<~lib/typedarray/Float32Array,f32>|inlined.0
      end
      local.get $2
      i32.const 1
@@ -7893,7 +7893,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Float32Array,f32> (; 188 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32> (; 188 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int32Array#constructor
@@ -8092,7 +8092,7 @@
   local.get $0
   f64.mul
  )
- (func $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|0 (; 190 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 190 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.mod
   f64.const 0
@@ -8103,7 +8103,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  block $~lib/internal/typedarray/EVERY<Float64Array,f64>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/EVERY<~lib/typedarray/Float64Array,f64>|inlined.0 (result i32)
    local.get $0
    i32.load offset=8
    i32.const 3
@@ -8138,7 +8138,7 @@
      i32.eqz
      if
       i32.const 0
-      br $~lib/internal/typedarray/EVERY<Float64Array,f64>|inlined.0
+      br $~lib/internal/typedarray/EVERY<~lib/typedarray/Float64Array,f64>|inlined.0
      end
      local.get $2
      i32.const 1
@@ -8150,7 +8150,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Float64Array,f64> (; 192 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64> (; 192 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 3
   call $~lib/typedarray/Int64Array#constructor
@@ -8190,7 +8190,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Int8Array,i8>~anonymous|0 (; 193 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 193 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.const 255
   i32.and
@@ -8289,7 +8289,7 @@
    end
   end
  )
- (func $std/typedarray/testArrayForEach<Int8Array,i8> (; 195 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8> (; 195 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -8420,7 +8420,7 @@
    end
   end
  )
- (func $std/typedarray/testArrayForEach<Uint8Array,u8> (; 197 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8> (; 197 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -8506,7 +8506,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Uint8ClampedArray,u8> (; 198 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8> (; 198 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -8591,7 +8591,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Int16Array,i16>~anonymous|0 (; 199 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 199 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.const 65535
   i32.and
@@ -8694,7 +8694,7 @@
    end
   end
  )
- (func $std/typedarray/testArrayForEach<Int16Array,i16> (; 201 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16> (; 201 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -8827,7 +8827,7 @@
    end
   end
  )
- (func $std/typedarray/testArrayForEach<Uint16Array,u16> (; 203 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16> (; 203 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -8911,7 +8911,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Int32Array,i32>~anonymous|0 (; 204 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 204 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   local.get $1
   global.get $std/typedarray/forEachValues
@@ -9011,7 +9011,7 @@
    end
   end
  )
- (func $std/typedarray/testArrayForEach<Int32Array,i32> (; 206 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32> (; 206 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -9090,7 +9090,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Uint32Array,u32> (; 207 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32> (; 207 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -9169,7 +9169,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Int64Array,i64>~anonymous|0 (; 208 ;) (type $FUNCSIG$vjii) (param $0 i64) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 208 ;) (type $FUNCSIG$vjii) (param $0 i64) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
   global.get $std/typedarray/forEachValues
@@ -9271,7 +9271,7 @@
    end
   end
  )
- (func $std/typedarray/testArrayForEach<Int64Array,i64> (; 210 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64> (; 210 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -9353,7 +9353,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Uint64Array,u64> (; 211 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64> (; 211 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -9435,7 +9435,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Float32Array,f32>~anonymous|0 (; 212 ;) (type $FUNCSIG$vfii) (param $0 f32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 212 ;) (type $FUNCSIG$vfii) (param $0 f32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -9536,7 +9536,7 @@
    end
   end
  )
- (func $std/typedarray/testArrayForEach<Float32Array,f32> (; 214 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32> (; 214 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -9617,7 +9617,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Float64Array,f64>~anonymous|0 (; 215 ;) (type $FUNCSIG$vdii) (param $0 f64) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 215 ;) (type $FUNCSIG$vdii) (param $0 f64) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   local.get $1
@@ -9718,7 +9718,7 @@
    end
   end
  )
- (func $std/typedarray/testArrayForEach<Float64Array,f64> (; 217 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64> (; 217 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -9861,7 +9861,7 @@
   end
   local.get $0
  )
- (func $std/typedarray/testArrayReverse<Int8Array,i8> (; 219 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int8Array,i8> (; 219 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10124,7 +10124,7 @@
   end
   local.get $0
  )
- (func $std/typedarray/testArrayReverse<Uint8Array,u8> (; 221 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8Array,u8> (; 221 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10321,7 +10321,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayReverse<Uint8ClampedArray,u8> (; 222 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8ClampedArray,u8> (; 222 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10639,7 +10639,7 @@
   i32.store offset=8
   local.get $2
  )
- (func $std/typedarray/testArrayReverse<Int16Array,i16> (; 225 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int16Array,i16> (; 225 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10908,7 +10908,7 @@
   end
   local.get $0
  )
- (func $std/typedarray/testArrayReverse<Uint16Array,u16> (; 227 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint16Array,u16> (; 227 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11173,7 +11173,7 @@
   end
   local.get $0
  )
- (func $std/typedarray/testArrayReverse<Int32Array,i32> (; 229 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int32Array,i32> (; 229 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11424,7 +11424,7 @@
   end
   local.get $0
  )
- (func $std/typedarray/testArrayReverse<Int64Array,i64> (; 231 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int64Array,i64> (; 231 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11679,7 +11679,7 @@
   end
   local.get $0
  )
- (func $std/typedarray/testArrayReverse<Float32Array,f32> (; 233 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Float32Array,f32> (; 233 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11934,7 +11934,7 @@
   end
   local.get $0
  )
- (func $std/typedarray/testArrayReverse<Float64Array,f64> (; 235 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Float64Array,f64> (; 235 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13038,94 +13038,94 @@
    call $~lib/env/abort
    unreachable
   end
-  call $std/typedarray/testReduce<Int8Array,i8>
-  call $std/typedarray/testReduce<Uint8Array,u8>
-  call $std/typedarray/testReduce<Uint8ClampedArray,u8>
-  call $std/typedarray/testReduce<Int16Array,i16>
-  call $std/typedarray/testReduce<Uint16Array,u16>
-  call $std/typedarray/testReduce<Int32Array,i32>
-  call $std/typedarray/testReduce<Uint32Array,u32>
-  call $std/typedarray/testReduce<Int64Array,i64>
-  call $std/typedarray/testReduce<Uint64Array,u64>
-  call $std/typedarray/testReduce<Float32Array,f32>
-  call $std/typedarray/testReduce<Float64Array,f64>
-  call $std/typedarray/testReduceRight<Int8Array,i8>
-  call $std/typedarray/testReduceRight<Uint8Array,u8>
-  call $std/typedarray/testReduceRight<Uint8ClampedArray,u8>
-  call $std/typedarray/testReduceRight<Int16Array,i16>
-  call $std/typedarray/testReduceRight<Uint16Array,u16>
-  call $std/typedarray/testReduceRight<Int32Array,i32>
-  call $std/typedarray/testReduceRight<Uint32Array,u32>
-  call $std/typedarray/testReduceRight<Int64Array,i64>
-  call $std/typedarray/testReduceRight<Uint64Array,u64>
-  call $std/typedarray/testReduceRight<Float32Array,f32>
-  call $std/typedarray/testReduceRight<Float64Array,f64>
-  call $std/typedarray/testArrayMap<Int8Array,i8>
-  call $std/typedarray/testArrayMap<Uint8Array,u8>
-  call $std/typedarray/testArrayMap<Uint8ClampedArray,u8>
-  call $std/typedarray/testArrayMap<Int16Array,i16>
-  call $std/typedarray/testArrayMap<Uint16Array,u16>
-  call $std/typedarray/testArrayMap<Int32Array,i32>
-  call $std/typedarray/testArrayMap<Uint32Array,u32>
-  call $std/typedarray/testArrayMap<Int64Array,i64>
-  call $std/typedarray/testArrayMap<Uint64Array,u64>
-  call $std/typedarray/testArrayMap<Float32Array,f32>
-  call $std/typedarray/testArrayMap<Float64Array,f64>
-  call $std/typedarray/testArraySome<Int8Array,i8>
-  call $std/typedarray/testArraySome<Uint8Array,u8>
-  call $std/typedarray/testArraySome<Uint8ClampedArray,u8>
-  call $std/typedarray/testArraySome<Int16Array,i16>
-  call $std/typedarray/testArraySome<Uint16Array,u16>
-  call $std/typedarray/testArraySome<Int32Array,i32>
-  call $std/typedarray/testArraySome<Uint32Array,u32>
-  call $std/typedarray/testArraySome<Int64Array,i64>
-  call $std/typedarray/testArraySome<Uint64Array,u64>
-  call $std/typedarray/testArraySome<Float32Array,f32>
-  call $std/typedarray/testArraySome<Float64Array,f64>
-  call $std/typedarray/testArrayFindIndex<Int8Array,i8>
-  call $std/typedarray/testArrayFindIndex<Uint8Array,u8>
-  call $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8>
-  call $std/typedarray/testArrayFindIndex<Int16Array,i16>
-  call $std/typedarray/testArrayFindIndex<Uint16Array,u16>
-  call $std/typedarray/testArrayFindIndex<Int32Array,i32>
-  call $std/typedarray/testArrayFindIndex<Uint32Array,u32>
-  call $std/typedarray/testArrayFindIndex<Int64Array,i64>
-  call $std/typedarray/testArrayFindIndex<Uint64Array,u64>
-  call $std/typedarray/testArrayFindIndex<Float32Array,f32>
-  call $std/typedarray/testArrayFindIndex<Float64Array,f64>
-  call $std/typedarray/testArrayEvery<Int8Array,i8>
-  call $std/typedarray/testArrayEvery<Uint8Array,u8>
-  call $std/typedarray/testArrayEvery<Uint8ClampedArray,u8>
-  call $std/typedarray/testArrayEvery<Int16Array,i16>
-  call $std/typedarray/testArrayEvery<Uint16Array,u16>
-  call $std/typedarray/testArrayEvery<Int32Array,i32>
-  call $std/typedarray/testArrayEvery<Uint32Array,u32>
-  call $std/typedarray/testArrayEvery<Int64Array,i64>
-  call $std/typedarray/testArrayEvery<Uint64Array,u64>
-  call $std/typedarray/testArrayEvery<Float32Array,f32>
-  call $std/typedarray/testArrayEvery<Float64Array,f64>
-  call $std/typedarray/testArrayForEach<Int8Array,i8>
-  call $std/typedarray/testArrayForEach<Uint8Array,u8>
-  call $std/typedarray/testArrayForEach<Uint8ClampedArray,u8>
-  call $std/typedarray/testArrayForEach<Int16Array,i16>
-  call $std/typedarray/testArrayForEach<Uint16Array,u16>
-  call $std/typedarray/testArrayForEach<Int32Array,i32>
-  call $std/typedarray/testArrayForEach<Uint32Array,u32>
-  call $std/typedarray/testArrayForEach<Int64Array,i64>
-  call $std/typedarray/testArrayForEach<Uint64Array,u64>
-  call $std/typedarray/testArrayForEach<Float32Array,f32>
-  call $std/typedarray/testArrayForEach<Float64Array,f64>
-  call $std/typedarray/testArrayReverse<Int8Array,i8>
-  call $std/typedarray/testArrayReverse<Uint8Array,u8>
-  call $std/typedarray/testArrayReverse<Uint8ClampedArray,u8>
-  call $std/typedarray/testArrayReverse<Int16Array,i16>
-  call $std/typedarray/testArrayReverse<Uint16Array,u16>
-  call $std/typedarray/testArrayReverse<Int32Array,i32>
-  call $std/typedarray/testArrayReverse<Int32Array,i32>
-  call $std/typedarray/testArrayReverse<Int64Array,i64>
-  call $std/typedarray/testArrayReverse<Int64Array,i64>
-  call $std/typedarray/testArrayReverse<Float32Array,f32>
-  call $std/typedarray/testArrayReverse<Float64Array,f64>
+  call $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>
+  call $std/typedarray/testReduce<~lib/typedarray/Uint8Array,u8>
+  call $std/typedarray/testReduce<~lib/typedarray/Uint8ClampedArray,u8>
+  call $std/typedarray/testReduce<~lib/typedarray/Int16Array,i16>
+  call $std/typedarray/testReduce<~lib/typedarray/Uint16Array,u16>
+  call $std/typedarray/testReduce<~lib/typedarray/Int32Array,i32>
+  call $std/typedarray/testReduce<~lib/typedarray/Uint32Array,u32>
+  call $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>
+  call $std/typedarray/testReduce<~lib/typedarray/Uint64Array,u64>
+  call $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>
+  call $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>
+  call $std/typedarray/testReduceRight<~lib/typedarray/Int8Array,i8>
+  call $std/typedarray/testReduceRight<~lib/typedarray/Uint8Array,u8>
+  call $std/typedarray/testReduceRight<~lib/typedarray/Uint8ClampedArray,u8>
+  call $std/typedarray/testReduceRight<~lib/typedarray/Int16Array,i16>
+  call $std/typedarray/testReduceRight<~lib/typedarray/Uint16Array,u16>
+  call $std/typedarray/testReduceRight<~lib/typedarray/Int32Array,i32>
+  call $std/typedarray/testReduceRight<~lib/typedarray/Uint32Array,u32>
+  call $std/typedarray/testReduceRight<~lib/typedarray/Int64Array,i64>
+  call $std/typedarray/testReduceRight<~lib/typedarray/Uint64Array,u64>
+  call $std/typedarray/testReduceRight<~lib/typedarray/Float32Array,f32>
+  call $std/typedarray/testReduceRight<~lib/typedarray/Float64Array,f64>
+  call $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>
+  call $std/typedarray/testArrayMap<~lib/typedarray/Uint8Array,u8>
+  call $std/typedarray/testArrayMap<~lib/typedarray/Uint8ClampedArray,u8>
+  call $std/typedarray/testArrayMap<~lib/typedarray/Int16Array,i16>
+  call $std/typedarray/testArrayMap<~lib/typedarray/Uint16Array,u16>
+  call $std/typedarray/testArrayMap<~lib/typedarray/Int32Array,i32>
+  call $std/typedarray/testArrayMap<~lib/typedarray/Uint32Array,u32>
+  call $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>
+  call $std/typedarray/testArrayMap<~lib/typedarray/Uint64Array,u64>
+  call $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32>
+  call $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64>
+  call $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>
+  call $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8>
+  call $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8>
+  call $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>
+  call $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16>
+  call $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>
+  call $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32>
+  call $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>
+  call $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64>
+  call $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>
+  call $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>
+  call $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>
+  call $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8>
+  call $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8>
+  call $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>
+  call $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16>
+  call $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>
+  call $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32>
+  call $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>
+  call $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64>
+  call $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>
+  call $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>
+  call $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>
+  call $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>
+  call $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8>
+  call $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>
+  call $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16>
+  call $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>
+  call $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32>
+  call $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>
+  call $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>
+  call $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>
+  call $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>
+  call $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>
+  call $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8>
+  call $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8>
+  call $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>
+  call $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16>
+  call $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>
+  call $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32>
+  call $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>
+  call $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64>
+  call $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>
+  call $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>
+  call $std/typedarray/testArrayReverse<~lib/typedarray/Int8Array,i8>
+  call $std/typedarray/testArrayReverse<~lib/typedarray/Uint8Array,u8>
+  call $std/typedarray/testArrayReverse<~lib/typedarray/Uint8ClampedArray,u8>
+  call $std/typedarray/testArrayReverse<~lib/typedarray/Int16Array,i16>
+  call $std/typedarray/testArrayReverse<~lib/typedarray/Uint16Array,u16>
+  call $std/typedarray/testArrayReverse<~lib/typedarray/Int32Array,i32>
+  call $std/typedarray/testArrayReverse<~lib/typedarray/Int32Array,i32>
+  call $std/typedarray/testArrayReverse<~lib/typedarray/Int64Array,i64>
+  call $std/typedarray/testArrayReverse<~lib/typedarray/Int64Array,i64>
+  call $std/typedarray/testArrayReverse<~lib/typedarray/Float32Array,f32>
+  call $std/typedarray/testArrayReverse<~lib/typedarray/Float64Array,f64>
  )
  (func $start (; 237 ;) (type $FUNCSIG$v)
   call $start:std/typedarray

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -78,7 +78,7 @@
  (data (i32.const 1056) "!\00\00\00T\00y\00p\00e\00d\00A\00r\00r\00a\00y\00 \00r\00e\00v\00e\00r\00s\00e\00 \00v\00a\00l\00u\00e\00 \00m\00i\00s\00m\00a\00t\00c\00h\00")
  (data (i32.const 1128) "+\00\00\00T\00y\00p\00e\00d\00A\00r\00r\00a\00y\00 \00r\00e\00v\00e\00r\00s\00e\00 \00w\00i\00t\00h\00 \00b\00y\00t\00e\00O\00f\00f\00s\00e\00t\00 \00m\00i\00s\00m\00a\00t\00c\00h\00")
  (table $0 112 funcref)
- (elem (i32.const 0) $null $~lib/internal/sort/COMPARATOR<f64>~anonymous|0 $std/typedarray/testReduce<Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<Uint8Array,u8>~anonymous|0 $std/typedarray/testReduce<Uint8ClampedArray,u8>~anonymous|0 $std/typedarray/testReduce<Int16Array,i16>~anonymous|0 $std/typedarray/testReduce<Uint16Array,u16>~anonymous|0 $std/typedarray/testReduce<Int32Array,i32>~anonymous|0 $std/typedarray/testReduce<Uint32Array,u32>~anonymous|0 $std/typedarray/testReduce<Int64Array,i64>~anonymous|0 $std/typedarray/testReduce<Uint64Array,u64>~anonymous|0 $std/typedarray/testReduce<Float32Array,f32>~anonymous|0 $std/typedarray/testReduce<Float64Array,f64>~anonymous|0 $std/typedarray/testReduceRight<Int8Array,i8>~anonymous|0 $std/typedarray/testReduceRight<Uint8Array,u8>~anonymous|0 $std/typedarray/testReduceRight<Uint8ClampedArray,u8>~anonymous|0 $std/typedarray/testReduceRight<Int16Array,i16>~anonymous|0 $std/typedarray/testReduceRight<Uint16Array,u16>~anonymous|0 $std/typedarray/testReduceRight<Int32Array,i32>~anonymous|0 $std/typedarray/testReduceRight<Uint32Array,u32>~anonymous|0 $std/typedarray/testReduceRight<Int64Array,i64>~anonymous|0 $std/typedarray/testReduceRight<Uint64Array,u64>~anonymous|0 $std/typedarray/testReduceRight<Float32Array,f32>~anonymous|0 $std/typedarray/testReduceRight<Float64Array,f64>~anonymous|0 $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|0 $std/typedarray/testArrayMap<Uint8Array,u8>~anonymous|0 $std/typedarray/testArrayMap<Uint8ClampedArray,u8>~anonymous|0 $std/typedarray/testArrayMap<Int16Array,i16>~anonymous|0 $std/typedarray/testArrayMap<Uint16Array,u16>~anonymous|0 $std/typedarray/testArrayMap<Int32Array,i32>~anonymous|0 $std/typedarray/testArrayMap<Uint32Array,u32>~anonymous|0 $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|0 $std/typedarray/testArrayMap<Uint64Array,u64>~anonymous|0 $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|0 $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|0 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|0 $std/typedarray/testArraySome<Int8Array,i8>~anonymous|1 $std/typedarray/testArraySome<Uint8Array,u8>~anonymous|0 $std/typedarray/testArraySome<Uint8Array,u8>~anonymous|1 $std/typedarray/testArraySome<Uint8ClampedArray,u8>~anonymous|0 $std/typedarray/testArraySome<Uint8ClampedArray,u8>~anonymous|1 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|0 $std/typedarray/testArraySome<Int16Array,i16>~anonymous|1 $std/typedarray/testArraySome<Uint16Array,u16>~anonymous|0 $std/typedarray/testArraySome<Uint16Array,u16>~anonymous|1 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|0 $std/typedarray/testArraySome<Int32Array,i32>~anonymous|1 $std/typedarray/testArraySome<Uint32Array,u32>~anonymous|0 $std/typedarray/testArraySome<Uint32Array,u32>~anonymous|1 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|0 $std/typedarray/testArraySome<Int64Array,i64>~anonymous|1 $std/typedarray/testArraySome<Uint64Array,u64>~anonymous|0 $std/typedarray/testArraySome<Uint64Array,u64>~anonymous|1 $std/typedarray/testArraySome<Float32Array,f32>~anonymous|0 $std/typedarray/testArraySome<Float32Array,f32>~anonymous|1 $std/typedarray/testArraySome<Float64Array,f64>~anonymous|0 $std/typedarray/testArraySome<Float64Array,f64>~anonymous|1 $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|0 $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|1 $std/typedarray/testArrayFindIndex<Uint8Array,u8>~anonymous|0 $std/typedarray/testArrayFindIndex<Uint8Array,u8>~anonymous|1 $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8>~anonymous|0 $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8>~anonymous|1 $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|0 $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|1 $std/typedarray/testArrayFindIndex<Uint16Array,u16>~anonymous|0 $std/typedarray/testArrayFindIndex<Uint16Array,u16>~anonymous|1 $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|0 $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|1 $std/typedarray/testArrayFindIndex<Uint32Array,u32>~anonymous|0 $std/typedarray/testArrayFindIndex<Uint32Array,u32>~anonymous|1 $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|0 $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|1 $std/typedarray/testArrayFindIndex<Uint64Array,u64>~anonymous|0 $std/typedarray/testArrayFindIndex<Uint64Array,u64>~anonymous|1 $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|0 $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|1 $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|0 $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|1 $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|0 $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|1 $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|0 $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|1 $std/typedarray/testArrayEvery<Uint8ClampedArray,u8>~anonymous|0 $std/typedarray/testArrayEvery<Uint8ClampedArray,u8>~anonymous|1 $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|0 $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|1 $std/typedarray/testArrayEvery<Uint16Array,u16>~anonymous|0 $std/typedarray/testArrayEvery<Uint16Array,u16>~anonymous|1 $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|0 $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|1 $std/typedarray/testArrayEvery<Uint32Array,u32>~anonymous|0 $std/typedarray/testArrayEvery<Uint32Array,u32>~anonymous|1 $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|0 $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|1 $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|0 $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|1 $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|0 $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|1 $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|0 $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|1 $std/typedarray/testArrayForEach<Int8Array,i8>~anonymous|0 $std/typedarray/testArrayForEach<Uint8Array,u8>~anonymous|0 $std/typedarray/testArrayForEach<Uint8ClampedArray,u8>~anonymous|0 $std/typedarray/testArrayForEach<Int16Array,i16>~anonymous|0 $std/typedarray/testArrayForEach<Uint16Array,u16>~anonymous|0 $std/typedarray/testArrayForEach<Int32Array,i32>~anonymous|0 $std/typedarray/testArrayForEach<Uint32Array,u32>~anonymous|0 $std/typedarray/testArrayForEach<Int64Array,i64>~anonymous|0 $std/typedarray/testArrayForEach<Uint64Array,u64>~anonymous|0 $std/typedarray/testArrayForEach<Float32Array,f32>~anonymous|0 $std/typedarray/testArrayForEach<Float64Array,f64>~anonymous|0)
+ (elem (i32.const 0) $null $~lib/internal/sort/COMPARATOR<f64>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Uint8Array,u8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Uint16Array,u16>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Uint32Array,u32>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Uint64Array,u64>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testReduceRight<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testReduceRight<~lib/typedarray/Uint8Array,u8>~anonymous|0 $std/typedarray/testReduceRight<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 $std/typedarray/testReduceRight<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testReduceRight<~lib/typedarray/Uint16Array,u16>~anonymous|0 $std/typedarray/testReduceRight<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testReduceRight<~lib/typedarray/Uint32Array,u32>~anonymous|0 $std/typedarray/testReduceRight<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testReduceRight<~lib/typedarray/Uint64Array,u64>~anonymous|0 $std/typedarray/testReduceRight<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testReduceRight<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Uint8Array,u8>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Uint16Array,u16>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Uint32Array,u32>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Uint64Array,u64>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|1 $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|1 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1 $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8>~anonymous|1 $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|1 $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16>~anonymous|1 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|1 $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32>~anonymous|1 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|1 $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64>~anonymous|1 $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|1 $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|1 $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|1 $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|1 $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|1 $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16>~anonymous|1 $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|1 $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32>~anonymous|1 $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|1 $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|1 $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|1 $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0 $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|1 $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0 $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0)
  (global $~lib/typedarray/Int8Array.BYTES_PER_ELEMENT i32 (i32.const 1))
  (global $~lib/typedarray/Uint8Array.BYTES_PER_ELEMENT i32 (i32.const 1))
  (global $~lib/typedarray/Uint8ClampedArray.BYTES_PER_ELEMENT i32 (i32.const 1))
@@ -2930,7 +2930,7 @@
   (local $11 f64)
   (local $12 f64)
   (local $13 i32)
-  block $~lib/internal/typedarray/SORT<Float64Array,f64>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/SORT<~lib/typedarray/Float64Array,f64>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -2952,7 +2952,7 @@
    i32.le_s
    if
     local.get $2
-    br $~lib/internal/typedarray/SORT<Float64Array,f64>|inlined.0
+    br $~lib/internal/typedarray/SORT<~lib/typedarray/Float64Array,f64>|inlined.0
    end
    local.get $2
    i32.load
@@ -3046,7 +3046,7 @@
      end
     end
     local.get $2
-    br $~lib/internal/typedarray/SORT<Float64Array,f64>|inlined.0
+    br $~lib/internal/typedarray/SORT<~lib/typedarray/Float64Array,f64>|inlined.0
    end
    block $~lib/internal/sort/SORT<f64>|inlined.0
     local.get $6
@@ -3935,7 +3935,7 @@
   local.get $3
   call $~lib/typedarray/Int32Array#fill
  )
- (func $std/typedarray/testReduce<Int8Array,i8>~anonymous|0 (; 56 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 56 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
@@ -4018,7 +4018,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Int8Array,i8> (; 58 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8> (; 58 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4059,7 +4059,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Uint8Array,u8>~anonymous|0 (; 59 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 59 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
@@ -4142,7 +4142,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Uint8Array,u8> (; 61 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint8Array,u8> (; 61 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4181,7 +4181,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Uint8ClampedArray,u8>~anonymous|0 (; 62 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 62 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
@@ -4264,7 +4264,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Uint8ClampedArray,u8> (; 64 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint8ClampedArray,u8> (; 64 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4344,7 +4344,7 @@
    i32.store16 offset=8
   end
  )
- (func $std/typedarray/testReduce<Int16Array,i16>~anonymous|0 (; 66 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 66 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
@@ -4427,7 +4427,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Int16Array,i16> (; 68 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int16Array,i16> (; 68 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4509,7 +4509,7 @@
    i32.store16 offset=8
   end
  )
- (func $std/typedarray/testReduce<Uint16Array,u16>~anonymous|0 (; 70 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 70 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
@@ -4592,7 +4592,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Uint16Array,u16> (; 72 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint16Array,u16> (; 72 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4631,7 +4631,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Int32Array,i32>~anonymous|0 (; 73 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 73 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
@@ -4714,7 +4714,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Int32Array,i32> (; 75 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int32Array,i32> (; 75 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4792,7 +4792,7 @@
    i32.store offset=8
   end
  )
- (func $std/typedarray/testReduce<Uint32Array,u32>~anonymous|0 (; 77 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 77 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
@@ -4875,7 +4875,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Uint32Array,u32> (; 79 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint32Array,u32> (; 79 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -4953,7 +4953,7 @@
    i64.store offset=8
   end
  )
- (func $std/typedarray/testReduce<Int64Array,i64>~anonymous|0 (; 81 ;) (type $FUNCSIG$jjjii) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 81 ;) (type $FUNCSIG$jjjii) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   local.get $0
   local.get $1
   i64.add
@@ -5036,7 +5036,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Int64Array,i64> (; 83 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64> (; 83 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -5114,7 +5114,7 @@
    i64.store offset=8
   end
  )
- (func $std/typedarray/testReduce<Uint64Array,u64>~anonymous|0 (; 85 ;) (type $FUNCSIG$jjjii) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 85 ;) (type $FUNCSIG$jjjii) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   local.get $0
   local.get $1
   i64.add
@@ -5197,7 +5197,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Uint64Array,u64> (; 87 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduce<~lib/typedarray/Uint64Array,u64> (; 87 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -5275,7 +5275,7 @@
    f32.store offset=8
   end
  )
- (func $std/typedarray/testReduce<Float32Array,f32>~anonymous|0 (; 89 ;) (type $FUNCSIG$fffii) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 89 ;) (type $FUNCSIG$fffii) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
   local.get $0
   local.get $1
   f32.add
@@ -5358,7 +5358,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Float32Array,f32> (; 91 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32> (; 91 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f32)
   i32.const 0
@@ -5395,7 +5395,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduce<Float64Array,f64>~anonymous|0 (; 92 ;) (type $FUNCSIG$dddii) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 92 ;) (type $FUNCSIG$dddii) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
   local.get $0
   local.get $1
   f64.add
@@ -5478,7 +5478,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduce<Float64Array,f64> (; 94 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64> (; 94 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f64)
   i32.const 0
@@ -5515,7 +5515,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Int8Array,i8>~anonymous|0 (; 95 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 95 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
@@ -5597,7 +5597,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Int8Array,i8> (; 97 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int8Array,i8> (; 97 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -5638,7 +5638,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint8Array,u8>~anonymous|0 (; 98 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 98 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
@@ -5720,7 +5720,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Uint8Array,u8> (; 100 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8Array,u8> (; 100 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -5759,7 +5759,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8>~anonymous|0 (; 101 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 101 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
@@ -5841,7 +5841,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Uint8ClampedArray,u8> (; 103 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint8ClampedArray,u8> (; 103 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -5880,7 +5880,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Int16Array,i16>~anonymous|0 (; 104 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 104 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
@@ -5962,7 +5962,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Int16Array,i16> (; 106 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int16Array,i16> (; 106 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -6003,7 +6003,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint16Array,u16>~anonymous|0 (; 107 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 107 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
@@ -6085,7 +6085,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Uint16Array,u16> (; 109 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint16Array,u16> (; 109 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -6124,7 +6124,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Int32Array,i32>~anonymous|0 (; 110 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 110 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
@@ -6206,7 +6206,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Int32Array,i32> (; 112 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int32Array,i32> (; 112 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -6243,7 +6243,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint32Array,u32>~anonymous|0 (; 113 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 113 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $0
   local.get $1
   i32.add
@@ -6325,7 +6325,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Uint32Array,u32> (; 115 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint32Array,u32> (; 115 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -6362,7 +6362,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Int64Array,i64>~anonymous|0 (; 116 ;) (type $FUNCSIG$jjjii) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 116 ;) (type $FUNCSIG$jjjii) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   local.get $0
   local.get $1
   i64.add
@@ -6444,7 +6444,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Int64Array,i64> (; 118 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Int64Array,i64> (; 118 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -6481,7 +6481,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Uint64Array,u64>~anonymous|0 (; 119 ;) (type $FUNCSIG$jjjii) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 119 ;) (type $FUNCSIG$jjjii) (param $0 i64) (param $1 i64) (param $2 i32) (param $3 i32) (result i64)
   local.get $0
   local.get $1
   i64.add
@@ -6563,7 +6563,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Uint64Array,u64> (; 121 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Uint64Array,u64> (; 121 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i64)
   i32.const 0
@@ -6600,7 +6600,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Float32Array,f32>~anonymous|0 (; 122 ;) (type $FUNCSIG$fffii) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 122 ;) (type $FUNCSIG$fffii) (param $0 f32) (param $1 f32) (param $2 i32) (param $3 i32) (result f32)
   local.get $0
   local.get $1
   f32.add
@@ -6682,7 +6682,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Float32Array,f32> (; 124 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Float32Array,f32> (; 124 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f32)
   i32.const 0
@@ -6719,7 +6719,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testReduceRight<Float64Array,f64>~anonymous|0 (; 125 ;) (type $FUNCSIG$dddii) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 125 ;) (type $FUNCSIG$dddii) (param $0 f64) (param $1 f64) (param $2 i32) (param $3 i32) (result f64)
   local.get $0
   local.get $1
   f64.add
@@ -6801,7 +6801,7 @@
   end
   local.get $5
  )
- (func $std/typedarray/testReduceRight<Float64Array,f64> (; 127 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testReduceRight<~lib/typedarray/Float64Array,f64> (; 127 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f64)
   i32.const 0
@@ -6838,7 +6838,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int8Array,i8>~anonymous|0 (; 128 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 128 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $0
   i32.mul
@@ -6949,7 +6949,7 @@
   end
   local.get $7
  )
- (func $std/typedarray/testArrayMap<Int8Array,i8> (; 130 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8> (; 130 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -7027,7 +7027,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint8Array,u8>~anonymous|0 (; 131 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 131 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $0
   i32.mul
@@ -7136,7 +7136,7 @@
   end
   local.get $7
  )
- (func $std/typedarray/testArrayMap<Uint8Array,u8> (; 133 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8Array,u8> (; 133 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -7208,7 +7208,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8>~anonymous|0 (; 134 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 134 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $0
   i32.mul
@@ -7317,7 +7317,7 @@
   end
   local.get $7
  )
- (func $std/typedarray/testArrayMap<Uint8ClampedArray,u8> (; 136 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint8ClampedArray,u8> (; 136 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -7389,7 +7389,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int16Array,i16>~anonymous|0 (; 137 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 137 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $0
   i32.mul
@@ -7537,7 +7537,7 @@
    i32.load16_s offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Int16Array,i16> (; 140 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int16Array,i16> (; 140 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -7615,7 +7615,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint16Array,u16>~anonymous|0 (; 141 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 141 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $0
   i32.mul
@@ -7761,7 +7761,7 @@
    i32.load16_u offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Uint16Array,u16> (; 144 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint16Array,u16> (; 144 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -7833,7 +7833,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int32Array,i32>~anonymous|0 (; 145 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 145 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $0
   i32.mul
@@ -7940,7 +7940,7 @@
   end
   local.get $7
  )
- (func $std/typedarray/testArrayMap<Int32Array,i32> (; 147 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int32Array,i32> (; 147 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -8006,7 +8006,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint32Array,u32>~anonymous|0 (; 148 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 148 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   local.get $0
   i32.mul
@@ -8150,7 +8150,7 @@
    i32.load offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Uint32Array,u32> (; 151 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint32Array,u32> (; 151 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -8216,7 +8216,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Int64Array,i64>~anonymous|0 (; 152 ;) (type $FUNCSIG$jjii) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 152 ;) (type $FUNCSIG$jjii) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
   local.get $0
   local.get $0
   i64.mul
@@ -8361,7 +8361,7 @@
    i64.load offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Int64Array,i64> (; 155 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64> (; 155 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -8427,7 +8427,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Uint64Array,u64>~anonymous|0 (; 156 ;) (type $FUNCSIG$jjii) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 156 ;) (type $FUNCSIG$jjii) (param $0 i64) (param $1 i32) (param $2 i32) (result i64)
   local.get $0
   local.get $0
   i64.mul
@@ -8572,7 +8572,7 @@
    i64.load offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Uint64Array,u64> (; 159 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Uint64Array,u64> (; 159 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -8638,7 +8638,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Float32Array,f32>~anonymous|0 (; 160 ;) (type $FUNCSIG$ffii) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 160 ;) (type $FUNCSIG$ffii) (param $0 f32) (param $1 i32) (param $2 i32) (result f32)
   local.get $0
   local.get $0
   f32.mul
@@ -8783,7 +8783,7 @@
    f32.load offset=8
   end
  )
- (func $std/typedarray/testArrayMap<Float32Array,f32> (; 163 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32> (; 163 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -8849,7 +8849,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayMap<Float64Array,f64>~anonymous|0 (; 164 ;) (type $FUNCSIG$ddii) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 164 ;) (type $FUNCSIG$ddii) (param $0 f64) (param $1 i32) (param $2 i32) (result f64)
   local.get $0
   local.get $0
   f64.mul
@@ -8957,7 +8957,7 @@
   end
   local.get $7
  )
- (func $std/typedarray/testArrayMap<Float64Array,f64> (; 166 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64> (; 166 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -9023,7 +9023,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Int8Array,i8>~anonymous|0 (; 167 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 167 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -9042,7 +9042,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/SOME<Int8Array,i8>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/SOME<~lib/typedarray/Int8Array,i8>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -9099,7 +9099,7 @@
      i32.ne
      if
       i32.const 1
-      br $~lib/internal/typedarray/SOME<Int8Array,i8>|inlined.0
+      br $~lib/internal/typedarray/SOME<~lib/typedarray/Int8Array,i8>|inlined.0
      end
      local.get $7
      i32.const 1
@@ -9113,7 +9113,7 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Int8Array,i8>~anonymous|1 (; 169 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>~anonymous|1 (; 169 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -9122,7 +9122,7 @@
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Int8Array,i8> (; 170 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8> (; 170 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9176,7 +9176,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint8Array,u8>~anonymous|0 (; 171 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 171 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -9193,7 +9193,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/SOME<Uint8Array,u8>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/SOME<~lib/typedarray/Uint8Array,u8>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -9250,7 +9250,7 @@
      i32.ne
      if
       i32.const 1
-      br $~lib/internal/typedarray/SOME<Uint8Array,u8>|inlined.0
+      br $~lib/internal/typedarray/SOME<~lib/typedarray/Uint8Array,u8>|inlined.0
      end
      local.get $7
      i32.const 1
@@ -9264,14 +9264,14 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Uint8Array,u8>~anonymous|1 (; 173 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8>~anonymous|1 (; 173 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Uint8Array,u8> (; 174 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8> (; 174 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9325,7 +9325,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint8ClampedArray,u8>~anonymous|0 (; 175 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 175 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -9342,7 +9342,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/SOME<Uint8ClampedArray,u8>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/SOME<~lib/typedarray/Uint8ClampedArray,u8>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -9399,7 +9399,7 @@
      i32.ne
      if
       i32.const 1
-      br $~lib/internal/typedarray/SOME<Uint8ClampedArray,u8>|inlined.0
+      br $~lib/internal/typedarray/SOME<~lib/typedarray/Uint8ClampedArray,u8>|inlined.0
      end
      local.get $7
      i32.const 1
@@ -9413,14 +9413,14 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Uint8ClampedArray,u8>~anonymous|1 (; 177 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 (; 177 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Uint8ClampedArray,u8> (; 178 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8> (; 178 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9474,7 +9474,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Int16Array,i16>~anonymous|0 (; 179 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 179 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -9493,7 +9493,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/SOME<Int16Array,i16>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/SOME<~lib/typedarray/Int16Array,i16>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -9550,7 +9550,7 @@
      i32.ne
      if
       i32.const 1
-      br $~lib/internal/typedarray/SOME<Int16Array,i16>|inlined.0
+      br $~lib/internal/typedarray/SOME<~lib/typedarray/Int16Array,i16>|inlined.0
      end
      local.get $7
      i32.const 1
@@ -9564,7 +9564,7 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Int16Array,i16>~anonymous|1 (; 181 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>~anonymous|1 (; 181 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -9573,7 +9573,7 @@
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Int16Array,i16> (; 182 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16> (; 182 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9627,7 +9627,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint16Array,u16>~anonymous|0 (; 183 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 183 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
@@ -9644,7 +9644,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/SOME<Uint16Array,u16>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/SOME<~lib/typedarray/Uint16Array,u16>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -9701,7 +9701,7 @@
      i32.ne
      if
       i32.const 1
-      br $~lib/internal/typedarray/SOME<Uint16Array,u16>|inlined.0
+      br $~lib/internal/typedarray/SOME<~lib/typedarray/Uint16Array,u16>|inlined.0
      end
      local.get $7
      i32.const 1
@@ -9715,14 +9715,14 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Uint16Array,u16>~anonymous|1 (; 185 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16>~anonymous|1 (; 185 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Uint16Array,u16> (; 186 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16> (; 186 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9776,7 +9776,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Int32Array,i32>~anonymous|0 (; 187 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 187 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.eq
@@ -9791,7 +9791,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/SOME<Int32Array,i32>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/SOME<~lib/typedarray/Int32Array,i32>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -9848,7 +9848,7 @@
      i32.ne
      if
       i32.const 1
-      br $~lib/internal/typedarray/SOME<Int32Array,i32>|inlined.0
+      br $~lib/internal/typedarray/SOME<~lib/typedarray/Int32Array,i32>|inlined.0
      end
      local.get $7
      i32.const 1
@@ -9862,12 +9862,12 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Int32Array,i32>~anonymous|1 (; 189 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>~anonymous|1 (; 189 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Int32Array,i32> (; 190 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32> (; 190 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9921,7 +9921,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint32Array,u32>~anonymous|0 (; 191 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 191 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.eq
@@ -9936,7 +9936,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/SOME<Uint32Array,u32>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/SOME<~lib/typedarray/Uint32Array,u32>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -9993,7 +9993,7 @@
      i32.ne
      if
       i32.const 1
-      br $~lib/internal/typedarray/SOME<Uint32Array,u32>|inlined.0
+      br $~lib/internal/typedarray/SOME<~lib/typedarray/Uint32Array,u32>|inlined.0
      end
      local.get $7
      i32.const 1
@@ -10007,12 +10007,12 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Uint32Array,u32>~anonymous|1 (; 193 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32>~anonymous|1 (; 193 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 0
   i32.eq
  )
- (func $std/typedarray/testArraySome<Uint32Array,u32> (; 194 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32> (; 194 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10066,7 +10066,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Int64Array,i64>~anonymous|0 (; 195 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 195 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.eq
@@ -10081,7 +10081,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/SOME<Int64Array,i64>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/SOME<~lib/typedarray/Int64Array,i64>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -10138,7 +10138,7 @@
      i32.ne
      if
       i32.const 1
-      br $~lib/internal/typedarray/SOME<Int64Array,i64>|inlined.0
+      br $~lib/internal/typedarray/SOME<~lib/typedarray/Int64Array,i64>|inlined.0
      end
      local.get $7
      i32.const 1
@@ -10152,12 +10152,12 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Int64Array,i64>~anonymous|1 (; 197 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>~anonymous|1 (; 197 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 0
   i64.eq
  )
- (func $std/typedarray/testArraySome<Int64Array,i64> (; 198 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64> (; 198 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10211,7 +10211,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Uint64Array,u64>~anonymous|0 (; 199 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 199 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.eq
@@ -10226,7 +10226,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/SOME<Uint64Array,u64>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/SOME<~lib/typedarray/Uint64Array,u64>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -10283,7 +10283,7 @@
      i32.ne
      if
       i32.const 1
-      br $~lib/internal/typedarray/SOME<Uint64Array,u64>|inlined.0
+      br $~lib/internal/typedarray/SOME<~lib/typedarray/Uint64Array,u64>|inlined.0
      end
      local.get $7
      i32.const 1
@@ -10297,12 +10297,12 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Uint64Array,u64>~anonymous|1 (; 201 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64>~anonymous|1 (; 201 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 0
   i64.eq
  )
- (func $std/typedarray/testArraySome<Uint64Array,u64> (; 202 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64> (; 202 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10356,7 +10356,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Float32Array,f32>~anonymous|0 (; 203 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 203 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 2
   f32.eq
@@ -10371,7 +10371,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/SOME<Float32Array,f32>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/SOME<~lib/typedarray/Float32Array,f32>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -10428,7 +10428,7 @@
      i32.ne
      if
       i32.const 1
-      br $~lib/internal/typedarray/SOME<Float32Array,f32>|inlined.0
+      br $~lib/internal/typedarray/SOME<~lib/typedarray/Float32Array,f32>|inlined.0
      end
      local.get $7
      i32.const 1
@@ -10442,12 +10442,12 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Float32Array,f32>~anonymous|1 (; 205 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>~anonymous|1 (; 205 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 0
   f32.eq
  )
- (func $std/typedarray/testArraySome<Float32Array,f32> (; 206 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32> (; 206 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10501,7 +10501,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArraySome<Float64Array,f64>~anonymous|0 (; 207 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 207 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 2
   f64.eq
@@ -10516,7 +10516,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/SOME<Float64Array,f64>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/SOME<~lib/typedarray/Float64Array,f64>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -10573,7 +10573,7 @@
      i32.ne
      if
       i32.const 1
-      br $~lib/internal/typedarray/SOME<Float64Array,f64>|inlined.0
+      br $~lib/internal/typedarray/SOME<~lib/typedarray/Float64Array,f64>|inlined.0
      end
      local.get $7
      i32.const 1
@@ -10587,12 +10587,12 @@
    i32.const 0
   end
  )
- (func $std/typedarray/testArraySome<Float64Array,f64>~anonymous|1 (; 209 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>~anonymous|1 (; 209 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 0
   f64.eq
  )
- (func $std/typedarray/testArraySome<Float64Array,f64> (; 210 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64> (; 210 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10646,7 +10646,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|0 (; 211 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 211 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -10665,7 +10665,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/FIND_INDEX<Int8Array,i8>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Int8Array,i8>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -10722,7 +10722,7 @@
      i32.ne
      if
       local.get $7
-      br $~lib/internal/typedarray/FIND_INDEX<Int8Array,i8>|inlined.0
+      br $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Int8Array,i8>|inlined.0
      end
      local.get $7
      i32.const 1
@@ -10736,7 +10736,7 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Int8Array,i8>~anonymous|1 (; 213 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>~anonymous|1 (; 213 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -10745,7 +10745,7 @@
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int8Array,i8> (; 214 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8> (; 214 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10798,7 +10798,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint8Array,u8>~anonymous|0 (; 215 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 215 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -10815,7 +10815,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/FIND_INDEX<Uint8Array,u8>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -10872,7 +10872,7 @@
      i32.ne
      if
       local.get $7
-      br $~lib/internal/typedarray/FIND_INDEX<Uint8Array,u8>|inlined.0
+      br $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Uint8Array,u8>|inlined.0
      end
      local.get $7
      i32.const 1
@@ -10886,14 +10886,14 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint8Array,u8>~anonymous|1 (; 217 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8>~anonymous|1 (; 217 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Uint8Array,u8> (; 218 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8> (; 218 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10946,7 +10946,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8>~anonymous|0 (; 219 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 219 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -10963,7 +10963,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/FIND_INDEX<Uint8ClampedArray,u8>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Uint8ClampedArray,u8>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -11020,7 +11020,7 @@
      i32.ne
      if
       local.get $7
-      br $~lib/internal/typedarray/FIND_INDEX<Uint8ClampedArray,u8>|inlined.0
+      br $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Uint8ClampedArray,u8>|inlined.0
      end
      local.get $7
      i32.const 1
@@ -11034,14 +11034,14 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8>~anonymous|1 (; 221 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 (; 221 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8> (; 222 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8> (; 222 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11094,7 +11094,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|0 (; 223 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 223 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -11113,7 +11113,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/FIND_INDEX<Int16Array,i16>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Int16Array,i16>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -11170,7 +11170,7 @@
      i32.ne
      if
       local.get $7
-      br $~lib/internal/typedarray/FIND_INDEX<Int16Array,i16>|inlined.0
+      br $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Int16Array,i16>|inlined.0
      end
      local.get $7
      i32.const 1
@@ -11184,7 +11184,7 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Int16Array,i16>~anonymous|1 (; 225 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>~anonymous|1 (; 225 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -11193,7 +11193,7 @@
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int16Array,i16> (; 226 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16> (; 226 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11246,7 +11246,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint16Array,u16>~anonymous|0 (; 227 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 227 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
@@ -11263,7 +11263,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/FIND_INDEX<Uint16Array,u16>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Uint16Array,u16>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -11320,7 +11320,7 @@
      i32.ne
      if
       local.get $7
-      br $~lib/internal/typedarray/FIND_INDEX<Uint16Array,u16>|inlined.0
+      br $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Uint16Array,u16>|inlined.0
      end
      local.get $7
      i32.const 1
@@ -11334,14 +11334,14 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint16Array,u16>~anonymous|1 (; 229 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16>~anonymous|1 (; 229 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Uint16Array,u16> (; 230 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16> (; 230 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11394,7 +11394,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|0 (; 231 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 231 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.eq
@@ -11409,7 +11409,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/FIND_INDEX<Int32Array,i32>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Int32Array,i32>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -11466,7 +11466,7 @@
      i32.ne
      if
       local.get $7
-      br $~lib/internal/typedarray/FIND_INDEX<Int32Array,i32>|inlined.0
+      br $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Int32Array,i32>|inlined.0
      end
      local.get $7
      i32.const 1
@@ -11480,12 +11480,12 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Int32Array,i32>~anonymous|1 (; 233 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>~anonymous|1 (; 233 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int32Array,i32> (; 234 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32> (; 234 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11538,7 +11538,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint32Array,u32>~anonymous|0 (; 235 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 235 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.eq
@@ -11553,7 +11553,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/FIND_INDEX<Uint32Array,u32>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Uint32Array,u32>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -11610,7 +11610,7 @@
      i32.ne
      if
       local.get $7
-      br $~lib/internal/typedarray/FIND_INDEX<Uint32Array,u32>|inlined.0
+      br $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Uint32Array,u32>|inlined.0
      end
      local.get $7
      i32.const 1
@@ -11624,12 +11624,12 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint32Array,u32>~anonymous|1 (; 237 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32>~anonymous|1 (; 237 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 4
   i32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Uint32Array,u32> (; 238 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32> (; 238 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11682,7 +11682,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|0 (; 239 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 239 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.eq
@@ -11697,7 +11697,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/FIND_INDEX<Int64Array,i64>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Int64Array,i64>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -11754,7 +11754,7 @@
      i32.ne
      if
       local.get $7
-      br $~lib/internal/typedarray/FIND_INDEX<Int64Array,i64>|inlined.0
+      br $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Int64Array,i64>|inlined.0
      end
      local.get $7
      i32.const 1
@@ -11768,12 +11768,12 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Int64Array,i64>~anonymous|1 (; 241 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>~anonymous|1 (; 241 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 4
   i64.eq
  )
- (func $std/typedarray/testArrayFindIndex<Int64Array,i64> (; 242 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64> (; 242 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11826,7 +11826,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint64Array,u64>~anonymous|0 (; 243 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 243 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.eq
@@ -11841,7 +11841,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/FIND_INDEX<Uint64Array,u64>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Uint64Array,u64>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -11898,7 +11898,7 @@
      i32.ne
      if
       local.get $7
-      br $~lib/internal/typedarray/FIND_INDEX<Uint64Array,u64>|inlined.0
+      br $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Uint64Array,u64>|inlined.0
      end
      local.get $7
      i32.const 1
@@ -11912,12 +11912,12 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Uint64Array,u64>~anonymous|1 (; 245 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64>~anonymous|1 (; 245 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 4
   i64.eq
  )
- (func $std/typedarray/testArrayFindIndex<Uint64Array,u64> (; 246 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64> (; 246 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11970,7 +11970,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|0 (; 247 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 247 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 2
   f32.eq
@@ -11985,7 +11985,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/FIND_INDEX<Float32Array,f32>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Float32Array,f32>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -12042,7 +12042,7 @@
      i32.ne
      if
       local.get $7
-      br $~lib/internal/typedarray/FIND_INDEX<Float32Array,f32>|inlined.0
+      br $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Float32Array,f32>|inlined.0
      end
      local.get $7
      i32.const 1
@@ -12056,12 +12056,12 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Float32Array,f32>~anonymous|1 (; 249 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>~anonymous|1 (; 249 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 4
   f32.eq
  )
- (func $std/typedarray/testArrayFindIndex<Float32Array,f32> (; 250 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32> (; 250 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12114,7 +12114,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|0 (; 251 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 251 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 2
   f64.eq
@@ -12129,7 +12129,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/FIND_INDEX<Float64Array,f64>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Float64Array,f64>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -12186,7 +12186,7 @@
      i32.ne
      if
       local.get $7
-      br $~lib/internal/typedarray/FIND_INDEX<Float64Array,f64>|inlined.0
+      br $~lib/internal/typedarray/FIND_INDEX<~lib/typedarray/Float64Array,f64>|inlined.0
      end
      local.get $7
      i32.const 1
@@ -12200,12 +12200,12 @@
    i32.const -1
   end
  )
- (func $std/typedarray/testArrayFindIndex<Float64Array,f64>~anonymous|1 (; 253 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>~anonymous|1 (; 253 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 4
   f64.eq
  )
- (func $std/typedarray/testArrayFindIndex<Float64Array,f64> (; 254 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64> (; 254 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12258,7 +12258,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|0 (; 255 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 255 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -12279,7 +12279,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/EVERY<Int8Array,i8>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/EVERY<~lib/typedarray/Int8Array,i8>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -12340,7 +12340,7 @@
         br $continue|0
        end
        i32.const 0
-       br $~lib/internal/typedarray/EVERY<Int8Array,i8>|inlined.0
+       br $~lib/internal/typedarray/EVERY<~lib/typedarray/Int8Array,i8>|inlined.0
        unreachable
       end
       unreachable
@@ -12357,7 +12357,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int8Array,i8>~anonymous|1 (; 257 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>~anonymous|1 (; 257 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -12366,7 +12366,7 @@
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Int8Array,i8> (; 258 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8> (; 258 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12420,7 +12420,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|0 (; 259 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 259 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -12439,7 +12439,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/EVERY<Uint8Array,u8>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/EVERY<~lib/typedarray/Uint8Array,u8>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -12500,7 +12500,7 @@
         br $continue|0
        end
        i32.const 0
-       br $~lib/internal/typedarray/EVERY<Uint8Array,u8>|inlined.0
+       br $~lib/internal/typedarray/EVERY<~lib/typedarray/Uint8Array,u8>|inlined.0
        unreachable
       end
       unreachable
@@ -12517,14 +12517,14 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Uint8Array,u8>~anonymous|1 (; 261 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>~anonymous|1 (; 261 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Uint8Array,u8> (; 262 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8> (; 262 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12578,7 +12578,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8>~anonymous|0 (; 263 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 263 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -12597,7 +12597,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/EVERY<Uint8ClampedArray,u8>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/EVERY<~lib/typedarray/Uint8ClampedArray,u8>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -12658,7 +12658,7 @@
         br $continue|0
        end
        i32.const 0
-       br $~lib/internal/typedarray/EVERY<Uint8ClampedArray,u8>|inlined.0
+       br $~lib/internal/typedarray/EVERY<~lib/typedarray/Uint8ClampedArray,u8>|inlined.0
        unreachable
       end
       unreachable
@@ -12675,14 +12675,14 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8>~anonymous|1 (; 265 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|1 (; 265 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Uint8ClampedArray,u8> (; 266 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8> (; 266 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12736,7 +12736,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|0 (; 267 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 267 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -12757,7 +12757,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/EVERY<Int16Array,i16>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/EVERY<~lib/typedarray/Int16Array,i16>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -12818,7 +12818,7 @@
         br $continue|0
        end
        i32.const 0
-       br $~lib/internal/typedarray/EVERY<Int16Array,i16>|inlined.0
+       br $~lib/internal/typedarray/EVERY<~lib/typedarray/Int16Array,i16>|inlined.0
        unreachable
       end
       unreachable
@@ -12835,7 +12835,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int16Array,i16>~anonymous|1 (; 269 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>~anonymous|1 (; 269 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -12844,7 +12844,7 @@
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Int16Array,i16> (; 270 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16> (; 270 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12898,7 +12898,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint16Array,u16>~anonymous|0 (; 271 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 271 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
@@ -12917,7 +12917,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/EVERY<Uint16Array,u16>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/EVERY<~lib/typedarray/Uint16Array,u16>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -12978,7 +12978,7 @@
         br $continue|0
        end
        i32.const 0
-       br $~lib/internal/typedarray/EVERY<Uint16Array,u16>|inlined.0
+       br $~lib/internal/typedarray/EVERY<~lib/typedarray/Uint16Array,u16>|inlined.0
        unreachable
       end
       unreachable
@@ -12995,14 +12995,14 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Uint16Array,u16>~anonymous|1 (; 273 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16>~anonymous|1 (; 273 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Uint16Array,u16> (; 274 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16> (; 274 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13056,7 +13056,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|0 (; 275 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 275 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.rem_s
@@ -13073,7 +13073,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/EVERY<Int32Array,i32>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/EVERY<~lib/typedarray/Int32Array,i32>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -13134,7 +13134,7 @@
         br $continue|0
        end
        i32.const 0
-       br $~lib/internal/typedarray/EVERY<Int32Array,i32>|inlined.0
+       br $~lib/internal/typedarray/EVERY<~lib/typedarray/Int32Array,i32>|inlined.0
        unreachable
       end
       unreachable
@@ -13151,12 +13151,12 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int32Array,i32>~anonymous|1 (; 277 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>~anonymous|1 (; 277 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Int32Array,i32> (; 278 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32> (; 278 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13210,7 +13210,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint32Array,u32>~anonymous|0 (; 279 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 279 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.rem_u
@@ -13227,7 +13227,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/EVERY<Uint32Array,u32>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/EVERY<~lib/typedarray/Uint32Array,u32>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -13288,7 +13288,7 @@
         br $continue|0
        end
        i32.const 0
-       br $~lib/internal/typedarray/EVERY<Uint32Array,u32>|inlined.0
+       br $~lib/internal/typedarray/EVERY<~lib/typedarray/Uint32Array,u32>|inlined.0
        unreachable
       end
       unreachable
@@ -13305,12 +13305,12 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Uint32Array,u32>~anonymous|1 (; 281 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32>~anonymous|1 (; 281 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.const 2
   i32.eq
  )
- (func $std/typedarray/testArrayEvery<Uint32Array,u32> (; 282 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32> (; 282 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13364,7 +13364,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|0 (; 283 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 283 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.rem_s
@@ -13381,7 +13381,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/EVERY<Int64Array,i64>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/EVERY<~lib/typedarray/Int64Array,i64>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -13442,7 +13442,7 @@
         br $continue|0
        end
        i32.const 0
-       br $~lib/internal/typedarray/EVERY<Int64Array,i64>|inlined.0
+       br $~lib/internal/typedarray/EVERY<~lib/typedarray/Int64Array,i64>|inlined.0
        unreachable
       end
       unreachable
@@ -13459,12 +13459,12 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Int64Array,i64>~anonymous|1 (; 285 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>~anonymous|1 (; 285 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.eq
  )
- (func $std/typedarray/testArrayEvery<Int64Array,i64> (; 286 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64> (; 286 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13518,7 +13518,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|0 (; 287 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 287 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.rem_u
@@ -13535,7 +13535,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/EVERY<Uint64Array,u64>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/EVERY<~lib/typedarray/Uint64Array,u64>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -13596,7 +13596,7 @@
         br $continue|0
        end
        i32.const 0
-       br $~lib/internal/typedarray/EVERY<Uint64Array,u64>|inlined.0
+       br $~lib/internal/typedarray/EVERY<~lib/typedarray/Uint64Array,u64>|inlined.0
        unreachable
       end
       unreachable
@@ -13613,12 +13613,12 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Uint64Array,u64>~anonymous|1 (; 289 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>~anonymous|1 (; 289 ;) (type $FUNCSIG$ijii) (param $0 i64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i64.const 2
   i64.eq
  )
- (func $std/typedarray/testArrayEvery<Uint64Array,u64> (; 290 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64> (; 290 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13928,7 +13928,7 @@
   local.get $2
   f32.reinterpret_i32
  )
- (func $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|0 (; 292 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 292 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 2
   call $~lib/math/NativeMathf.mod
@@ -13945,7 +13945,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/EVERY<Float32Array,f32>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/EVERY<~lib/typedarray/Float32Array,f32>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -14006,7 +14006,7 @@
         br $continue|0
        end
        i32.const 0
-       br $~lib/internal/typedarray/EVERY<Float32Array,f32>|inlined.0
+       br $~lib/internal/typedarray/EVERY<~lib/typedarray/Float32Array,f32>|inlined.0
        unreachable
       end
       unreachable
@@ -14023,12 +14023,12 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Float32Array,f32>~anonymous|1 (; 294 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|1 (; 294 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f32.const 2
   f32.eq
  )
- (func $std/typedarray/testArrayEvery<Float32Array,f32> (; 295 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32> (; 295 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14340,7 +14340,7 @@
   local.get $2
   f64.reinterpret_i64
  )
- (func $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|0 (; 297 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 297 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 2
   call $~lib/math/NativeMath.mod
@@ -14357,7 +14357,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  block $~lib/internal/typedarray/EVERY<Float64Array,f64>|inlined.0 (result i32)
+  block $~lib/internal/typedarray/EVERY<~lib/typedarray/Float64Array,f64>|inlined.0 (result i32)
    local.get $0
    local.set $2
    local.get $1
@@ -14418,7 +14418,7 @@
         br $continue|0
        end
        i32.const 0
-       br $~lib/internal/typedarray/EVERY<Float64Array,f64>|inlined.0
+       br $~lib/internal/typedarray/EVERY<~lib/typedarray/Float64Array,f64>|inlined.0
        unreachable
       end
       unreachable
@@ -14435,12 +14435,12 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<Float64Array,f64>~anonymous|1 (; 299 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|1 (; 299 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   f64.const 2
   f64.eq
  )
- (func $std/typedarray/testArrayEvery<Float64Array,f64> (; 300 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64> (; 300 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14494,7 +14494,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Int8Array,i8>~anonymous|0 (; 301 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 301 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   global.get $std/typedarray/forEachValues
   local.get $1
@@ -14621,7 +14621,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Int8Array,i8> (; 303 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8> (; 303 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   global.set $std/typedarray/forEachCallCount
@@ -14677,7 +14677,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Uint8Array,u8>~anonymous|0 (; 304 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 304 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   global.get $std/typedarray/forEachValues
   local.get $1
@@ -14800,7 +14800,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Uint8Array,u8> (; 306 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8> (; 306 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   global.set $std/typedarray/forEachCallCount
@@ -14850,7 +14850,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Uint8ClampedArray,u8>~anonymous|0 (; 307 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 307 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   global.get $std/typedarray/forEachValues
   local.get $1
@@ -14973,7 +14973,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Uint8ClampedArray,u8> (; 309 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8> (; 309 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   global.set $std/typedarray/forEachCallCount
@@ -15023,7 +15023,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Int16Array,i16>~anonymous|0 (; 310 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 310 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   global.get $std/typedarray/forEachValues
   local.get $1
@@ -15150,7 +15150,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Int16Array,i16> (; 312 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16> (; 312 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   global.set $std/typedarray/forEachCallCount
@@ -15206,7 +15206,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Uint16Array,u16>~anonymous|0 (; 313 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 313 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   global.get $std/typedarray/forEachValues
   local.get $1
@@ -15329,7 +15329,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Uint16Array,u16> (; 315 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16> (; 315 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   global.set $std/typedarray/forEachCallCount
@@ -15379,7 +15379,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Int32Array,i32>~anonymous|0 (; 316 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 316 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   global.get $std/typedarray/forEachValues
   local.get $1
@@ -15498,7 +15498,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Int32Array,i32> (; 318 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32> (; 318 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   global.set $std/typedarray/forEachCallCount
@@ -15542,7 +15542,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Uint32Array,u32>~anonymous|0 (; 319 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 319 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   global.get $std/typedarray/forEachValues
   local.get $1
@@ -15661,7 +15661,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Uint32Array,u32> (; 321 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32> (; 321 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   global.set $std/typedarray/forEachCallCount
@@ -15705,7 +15705,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Int64Array,i64>~anonymous|0 (; 322 ;) (type $FUNCSIG$vjii) (param $0 i64) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 322 ;) (type $FUNCSIG$vjii) (param $0 i64) (param $1 i32) (param $2 i32)
   (local $3 i32)
   global.get $std/typedarray/forEachValues
   local.get $1
@@ -15825,7 +15825,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Int64Array,i64> (; 324 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64> (; 324 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   global.set $std/typedarray/forEachCallCount
@@ -15872,7 +15872,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Uint64Array,u64>~anonymous|0 (; 325 ;) (type $FUNCSIG$vjii) (param $0 i64) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 325 ;) (type $FUNCSIG$vjii) (param $0 i64) (param $1 i32) (param $2 i32)
   (local $3 i32)
   global.get $std/typedarray/forEachValues
   local.get $1
@@ -15992,7 +15992,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Uint64Array,u64> (; 327 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64> (; 327 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   global.set $std/typedarray/forEachCallCount
@@ -16039,7 +16039,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Float32Array,f32>~anonymous|0 (; 328 ;) (type $FUNCSIG$vfii) (param $0 f32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 328 ;) (type $FUNCSIG$vfii) (param $0 f32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   global.get $std/typedarray/forEachValues
   local.get $1
@@ -16159,7 +16159,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Float32Array,f32> (; 330 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32> (; 330 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   global.set $std/typedarray/forEachCallCount
@@ -16206,7 +16206,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Float64Array,f64>~anonymous|0 (; 331 ;) (type $FUNCSIG$vdii) (param $0 f64) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 331 ;) (type $FUNCSIG$vdii) (param $0 f64) (param $1 i32) (param $2 i32)
   (local $3 i32)
   global.get $std/typedarray/forEachValues
   local.get $1
@@ -16326,7 +16326,7 @@
    unreachable
   end
  )
- (func $std/typedarray/testArrayForEach<Float64Array,f64> (; 333 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64> (; 333 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   global.set $std/typedarray/forEachCallCount
@@ -16504,7 +16504,7 @@
   end
   local.get $1
  )
- (func $std/typedarray/testArrayReverse<Int8Array,i8> (; 335 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int8Array,i8> (; 335 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -16929,7 +16929,7 @@
   i32.store offset=8
   local.get $7
  )
- (func $std/typedarray/testArrayReverse<Uint8Array,u8> (; 338 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8Array,u8> (; 338 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -17338,7 +17338,7 @@
   i32.store offset=8
   local.get $7
  )
- (func $std/typedarray/testArrayReverse<Uint8ClampedArray,u8> (; 341 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8ClampedArray,u8> (; 341 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -17747,7 +17747,7 @@
   i32.store offset=8
   local.get $7
  )
- (func $std/typedarray/testArrayReverse<Int16Array,i16> (; 344 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int16Array,i16> (; 344 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -18172,7 +18172,7 @@
   i32.store offset=8
   local.get $7
  )
- (func $std/typedarray/testArrayReverse<Uint16Array,u16> (; 347 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint16Array,u16> (; 347 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -18471,7 +18471,7 @@
   end
   local.get $1
  )
- (func $std/typedarray/testArrayReverse<Int32Array,i32> (; 349 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int32Array,i32> (; 349 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -18864,7 +18864,7 @@
   i32.store offset=8
   local.get $7
  )
- (func $std/typedarray/testArrayReverse<Uint32Array,u32> (; 352 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint32Array,u32> (; 352 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -19258,7 +19258,7 @@
   i32.store offset=8
   local.get $7
  )
- (func $std/typedarray/testArrayReverse<Int64Array,i64> (; 355 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int64Array,i64> (; 355 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -19655,7 +19655,7 @@
   i32.store offset=8
   local.get $7
  )
- (func $std/typedarray/testArrayReverse<Uint64Array,u64> (; 358 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint64Array,u64> (; 358 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -20052,7 +20052,7 @@
   i32.store offset=8
   local.get $7
  )
- (func $std/typedarray/testArrayReverse<Float32Array,f32> (; 361 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Float32Array,f32> (; 361 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -20339,7 +20339,7 @@
   end
   local.get $1
  )
- (func $std/typedarray/testArrayReverse<Float64Array,f64> (; 363 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Float64Array,f64> (; 363 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -21664,94 +21664,94 @@
    call $~lib/env/abort
    unreachable
   end
-  call $std/typedarray/testReduce<Int8Array,i8>
-  call $std/typedarray/testReduce<Uint8Array,u8>
-  call $std/typedarray/testReduce<Uint8ClampedArray,u8>
-  call $std/typedarray/testReduce<Int16Array,i16>
-  call $std/typedarray/testReduce<Uint16Array,u16>
-  call $std/typedarray/testReduce<Int32Array,i32>
-  call $std/typedarray/testReduce<Uint32Array,u32>
-  call $std/typedarray/testReduce<Int64Array,i64>
-  call $std/typedarray/testReduce<Uint64Array,u64>
-  call $std/typedarray/testReduce<Float32Array,f32>
-  call $std/typedarray/testReduce<Float64Array,f64>
-  call $std/typedarray/testReduceRight<Int8Array,i8>
-  call $std/typedarray/testReduceRight<Uint8Array,u8>
-  call $std/typedarray/testReduceRight<Uint8ClampedArray,u8>
-  call $std/typedarray/testReduceRight<Int16Array,i16>
-  call $std/typedarray/testReduceRight<Uint16Array,u16>
-  call $std/typedarray/testReduceRight<Int32Array,i32>
-  call $std/typedarray/testReduceRight<Uint32Array,u32>
-  call $std/typedarray/testReduceRight<Int64Array,i64>
-  call $std/typedarray/testReduceRight<Uint64Array,u64>
-  call $std/typedarray/testReduceRight<Float32Array,f32>
-  call $std/typedarray/testReduceRight<Float64Array,f64>
-  call $std/typedarray/testArrayMap<Int8Array,i8>
-  call $std/typedarray/testArrayMap<Uint8Array,u8>
-  call $std/typedarray/testArrayMap<Uint8ClampedArray,u8>
-  call $std/typedarray/testArrayMap<Int16Array,i16>
-  call $std/typedarray/testArrayMap<Uint16Array,u16>
-  call $std/typedarray/testArrayMap<Int32Array,i32>
-  call $std/typedarray/testArrayMap<Uint32Array,u32>
-  call $std/typedarray/testArrayMap<Int64Array,i64>
-  call $std/typedarray/testArrayMap<Uint64Array,u64>
-  call $std/typedarray/testArrayMap<Float32Array,f32>
-  call $std/typedarray/testArrayMap<Float64Array,f64>
-  call $std/typedarray/testArraySome<Int8Array,i8>
-  call $std/typedarray/testArraySome<Uint8Array,u8>
-  call $std/typedarray/testArraySome<Uint8ClampedArray,u8>
-  call $std/typedarray/testArraySome<Int16Array,i16>
-  call $std/typedarray/testArraySome<Uint16Array,u16>
-  call $std/typedarray/testArraySome<Int32Array,i32>
-  call $std/typedarray/testArraySome<Uint32Array,u32>
-  call $std/typedarray/testArraySome<Int64Array,i64>
-  call $std/typedarray/testArraySome<Uint64Array,u64>
-  call $std/typedarray/testArraySome<Float32Array,f32>
-  call $std/typedarray/testArraySome<Float64Array,f64>
-  call $std/typedarray/testArrayFindIndex<Int8Array,i8>
-  call $std/typedarray/testArrayFindIndex<Uint8Array,u8>
-  call $std/typedarray/testArrayFindIndex<Uint8ClampedArray,u8>
-  call $std/typedarray/testArrayFindIndex<Int16Array,i16>
-  call $std/typedarray/testArrayFindIndex<Uint16Array,u16>
-  call $std/typedarray/testArrayFindIndex<Int32Array,i32>
-  call $std/typedarray/testArrayFindIndex<Uint32Array,u32>
-  call $std/typedarray/testArrayFindIndex<Int64Array,i64>
-  call $std/typedarray/testArrayFindIndex<Uint64Array,u64>
-  call $std/typedarray/testArrayFindIndex<Float32Array,f32>
-  call $std/typedarray/testArrayFindIndex<Float64Array,f64>
-  call $std/typedarray/testArrayEvery<Int8Array,i8>
-  call $std/typedarray/testArrayEvery<Uint8Array,u8>
-  call $std/typedarray/testArrayEvery<Uint8ClampedArray,u8>
-  call $std/typedarray/testArrayEvery<Int16Array,i16>
-  call $std/typedarray/testArrayEvery<Uint16Array,u16>
-  call $std/typedarray/testArrayEvery<Int32Array,i32>
-  call $std/typedarray/testArrayEvery<Uint32Array,u32>
-  call $std/typedarray/testArrayEvery<Int64Array,i64>
-  call $std/typedarray/testArrayEvery<Uint64Array,u64>
-  call $std/typedarray/testArrayEvery<Float32Array,f32>
-  call $std/typedarray/testArrayEvery<Float64Array,f64>
-  call $std/typedarray/testArrayForEach<Int8Array,i8>
-  call $std/typedarray/testArrayForEach<Uint8Array,u8>
-  call $std/typedarray/testArrayForEach<Uint8ClampedArray,u8>
-  call $std/typedarray/testArrayForEach<Int16Array,i16>
-  call $std/typedarray/testArrayForEach<Uint16Array,u16>
-  call $std/typedarray/testArrayForEach<Int32Array,i32>
-  call $std/typedarray/testArrayForEach<Uint32Array,u32>
-  call $std/typedarray/testArrayForEach<Int64Array,i64>
-  call $std/typedarray/testArrayForEach<Uint64Array,u64>
-  call $std/typedarray/testArrayForEach<Float32Array,f32>
-  call $std/typedarray/testArrayForEach<Float64Array,f64>
-  call $std/typedarray/testArrayReverse<Int8Array,i8>
-  call $std/typedarray/testArrayReverse<Uint8Array,u8>
-  call $std/typedarray/testArrayReverse<Uint8ClampedArray,u8>
-  call $std/typedarray/testArrayReverse<Int16Array,i16>
-  call $std/typedarray/testArrayReverse<Uint16Array,u16>
-  call $std/typedarray/testArrayReverse<Int32Array,i32>
-  call $std/typedarray/testArrayReverse<Uint32Array,u32>
-  call $std/typedarray/testArrayReverse<Int64Array,i64>
-  call $std/typedarray/testArrayReverse<Uint64Array,u64>
-  call $std/typedarray/testArrayReverse<Float32Array,f32>
-  call $std/typedarray/testArrayReverse<Float64Array,f64>
+  call $std/typedarray/testReduce<~lib/typedarray/Int8Array,i8>
+  call $std/typedarray/testReduce<~lib/typedarray/Uint8Array,u8>
+  call $std/typedarray/testReduce<~lib/typedarray/Uint8ClampedArray,u8>
+  call $std/typedarray/testReduce<~lib/typedarray/Int16Array,i16>
+  call $std/typedarray/testReduce<~lib/typedarray/Uint16Array,u16>
+  call $std/typedarray/testReduce<~lib/typedarray/Int32Array,i32>
+  call $std/typedarray/testReduce<~lib/typedarray/Uint32Array,u32>
+  call $std/typedarray/testReduce<~lib/typedarray/Int64Array,i64>
+  call $std/typedarray/testReduce<~lib/typedarray/Uint64Array,u64>
+  call $std/typedarray/testReduce<~lib/typedarray/Float32Array,f32>
+  call $std/typedarray/testReduce<~lib/typedarray/Float64Array,f64>
+  call $std/typedarray/testReduceRight<~lib/typedarray/Int8Array,i8>
+  call $std/typedarray/testReduceRight<~lib/typedarray/Uint8Array,u8>
+  call $std/typedarray/testReduceRight<~lib/typedarray/Uint8ClampedArray,u8>
+  call $std/typedarray/testReduceRight<~lib/typedarray/Int16Array,i16>
+  call $std/typedarray/testReduceRight<~lib/typedarray/Uint16Array,u16>
+  call $std/typedarray/testReduceRight<~lib/typedarray/Int32Array,i32>
+  call $std/typedarray/testReduceRight<~lib/typedarray/Uint32Array,u32>
+  call $std/typedarray/testReduceRight<~lib/typedarray/Int64Array,i64>
+  call $std/typedarray/testReduceRight<~lib/typedarray/Uint64Array,u64>
+  call $std/typedarray/testReduceRight<~lib/typedarray/Float32Array,f32>
+  call $std/typedarray/testReduceRight<~lib/typedarray/Float64Array,f64>
+  call $std/typedarray/testArrayMap<~lib/typedarray/Int8Array,i8>
+  call $std/typedarray/testArrayMap<~lib/typedarray/Uint8Array,u8>
+  call $std/typedarray/testArrayMap<~lib/typedarray/Uint8ClampedArray,u8>
+  call $std/typedarray/testArrayMap<~lib/typedarray/Int16Array,i16>
+  call $std/typedarray/testArrayMap<~lib/typedarray/Uint16Array,u16>
+  call $std/typedarray/testArrayMap<~lib/typedarray/Int32Array,i32>
+  call $std/typedarray/testArrayMap<~lib/typedarray/Uint32Array,u32>
+  call $std/typedarray/testArrayMap<~lib/typedarray/Int64Array,i64>
+  call $std/typedarray/testArrayMap<~lib/typedarray/Uint64Array,u64>
+  call $std/typedarray/testArrayMap<~lib/typedarray/Float32Array,f32>
+  call $std/typedarray/testArrayMap<~lib/typedarray/Float64Array,f64>
+  call $std/typedarray/testArraySome<~lib/typedarray/Int8Array,i8>
+  call $std/typedarray/testArraySome<~lib/typedarray/Uint8Array,u8>
+  call $std/typedarray/testArraySome<~lib/typedarray/Uint8ClampedArray,u8>
+  call $std/typedarray/testArraySome<~lib/typedarray/Int16Array,i16>
+  call $std/typedarray/testArraySome<~lib/typedarray/Uint16Array,u16>
+  call $std/typedarray/testArraySome<~lib/typedarray/Int32Array,i32>
+  call $std/typedarray/testArraySome<~lib/typedarray/Uint32Array,u32>
+  call $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64>
+  call $std/typedarray/testArraySome<~lib/typedarray/Uint64Array,u64>
+  call $std/typedarray/testArraySome<~lib/typedarray/Float32Array,f32>
+  call $std/typedarray/testArraySome<~lib/typedarray/Float64Array,f64>
+  call $std/typedarray/testArrayFindIndex<~lib/typedarray/Int8Array,i8>
+  call $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8Array,u8>
+  call $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint8ClampedArray,u8>
+  call $std/typedarray/testArrayFindIndex<~lib/typedarray/Int16Array,i16>
+  call $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint16Array,u16>
+  call $std/typedarray/testArrayFindIndex<~lib/typedarray/Int32Array,i32>
+  call $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint32Array,u32>
+  call $std/typedarray/testArrayFindIndex<~lib/typedarray/Int64Array,i64>
+  call $std/typedarray/testArrayFindIndex<~lib/typedarray/Uint64Array,u64>
+  call $std/typedarray/testArrayFindIndex<~lib/typedarray/Float32Array,f32>
+  call $std/typedarray/testArrayFindIndex<~lib/typedarray/Float64Array,f64>
+  call $std/typedarray/testArrayEvery<~lib/typedarray/Int8Array,i8>
+  call $std/typedarray/testArrayEvery<~lib/typedarray/Uint8Array,u8>
+  call $std/typedarray/testArrayEvery<~lib/typedarray/Uint8ClampedArray,u8>
+  call $std/typedarray/testArrayEvery<~lib/typedarray/Int16Array,i16>
+  call $std/typedarray/testArrayEvery<~lib/typedarray/Uint16Array,u16>
+  call $std/typedarray/testArrayEvery<~lib/typedarray/Int32Array,i32>
+  call $std/typedarray/testArrayEvery<~lib/typedarray/Uint32Array,u32>
+  call $std/typedarray/testArrayEvery<~lib/typedarray/Int64Array,i64>
+  call $std/typedarray/testArrayEvery<~lib/typedarray/Uint64Array,u64>
+  call $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>
+  call $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>
+  call $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>
+  call $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8>
+  call $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8>
+  call $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>
+  call $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16>
+  call $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>
+  call $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32>
+  call $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>
+  call $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64>
+  call $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>
+  call $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>
+  call $std/typedarray/testArrayReverse<~lib/typedarray/Int8Array,i8>
+  call $std/typedarray/testArrayReverse<~lib/typedarray/Uint8Array,u8>
+  call $std/typedarray/testArrayReverse<~lib/typedarray/Uint8ClampedArray,u8>
+  call $std/typedarray/testArrayReverse<~lib/typedarray/Int16Array,i16>
+  call $std/typedarray/testArrayReverse<~lib/typedarray/Uint16Array,u16>
+  call $std/typedarray/testArrayReverse<~lib/typedarray/Int32Array,i32>
+  call $std/typedarray/testArrayReverse<~lib/typedarray/Uint32Array,u32>
+  call $std/typedarray/testArrayReverse<~lib/typedarray/Int64Array,i64>
+  call $std/typedarray/testArrayReverse<~lib/typedarray/Uint64Array,u64>
+  call $std/typedarray/testArrayReverse<~lib/typedarray/Float32Array,f32>
+  call $std/typedarray/testArrayReverse<~lib/typedarray/Float64Array,f64>
  )
  (func $start (; 365 ;) (type $FUNCSIG$v)
   call $start:std/typedarray


### PR DESCRIPTION
This PR addresses a probable cause for the `Type 'Foo' is not assignable to type 'Foo'` issue. See also [this comment](https://github.com/AssemblyScript/assemblyscript/issues/539#issuecomment-473518110).

most likely fixes #539 / cc @vgrichina