### PR TITLE
Move OptionDescription to utils/options so types agree

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -13,6 +13,7 @@ under the licensing terms detailed in LICENSE:
 * Joshua Tenner <tenner.joshua@gmail.com>
 * Nidin Vinayakan <01@01alchemist.com>
 * Aaron Turner <aaron@aaronthedev.com>
+* Willem Wyndham <willem@cs.umd.edu>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/cli/asc.d.ts
+++ b/cli/asc.d.ts
@@ -1,4 +1,4 @@
-import { OptionDescription }from "./util/options";
+import { OptionDescription } from "./util/options";
 export { OptionDescription };
 
 /** Whether this is a webpack bundle or not. */

--- a/cli/asc.d.ts
+++ b/cli/asc.d.ts
@@ -1,5 +1,5 @@
-import {OptionDescription}from "./util/options";
-export {OptionDescription};
+import { OptionDescription }from "./util/options";
+export { OptionDescription };
 
 /** Whether this is a webpack bundle or not. */
 export const isBundle: boolean;

--- a/cli/asc.d.ts
+++ b/cli/asc.d.ts
@@ -1,3 +1,6 @@
+import {OptionDescription}from "./util/options";
+export {OptionDescription};
+
 /** Whether this is a webpack bundle or not. */
 export const isBundle: boolean;
 
@@ -6,16 +9,6 @@ export const isDev: boolean;
 
 /** AssemblyScript version. */
 export const version: string;
-
-/** Command line option description. */
-export interface OptionDescription {
-  /** Textual description. */
-  description: string | string[];
-  /** Option type, e.g. `string`. */
-  type: string;
-  /** Option aliases, if any. */
-  aliases?: string[];
-}
 
 /** Available CLI options. */
 export const options: { [key: string]: OptionDescription };

--- a/cli/util/options.d.ts
+++ b/cli/util/options.d.ts
@@ -3,7 +3,7 @@ export interface OptionDescription {
   /** Textual description. */
   description?: string | string[],
   /** Data type. One of (b)oolean [default], (i)nteger, (f)loat or (s)tring. Uppercase means multiple values. */
-  type?: "b" | "i" | "f" | "s", "I", "F", "S",
+  type?: "b" | "i" | "f" | "s" | "I" | "F" | "S",
   /** Substituted options, if any. */
   value?: { [key: string]: number | string },
   /** Short alias, if any. */

--- a/cli/util/options.d.ts
+++ b/cli/util/options.d.ts
@@ -1,15 +1,18 @@
+/** Command line option description. */
+export interface OptionDescription {
+  /** Textual description. */
+  description?: string | string[],
+  /** Data type. One of (b)oolean [default], (i)nteger, (f)loat or (s)tring. Uppercase means multiple values. */
+  type?: "b" | "i" | "f" | "s", "I", "F", "S",
+  /** Substituted options, if any. */
+  value?: { [key: string]: number | string },
+  /** Short alias, if any. */
+  alias?: string
+}
+
 /** Configuration object. */
 interface Config {
-  [key: string]: {
-    /** Textual description. */
-    description?: string | string[],
-    /** Data type. One of (b)oolean [default], (i)nteger, (f)loat or (s)tring. Uppercase means multiple values. */
-    type?: "b" | "i" | "f" | "s", "I", "F", "S",
-    /** Substituted options, if any. */
-    value?: { [key: string]: number | string },
-    /** Short alias, if any. */
-    alias?: string
-  };
+  [key: string]: OptionDescription;
 }
 
 /** Parsing result. */


### PR DESCRIPTION
I found this when using the options parser in as-pect and `asc.exports` disagreed with `util.parse`'s expected argument type `Config`.