### PR TITLE
Utilize new inlining utility to potentially inline any call

### DIFF
--- a/tests/compiler/std/operator-overloading.untouched.wat
+++ b/tests/compiler/std/operator-overloading.untouched.wat
@@ -2004,54 +2004,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $std/operator-overloading/TesterInlineStatic.postInc (; 34 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  local.get $0
-  call $~lib/rt/stub/__retain
-  drop
-  i32.const 0
-  local.get $0
-  i32.load
-  i32.const 1
-  i32.add
-  local.get $0
-  i32.load offset=4
-  i32.const 1
-  i32.add
-  call $std/operator-overloading/TesterInlineStatic#constructor
-  local.set $1
-  local.get $0
-  call $~lib/rt/stub/__release
-  local.get $1
- )
- (func $std/operator-overloading/TesterInlineStatic.add (; 35 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/rt/stub/__retain
-  drop
-  local.get $1
-  call $~lib/rt/stub/__retain
-  drop
-  i32.const 0
-  local.get $0
-  i32.load
-  local.get $1
-  i32.load
-  i32.add
-  local.get $0
-  i32.load offset=4
-  local.get $1
-  i32.load offset=4
-  i32.add
-  call $std/operator-overloading/TesterInlineStatic#constructor
-  local.set $2
-  local.get $0
-  call $~lib/rt/stub/__release
-  local.get $1
-  call $~lib/rt/stub/__release
-  local.get $2
- )
- (func $std/operator-overloading/TesterInlineInstance#constructor (; 36 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/operator-overloading/TesterInlineInstance#constructor (; 34 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -2069,41 +2022,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $std/operator-overloading/TesterInlineInstance#postInc (; 37 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  i32.const 0
-  local.get $0
-  i32.load
-  i32.const 1
-  i32.add
-  local.get $0
-  i32.load offset=4
-  i32.const 1
-  i32.add
-  call $std/operator-overloading/TesterInlineInstance#constructor
- )
- (func $std/operator-overloading/TesterInlineInstance#add (; 38 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  local.get $1
-  call $~lib/rt/stub/__retain
-  drop
-  i32.const 0
-  local.get $0
-  i32.load
-  local.get $1
-  i32.load
-  i32.add
-  local.get $0
-  i32.load offset=4
-  local.get $1
-  i32.load offset=4
-  i32.add
-  call $std/operator-overloading/TesterInlineInstance#constructor
-  local.set $2
-  local.get $1
-  call $~lib/rt/stub/__release
-  local.get $2
- )
- (func $start:std/operator-overloading (; 39 ;) (type $FUNCSIG$v)
+ (func $start:std/operator-overloading (; 35 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -2128,6 +2047,7 @@
   (local $21 i32)
   (local $22 i32)
   (local $23 i32)
+  (local $24 i32)
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -3143,20 +3063,35 @@
   call $std/operator-overloading/TesterInlineStatic#constructor
   global.set $std/operator-overloading/ais1
   global.get $std/operator-overloading/ais1
-  call $std/operator-overloading/TesterInlineStatic.postInc
-  local.tee $21
+  call $~lib/rt/stub/__retain
+  local.set $20
+  i32.const 0
+  local.get $20
+  i32.load
+  i32.const 1
+  i32.add
+  local.get $20
+  i32.load offset=4
+  i32.const 1
+  i32.add
+  call $std/operator-overloading/TesterInlineStatic#constructor
+  local.set $21
+  local.get $20
+  call $~lib/rt/stub/__release
+  local.get $21
   local.tee $20
-  global.get $std/operator-overloading/ais1
   local.tee $18
+  global.get $std/operator-overloading/ais1
+  local.tee $21
   i32.ne
   if
-   local.get $20
+   local.get $18
    call $~lib/rt/stub/__retain
    drop
-   local.get $18
+   local.get $21
    call $~lib/rt/stub/__release
   end
-  local.get $20
+  local.get $18
   global.set $std/operator-overloading/ais1
   i32.const 0
   i32.const 2
@@ -3164,9 +3099,30 @@
   call $std/operator-overloading/TesterInlineStatic#constructor
   global.set $std/operator-overloading/ais2
   global.get $std/operator-overloading/ais1
+  call $~lib/rt/stub/__retain
+  local.set $18
   global.get $std/operator-overloading/ais2
-  call $std/operator-overloading/TesterInlineStatic.add
-  local.tee $20
+  call $~lib/rt/stub/__retain
+  local.set $21
+  i32.const 0
+  local.get $18
+  i32.load
+  local.get $21
+  i32.load
+  i32.add
+  local.get $18
+  i32.load offset=4
+  local.get $21
+  i32.load offset=4
+  i32.add
+  call $std/operator-overloading/TesterInlineStatic#constructor
+  local.set $22
+  local.get $21
+  call $~lib/rt/stub/__release
+  local.get $18
+  call $~lib/rt/stub/__release
+  local.get $22
+  local.tee $18
   call $~lib/rt/stub/__retain
   global.set $std/operator-overloading/ais
   global.get $std/operator-overloading/ais
@@ -3196,20 +3152,30 @@
   call $std/operator-overloading/TesterInlineInstance#constructor
   global.set $std/operator-overloading/aii1
   global.get $std/operator-overloading/aii1
-  call $std/operator-overloading/TesterInlineInstance#postInc
-  local.tee $18
+  local.set $22
+  i32.const 0
+  local.get $22
+  i32.load
+  i32.const 1
+  i32.add
+  local.get $22
+  i32.load offset=4
+  i32.const 1
+  i32.add
+  call $std/operator-overloading/TesterInlineInstance#constructor
   local.tee $22
+  local.tee $21
   global.get $std/operator-overloading/aii1
   local.tee $23
   i32.ne
   if
-   local.get $22
+   local.get $21
    call $~lib/rt/stub/__retain
    drop
    local.get $23
    call $~lib/rt/stub/__release
   end
-  local.get $22
+  local.get $21
   global.set $std/operator-overloading/aii1
   i32.const 0
   i32.const 2
@@ -3217,9 +3183,27 @@
   call $std/operator-overloading/TesterInlineInstance#constructor
   global.set $std/operator-overloading/aii2
   global.get $std/operator-overloading/aii1
+  local.set $21
   global.get $std/operator-overloading/aii2
-  call $std/operator-overloading/TesterInlineInstance#add
-  local.tee $22
+  call $~lib/rt/stub/__retain
+  local.set $23
+  i32.const 0
+  local.get $21
+  i32.load
+  local.get $23
+  i32.load
+  i32.add
+  local.get $21
+  i32.load offset=4
+  local.get $23
+  i32.load offset=4
+  i32.add
+  call $std/operator-overloading/TesterInlineInstance#constructor
+  local.set $24
+  local.get $23
+  call $~lib/rt/stub/__release
+  local.get $24
+  local.tee $21
   call $~lib/rt/stub/__retain
   global.set $std/operator-overloading/aii
   global.get $std/operator-overloading/aii
@@ -3290,9 +3274,9 @@
   local.get $22
   call $~lib/rt/stub/__release
  )
- (func $start (; 40 ;) (type $FUNCSIG$v)
+ (func $start (; 36 ;) (type $FUNCSIG$v)
   call $start:std/operator-overloading
  )
- (func $null (; 41 ;) (type $FUNCSIG$v)
+ (func $null (; 37 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/pointer.optimized.wat
+++ b/tests/compiler/std/pointer.optimized.wat
@@ -1,7 +1,5 @@
 (module
- (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
- (type $FUNCSIG$viif (func (param i32 i32 f32)))
  (type $FUNCSIG$v (func))
  (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$vii (func (param i32 i32)))
@@ -16,12 +14,7 @@
  (global $std/pointer/buf (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $start)
- (func $std/pointer/Pointer<std/pointer/Entry>#dec (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  local.get $0
-  i32.const 8
-  i32.sub
- )
- (func $~lib/memory/memory.fill (; 2 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/memory/memory.fill (; 1 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.const 0
@@ -65,7 +58,7 @@
   i32.const 0
   i32.store8
  )
- (func $~lib/memory/memory.copy (; 3 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/memory/memory.copy (; 2 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -239,16 +232,7 @@
    end
   end
  )
- (func $std/pointer/Pointer<f32>#set (; 4 ;) (type $FUNCSIG$viif) (param $0 i32) (param $1 i32) (param $2 f32)
-  local.get $1
-  i32.const 2
-  i32.shl
-  local.get $0
-  i32.add
-  local.get $2
-  f32.store
- )
- (func $start:std/pointer (; 5 ;) (type $FUNCSIG$v)
+ (func $start:std/pointer (; 3 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 8
@@ -307,8 +291,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $std/pointer/one
   global.get $std/pointer/two
+  global.get $std/pointer/one
   i32.add
   global.set $std/pointer/add
   global.get $std/pointer/add
@@ -388,10 +372,12 @@
    unreachable
   end
   global.get $std/pointer/two
-  call $std/pointer/Pointer<std/pointer/Entry>#dec
+  i32.const 8
+  i32.sub
   global.set $std/pointer/two
   global.get $std/pointer/two
-  call $std/pointer/Pointer<std/pointer/Entry>#dec
+  i32.const 8
+  i32.sub
   global.set $std/pointer/two
   global.get $std/pointer/two
   i32.const 8
@@ -478,13 +464,13 @@
   i32.const 0
   global.set $std/pointer/buf
   global.get $std/pointer/buf
-  i32.const 0
   f32.const 1.100000023841858
-  call $std/pointer/Pointer<f32>#set
+  f32.store
   global.get $std/pointer/buf
-  i32.const 1
+  i32.const 4
+  i32.add
   f32.const 1.2000000476837158
-  call $std/pointer/Pointer<f32>#set
+  f32.store
   global.get $std/pointer/buf
   f32.load
   f32.const 1.100000023841858
@@ -634,10 +620,10 @@
    unreachable
   end
  )
- (func $start (; 6 ;) (type $FUNCSIG$v)
+ (func $start (; 4 ;) (type $FUNCSIG$v)
   call $start:std/pointer
  )
- (func $null (; 7 ;) (type $FUNCSIG$v)
+ (func $null (; 5 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/pointer.untouched.wat
+++ b/tests/compiler/std/pointer.untouched.wat
@@ -1,12 +1,8 @@
 (module
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
- (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (type $FUNCSIG$vi (func (param i32)))
- (type $FUNCSIG$vii (func (param i32 i32)))
  (type $FUNCSIG$viii (func (param i32 i32 i32)))
- (type $FUNCSIG$viif (func (param i32 i32 f32)))
- (type $FUNCSIG$vif (func (param i32 f32)))
  (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -28,47 +24,7 @@
  (func $~lib/rt/stub/__release (; 2 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $std/pointer/Pointer<std/pointer/Entry>#add (; 3 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  local.get $1
-  call $~lib/rt/stub/__retain
-  drop
-  local.get $0
-  local.get $1
-  i32.add
-  call $~lib/rt/stub/__retain
-  local.set $2
-  local.get $1
-  call $~lib/rt/stub/__release
-  local.get $2
- )
- (func $std/pointer/Pointer<std/pointer/Entry>#sub (; 4 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  local.get $1
-  call $~lib/rt/stub/__retain
-  drop
-  local.get $0
-  local.get $1
-  i32.sub
-  call $~lib/rt/stub/__retain
-  local.set $2
-  local.get $1
-  call $~lib/rt/stub/__release
-  local.get $2
- )
- (func $std/pointer/Pointer<std/pointer/Entry>#inc (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  local.get $0
-  i32.const 8
-  i32.add
-  call $~lib/rt/stub/__retain
- )
- (func $std/pointer/Pointer<std/pointer/Entry>#dec (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  local.get $0
-  i32.const 8
-  i32.sub
-  call $~lib/rt/stub/__retain
- )
- (func $~lib/memory/memory.fill (; 7 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.fill (; 3 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -332,7 +288,7 @@
    end
   end
  )
- (func $~lib/util/memory/memcpy (; 8 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (; 4 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1360,7 +1316,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 9 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 5 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1585,37 +1541,7 @@
    end
   end
  )
- (func $std/pointer/Pointer<std/pointer/Entry>#set:value (; 10 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
-  local.get $1
-  i32.const 0
-  i32.eq
-  if
-   local.get $0
-   i32.const 0
-   i32.const 8
-   call $~lib/memory/memory.fill
-  else   
-   local.get $0
-   local.get $1
-   i32.const 8
-   call $~lib/memory/memory.copy
-  end
- )
- (func $std/pointer/Pointer<f32>#set (; 11 ;) (type $FUNCSIG$viif) (param $0 i32) (param $1 i32) (param $2 f32)
-  local.get $0
-  local.get $1
-  i32.const 4
-  i32.mul
-  i32.add
-  local.get $2
-  f32.store
- )
- (func $std/pointer/Pointer<f32>#set:value (; 12 ;) (type $FUNCSIG$vif) (param $0 i32) (param $1 f32)
-  local.get $0
-  local.get $1
-  f32.store
- )
- (func $start:std/pointer (; 13 ;) (type $FUNCSIG$v)
+ (func $start:std/pointer (; 6 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1623,7 +1549,8 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  (local $7 f32)
+  (local $7 i32)
+  (local $8 f32)
   i32.const 0
   local.set $1
   i32.const 8
@@ -1719,14 +1646,24 @@
    unreachable
   end
   global.get $std/pointer/one
+  local.set $1
   global.get $std/pointer/two
-  call $std/pointer/Pointer<std/pointer/Entry>#add
+  call $~lib/rt/stub/__retain
+  local.set $0
+  local.get $1
+  local.get $0
+  i32.add
+  call $~lib/rt/stub/__retain
+  local.set $2
+  local.get $0
+  call $~lib/rt/stub/__release
+  local.get $2
   local.tee $1
   call $~lib/rt/stub/__retain
   global.set $std/pointer/add
   global.get $std/pointer/add
-  local.set $0
-  local.get $0
+  local.set $2
+  local.get $2
   i32.const 32
   i32.eq
   i32.eqz
@@ -1739,14 +1676,24 @@
    unreachable
   end
   global.get $std/pointer/two
+  local.set $2
   global.get $std/pointer/one
-  call $std/pointer/Pointer<std/pointer/Entry>#sub
-  local.tee $0
+  call $~lib/rt/stub/__retain
+  local.set $0
+  local.get $2
+  local.get $0
+  i32.sub
+  call $~lib/rt/stub/__retain
+  local.set $3
+  local.get $0
+  call $~lib/rt/stub/__release
+  local.get $3
+  local.tee $2
   call $~lib/rt/stub/__retain
   global.set $std/pointer/sub
   global.get $std/pointer/sub
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   i32.const 16
   i32.eq
   i32.eqz
@@ -1759,8 +1706,8 @@
    unreachable
   end
   global.get $std/pointer/one
-  local.set $2
-  local.get $2
+  local.set $0
+  local.get $0
   i32.const 8
   i32.eq
   i32.eqz
@@ -1773,20 +1720,24 @@
    unreachable
   end
   global.get $std/pointer/one
-  call $std/pointer/Pointer<std/pointer/Entry>#inc
-  local.tee $2
+  local.set $3
+  local.get $3
+  i32.const 8
+  i32.add
+  call $~lib/rt/stub/__retain
   local.tee $3
+  local.tee $0
   global.get $std/pointer/one
   local.tee $4
   i32.ne
   if
-   local.get $3
+   local.get $0
    call $~lib/rt/stub/__retain
    drop
    local.get $4
    call $~lib/rt/stub/__release
   end
-  local.get $3
+  local.get $0
   global.set $std/pointer/one
   global.get $std/pointer/one
   call $~lib/rt/stub/__retain
@@ -1818,8 +1769,8 @@
    unreachable
   end
   global.get $std/pointer/two
-  local.set $3
-  local.get $3
+  local.set $0
+  local.get $0
   i32.const 24
   i32.eq
   i32.eqz
@@ -1832,36 +1783,44 @@
    unreachable
   end
   global.get $std/pointer/two
-  call $std/pointer/Pointer<std/pointer/Entry>#dec
-  local.tee $3
+  local.set $4
+  local.get $4
+  i32.const 8
+  i32.sub
+  call $~lib/rt/stub/__retain
   local.tee $4
+  local.tee $0
   global.get $std/pointer/two
   local.tee $5
   i32.ne
   if
-   local.get $4
+   local.get $0
    call $~lib/rt/stub/__retain
    drop
    local.get $5
    call $~lib/rt/stub/__release
   end
-  local.get $4
+  local.get $0
   global.set $std/pointer/two
   global.get $std/pointer/two
-  call $std/pointer/Pointer<std/pointer/Entry>#dec
-  local.tee $4
+  local.set $5
+  local.get $5
+  i32.const 8
+  i32.sub
+  call $~lib/rt/stub/__retain
   local.tee $5
+  local.tee $0
   global.get $std/pointer/two
   local.tee $6
   i32.ne
   if
-   local.get $5
+   local.get $0
    call $~lib/rt/stub/__retain
    drop
    local.get $6
    call $~lib/rt/stub/__release
   end
-  local.get $5
+  local.get $0
   global.set $std/pointer/two
   global.get $std/pointer/two
   local.set $6
@@ -1879,8 +1838,8 @@
   end
   block $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.4 (result i32)
    global.get $std/pointer/two
-   local.set $5
-   local.get $5
+   local.set $0
+   local.get $0
    br $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.4
   end
   i32.load
@@ -1914,19 +1873,34 @@
    unreachable
   end
   global.get $std/pointer/one
+  local.set $7
   block $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.6 (result i32)
    global.get $std/pointer/two
-   local.set $5
-   local.get $5
+   local.set $0
+   local.get $0
    br $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.6
   end
-  call $std/pointer/Pointer<std/pointer/Entry>#set:value
-  global.get $std/pointer/one
   local.set $6
   local.get $6
+  i32.const 0
+  i32.eq
+  if
+   local.get $7
+   i32.const 0
+   i32.const 8
+   call $~lib/memory/memory.fill
+  else   
+   local.get $7
+   local.get $6
+   i32.const 8
+   call $~lib/memory/memory.copy
+  end
+  global.get $std/pointer/one
+  local.set $0
+  local.get $0
   global.get $std/pointer/two
-  local.set $5
-  local.get $5
+  local.set $6
+  local.get $6
   i32.ne
   i32.eqz
   if
@@ -1939,8 +1913,8 @@
   end
   block $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.7 (result i32)
    global.get $std/pointer/one
-   local.set $6
-   local.get $6
+   local.set $7
+   local.get $7
    br $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.7
   end
   i32.load
@@ -1957,8 +1931,8 @@
   end
   block $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.8 (result i32)
    global.get $std/pointer/one
-   local.set $5
-   local.get $5
+   local.set $0
+   local.get $0
    br $std/pointer/Pointer<std/pointer/Entry>#get:value|inlined.8
   end
   i32.load offset=4
@@ -1974,25 +1948,43 @@
    unreachable
   end
   i32.const 0
-  local.set $5
+  local.set $7
   i32.const 0
   local.set $6
   local.get $6
   call $~lib/rt/stub/__retain
   global.set $std/pointer/buf
   global.get $std/pointer/buf
+  local.set $6
   i32.const 0
+  local.set $0
   f32.const 1.100000023841858
-  call $std/pointer/Pointer<f32>#set
+  local.set $8
+  local.get $6
+  local.get $0
+  i32.const 4
+  i32.mul
+  i32.add
+  local.get $8
+  f32.store
   global.get $std/pointer/buf
+  local.set $0
   i32.const 1
+  local.set $7
   f32.const 1.2000000476837158
-  call $std/pointer/Pointer<f32>#set
+  local.set $8
+  local.get $0
+  local.get $7
+  i32.const 4
+  i32.mul
+  i32.add
+  local.get $8
+  f32.store
   global.get $std/pointer/buf
-  local.set $5
+  local.set $7
   i32.const 0
   local.set $6
-  local.get $5
+  local.get $7
   local.get $6
   i32.const 4
   i32.mul
@@ -2010,11 +2002,11 @@
    unreachable
   end
   global.get $std/pointer/buf
-  local.set $5
-  i32.const 1
   local.set $6
-  local.get $5
+  i32.const 1
+  local.set $0
   local.get $6
+  local.get $0
   i32.const 4
   i32.mul
   i32.add
@@ -2031,11 +2023,11 @@
    unreachable
   end
   global.get $std/pointer/buf
-  local.set $5
+  local.set $0
   i32.const 0
-  local.set $6
-  local.get $5
-  local.get $6
+  local.set $7
+  local.get $0
+  local.get $7
   i32.const 4
   i32.mul
   i32.add
@@ -2052,10 +2044,10 @@
    unreachable
   end
   global.get $std/pointer/buf
-  local.set $5
+  local.set $7
   i32.const 1
   local.set $6
-  local.get $5
+  local.get $7
   local.get $6
   i32.const 4
   i32.mul
@@ -2099,24 +2091,24 @@
    unreachable
   end
   global.get $std/pointer/buf
-  local.set $5
-  i32.const 2
   local.set $6
+  i32.const 2
+  local.set $0
   f32.const 1.2999999523162842
-  local.set $7
-  local.get $5
+  local.set $8
   local.get $6
+  local.get $0
   i32.const 4
   i32.mul
   i32.add
-  local.get $7
+  local.get $8
   f32.store
   global.get $std/pointer/buf
-  local.set $5
+  local.set $0
   i32.const 2
-  local.set $6
-  local.get $5
-  local.get $6
+  local.set $7
+  local.get $0
+  local.get $7
   i32.const 4
   i32.mul
   i32.add
@@ -2133,10 +2125,10 @@
    unreachable
   end
   global.get $std/pointer/buf
-  local.set $5
+  local.set $7
   i32.const 2
   local.set $6
-  local.get $5
+  local.get $7
   local.get $6
   i32.const 4
   i32.mul
@@ -2167,8 +2159,12 @@
    unreachable
   end
   global.get $std/pointer/buf
+  local.set $0
   f32.const 1.399999976158142
-  call $std/pointer/Pointer<f32>#set:value
+  local.set $8
+  local.get $0
+  local.get $8
+  f32.store
   block $std/pointer/Pointer<f32>#get:value|inlined.0 (result f32)
    global.get $std/pointer/buf
    local.set $6
@@ -2200,8 +2196,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  call $~lib/rt/stub/__release
   local.get $1
   call $~lib/rt/stub/__release
   local.get $2
@@ -2210,10 +2204,12 @@
   call $~lib/rt/stub/__release
   local.get $4
   call $~lib/rt/stub/__release
+  local.get $5
+  call $~lib/rt/stub/__release
  )
- (func $start (; 14 ;) (type $FUNCSIG$v)
+ (func $start (; 7 ;) (type $FUNCSIG$v)
   call $start:std/pointer
  )
- (func $null (; 15 ;) (type $FUNCSIG$v)
+ (func $null (; 8 ;) (type $FUNCSIG$v)
  )
 )


### PR DESCRIPTION
As reported in https://github.com/MaxGraey/bignum.wasm/issues/20 the compiler didn't yet attempt to inline all possible call sites (while emitting an AS224 warning), but this should be possible now by using the utility introduced with the runtime branch. Essentially, whenever a call is inlined, the locals used in operands are blocked right-to-left so other temps don't conflict.