### PR TITLE
Allow internal abort to be disabled

### DIFF
--- a/cli/asc.js
+++ b/cli/asc.js
@@ -459,10 +459,10 @@ exports.main = function main(argv, options, callback) {
       let part = aliases[i];
       let p = part.indexOf("=");
       if (p < 0) return callback(Error("Global alias '" + part + "' is invalid."));
-      let name = part.substring(0, p).trim();
-      let alias = part.substring(p + 1).trim();
-      if (!name.length) return callback(Error("Global alias '" + part + "' is invalid."));
-      assemblyscript.setGlobalAlias(compilerOptions, name, alias);
+      let alias = part.substring(0, p).trim();
+      let name = part.substring(p + 1).trim();
+      if (!alias.length) return callback(Error("Global alias '" + part + "' is invalid."));
+      assemblyscript.setGlobalAlias(compilerOptions, alias, name);
     }
   }
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -197,7 +197,7 @@ export class Options {
   explicitStart: bool = false;
   /** Static memory start offset. */
   memoryBase: i32 = 0;
-  /** Global aliases. */
+  /** Global aliases, mapping alias names as the key to internal names to be aliased as the value. */
   globalAliases: Map<string,string> | null = null;
   /** Additional features to activate. */
   features: Feature = Feature.NONE;

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,10 +93,10 @@ export function setMemoryBase(options: Options, memoryBase: u32): void {
 }
 
 /** Sets a 'globalAliases' value. */
-export function setGlobalAlias(options: Options, name: string, alias: string): void {
+export function setGlobalAlias(options: Options, alias: string, name: string): void {
   var globalAliases = options.globalAliases;
   if (!globalAliases) options.globalAliases = globalAliases = new Map();
-  globalAliases.set(name, alias);
+  globalAliases.set(alias, name);
 }
 
 /** Sets the `explicitStart` option. */

--- a/src/program.ts
+++ b/src/program.ts
@@ -375,8 +375,8 @@ export class Program extends DiagnosticEmitter {
   f64ArrayPrototype: ClassPrototype;
   /** String instance reference. */
   stringInstance: Class;
-  /** Abort function reference, if present. */
-  abortInstance: Function;
+  /** Abort function reference, if not explicitly disabled. */
+  abortInstance: Function | null;
 
   // runtime references
 
@@ -849,7 +849,7 @@ export class Program extends DiagnosticEmitter {
     this.fixedArrayPrototype = <ClassPrototype>this.require(CommonSymbols.FixedArray, ElementKind.CLASS_PROTOTYPE);
     this.setPrototype = <ClassPrototype>this.require(CommonSymbols.Set, ElementKind.CLASS_PROTOTYPE);
     this.mapPrototype = <ClassPrototype>this.require(CommonSymbols.Map, ElementKind.CLASS_PROTOTYPE);
-    this.abortInstance = this.requireFunction(CommonSymbols.abort);
+    this.abortInstance = this.lookupFunction(CommonSymbols.abort); // can be disabled
     this.allocInstance = this.requireFunction(CommonSymbols.alloc);
     this.reallocInstance = this.requireFunction(CommonSymbols.realloc);
     this.freeInstance = this.requireFunction(CommonSymbols.free);
@@ -883,6 +883,13 @@ export class Program extends DiagnosticEmitter {
     var resolved = this.resolver.resolveClass(<ClassPrototype>prototype, null);
     if (!resolved) throw new Error("invalid " + name);
     return resolved;
+  }
+
+  /** Obtains a non-generic global function and returns it. Returns `null` if it does not exist. */
+  private lookupFunction(name: string): Function | null {
+    var prototype = this.lookupGlobal(name);
+    if (!prototype || prototype.kind != ElementKind.FUNCTION_PROTOTYPE) return null;
+    return this.resolver.resolveFunction(<FunctionPrototype>prototype, null);
   }
 
   /** Requires that a non-generic global function is present and returns it. */


### PR DESCRIPTION
As mentioned in https://github.com/AssemblyScript/assemblyscript/issues/676, it is not possible to completely disable the use of the internal `abort` function, making it necessary to at least provide an alternative. This PR changes this by just emitting an `unreachable` instruction if the abort function has been disabled explicitly through `--use abort=`.