### PR TITLE
Added paths option to resolve stdlib imports in IDE's

### DIFF
--- a/std/assembly.json
+++ b/std/assembly.json
@@ -6,6 +6,12 @@
     "noLib": true,
     "allowJs": false,
     "typeRoots": [ "types" ],
-    "types": [ "assembly" ]
+    "types": [ "assembly" ],
+    "baseUrl": ".",
+    "paths": {
+      "*": [
+        "./assembly/*"
+      ]
+    }
   }
 }

--- a/std/assembly/rt/index.d.ts
+++ b/std/assembly/rt/index.d.ts
@@ -10,3 +10,4 @@ declare function __visit(ref: usize, cookie: i32): void;
 declare function __visit_globals(cookie: u32): void;
 declare function __visit_members(ref: usize, cookie: u32): void;
 declare function __allocArray(length: i32, alignLog2: usize, id: u32, data?: usize): usize;
+declare const ASC_RTRACE: boolean;

--- a/std/assembly/rt/pure.ts
+++ b/std/assembly/rt/pure.ts
@@ -15,7 +15,7 @@ import { onincrement, ondecrement, onfree, onalloc } from "./rtrace";
 // B: buffered
 
 // @ts-ignore: decorator
-@inline const BUFFERED_MASK: u32 = 1 << (sizeof<u32>() * 8 - 1);
+@inline const BUFFERED_MASK: u32 = 1 << ((sizeof<u32>() * 8) - 1);
 // @ts-ignore: decorator
 @inline const COLOR_BITS = 3;
 // @ts-ignore: decorator


### PR DESCRIPTION
Currently IDE's can't resolve stdlib imports that aren't relative.  This uses the ts path compiler option to try to resolve non-relative paths with the stdlib. 

This also fixes two typing errors that IDE found. 