### PR TITLE
Update Binaryen to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -567,9 +567,9 @@
       "dev": true
     },
     "binaryen": {
-      "version": "73.0.0-nightly.20190327",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-73.0.0-nightly.20190327.tgz",
-      "integrity": "sha512-FMHRsdX5pkPX3qO3Ez6CFMk1gCigk5tBkyGXDYlWATslR8l5rPB4UGGq/DYfB3yE1riEHzV9VFUlz/WXG0W3vA=="
+      "version": "77.0.0-nightly.20190407",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-77.0.0-nightly.20190407.tgz",
+      "integrity": "sha512-1mxYNvQ0xywMe582K7V6Vo2zzhZZxMTeGHH8aE/+/AND8f64D8Q1GThVY3RVRwGY/4p+p95ccw9Xbw2ovFXRIg=="
     },
     "bluebird": {
       "version": "3.5.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@protobufjs/utf8": "^1.1.0",
-    "binaryen": "73.0.0-nightly.20190327",
+    "binaryen": "77.0.0-nightly.20190407",
     "glob": "^7.1.3",
     "long": "^4.0.0",
     "opencollective-postinstall": "^2.0.0",

--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -278,8 +278,6 @@ export namespace BuiltinSymbols {
   export const i64_atomic_rmw_cmpxchg = "~lib/builtins/i64.atomic.rmw.cmpxchg";
   export const i32_wait = "~lib/builtins/i32.wait";
   export const i64_wait = "~lib/builtins/i64.wait";
-  export const i32_notify = "~lib/builtins/i32.notify";
-  export const i64_notify = "~lib/builtins/i64.notify";
 
   export const v128_splat = "~lib/builtins/v128.splat";
   export const v128_extract_lane = "~lib/builtins/v128.extract_lane";
@@ -3784,8 +3782,6 @@ function tryDeferASM(
 
       case BuiltinSymbols.i32_wait: return deferASM(BuiltinSymbols.atomic_wait, compiler, Type.i32, operands, Type.i32, reportNode);
       case BuiltinSymbols.i64_wait: return deferASM(BuiltinSymbols.atomic_wait, compiler, Type.i64, operands, Type.i32, reportNode);
-      case BuiltinSymbols.i32_notify: return deferASM(BuiltinSymbols.atomic_notify, compiler, Type.i32, operands, Type.i32, reportNode);
-      case BuiltinSymbols.i64_notify: return deferASM(BuiltinSymbols.atomic_notify, compiler, Type.i64, operands, Type.i32, reportNode);
     }
   }
   if (compiler.options.hasFeature(Feature.SIMD)) {

--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -1944,21 +1944,13 @@ export function compileCall(
       compiler.currentType = Type.i32;
       return module.createAtomicWait(arg0, arg1, arg2, type.toNativeType());
     }
-    case BuiltinSymbols.atomic_notify: { // notify<T!>(ptr: usize, count: i32): i32;
+    case BuiltinSymbols.atomic_notify: { // notify(ptr: usize, count: i32): i32;
       if (!compiler.options.hasFeature(Feature.THREADS)) break;
       compiler.currentType = Type.i32;
       if (
-        checkTypeRequired(typeArguments, reportNode, compiler) |
+        checkTypeAbsent(typeArguments, reportNode, prototype) |
         checkArgsRequired(operands, 2, reportNode, compiler)
       ) return module.createUnreachable();
-      let type = typeArguments![0];
-      if (!type.is(TypeFlags.INTEGER) || type.size < 32) {
-        compiler.error(
-          DiagnosticCode.Operation_not_supported,
-          reportNode.typeArgumentsRange
-        );
-        return module.createUnreachable();
-      }
       let arg0 = compiler.compileExpression(
         operands[0],
         compiler.options.usizeType,
@@ -1967,12 +1959,12 @@ export function compileCall(
       );
       let arg1 = compiler.compileExpression(
         operands[1],
-        type,
+        Type.i32,
         ConversionKind.IMPLICIT,
         WrapMode.NONE
       );
       compiler.currentType = Type.i32;
-      return module.createAtomicWake(arg0, arg1);
+      return module.createAtomicNotify(arg0, arg1);
     }
 
     // === Control flow ===========================================================================

--- a/src/decompiler.ts
+++ b/src/decompiler.ts
@@ -856,7 +856,7 @@ export class Decompiler {
       case ExpressionId.AtomicCmpxchg:
       case ExpressionId.AtomicRMW:
       case ExpressionId.AtomicWait:
-      case ExpressionId.AtomicWake:
+      case ExpressionId.AtomicNotify:
     }
     throw new Error("not implemented");
   }

--- a/src/glue/binaryen.d.ts
+++ b/src/glue/binaryen.d.ts
@@ -50,7 +50,7 @@ declare function _BinaryenUnreachableId(): BinaryenExpressionId;
 declare function _BinaryenAtomicCmpxchgId(): BinaryenExpressionId;
 declare function _BinaryenAtomicRMWId(): BinaryenExpressionId;
 declare function _BinaryenAtomicWaitId(): BinaryenExpressionId;
-declare function _BinaryenAtomicWakeId(): BinaryenExpressionId;
+declare function _BinaryenAtomicNotifyId(): BinaryenExpressionId;
 declare function _BinaryenSIMDExtractId(): BinaryenExpressionId;
 declare function _BinaryenSIMDReplaceId(): BinaryenExpressionId;
 declare function _BinaryenSIMDShuffleId(): BinaryenExpressionId;
@@ -392,7 +392,7 @@ declare function _BinaryenAtomicStore(module: BinaryenModuleRef, bytes: Binaryen
 declare function _BinaryenAtomicRMW(module: BinaryenModuleRef, op: BinaryenAtomicRMWOp, bytes: i32, offset: i32, ptr: BinaryenExpressionRef, value: BinaryenExpressionRef, type: BinaryenType): BinaryenExpressionRef;
 declare function _BinaryenAtomicCmpxchg(module: BinaryenModuleRef, bytes: i32, offset: i32, ptr: BinaryenExpressionRef, expected: BinaryenExpressionRef, replacement: BinaryenExpressionRef, type: BinaryenType): BinaryenExpressionRef;
 declare function _BinaryenAtomicWait(module: BinaryenModuleRef, ptr: BinaryenExpressionRef, expected: BinaryenExpressionRef, timeout: BinaryenExpressionRef, expectedType: BinaryenType): BinaryenExpressionRef;
-declare function _BinaryenAtomicWake(module: BinaryenModuleRef, ptr: BinaryenExpressionRef, wakeCount: BinaryenExpressionRef): BinaryenExpressionRef;
+declare function _BinaryenAtomicNotify(module: BinaryenModuleRef, ptr: BinaryenExpressionRef, notifyCount: BinaryenExpressionRef): BinaryenExpressionRef;
 
 declare function _BinaryenSIMDExtract(module: BinaryenModuleRef, op: BinaryenSIMDOp, vec: BinaryenExpressionRef, idx: u8): BinaryenExpressionRef;
 declare function _BinaryenSIMDReplace(module: BinaryenModuleRef, op: BinaryenSIMDOp, vec: BinaryenExpressionRef, idx: u8, value: BinaryenExpressionRef): BinaryenExpressionRef;
@@ -506,8 +506,8 @@ declare function _BinaryenAtomicWaitGetExpected(expr: BinaryenExpressionRef): Bi
 declare function _BinaryenAtomicWaitGetTimeout(expr: BinaryenExpressionRef): BinaryenExpressionRef;
 declare function _BinaryenAtomicWaitGetExpectedType(expr: BinaryenExpressionRef): BinaryenType;
 
-declare function _BinaryenAtomicWakeGetPtr(expr: BinaryenExpressionRef): BinaryenExpressionRef;
-declare function _BinaryenAtomicWakeGetWakeCount(expr: BinaryenExpressionRef): BinaryenExpressionRef;
+declare function _BinaryenAtomicNotifyGetPtr(expr: BinaryenExpressionRef): BinaryenExpressionRef;
+declare function _BinaryenAtomicNotifyGetNotifyCount(expr: BinaryenExpressionRef): BinaryenExpressionRef;
 
 declare function _BinaryenSIMDExtractGetOp(expr: BinaryenExpressionRef): BinaryenSIMDOp;
 declare function _BinaryenSIMDExtractGetVec(expr: BinaryenExpressionRef): BinaryenExpressionRef;
@@ -596,7 +596,7 @@ declare function _BinaryenRemoveGlobal(module: BinaryenModuleRef, name: usize): 
 
 declare function _BinaryenSetFunctionTable(module: BinaryenModuleRef, initial: BinaryenIndex, maximum: BinaryenIndex, funcs: usize, numFuncs: BinaryenIndex): void;
 
-declare function _BinaryenSetMemory(module: BinaryenModuleRef, initial: BinaryenIndex, maximum: BinaryenIndex, exportName: usize, segments: usize, segmentOffsets: usize, segmentSizes: usize, numSegments: BinaryenIndex, shared: bool): void;
+declare function _BinaryenSetMemory(module: BinaryenModuleRef, initial: BinaryenIndex, maximum: BinaryenIndex, exportName: usize, segments: usize, segmentPassive: usize, segmentOffsets: usize, segmentSizes: usize, numSegments: BinaryenIndex, shared: bool): void;
 
 declare function _BinaryenSetStart(module: BinaryenModuleRef, start: BinaryenFunctionRef): void;
 

--- a/std/assembly/builtins.ts
+++ b/std/assembly/builtins.ts
@@ -57,7 +57,7 @@ export namespace atomic {
   @builtin export declare function xchg<T>(ptr: usize, value: T, immOffset?: usize): T;
   @builtin export declare function cmpxchg<T>(ptr: usize, expected: T, replacement: T, immOffset?: usize): T;
   @builtin export declare function wait<T>(ptr: usize, expected: T, timeout: i64): AtomicWaitResult;
-  @builtin export declare function notify<T>(ptr: usize, count: i32): i32;
+  @builtin export declare function notify(ptr: usize, count: i32): i32;
 }
 
 @lazy export const enum AtomicWaitResult {
@@ -105,7 +105,6 @@ export namespace i32 {
     @builtin export declare function store16(offset: usize, value: i32, immOffset?: usize): void;
     @builtin export declare function store(offset: usize, value: i32, immOffset?: usize): void;
     @builtin export declare function wait(ptr: usize, expected: i32, timeout: i64): AtomicWaitResult;
-    @builtin export declare function notify(ptr: usize, count: i32): i32;
 
     export namespace rmw8 {
       @builtin export declare function add_u(offset: usize, value: i32, immOffset?: usize): i32;
@@ -169,7 +168,6 @@ export namespace i64 {
     @builtin export declare function store32(offset: usize, value: i64, immOffset?: usize): void;
     @builtin export declare function store(offset: usize, value: i64, immOffset?: usize): void;
     @builtin export declare function wait(ptr: usize, expected: i64, timeout: i64): AtomicWaitResult;
-    @builtin export declare function notify(ptr: usize, count: i32): i32;
 
     export namespace rmw8 {
       @builtin export declare function add_u(offset: usize, value: i64, immOffset?: usize): i64;

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -183,10 +183,10 @@ declare namespace atomic {
   export function xchg<T>(ptr: usize, value: T, immOffset?: usize): T;
   /** Atomically compares and exchanges an integer value in memory if the condition is met. */
   export function cmpxchg<T>(ptr: usize, expected: T, replacement: T, immOffset?: usize): T;
-  /** Performs a wait operation on an integer value in memory suspending this agent if the condition is met. */
+  /** Performs a wait operation on an address in memory suspending this agent if the integer condition is met. */
   export function wait<T>(ptr: usize, expected: T, timeout: i64): AtomicWaitResult;
-  /** Performs a notify operation on an integer value in memory waking up suspended agents. */
-  export function notify<T>(ptr: usize, count: i32): i32;
+  /** Performs a notify operation on an address in memory waking up suspended agents. */
+  export function notify(ptr: usize, count: i32): i32;
 }
 
 /** Describes the result of an atomic wait operation. */
@@ -254,8 +254,6 @@ declare namespace i32 {
     export function store(offset: usize, value: i32, immOffset?: usize): void;
     /** Performs a wait operation on a 32-bit integer value in memory suspending this agent if the condition is met. */
     export function wait(ptr: usize, expected: i32, timeout: i64): AtomicWaitResult;
-    /** Performs a notify operation on a 32-bit integer value in memory waking up suspended agents. */
-    export function notify(ptr: usize, count: i32): i32;
     /** Atomic 32-bit integer read-modify-write operations on 8-bit values. */
     export namespace rmw8 {
       /** Atomically adds an 8-bit unsigned integer value in memory. */
@@ -358,8 +356,6 @@ declare namespace i64 {
     export function store(offset: usize, value: i64, immOffset?: usize): void;
     /** Performs a wait operation on a 64-bit integer value in memory suspending this agent if the condition is met. */
     export function wait(ptr: usize, expected: i64, timeout: i64): AtomicWaitResult;
-    /** Performs a notify operation on a 64-bit integer value in memory waking up suspended agents. */
-    export function notify(ptr: usize, count: i32): i32;
     /** Atomic 64-bit integer read-modify-write operations on 8-bit values. */
     export namespace rmw8 {
       /** Atomically adds an 8-bit unsigned integer value in memory. */


### PR DESCRIPTION
This PR updates Binaryen to v77.0.0-nightly.20190407 and incorporates their latest changes. In particular:

* There's a new argument to `BinaryenSetMemory` indicating passive segments
* Anything `AtomicWake` has been renamed to `AtomicNotify` and
* `i32.atomic.notify` and `i64.atomic.notify` have been collapsed to just `atomic.notify`, which in turn makes our builtin `atomic.notify<T>` non-generic, plus removing the `i32.` and `i64.` versions.

Should also unbreak WebAssembly Studio when using AssemblyScript, once dist files have been updated.