### PR TITLE
Fix arrow function body parsing precedence

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1437,9 +1437,14 @@ export class Parser extends DiagnosticEmitter {
       tn.range(signatureStart, tn.pos)
     );
 
-    var body: Statement | null;
+    var body: Statement | null = null;
     if (arrowKind) {
-      body = this.parseStatement(tn, false);
+      if (tn.skip(Token.OPENBRACE)) {
+        body = this.parseBlockStatement(tn, false);
+      } else {
+        let bodyExpression = this.parseExpression(tn, Precedence.COMMA + 1);
+        if (bodyExpression) body = Node.createExpressionStatement(bodyExpression);
+      }
     } else {
       if (!tn.skip(Token.OPENBRACE)) {
         this.error(


### PR DESCRIPTION
This PR corrects parsing of e.g. `arr.reduce<i32>((a, b) => a + b, 0)`, which previously parsed the inner arrow function body as `a + b, 0`, resulting in just one argument to `.reduce<i32>(...)` etc.

fixes #543