### PR TITLE
typings(Loader): Make ImportsObject.env optional

### DIFF
--- a/lib/loader/index.d.ts
+++ b/lib/loader/index.d.ts
@@ -6,7 +6,7 @@ interface ImportsObject extends Record<string, any> {
     memory?: WebAssembly.Memory,
     table?: WebAssembly.Table,
     abort?: (msg: number, file: number, line: number, column: number) => void,
-    trace?: (msg: number, n: number, ...rest: any[]) => void
+    trace?: (msg: number, numArgs?: number, ...rest: any[]) => void
   }
 }
 

--- a/lib/loader/index.d.ts
+++ b/lib/loader/index.d.ts
@@ -1,12 +1,12 @@
 import "@types/webassembly-js-api";
 
 /** WebAssembly imports with two levels of nesting. */
-interface ImportsObject {
-  [key: string]: {},
+interface ImportsObject extends Record<string, any> {
   env?: {
     memory?: WebAssembly.Memory,
     table?: WebAssembly.Table,
-    abort?: (msg: number, file: number, line: number, column: number) => void
+    abort?: (msg: number, file: number, line: number, column: number) => void,
+    trace?: (msg: number, n: string, ...rest: any[]) => void
   }
 }
 

--- a/lib/loader/index.d.ts
+++ b/lib/loader/index.d.ts
@@ -3,7 +3,7 @@ import "@types/webassembly-js-api";
 /** WebAssembly imports with two levels of nesting. */
 interface ImportsObject {
   [key: string]: {},
-  env: {
+  env?: {
     memory?: WebAssembly.Memory,
     table?: WebAssembly.Table,
     abort?: (msg: number, file: number, line: number, column: number) => void

--- a/lib/loader/index.d.ts
+++ b/lib/loader/index.d.ts
@@ -6,7 +6,7 @@ interface ImportsObject extends Record<string, any> {
     memory?: WebAssembly.Memory,
     table?: WebAssembly.Table,
     abort?: (msg: number, file: number, line: number, column: number) => void,
-    trace?: (msg: number, n: string, ...rest: any[]) => void
+    trace?: (msg: number, n: number, ...rest: any[]) => void
   }
 }
 


### PR DESCRIPTION
Examples use `instantiateStreaming(fetch('url'), {});` with an empty imports object, however, this errors in TypeScript as `env` is marked required, though it's optional as shown below:

https://github.com/AssemblyScript/assemblyscript/blob/36040d5b5312f19a025782b5e36663823494c2f3/lib/loader/index.js#L34

This PR makes that property optional so we can either don't pass an object (since it's optional), or an empty object (without the `env` property).