### PR TITLE
Implement resolveBinaryExpression

### DIFF
--- a/tests/compiler/resolve-operator.json
+++ b/tests/compiler/resolve-operator.json
@@ -1,0 +1,5 @@
+{
+  "asc_flags": [
+    "--runtime none"
+  ]
+}

--- a/tests/compiler/resolve-operator.optimized.wat
+++ b/tests/compiler/resolve-operator.optimized.wat
@@ -1,0 +1,270 @@
+(module
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$iij (func (param i32 i64) (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ij (func (param i64) (result i32)))
+ (memory $0 1)
+ (data (i32.const 8) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\000")
+ (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
+ (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
+ (export "memory" (memory $0))
+ (export "operatorAccessLiteral" (func $resolve-operator/operatorAccessLiteral))
+ (export "operatorAccess" (func $resolve-operator/operatorAccess))
+ (export "OperatorOverloadingAccess" (func $resolve-operator/OperatorOverloadingAccess))
+ (export "OperatorOverloadingSubclassAccess" (func $resolve-operator/OperatorOverloadingSubclassAccess))
+ (start $start)
+ (func $~lib/util/number/decimalCount32 (; 0 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  i32.const 1
+  i32.const 2
+  local.get $0
+  i32.const 10
+  i32.lt_u
+  select
+  i32.const 3
+  i32.const 4
+  i32.const 5
+  local.get $0
+  i32.const 10000
+  i32.lt_u
+  select
+  local.get $0
+  i32.const 1000
+  i32.lt_u
+  select
+  local.get $0
+  i32.const 100
+  i32.lt_u
+  select
+  i32.const 6
+  i32.const 7
+  local.get $0
+  i32.const 1000000
+  i32.lt_u
+  select
+  i32.const 8
+  i32.const 9
+  i32.const 10
+  local.get $0
+  i32.const 1000000000
+  i32.lt_u
+  select
+  local.get $0
+  i32.const 100000000
+  i32.lt_u
+  select
+  local.get $0
+  i32.const 10000000
+  i32.lt_u
+  select
+  local.get $0
+  i32.const 100000
+  i32.lt_u
+  select
+ )
+ (func $~lib/rt/stub/__alloc (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  i32.const 1073741808
+  i32.gt_u
+  if
+   unreachable
+  end
+  global.get $~lib/rt/stub/offset
+  i32.const 16
+  i32.add
+  local.tee $3
+  local.get $0
+  i32.const 1
+  local.get $0
+  i32.const 1
+  i32.gt_u
+  select
+  i32.add
+  i32.const 15
+  i32.add
+  i32.const -16
+  i32.and
+  local.tee $2
+  memory.size
+  local.tee $4
+  i32.const 16
+  i32.shl
+  i32.gt_u
+  if
+   local.get $4
+   local.get $2
+   local.get $3
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const -65536
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_s
+   select
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $5
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $2
+  global.set $~lib/rt/stub/offset
+  local.get $3
+  i32.const 16
+  i32.sub
+  local.tee $2
+  local.get $1
+  i32.store offset=8
+  local.get $2
+  local.get $0
+  i32.store offset=12
+  local.get $3
+ )
+ (func $~lib/util/number/utoa_simple<u32> (; 2 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  loop $continue|0
+   local.get $1
+   i32.const 10
+   i32.rem_u
+   local.set $3
+   local.get $1
+   i32.const 10
+   i32.div_u
+   local.set $1
+   local.get $2
+   i32.const 1
+   i32.sub
+   local.tee $2
+   i32.const 1
+   i32.shl
+   local.get $0
+   i32.add
+   local.get $3
+   i32.const 48
+   i32.add
+   i32.store16
+   local.get $1
+   br_if $continue|0
+  end
+ )
+ (func $~lib/util/number/utoa32 (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 24
+   return
+  end
+  local.get $0
+  call $~lib/util/number/decimalCount32
+  local.tee $1
+  i32.const 1
+  i32.shl
+  i32.const 1
+  call $~lib/rt/stub/__alloc
+  local.tee $2
+  local.get $0
+  local.get $1
+  call $~lib/util/number/utoa_simple<u32>
+  local.get $2
+ )
+ (func $resolve-operator/operatorAccessLiteral (; 4 ;) (type $FUNCSIG$i) (result i32)
+  i32.const 3
+  call $~lib/util/number/utoa32
+ )
+ (func $resolve-operator/operatorAccess (; 5 ;) (type $FUNCSIG$i) (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  i32.const 3
+  call $~lib/util/number/decimalCount32
+  local.tee $0
+  i32.const 1
+  i32.shl
+  i32.const 1
+  call $~lib/rt/stub/__alloc
+  local.tee $1
+  i32.const 3
+  local.get $0
+  call $~lib/util/number/utoa_simple<u32>
+  local.get $1
+ )
+ (func $resolve-operator/Container#constructor (; 6 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 8
+   i32.const 3
+   call $~lib/rt/stub/__alloc
+   local.set $0
+  end
+  local.get $0
+  i64.const 0
+  i64.store
+  local.get $0
+  local.get $1
+  i64.store
+  local.get $0
+ )
+ (func $resolve-operator/Container.add (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  i32.const 0
+  local.get $0
+  i64.load
+  local.get $1
+  i64.load
+  i64.add
+  call $resolve-operator/Container#constructor
+ )
+ (func $resolve-operator/OperatorOverloadingAccess (; 8 ;) (type $FUNCSIG$i) (result i32)
+  i32.const 0
+  i64.const 1
+  call $resolve-operator/Container#constructor
+  i32.const 0
+  i64.const 2
+  call $resolve-operator/Container#constructor
+  call $resolve-operator/Container.add
+  call $~lib/util/number/utoa32
+ )
+ (func $resolve-operator/SubContainer#constructor (; 9 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+  i32.const 8
+  i32.const 4
+  call $~lib/rt/stub/__alloc
+  local.get $0
+  call $resolve-operator/Container#constructor
+ )
+ (func $resolve-operator/OperatorOverloadingSubclassAccess (; 10 ;) (type $FUNCSIG$i) (result i32)
+  i64.const 1
+  call $resolve-operator/SubContainer#constructor
+  i64.const 2
+  call $resolve-operator/SubContainer#constructor
+  call $resolve-operator/Container.add
+  call $~lib/util/number/utoa32
+ )
+ (func $start (; 11 ;) (type $FUNCSIG$v)
+  i32.const 32
+  global.set $~lib/rt/stub/startOffset
+  global.get $~lib/rt/stub/startOffset
+  global.set $~lib/rt/stub/offset
+ )
+ (func $null (; 12 ;) (type $FUNCSIG$v)
+  nop
+ )
+)

--- a/tests/compiler/resolve-operator.ts
+++ b/tests/compiler/resolve-operator.ts
@@ -1,0 +1,45 @@
+export function operatorAccessLiteral(): string {
+  return (1 + 2).toString();
+}
+
+export function operatorAccess(): string {
+  let a: u64 = 1;
+  let b: u64 = 2;
+  return (a + b).toString();
+}
+
+class Container {
+  u64Val: u64;
+
+  constructor(u64Val: u64) {
+    this.u64Val = u64Val;
+  }
+
+  @operator('+')
+  static add(a: Container, b: Container): Container {
+    return new Container(a.u64Val + b.u64Val);
+  }
+
+  toString(): string {
+    return this.u64Val.toString();
+  }
+}
+
+export function OperatorOverloadingAccess(): string {
+  let a = new Container(1);
+  let b = new Container(2);
+  return (a + b).toString();
+}
+
+
+class SubContainer extends Container {
+  toU64(): u64 {
+    return this.u64Val;
+  }
+}
+
+export function OperatorOverloadingSubclassAccess(): string {
+  let a = new SubContainer(1);
+  let b = new SubContainer(2);
+  return (a + b).toString();
+}

--- a/tests/compiler/resolve-operator.untouched.wat
+++ b/tests/compiler/resolve-operator.untouched.wat
@@ -1,0 +1,803 @@
+(module
+ (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$ij (func (param i64) (result i32)))
+ (type $FUNCSIG$viji (func (param i32 i64 i32)))
+ (type $FUNCSIG$iij (func (param i32 i64) (result i32)))
+ (type $FUNCSIG$v (func))
+ (memory $0 1)
+ (data (i32.const 8) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\000\00")
+ (data (i32.const 32) "\90\01\00\00\01\00\00\00\00\00\00\00\90\01\00\000\000\000\001\000\002\000\003\000\004\000\005\000\006\000\007\000\008\000\009\001\000\001\001\001\002\001\003\001\004\001\005\001\006\001\007\001\008\001\009\002\000\002\001\002\002\002\003\002\004\002\005\002\006\002\007\002\008\002\009\003\000\003\001\003\002\003\003\003\004\003\005\003\006\003\007\003\008\003\009\004\000\004\001\004\002\004\003\004\004\004\005\004\006\004\007\004\008\004\009\005\000\005\001\005\002\005\003\005\004\005\005\005\006\005\007\005\008\005\009\006\000\006\001\006\002\006\003\006\004\006\005\006\006\006\007\006\008\006\009\007\000\007\001\007\002\007\003\007\004\007\005\007\006\007\007\007\008\007\009\008\000\008\001\008\002\008\003\008\004\008\005\008\006\008\007\008\008\008\009\009\000\009\001\009\002\009\003\009\004\009\005\009\006\009\007\009\008\009\009\00")
+ (data (i32.const 448) "\10\00\00\00\01\00\00\00\03\00\00\00\10\00\00\000\00\00\000\00\00\00\90\01\00\00d\00\00\00")
+ (table $0 1 funcref)
+ (elem (i32.const 0) $null)
+ (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
+ (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
+ (global $~lib/ASC_SHRINK_LEVEL i32 (i32.const 0))
+ (global $~lib/builtins/u32.MAX_VALUE i32 (i32.const -1))
+ (global $~lib/heap/__heap_base i32 (i32.const 480))
+ (export "memory" (memory $0))
+ (export "operatorAccessLiteral" (func $resolve-operator/operatorAccessLiteral))
+ (export "operatorAccess" (func $resolve-operator/operatorAccess))
+ (export "OperatorOverloadingAccess" (func $resolve-operator/OperatorOverloadingAccess))
+ (export "OperatorOverloadingSubclassAccess" (func $resolve-operator/OperatorOverloadingSubclassAccess))
+ (start $start)
+ (func $~lib/rt/stub/__retain (; 0 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+ )
+ (func $~lib/util/number/decimalCount32 (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  local.get $0
+  i32.const 100000
+  i32.lt_u
+  if
+   local.get $0
+   i32.const 100
+   i32.lt_u
+   if
+    i32.const 1
+    i32.const 2
+    local.get $0
+    i32.const 10
+    i32.lt_u
+    select
+    return
+   else    
+    i32.const 4
+    i32.const 5
+    local.get $0
+    i32.const 10000
+    i32.lt_u
+    select
+    local.set $1
+    i32.const 3
+    local.get $1
+    local.get $0
+    i32.const 1000
+    i32.lt_u
+    select
+    return
+   end
+   unreachable
+  else   
+   local.get $0
+   i32.const 10000000
+   i32.lt_u
+   if
+    i32.const 6
+    i32.const 7
+    local.get $0
+    i32.const 1000000
+    i32.lt_u
+    select
+    return
+   else    
+    i32.const 9
+    i32.const 10
+    local.get $0
+    i32.const 1000000000
+    i32.lt_u
+    select
+    local.set $1
+    i32.const 8
+    local.get $1
+    local.get $0
+    i32.const 100000000
+    i32.lt_u
+    select
+    return
+   end
+   unreachable
+  end
+  unreachable
+ )
+ (func $~lib/rt/stub/__alloc (; 2 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $0
+  i32.const 1073741808
+  i32.gt_u
+  if
+   unreachable
+  end
+  global.get $~lib/rt/stub/offset
+  i32.const 16
+  i32.add
+  local.set $2
+  local.get $2
+  local.get $0
+  local.tee $3
+  i32.const 1
+  local.tee $4
+  local.get $3
+  local.get $4
+  i32.gt_u
+  select
+  i32.add
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $5
+  memory.size
+  local.set $6
+  local.get $5
+  local.get $6
+  i32.const 16
+  i32.shl
+  i32.gt_u
+  if
+   local.get $5
+   local.get $2
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const 65535
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.set $3
+   local.get $6
+   local.tee $4
+   local.get $3
+   local.tee $7
+   local.get $4
+   local.get $7
+   i32.gt_s
+   select
+   local.set $4
+   local.get $4
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $3
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $5
+  global.set $~lib/rt/stub/offset
+  local.get $2
+  i32.const 16
+  i32.sub
+  local.set $8
+  local.get $8
+  local.get $1
+  i32.store offset=8
+  local.get $8
+  local.get $0
+  i32.store offset=12
+  local.get $2
+ )
+ (func $~lib/util/number/utoa32_lut (; 3 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i64)
+  (local $9 i64)
+  i32.const 464
+  i32.load offset=4
+  local.set $3
+  block $break|0
+   loop $continue|0
+    local.get $1
+    i32.const 10000
+    i32.ge_u
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    i32.const 10000
+    i32.div_u
+    local.set $4
+    local.get $1
+    i32.const 10000
+    i32.rem_u
+    local.set $5
+    local.get $4
+    local.set $1
+    local.get $5
+    i32.const 100
+    i32.div_u
+    local.set $6
+    local.get $5
+    i32.const 100
+    i32.rem_u
+    local.set $7
+    local.get $3
+    local.get $6
+    i32.const 2
+    i32.shl
+    i32.add
+    i64.load32_u
+    local.set $8
+    local.get $3
+    local.get $7
+    i32.const 2
+    i32.shl
+    i32.add
+    i64.load32_u
+    local.set $9
+    local.get $2
+    i32.const 4
+    i32.sub
+    local.set $2
+    local.get $0
+    local.get $2
+    i32.const 1
+    i32.shl
+    i32.add
+    local.get $8
+    local.get $9
+    i64.const 32
+    i64.shl
+    i64.or
+    i64.store
+    br $continue|0
+   end
+   unreachable
+  end
+  local.get $1
+  i32.const 100
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 100
+   i32.div_u
+   local.set $7
+   local.get $1
+   i32.const 100
+   i32.rem_u
+   local.set $6
+   local.get $7
+   local.set $1
+   local.get $2
+   i32.const 2
+   i32.sub
+   local.set $2
+   local.get $3
+   local.get $6
+   i32.const 2
+   i32.shl
+   i32.add
+   i32.load
+   local.set $5
+   local.get $0
+   local.get $2
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $5
+   i32.store
+  end
+  local.get $1
+  i32.const 10
+  i32.ge_u
+  if
+   local.get $2
+   i32.const 2
+   i32.sub
+   local.set $2
+   local.get $3
+   local.get $1
+   i32.const 2
+   i32.shl
+   i32.add
+   i32.load
+   local.set $5
+   local.get $0
+   local.get $2
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $5
+   i32.store
+  else   
+   local.get $2
+   i32.const 1
+   i32.sub
+   local.set $2
+   i32.const 48
+   local.get $1
+   i32.add
+   local.set $5
+   local.get $0
+   local.get $2
+   i32.const 1
+   i32.shl
+   i32.add
+   local.get $5
+   i32.store16
+  end
+ )
+ (func $~lib/util/number/utoa32 (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 24
+   call $~lib/rt/stub/__retain
+   return
+  end
+  local.get $0
+  call $~lib/util/number/decimalCount32
+  local.set $1
+  local.get $1
+  i32.const 1
+  i32.shl
+  i32.const 1
+  call $~lib/rt/stub/__alloc
+  local.set $2
+  local.get $2
+  local.set $5
+  local.get $0
+  local.set $4
+  local.get $1
+  local.set $3
+  local.get $5
+  local.get $4
+  local.get $3
+  call $~lib/util/number/utoa32_lut
+  local.get $2
+  call $~lib/rt/stub/__retain
+ )
+ (func $~lib/util/number/itoa<usize> (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  call $~lib/util/number/utoa32
+  return
+ )
+ (func $~lib/rt/stub/__release (; 6 ;) (type $FUNCSIG$vi) (param $0 i32)
+  nop
+ )
+ (func $~lib/number/Usize#toString (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  call $~lib/util/number/itoa<usize>
+  local.tee $1
+  call $~lib/rt/stub/__retain
+  local.set $2
+  local.get $1
+  call $~lib/rt/stub/__release
+  local.get $2
+ )
+ (func $resolve-operator/operatorAccessLiteral (; 8 ;) (type $FUNCSIG$i) (result i32)
+  i32.const 1
+  i32.const 2
+  i32.add
+  call $~lib/number/Usize#toString
+ )
+ (func $~lib/util/number/decimalCount64 (; 9 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+  (local $1 i32)
+  local.get $0
+  i64.const 1000000000000000
+  i64.lt_u
+  if
+   local.get $0
+   i64.const 1000000000000
+   i64.lt_u
+   if
+    i32.const 11
+    i32.const 12
+    local.get $0
+    i64.const 100000000000
+    i64.lt_u
+    select
+    return
+   else    
+    i32.const 14
+    i32.const 15
+    local.get $0
+    i64.const 100000000000000
+    i64.lt_u
+    select
+    local.set $1
+    i32.const 13
+    local.get $1
+    local.get $0
+    i64.const 10000000000000
+    i64.lt_u
+    select
+    return
+   end
+   unreachable
+  else   
+   local.get $0
+   i64.const 100000000000000000
+   i64.lt_u
+   if
+    i32.const 16
+    i32.const 17
+    local.get $0
+    i64.const 10000000000000000
+    i64.lt_u
+    select
+    return
+   else    
+    i32.const 19
+    i32.const 20
+    local.get $0
+    i64.const -8446744073709551616
+    i64.lt_u
+    select
+    local.set $1
+    i32.const 18
+    local.get $1
+    local.get $0
+    i64.const 1000000000000000000
+    i64.lt_u
+    select
+    return
+   end
+   unreachable
+  end
+  unreachable
+ )
+ (func $~lib/util/number/utoa64_lut (; 10 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
+  (local $3 i32)
+  (local $4 i64)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i64)
+  (local $13 i64)
+  i32.const 464
+  i32.load offset=4
+  local.set $3
+  block $break|0
+   loop $continue|0
+    local.get $1
+    i64.const 100000000
+    i64.ge_u
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    i64.const 100000000
+    i64.div_u
+    local.set $4
+    local.get $1
+    local.get $4
+    i64.const 100000000
+    i64.mul
+    i64.sub
+    i32.wrap_i64
+    local.set $5
+    local.get $4
+    local.set $1
+    local.get $5
+    i32.const 10000
+    i32.div_u
+    local.set $6
+    local.get $5
+    i32.const 10000
+    i32.rem_u
+    local.set $7
+    local.get $6
+    i32.const 100
+    i32.div_u
+    local.set $8
+    local.get $6
+    i32.const 100
+    i32.rem_u
+    local.set $9
+    local.get $7
+    i32.const 100
+    i32.div_u
+    local.set $10
+    local.get $7
+    i32.const 100
+    i32.rem_u
+    local.set $11
+    local.get $3
+    local.get $10
+    i32.const 2
+    i32.shl
+    i32.add
+    i64.load32_u
+    local.set $12
+    local.get $3
+    local.get $11
+    i32.const 2
+    i32.shl
+    i32.add
+    i64.load32_u
+    local.set $13
+    local.get $2
+    i32.const 4
+    i32.sub
+    local.set $2
+    local.get $0
+    local.get $2
+    i32.const 1
+    i32.shl
+    i32.add
+    local.get $12
+    local.get $13
+    i64.const 32
+    i64.shl
+    i64.or
+    i64.store
+    local.get $3
+    local.get $8
+    i32.const 2
+    i32.shl
+    i32.add
+    i64.load32_u
+    local.set $12
+    local.get $3
+    local.get $9
+    i32.const 2
+    i32.shl
+    i32.add
+    i64.load32_u
+    local.set $13
+    local.get $2
+    i32.const 4
+    i32.sub
+    local.set $2
+    local.get $0
+    local.get $2
+    i32.const 1
+    i32.shl
+    i32.add
+    local.get $12
+    local.get $13
+    i64.const 32
+    i64.shl
+    i64.or
+    i64.store
+    br $continue|0
+   end
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  i32.wrap_i64
+  local.get $2
+  call $~lib/util/number/utoa32_lut
+ )
+ (func $~lib/util/number/utoa64 (; 11 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i64)
+  local.get $0
+  i64.eqz
+  if
+   i32.const 24
+   call $~lib/rt/stub/__retain
+   return
+  end
+  local.get $0
+  i64.const 4294967295
+  i64.le_u
+  if
+   local.get $0
+   i32.wrap_i64
+   local.set $2
+   local.get $2
+   call $~lib/util/number/decimalCount32
+   local.set $3
+   local.get $3
+   i32.const 1
+   i32.shl
+   i32.const 1
+   call $~lib/rt/stub/__alloc
+   local.set $1
+   local.get $1
+   local.set $6
+   local.get $2
+   local.set $5
+   local.get $3
+   local.set $4
+   local.get $6
+   local.get $5
+   local.get $4
+   call $~lib/util/number/utoa32_lut
+  else   
+   local.get $0
+   call $~lib/util/number/decimalCount64
+   local.set $3
+   local.get $3
+   i32.const 1
+   i32.shl
+   i32.const 1
+   call $~lib/rt/stub/__alloc
+   local.set $1
+   local.get $1
+   local.set $5
+   local.get $0
+   local.set $7
+   local.get $3
+   local.set $4
+   local.get $5
+   local.get $7
+   local.get $4
+   call $~lib/util/number/utoa64_lut
+  end
+  local.get $1
+  call $~lib/rt/stub/__retain
+ )
+ (func $~lib/util/number/itoa<u64> (; 12 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+  local.get $0
+  call $~lib/util/number/utoa64
+  return
+ )
+ (func $~lib/number/U64#toString (; 13 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  call $~lib/util/number/itoa<u64>
+  local.tee $1
+  call $~lib/rt/stub/__retain
+  local.set $2
+  local.get $1
+  call $~lib/rt/stub/__release
+  local.get $2
+ )
+ (func $resolve-operator/operatorAccess (; 14 ;) (type $FUNCSIG$i) (result i32)
+  (local $0 i64)
+  (local $1 i64)
+  i64.const 1
+  local.set $0
+  i64.const 2
+  local.set $1
+  local.get $0
+  local.get $1
+  i64.add
+  call $~lib/number/U64#toString
+ )
+ (func $resolve-operator/Container#constructor (; 15 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 8
+   i32.const 4
+   call $~lib/rt/stub/__alloc
+   call $~lib/rt/stub/__retain
+   local.set $0
+  end
+  local.get $0
+  i64.const 0
+  i64.store
+  local.get $0
+  local.get $1
+  i64.store
+  local.get $0
+ )
+ (func $resolve-operator/Container.add (; 16 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $0
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $1
+  call $~lib/rt/stub/__retain
+  drop
+  i32.const 0
+  local.get $0
+  i64.load
+  local.get $1
+  i64.load
+  i64.add
+  call $resolve-operator/Container#constructor
+  local.set $2
+  local.get $0
+  call $~lib/rt/stub/__release
+  local.get $1
+  call $~lib/rt/stub/__release
+  local.get $2
+ )
+ (func $resolve-operator/OperatorOverloadingAccess (; 17 ;) (type $FUNCSIG$i) (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  i32.const 0
+  i64.const 1
+  call $resolve-operator/Container#constructor
+  local.set $0
+  i32.const 0
+  i64.const 2
+  call $resolve-operator/Container#constructor
+  local.set $1
+  local.get $0
+  local.get $1
+  call $resolve-operator/Container.add
+  local.tee $2
+  call $~lib/number/Usize#toString
+  local.set $3
+  local.get $0
+  call $~lib/rt/stub/__release
+  local.get $1
+  call $~lib/rt/stub/__release
+  local.get $2
+  call $~lib/rt/stub/__release
+  local.get $3
+ )
+ (func $resolve-operator/SubContainer#constructor (; 18 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 8
+   i32.const 5
+   call $~lib/rt/stub/__alloc
+   call $~lib/rt/stub/__retain
+   local.set $0
+  end
+  local.get $0
+  local.get $1
+  call $resolve-operator/Container#constructor
+  local.set $0
+  local.get $0
+ )
+ (func $resolve-operator/OperatorOverloadingSubclassAccess (; 19 ;) (type $FUNCSIG$i) (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  i32.const 0
+  i64.const 1
+  call $resolve-operator/SubContainer#constructor
+  local.set $0
+  i32.const 0
+  i64.const 2
+  call $resolve-operator/SubContainer#constructor
+  local.set $1
+  local.get $0
+  local.get $1
+  call $resolve-operator/Container.add
+  local.tee $2
+  call $~lib/number/Usize#toString
+  local.set $3
+  local.get $0
+  call $~lib/rt/stub/__release
+  local.get $1
+  call $~lib/rt/stub/__release
+  local.get $2
+  call $~lib/rt/stub/__release
+  local.get $3
+ )
+ (func $start (; 20 ;) (type $FUNCSIG$v)
+  global.get $~lib/heap/__heap_base
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  global.set $~lib/rt/stub/startOffset
+  global.get $~lib/rt/stub/startOffset
+  global.set $~lib/rt/stub/offset
+ )
+ (func $null (; 21 ;) (type $FUNCSIG$v)
+ )
+)


### PR DESCRIPTION
An attempt to implement `resolveBinaryExpression` to further improve the resolver and fix bugs like #625. The function is implemented by resolving to the common denominator of left expression and right expression and then checking operator overloading. However, I noticed that the helper function `commonDenominator` is not properly implemented and does not resolve to the common superclass of two subclasses, if the two subclasses are different. This limitation can probably be addressed later. For now, expressions like `(a + b).toString()` can be properly resolved, even if it involves operator overloading.