### PR TITLE
Fix TLSF failing on certain sizes when implicitly growing memory

### DIFF
--- a/std/assembly/rt/tlsf.ts
+++ b/std/assembly/rt/tlsf.ts
@@ -442,9 +442,7 @@ function growMemory(root: Root, size: usize): void {
   // and additional BLOCK_OVERHEAD must be taken into account. If we are going
   // to merge with the tail block, that's one time, otherwise it's two times.
   var pagesBefore = memory.size();
-  size += (<usize>pagesBefore << 16) - BLOCK_OVERHEAD == changetype<usize>(GETTAIL(root))
-    ? BLOCK_OVERHEAD
-    : BLOCK_OVERHEAD << 1;
+  size += BLOCK_OVERHEAD << usize((<usize>pagesBefore << 16) - BLOCK_OVERHEAD != changetype<usize>(GETTAIL(root)));
   var pagesNeeded = <i32>(((size + 0xffff) & ~0xffff) >>> 16);
   var pagesWanted = max(pagesBefore, pagesNeeded); // double memory
   if (memory.grow(pagesWanted) < 0) {

--- a/std/assembly/rt/tlsf.ts
+++ b/std/assembly/rt/tlsf.ts
@@ -415,7 +415,7 @@ function addMemory(root: Root, start: usize, end: usize): bool {
   }
 
   // left size is total minus its own and the zero-length tail's header
-  var leftSize = size - 2 * BLOCK_OVERHEAD;
+  var leftSize = size - (BLOCK_OVERHEAD << 1);
   var left = changetype<Block>(start);
   left.mmInfo = leftSize | FREE | (tailInfo & LEFTFREE);
   left.prev = null;
@@ -433,7 +433,18 @@ function addMemory(root: Root, start: usize, end: usize): bool {
 
 /** Grows memory to fit at least another block of the specified size. */
 function growMemory(root: Root, size: usize): void {
+  // Here, both rounding performed in searchBlock ...
+  const halfMaxSize = BLOCK_MAXSIZE >> 1;
+  if (size < halfMaxSize) { // don't round last fl
+    const invRound = (sizeof<usize>() * 8 - 1) - SL_BITS;
+    size += (1 << (invRound - clz<usize>(size))) - 1;
+  }
+  // and additional BLOCK_OVERHEAD must be taken into account. If we are going
+  // to merge with the tail block, that's one time, otherwise it's two times.
   var pagesBefore = memory.size();
+  size += (<usize>pagesBefore << 16) - BLOCK_OVERHEAD == changetype<usize>(GETTAIL(root))
+    ? BLOCK_OVERHEAD
+    : BLOCK_OVERHEAD << 1;
   var pagesNeeded = <i32>(((size + 0xffff) & ~0xffff) >>> 16);
   var pagesWanted = max(pagesBefore, pagesNeeded); // double memory
   if (memory.grow(pagesWanted) < 0) {

--- a/tests/compiler/empty.json
+++ b/tests/compiler/empty.json
@@ -1,6 +1,6 @@
 {
   "asc_flags": [
-    "--runtime none",
+    "--runtime half",
     "--use ASC_RTRACE=1"
   ]
 }

--- a/tests/compiler/rc/global-init.optimized.wat
+++ b/tests/compiler/rc/global-init.optimized.wat
@@ -541,7 +541,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -781,7 +781,7 @@
   if
    i32.const 232
    i32.const 88
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -931,7 +931,18 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 15 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
-  (local $3 i32)
+  memory.size
+  local.tee $2
+  i32.const 16
+  local.get $0
+  i32.load offset=1568
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  i32.ne
+  i32.shl
   i32.const 1
   i32.const 27
   local.get $1
@@ -947,25 +958,6 @@
   i32.const 536870904
   i32.lt_u
   select
-  local.set $1
-  memory.size
-  local.tee $2
-  i32.const 16
-  i32.shl
-  i32.const 16
-  i32.sub
-  local.get $0
-  i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 32
-  end
-  local.set $3
-  local.get $2
-  local.get $1
-  local.get $3
   i32.add
   i32.const 65535
   i32.add
@@ -1097,7 +1089,7 @@
    if
     i32.const 0
     i32.const 88
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1112,7 +1104,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1335,7 +1327,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1351,7 +1343,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/global-init.optimized.wat
+++ b/tests/compiler/rc/global-init.optimized.wat
@@ -541,7 +541,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -781,7 +781,7 @@
   if
    i32.const 232
    i32.const 88
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -931,9 +931,42 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 15 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  i32.const 1
+  i32.const 27
+  local.get $1
+  i32.clz
+  i32.sub
+  i32.shl
+  i32.const 1
+  i32.sub
+  local.get $1
+  i32.add
+  local.get $1
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  select
+  local.set $1
   memory.size
   local.tee $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 32
+  end
+  local.set $3
+  local.get $2
   local.get $1
+  local.get $3
+  i32.add
   i32.const 65535
   i32.add
   i32.const -65536
@@ -1064,7 +1097,7 @@
    if
     i32.const 0
     i32.const 88
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1079,7 +1112,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1302,7 +1335,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1318,7 +1351,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/global-init.untouched.wat
+++ b/tests/compiler/rc/global-init.untouched.wat
@@ -668,7 +668,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1011,7 +1011,7 @@
   if
    i32.const 232
    i32.const 88
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1240,6 +1240,7 @@
   memory.size
   local.set $2
   local.get $1
+  i32.const 16
   local.get $2
   i32.const 16
   i32.shl
@@ -1249,14 +1250,8 @@
   local.set $3
   local.get $3
   i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 16
-   i32.const 1
-   i32.shl
-  end
+  i32.ne
+  i32.shl
   i32.add
   local.set $1
   local.get $1
@@ -1423,7 +1418,7 @@
    if
     i32.const 0
     i32.const 88
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1439,7 +1434,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2743,7 +2738,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2763,7 +2758,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/global-init.untouched.wat
+++ b/tests/compiler/rc/global-init.untouched.wat
@@ -668,7 +668,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -812,9 +812,9 @@
    return
   end
   local.get $6
-  i32.const 2
   i32.const 16
-  i32.mul
+  i32.const 1
+  i32.shl
   i32.sub
   local.set $7
   local.get $1
@@ -1011,7 +1011,7 @@
   if
    i32.const 232
    i32.const 88
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1221,8 +1221,44 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $1
+  end
   memory.size
   local.set $2
+  local.get $1
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 16
+   i32.const 1
+   i32.shl
+  end
+  i32.add
+  local.set $1
   local.get $1
   i32.const 65535
   i32.add
@@ -1232,12 +1268,12 @@
   i32.and
   i32.const 16
   i32.shr_u
-  local.set $3
+  local.set $4
   local.get $2
-  local.tee $4
-  local.get $3
-  local.tee $5
+  local.tee $3
   local.get $4
+  local.tee $5
+  local.get $3
   local.get $5
   i32.gt_s
   select
@@ -1247,7 +1283,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $4
    memory.grow
    i32.const 0
    i32.lt_s
@@ -1387,7 +1423,7 @@
    if
     i32.const 0
     i32.const 88
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1403,7 +1439,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2707,7 +2743,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2727,7 +2763,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/local-init.optimized.wat
+++ b/tests/compiler/rc/local-init.optimized.wat
@@ -539,7 +539,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -779,7 +779,7 @@
   if
    i32.const 232
    i32.const 88
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -929,7 +929,18 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 15 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
-  (local $3 i32)
+  memory.size
+  local.tee $2
+  i32.const 16
+  local.get $0
+  i32.load offset=1568
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  i32.ne
+  i32.shl
   i32.const 1
   i32.const 27
   local.get $1
@@ -945,25 +956,6 @@
   i32.const 536870904
   i32.lt_u
   select
-  local.set $1
-  memory.size
-  local.tee $2
-  i32.const 16
-  i32.shl
-  i32.const 16
-  i32.sub
-  local.get $0
-  i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 32
-  end
-  local.set $3
-  local.get $2
-  local.get $1
-  local.get $3
   i32.add
   i32.const 65535
   i32.add
@@ -1095,7 +1087,7 @@
    if
     i32.const 0
     i32.const 88
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1110,7 +1102,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1332,7 +1324,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1348,7 +1340,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/local-init.optimized.wat
+++ b/tests/compiler/rc/local-init.optimized.wat
@@ -539,7 +539,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -779,7 +779,7 @@
   if
    i32.const 232
    i32.const 88
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -929,9 +929,42 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 15 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  i32.const 1
+  i32.const 27
+  local.get $1
+  i32.clz
+  i32.sub
+  i32.shl
+  i32.const 1
+  i32.sub
+  local.get $1
+  i32.add
+  local.get $1
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  select
+  local.set $1
   memory.size
   local.tee $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 32
+  end
+  local.set $3
+  local.get $2
   local.get $1
+  local.get $3
+  i32.add
   i32.const 65535
   i32.add
   i32.const -65536
@@ -1062,7 +1095,7 @@
    if
     i32.const 0
     i32.const 88
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1077,7 +1110,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1299,7 +1332,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1315,7 +1348,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/local-init.untouched.wat
+++ b/tests/compiler/rc/local-init.untouched.wat
@@ -662,7 +662,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1005,7 +1005,7 @@
   if
    i32.const 232
    i32.const 88
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1234,6 +1234,7 @@
   memory.size
   local.set $2
   local.get $1
+  i32.const 16
   local.get $2
   i32.const 16
   i32.shl
@@ -1243,14 +1244,8 @@
   local.set $3
   local.get $3
   i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 16
-   i32.const 1
-   i32.shl
-  end
+  i32.ne
+  i32.shl
   i32.add
   local.set $1
   local.get $1
@@ -1417,7 +1412,7 @@
    if
     i32.const 0
     i32.const 88
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1433,7 +1428,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2737,7 +2732,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2757,7 +2752,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/local-init.untouched.wat
+++ b/tests/compiler/rc/local-init.untouched.wat
@@ -662,7 +662,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -806,9 +806,9 @@
    return
   end
   local.get $6
-  i32.const 2
   i32.const 16
-  i32.mul
+  i32.const 1
+  i32.shl
   i32.sub
   local.set $7
   local.get $1
@@ -1005,7 +1005,7 @@
   if
    i32.const 232
    i32.const 88
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1215,8 +1215,44 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $1
+  end
   memory.size
   local.set $2
+  local.get $1
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 16
+   i32.const 1
+   i32.shl
+  end
+  i32.add
+  local.set $1
   local.get $1
   i32.const 65535
   i32.add
@@ -1226,12 +1262,12 @@
   i32.and
   i32.const 16
   i32.shr_u
-  local.set $3
+  local.set $4
   local.get $2
-  local.tee $4
-  local.get $3
-  local.tee $5
+  local.tee $3
   local.get $4
+  local.tee $5
+  local.get $3
   local.get $5
   i32.gt_s
   select
@@ -1241,7 +1277,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $4
    memory.grow
    i32.const 0
    i32.lt_s
@@ -1381,7 +1417,7 @@
    if
     i32.const 0
     i32.const 88
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1397,7 +1433,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2701,7 +2737,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2721,7 +2757,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/logical-and-mismatch.optimized.wat
+++ b/tests/compiler/rc/logical-and-mismatch.optimized.wat
@@ -681,7 +681,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -831,9 +831,42 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 11 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  i32.const 1
+  i32.const 27
+  local.get $1
+  i32.clz
+  i32.sub
+  i32.shl
+  i32.const 1
+  i32.sub
+  local.get $1
+  i32.add
+  local.get $1
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  select
+  local.set $1
   memory.size
   local.tee $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 32
+  end
+  local.set $3
+  local.get $2
   local.get $1
+  local.get $3
+  i32.add
   i32.const 65535
   i32.add
   i32.const -65536
@@ -964,7 +997,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -979,7 +1012,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1089,7 +1122,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1306,7 +1339,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1322,7 +1355,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/logical-and-mismatch.optimized.wat
+++ b/tests/compiler/rc/logical-and-mismatch.optimized.wat
@@ -681,7 +681,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -831,7 +831,18 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 11 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
-  (local $3 i32)
+  memory.size
+  local.tee $2
+  i32.const 16
+  local.get $0
+  i32.load offset=1568
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  i32.ne
+  i32.shl
   i32.const 1
   i32.const 27
   local.get $1
@@ -847,25 +858,6 @@
   i32.const 536870904
   i32.lt_u
   select
-  local.set $1
-  memory.size
-  local.tee $2
-  i32.const 16
-  i32.shl
-  i32.const 16
-  i32.sub
-  local.get $0
-  i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 32
-  end
-  local.set $3
-  local.get $2
-  local.get $1
-  local.get $3
   i32.add
   i32.const 65535
   i32.add
@@ -997,7 +989,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1012,7 +1004,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1122,7 +1114,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1339,7 +1331,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1355,7 +1347,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/logical-and-mismatch.untouched.wat
+++ b/tests/compiler/rc/logical-and-mismatch.untouched.wat
@@ -695,9 +695,9 @@
    return
   end
   local.get $6
-  i32.const 2
   i32.const 16
-  i32.mul
+  i32.const 1
+  i32.shl
   i32.sub
   local.set $7
   local.get $1
@@ -894,7 +894,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1104,8 +1104,44 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $1
+  end
   memory.size
   local.set $2
+  local.get $1
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 16
+   i32.const 1
+   i32.shl
+  end
+  i32.add
+  local.set $1
   local.get $1
   i32.const 65535
   i32.add
@@ -1115,12 +1151,12 @@
   i32.and
   i32.const 16
   i32.shr_u
-  local.set $3
+  local.set $4
   local.get $2
-  local.tee $4
-  local.get $3
-  local.tee $5
+  local.tee $3
   local.get $4
+  local.tee $5
+  local.get $3
   local.get $5
   i32.gt_s
   select
@@ -1130,7 +1166,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $4
    memory.grow
    i32.const 0
    i32.lt_s
@@ -1270,7 +1306,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1286,7 +1322,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1417,7 +1453,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2717,7 +2753,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2737,7 +2773,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/logical-and-mismatch.untouched.wat
+++ b/tests/compiler/rc/logical-and-mismatch.untouched.wat
@@ -894,7 +894,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1123,6 +1123,7 @@
   memory.size
   local.set $2
   local.get $1
+  i32.const 16
   local.get $2
   i32.const 16
   i32.shl
@@ -1132,14 +1133,8 @@
   local.set $3
   local.get $3
   i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 16
-   i32.const 1
-   i32.shl
-  end
+  i32.ne
+  i32.shl
   i32.add
   local.set $1
   local.get $1
@@ -1306,7 +1301,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1322,7 +1317,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1453,7 +1448,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2753,7 +2748,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2773,7 +2768,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/logical-or-mismatch.optimized.wat
+++ b/tests/compiler/rc/logical-or-mismatch.optimized.wat
@@ -681,7 +681,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -831,9 +831,42 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 11 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  i32.const 1
+  i32.const 27
+  local.get $1
+  i32.clz
+  i32.sub
+  i32.shl
+  i32.const 1
+  i32.sub
+  local.get $1
+  i32.add
+  local.get $1
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  select
+  local.set $1
   memory.size
   local.tee $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 32
+  end
+  local.set $3
+  local.get $2
   local.get $1
+  local.get $3
+  i32.add
   i32.const 65535
   i32.add
   i32.const -65536
@@ -964,7 +997,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -979,7 +1012,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1089,7 +1122,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1306,7 +1339,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1322,7 +1355,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/logical-or-mismatch.optimized.wat
+++ b/tests/compiler/rc/logical-or-mismatch.optimized.wat
@@ -681,7 +681,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -831,7 +831,18 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 11 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
-  (local $3 i32)
+  memory.size
+  local.tee $2
+  i32.const 16
+  local.get $0
+  i32.load offset=1568
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  i32.ne
+  i32.shl
   i32.const 1
   i32.const 27
   local.get $1
@@ -847,25 +858,6 @@
   i32.const 536870904
   i32.lt_u
   select
-  local.set $1
-  memory.size
-  local.tee $2
-  i32.const 16
-  i32.shl
-  i32.const 16
-  i32.sub
-  local.get $0
-  i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 32
-  end
-  local.set $3
-  local.get $2
-  local.get $1
-  local.get $3
   i32.add
   i32.const 65535
   i32.add
@@ -997,7 +989,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1012,7 +1004,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1122,7 +1114,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1339,7 +1331,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1355,7 +1347,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/logical-or-mismatch.untouched.wat
+++ b/tests/compiler/rc/logical-or-mismatch.untouched.wat
@@ -695,9 +695,9 @@
    return
   end
   local.get $6
-  i32.const 2
   i32.const 16
-  i32.mul
+  i32.const 1
+  i32.shl
   i32.sub
   local.set $7
   local.get $1
@@ -894,7 +894,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1104,8 +1104,44 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $1
+  end
   memory.size
   local.set $2
+  local.get $1
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 16
+   i32.const 1
+   i32.shl
+  end
+  i32.add
+  local.set $1
   local.get $1
   i32.const 65535
   i32.add
@@ -1115,12 +1151,12 @@
   i32.and
   i32.const 16
   i32.shr_u
-  local.set $3
+  local.set $4
   local.get $2
-  local.tee $4
-  local.get $3
-  local.tee $5
+  local.tee $3
   local.get $4
+  local.tee $5
+  local.get $3
   local.get $5
   i32.gt_s
   select
@@ -1130,7 +1166,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $4
    memory.grow
    i32.const 0
    i32.lt_s
@@ -1270,7 +1306,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1286,7 +1322,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1417,7 +1453,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2717,7 +2753,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2737,7 +2773,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/logical-or-mismatch.untouched.wat
+++ b/tests/compiler/rc/logical-or-mismatch.untouched.wat
@@ -894,7 +894,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1123,6 +1123,7 @@
   memory.size
   local.set $2
   local.get $1
+  i32.const 16
   local.get $2
   i32.const 16
   i32.shl
@@ -1132,14 +1133,8 @@
   local.set $3
   local.get $3
   i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 16
-   i32.const 1
-   i32.shl
-  end
+  i32.ne
+  i32.shl
   i32.add
   local.set $1
   local.get $1
@@ -1306,7 +1301,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1322,7 +1317,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1453,7 +1448,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2753,7 +2748,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2773,7 +2768,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/rereturn.optimized.wat
+++ b/tests/compiler/rc/rereturn.optimized.wat
@@ -681,7 +681,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -831,7 +831,18 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 7 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
-  (local $3 i32)
+  memory.size
+  local.tee $2
+  i32.const 16
+  local.get $0
+  i32.load offset=1568
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  i32.ne
+  i32.shl
   i32.const 1
   i32.const 27
   local.get $1
@@ -847,25 +858,6 @@
   i32.const 536870904
   i32.lt_u
   select
-  local.set $1
-  memory.size
-  local.tee $2
-  i32.const 16
-  i32.shl
-  i32.const 16
-  i32.sub
-  local.get $0
-  i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 32
-  end
-  local.set $3
-  local.get $2
-  local.get $1
-  local.get $3
   i32.add
   i32.const 65535
   i32.add
@@ -997,7 +989,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1012,7 +1004,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1112,7 +1104,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1327,7 +1319,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1343,7 +1335,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/rereturn.optimized.wat
+++ b/tests/compiler/rc/rereturn.optimized.wat
@@ -681,7 +681,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -831,9 +831,42 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 7 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  i32.const 1
+  i32.const 27
+  local.get $1
+  i32.clz
+  i32.sub
+  i32.shl
+  i32.const 1
+  i32.sub
+  local.get $1
+  i32.add
+  local.get $1
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  select
+  local.set $1
   memory.size
   local.tee $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 32
+  end
+  local.set $3
+  local.get $2
   local.get $1
+  local.get $3
+  i32.add
   i32.const 65535
   i32.add
   i32.const -65536
@@ -964,7 +997,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -979,7 +1012,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1079,7 +1112,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1294,7 +1327,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1310,7 +1343,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/rereturn.untouched.wat
+++ b/tests/compiler/rc/rereturn.untouched.wat
@@ -894,7 +894,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1123,6 +1123,7 @@
   memory.size
   local.set $2
   local.get $1
+  i32.const 16
   local.get $2
   i32.const 16
   i32.shl
@@ -1132,14 +1133,8 @@
   local.set $3
   local.get $3
   i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 16
-   i32.const 1
-   i32.shl
-  end
+  i32.ne
+  i32.shl
   i32.add
   local.set $1
   local.get $1
@@ -1306,7 +1301,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1322,7 +1317,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1433,7 +1428,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2731,7 +2726,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2751,7 +2746,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/rereturn.untouched.wat
+++ b/tests/compiler/rc/rereturn.untouched.wat
@@ -695,9 +695,9 @@
    return
   end
   local.get $6
-  i32.const 2
   i32.const 16
-  i32.mul
+  i32.const 1
+  i32.shl
   i32.sub
   local.set $7
   local.get $1
@@ -894,7 +894,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1104,8 +1104,44 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $1
+  end
   memory.size
   local.set $2
+  local.get $1
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 16
+   i32.const 1
+   i32.shl
+  end
+  i32.add
+  local.set $1
   local.get $1
   i32.const 65535
   i32.add
@@ -1115,12 +1151,12 @@
   i32.and
   i32.const 16
   i32.shr_u
-  local.set $3
+  local.set $4
   local.get $2
-  local.tee $4
-  local.get $3
-  local.tee $5
+  local.tee $3
   local.get $4
+  local.tee $5
+  local.get $3
   local.get $5
   i32.gt_s
   select
@@ -1130,7 +1166,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $4
    memory.grow
    i32.const 0
    i32.lt_s
@@ -1270,7 +1306,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1286,7 +1322,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1397,7 +1433,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2695,7 +2731,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2715,7 +2751,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/ternary-mismatch.optimized.wat
+++ b/tests/compiler/rc/ternary-mismatch.optimized.wat
@@ -683,7 +683,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -833,7 +833,18 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 11 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
-  (local $3 i32)
+  memory.size
+  local.tee $2
+  i32.const 16
+  local.get $0
+  i32.load offset=1568
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  i32.ne
+  i32.shl
   i32.const 1
   i32.const 27
   local.get $1
@@ -849,25 +860,6 @@
   i32.const 536870904
   i32.lt_u
   select
-  local.set $1
-  memory.size
-  local.tee $2
-  i32.const 16
-  i32.shl
-  i32.const 16
-  i32.sub
-  local.get $0
-  i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 32
-  end
-  local.set $3
-  local.get $2
-  local.get $1
-  local.get $3
   i32.add
   i32.const 65535
   i32.add
@@ -999,7 +991,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1014,7 +1006,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1133,7 +1125,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1350,7 +1342,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1366,7 +1358,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/ternary-mismatch.optimized.wat
+++ b/tests/compiler/rc/ternary-mismatch.optimized.wat
@@ -683,7 +683,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -833,9 +833,42 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 11 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  i32.const 1
+  i32.const 27
+  local.get $1
+  i32.clz
+  i32.sub
+  i32.shl
+  i32.const 1
+  i32.sub
+  local.get $1
+  i32.add
+  local.get $1
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  select
+  local.set $1
   memory.size
   local.tee $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 32
+  end
+  local.set $3
+  local.get $2
   local.get $1
+  local.get $3
+  i32.add
   i32.const 65535
   i32.add
   i32.const -65536
@@ -966,7 +999,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -981,7 +1014,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1100,7 +1133,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1317,7 +1350,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1333,7 +1366,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/ternary-mismatch.untouched.wat
+++ b/tests/compiler/rc/ternary-mismatch.untouched.wat
@@ -896,7 +896,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1125,6 +1125,7 @@
   memory.size
   local.set $2
   local.get $1
+  i32.const 16
   local.get $2
   i32.const 16
   i32.shl
@@ -1134,14 +1135,8 @@
   local.set $3
   local.get $3
   i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 16
-   i32.const 1
-   i32.shl
-  end
+  i32.ne
+  i32.shl
   i32.add
   local.set $1
   local.get $1
@@ -1308,7 +1303,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1324,7 +1319,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1464,7 +1459,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2764,7 +2759,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2784,7 +2779,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/ternary-mismatch.untouched.wat
+++ b/tests/compiler/rc/ternary-mismatch.untouched.wat
@@ -697,9 +697,9 @@
    return
   end
   local.get $6
-  i32.const 2
   i32.const 16
-  i32.mul
+  i32.const 1
+  i32.shl
   i32.sub
   local.set $7
   local.get $1
@@ -896,7 +896,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1106,8 +1106,44 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $1
+  end
   memory.size
   local.set $2
+  local.get $1
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 16
+   i32.const 1
+   i32.shl
+  end
+  i32.add
+  local.set $1
   local.get $1
   i32.const 65535
   i32.add
@@ -1117,12 +1153,12 @@
   i32.and
   i32.const 16
   i32.shr_u
-  local.set $3
+  local.set $4
   local.get $2
-  local.tee $4
-  local.get $3
-  local.tee $5
+  local.tee $3
   local.get $4
+  local.tee $5
+  local.get $3
   local.get $5
   i32.gt_s
   select
@@ -1132,7 +1168,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $4
    memory.grow
    i32.const 0
    i32.lt_s
@@ -1272,7 +1308,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1288,7 +1324,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1428,7 +1464,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2728,7 +2764,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2748,7 +2784,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/retain-release-sanity.optimized.wat
+++ b/tests/compiler/retain-release-sanity.optimized.wat
@@ -690,7 +690,7 @@
   if
    i32.const 176
    i32.const 128
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -840,7 +840,18 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 11 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
-  (local $3 i32)
+  memory.size
+  local.tee $2
+  i32.const 16
+  local.get $0
+  i32.load offset=1568
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  i32.ne
+  i32.shl
   i32.const 1
   i32.const 27
   local.get $1
@@ -856,25 +867,6 @@
   i32.const 536870904
   i32.lt_u
   select
-  local.set $1
-  memory.size
-  local.tee $2
-  i32.const 16
-  i32.shl
-  i32.const 16
-  i32.sub
-  local.get $0
-  i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 32
-  end
-  local.set $3
-  local.get $2
-  local.get $1
-  local.get $3
   i32.add
   i32.const 65535
   i32.add
@@ -1006,7 +998,7 @@
    if
     i32.const 0
     i32.const 128
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1021,7 +1013,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1334,7 +1326,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1551,7 +1543,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1567,7 +1559,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1837,7 +1829,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 506
+   i32.const 504
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -1939,7 +1931,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 570
+   i32.const 568
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1955,7 +1947,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 571
+   i32.const 569
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/retain-release-sanity.optimized.wat
+++ b/tests/compiler/retain-release-sanity.optimized.wat
@@ -690,7 +690,7 @@
   if
    i32.const 176
    i32.const 128
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -840,9 +840,42 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 11 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  i32.const 1
+  i32.const 27
+  local.get $1
+  i32.clz
+  i32.sub
+  i32.shl
+  i32.const 1
+  i32.sub
+  local.get $1
+  i32.add
+  local.get $1
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  select
+  local.set $1
   memory.size
   local.tee $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 32
+  end
+  local.set $3
+  local.get $2
   local.get $1
+  local.get $3
+  i32.add
   i32.const 65535
   i32.add
   i32.const -65536
@@ -973,7 +1006,7 @@
    if
     i32.const 0
     i32.const 128
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -988,7 +1021,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1301,7 +1334,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1518,7 +1551,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1534,7 +1567,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1804,7 +1837,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 495
+   i32.const 506
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -1906,7 +1939,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 559
+   i32.const 570
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1922,7 +1955,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 560
+   i32.const 571
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/retain-release-sanity.untouched.wat
+++ b/tests/compiler/retain-release-sanity.untouched.wat
@@ -703,9 +703,9 @@
    return
   end
   local.get $6
-  i32.const 2
   i32.const 16
-  i32.mul
+  i32.const 1
+  i32.shl
   i32.sub
   local.set $7
   local.get $1
@@ -902,7 +902,7 @@
   if
    i32.const 176
    i32.const 128
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1112,8 +1112,44 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $1
+  end
   memory.size
   local.set $2
+  local.get $1
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 16
+   i32.const 1
+   i32.shl
+  end
+  i32.add
+  local.set $1
   local.get $1
   i32.const 65535
   i32.add
@@ -1123,12 +1159,12 @@
   i32.and
   i32.const 16
   i32.shr_u
-  local.set $3
+  local.set $4
   local.get $2
-  local.tee $4
-  local.get $3
-  local.tee $5
+  local.tee $3
   local.get $4
+  local.tee $5
+  local.get $3
   local.get $5
   i32.gt_s
   select
@@ -1138,7 +1174,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $4
    memory.grow
    i32.const 0
    i32.lt_s
@@ -1278,7 +1314,7 @@
    if
     i32.const 0
     i32.const 128
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1294,7 +1330,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1673,7 +1709,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2973,7 +3009,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2993,7 +3029,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3320,7 +3356,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 495
+   i32.const 506
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -3434,7 +3470,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 559
+   i32.const 570
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -3454,7 +3490,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 560
+   i32.const 571
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/retain-release-sanity.untouched.wat
+++ b/tests/compiler/retain-release-sanity.untouched.wat
@@ -902,7 +902,7 @@
   if
    i32.const 176
    i32.const 128
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1131,6 +1131,7 @@
   memory.size
   local.set $2
   local.get $1
+  i32.const 16
   local.get $2
   i32.const 16
   i32.shl
@@ -1140,14 +1141,8 @@
   local.set $3
   local.get $3
   i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 16
-   i32.const 1
-   i32.shl
-  end
+  i32.ne
+  i32.shl
   i32.add
   local.set $1
   local.get $1
@@ -1314,7 +1309,7 @@
    if
     i32.const 0
     i32.const 128
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1330,7 +1325,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1709,7 +1704,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3009,7 +3004,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -3029,7 +3024,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3356,7 +3351,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 506
+   i32.const 504
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -3470,7 +3465,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 570
+   i32.const 568
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -3490,7 +3485,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 571
+   i32.const 569
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/runtime-full.optimized.wat
+++ b/tests/compiler/runtime-full.optimized.wat
@@ -680,7 +680,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -830,9 +830,42 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 7 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  i32.const 1
+  i32.const 27
+  local.get $1
+  i32.clz
+  i32.sub
+  i32.shl
+  i32.const 1
+  i32.sub
+  local.get $1
+  i32.add
+  local.get $1
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  select
+  local.set $1
   memory.size
   local.tee $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 32
+  end
+  local.set $3
+  local.get $2
   local.get $1
+  local.get $3
+  i32.add
   i32.const 65535
   i32.add
   i32.const -65536
@@ -963,7 +996,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -978,7 +1011,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1078,7 +1111,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1293,7 +1326,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1309,7 +1342,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/runtime-full.optimized.wat
+++ b/tests/compiler/runtime-full.optimized.wat
@@ -680,7 +680,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -830,7 +830,18 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 7 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
-  (local $3 i32)
+  memory.size
+  local.tee $2
+  i32.const 16
+  local.get $0
+  i32.load offset=1568
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  i32.ne
+  i32.shl
   i32.const 1
   i32.const 27
   local.get $1
@@ -846,25 +857,6 @@
   i32.const 536870904
   i32.lt_u
   select
-  local.set $1
-  memory.size
-  local.tee $2
-  i32.const 16
-  i32.shl
-  i32.const 16
-  i32.sub
-  local.get $0
-  i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 32
-  end
-  local.set $3
-  local.get $2
-  local.get $1
-  local.get $3
   i32.add
   i32.const 65535
   i32.add
@@ -996,7 +988,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1011,7 +1003,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1111,7 +1103,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1326,7 +1318,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1342,7 +1334,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/runtime-full.untouched.wat
+++ b/tests/compiler/runtime-full.untouched.wat
@@ -892,7 +892,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1121,6 +1121,7 @@
   memory.size
   local.set $2
   local.get $1
+  i32.const 16
   local.get $2
   i32.const 16
   i32.shl
@@ -1130,14 +1131,8 @@
   local.set $3
   local.get $3
   i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 16
-   i32.const 1
-   i32.shl
-  end
+  i32.ne
+  i32.shl
   i32.add
   local.set $1
   local.get $1
@@ -1304,7 +1299,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1320,7 +1315,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1431,7 +1426,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2729,7 +2724,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2749,7 +2744,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/runtime-full.untouched.wat
+++ b/tests/compiler/runtime-full.untouched.wat
@@ -693,9 +693,9 @@
    return
   end
   local.get $6
-  i32.const 2
   i32.const 16
-  i32.mul
+  i32.const 1
+  i32.shl
   i32.sub
   local.set $7
   local.get $1
@@ -892,7 +892,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1102,8 +1102,44 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $1
+  end
   memory.size
   local.set $2
+  local.get $1
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 16
+   i32.const 1
+   i32.shl
+  end
+  i32.add
+  local.set $1
   local.get $1
   i32.const 65535
   i32.add
@@ -1113,12 +1149,12 @@
   i32.and
   i32.const 16
   i32.shr_u
-  local.set $3
+  local.set $4
   local.get $2
-  local.tee $4
-  local.get $3
-  local.tee $5
+  local.tee $3
   local.get $4
+  local.tee $5
+  local.get $3
   local.get $5
   i32.gt_s
   select
@@ -1128,7 +1164,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $4
    memory.grow
    i32.const 0
    i32.lt_s
@@ -1268,7 +1304,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1284,7 +1320,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1395,7 +1431,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2693,7 +2729,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2713,7 +2749,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -736,7 +736,7 @@
   if
    i32.const 400
    i32.const 352
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -886,9 +886,42 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 13 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  i32.const 1
+  i32.const 27
+  local.get $1
+  i32.clz
+  i32.sub
+  i32.shl
+  i32.const 1
+  i32.sub
+  local.get $1
+  i32.add
+  local.get $1
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  select
+  local.set $1
   memory.size
   local.tee $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 32
+  end
+  local.set $3
+  local.get $2
   local.get $1
+  local.get $3
+  i32.add
   i32.const 65535
   i32.add
   i32.const -65536
@@ -1019,7 +1052,7 @@
    if
     i32.const 0
     i32.const 352
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1034,7 +1067,7 @@
   if
    i32.const 0
    i32.const 352
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1351,7 +1384,7 @@
   if
    i32.const 0
    i32.const 352
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1393,7 +1426,7 @@
   if
    i32.const 0
    i32.const 352
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1409,7 +1442,7 @@
   if
    i32.const 0
    i32.const 352
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -736,7 +736,7 @@
   if
    i32.const 400
    i32.const 352
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -886,7 +886,18 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 13 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
-  (local $3 i32)
+  memory.size
+  local.tee $2
+  i32.const 16
+  local.get $0
+  i32.load offset=1568
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  i32.ne
+  i32.shl
   i32.const 1
   i32.const 27
   local.get $1
@@ -902,25 +913,6 @@
   i32.const 536870904
   i32.lt_u
   select
-  local.set $1
-  memory.size
-  local.tee $2
-  i32.const 16
-  i32.shl
-  i32.const 16
-  i32.sub
-  local.get $0
-  i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 32
-  end
-  local.set $3
-  local.get $2
-  local.get $1
-  local.get $3
   i32.add
   i32.const 65535
   i32.add
@@ -1052,7 +1044,7 @@
    if
     i32.const 0
     i32.const 352
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1067,7 +1059,7 @@
   if
    i32.const 0
    i32.const 352
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1384,7 +1376,7 @@
   if
    i32.const 0
    i32.const 352
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1426,7 +1418,7 @@
   if
    i32.const 0
    i32.const 352
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1442,7 +1434,7 @@
   if
    i32.const 0
    i32.const 352
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -774,9 +774,9 @@
    return
   end
   local.get $6
-  i32.const 2
   i32.const 16
-  i32.mul
+  i32.const 1
+  i32.shl
   i32.sub
   local.set $7
   local.get $1
@@ -973,7 +973,7 @@
   if
    i32.const 400
    i32.const 352
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1183,8 +1183,44 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $1
+  end
   memory.size
   local.set $2
+  local.get $1
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 16
+   i32.const 1
+   i32.shl
+  end
+  i32.add
+  local.set $1
   local.get $1
   i32.const 65535
   i32.add
@@ -1194,12 +1230,12 @@
   i32.and
   i32.const 16
   i32.shr_u
-  local.set $3
+  local.set $4
   local.get $2
-  local.tee $4
-  local.get $3
-  local.tee $5
+  local.tee $3
   local.get $4
+  local.tee $5
+  local.get $3
   local.get $5
   i32.gt_s
   select
@@ -1209,7 +1245,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $4
    memory.grow
    i32.const 0
    i32.lt_s
@@ -1349,7 +1385,7 @@
    if
     i32.const 0
     i32.const 352
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1365,7 +1401,7 @@
   if
    i32.const 0
    i32.const 352
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2803,7 +2839,7 @@
   if
    i32.const 0
    i32.const 352
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2850,7 +2886,7 @@
   if
    i32.const 0
    i32.const 352
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2870,7 +2906,7 @@
   if
    i32.const 0
    i32.const 352
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -973,7 +973,7 @@
   if
    i32.const 400
    i32.const 352
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1202,6 +1202,7 @@
   memory.size
   local.set $2
   local.get $1
+  i32.const 16
   local.get $2
   i32.const 16
   i32.shl
@@ -1211,14 +1212,8 @@
   local.set $3
   local.get $3
   i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 16
-   i32.const 1
-   i32.shl
-  end
+  i32.ne
+  i32.shl
   i32.add
   local.set $1
   local.get $1
@@ -1385,7 +1380,7 @@
    if
     i32.const 0
     i32.const 352
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1401,7 +1396,7 @@
   if
    i32.const 0
    i32.const 352
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2839,7 +2834,7 @@
   if
    i32.const 0
    i32.const 352
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2886,7 +2881,7 @@
   if
    i32.const 0
    i32.const 352
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2906,7 +2901,7 @@
   if
    i32.const 0
    i32.const 352
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -888,7 +888,7 @@
   if
    i32.const 176
    i32.const 128
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1038,9 +1038,42 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 12 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  i32.const 1
+  i32.const 27
+  local.get $1
+  i32.clz
+  i32.sub
+  i32.shl
+  i32.const 1
+  i32.sub
+  local.get $1
+  i32.add
+  local.get $1
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  select
+  local.set $1
   memory.size
   local.tee $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 32
+  end
+  local.set $3
+  local.get $2
   local.get $1
+  local.get $3
+  i32.add
   i32.const 65535
   i32.add
   i32.const -65536
@@ -1171,7 +1204,7 @@
    if
     i32.const 0
     i32.const 128
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1186,7 +1219,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1514,7 +1547,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1731,7 +1764,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1747,7 +1780,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2411,7 +2444,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 495
+   i32.const 506
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -2513,7 +2546,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 559
+   i32.const 570
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2529,7 +2562,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 560
+   i32.const 571
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -888,7 +888,7 @@
   if
    i32.const 176
    i32.const 128
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1038,7 +1038,18 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 12 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
-  (local $3 i32)
+  memory.size
+  local.tee $2
+  i32.const 16
+  local.get $0
+  i32.load offset=1568
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  i32.ne
+  i32.shl
   i32.const 1
   i32.const 27
   local.get $1
@@ -1054,25 +1065,6 @@
   i32.const 536870904
   i32.lt_u
   select
-  local.set $1
-  memory.size
-  local.tee $2
-  i32.const 16
-  i32.shl
-  i32.const 16
-  i32.sub
-  local.get $0
-  i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 32
-  end
-  local.set $3
-  local.get $2
-  local.get $1
-  local.get $3
   i32.add
   i32.const 65535
   i32.add
@@ -1204,7 +1196,7 @@
    if
     i32.const 0
     i32.const 128
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1219,7 +1211,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1547,7 +1539,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1764,7 +1756,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1780,7 +1772,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2444,7 +2436,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 506
+   i32.const 504
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -2546,7 +2538,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 570
+   i32.const 568
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2562,7 +2554,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 571
+   i32.const 569
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -1100,7 +1100,7 @@
   if
    i32.const 176
    i32.const 128
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1329,6 +1329,7 @@
   memory.size
   local.set $2
   local.get $1
+  i32.const 16
   local.get $2
   i32.const 16
   i32.shl
@@ -1338,14 +1339,8 @@
   local.set $3
   local.get $3
   i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 16
-   i32.const 1
-   i32.shl
-  end
+  i32.ne
+  i32.shl
   i32.add
   local.set $1
   local.get $1
@@ -1512,7 +1507,7 @@
    if
     i32.const 0
     i32.const 128
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1528,7 +1523,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1907,7 +1902,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3207,7 +3202,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -3227,7 +3222,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -4148,7 +4143,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 506
+   i32.const 504
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -4262,7 +4257,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 570
+   i32.const 568
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -4282,7 +4277,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 571
+   i32.const 569
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -901,9 +901,9 @@
    return
   end
   local.get $6
-  i32.const 2
   i32.const 16
-  i32.mul
+  i32.const 1
+  i32.shl
   i32.sub
   local.set $7
   local.get $1
@@ -1100,7 +1100,7 @@
   if
    i32.const 176
    i32.const 128
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1310,8 +1310,44 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $1
+  end
   memory.size
   local.set $2
+  local.get $1
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 16
+   i32.const 1
+   i32.shl
+  end
+  i32.add
+  local.set $1
   local.get $1
   i32.const 65535
   i32.add
@@ -1321,12 +1357,12 @@
   i32.and
   i32.const 16
   i32.shr_u
-  local.set $3
+  local.set $4
   local.get $2
-  local.tee $4
-  local.get $3
-  local.tee $5
+  local.tee $3
   local.get $4
+  local.tee $5
+  local.get $3
   local.get $5
   i32.gt_s
   select
@@ -1336,7 +1372,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $4
    memory.grow
    i32.const 0
    i32.lt_s
@@ -1476,7 +1512,7 @@
    if
     i32.const 0
     i32.const 128
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1492,7 +1528,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1871,7 +1907,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3171,7 +3207,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -3191,7 +3227,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -4112,7 +4148,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 495
+   i32.const 506
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -4226,7 +4262,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 559
+   i32.const 570
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -4246,7 +4282,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 560
+   i32.const 571
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -687,7 +687,7 @@
   if
    i32.const 176
    i32.const 128
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -837,9 +837,42 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 11 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  i32.const 1
+  i32.const 27
+  local.get $1
+  i32.clz
+  i32.sub
+  i32.shl
+  i32.const 1
+  i32.sub
+  local.get $1
+  i32.add
+  local.get $1
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  select
+  local.set $1
   memory.size
   local.tee $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 32
+  end
+  local.set $3
+  local.get $2
   local.get $1
+  local.get $3
+  i32.add
   i32.const 65535
   i32.add
   i32.const -65536
@@ -970,7 +1003,7 @@
    if
     i32.const 0
     i32.const 128
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -985,7 +1018,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1547,7 +1580,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1589,7 +1622,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1605,7 +1638,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -687,7 +687,7 @@
   if
    i32.const 176
    i32.const 128
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -837,7 +837,18 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 11 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
-  (local $3 i32)
+  memory.size
+  local.tee $2
+  i32.const 16
+  local.get $0
+  i32.load offset=1568
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  i32.ne
+  i32.shl
   i32.const 1
   i32.const 27
   local.get $1
@@ -853,25 +864,6 @@
   i32.const 536870904
   i32.lt_u
   select
-  local.set $1
-  memory.size
-  local.tee $2
-  i32.const 16
-  i32.shl
-  i32.const 16
-  i32.sub
-  local.get $0
-  i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 32
-  end
-  local.set $3
-  local.get $2
-  local.get $1
-  local.get $3
   i32.add
   i32.const 65535
   i32.add
@@ -1003,7 +995,7 @@
    if
     i32.const 0
     i32.const 128
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1018,7 +1010,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1580,7 +1572,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1622,7 +1614,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1638,7 +1630,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/arraybuffer.untouched.wat
+++ b/tests/compiler/std/arraybuffer.untouched.wat
@@ -700,9 +700,9 @@
    return
   end
   local.get $6
-  i32.const 2
   i32.const 16
-  i32.mul
+  i32.const 1
+  i32.shl
   i32.sub
   local.set $7
   local.get $1
@@ -899,7 +899,7 @@
   if
    i32.const 176
    i32.const 128
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1109,8 +1109,44 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $1
+  end
   memory.size
   local.set $2
+  local.get $1
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 16
+   i32.const 1
+   i32.shl
+  end
+  i32.add
+  local.set $1
   local.get $1
   i32.const 65535
   i32.add
@@ -1120,12 +1156,12 @@
   i32.and
   i32.const 16
   i32.shr_u
-  local.set $3
+  local.set $4
   local.get $2
-  local.tee $4
-  local.get $3
-  local.tee $5
+  local.tee $3
   local.get $4
+  local.tee $5
+  local.get $3
   local.get $5
   i32.gt_s
   select
@@ -1135,7 +1171,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $4
    memory.grow
    i32.const 0
    i32.lt_s
@@ -1275,7 +1311,7 @@
    if
     i32.const 0
     i32.const 128
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1291,7 +1327,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -3036,7 +3072,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3083,7 +3119,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -3103,7 +3139,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/arraybuffer.untouched.wat
+++ b/tests/compiler/std/arraybuffer.untouched.wat
@@ -899,7 +899,7 @@
   if
    i32.const 176
    i32.const 128
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1128,6 +1128,7 @@
   memory.size
   local.set $2
   local.get $1
+  i32.const 16
   local.get $2
   i32.const 16
   i32.shl
@@ -1137,14 +1138,8 @@
   local.set $3
   local.get $3
   i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 16
-   i32.const 1
-   i32.shl
-  end
+  i32.ne
+  i32.shl
   i32.add
   local.set $1
   local.get $1
@@ -1311,7 +1306,7 @@
    if
     i32.const 0
     i32.const 128
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1327,7 +1322,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -3072,7 +3067,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3119,7 +3114,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -3139,7 +3134,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/dataview.optimized.wat
+++ b/tests/compiler/std/dataview.optimized.wat
@@ -693,7 +693,7 @@
   if
    i32.const 176
    i32.const 128
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -843,9 +843,42 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 11 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  i32.const 1
+  i32.const 27
+  local.get $1
+  i32.clz
+  i32.sub
+  i32.shl
+  i32.const 1
+  i32.sub
+  local.get $1
+  i32.add
+  local.get $1
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  select
+  local.set $1
   memory.size
   local.tee $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 32
+  end
+  local.set $3
+  local.get $2
   local.get $1
+  local.get $3
+  i32.add
   i32.const 65535
   i32.add
   i32.const -65536
@@ -976,7 +1009,7 @@
    if
     i32.const 0
     i32.const 128
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -991,7 +1024,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1139,7 +1172,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1356,7 +1389,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1372,7 +1405,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/dataview.optimized.wat
+++ b/tests/compiler/std/dataview.optimized.wat
@@ -693,7 +693,7 @@
   if
    i32.const 176
    i32.const 128
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -843,7 +843,18 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 11 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
-  (local $3 i32)
+  memory.size
+  local.tee $2
+  i32.const 16
+  local.get $0
+  i32.load offset=1568
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  i32.ne
+  i32.shl
   i32.const 1
   i32.const 27
   local.get $1
@@ -859,25 +870,6 @@
   i32.const 536870904
   i32.lt_u
   select
-  local.set $1
-  memory.size
-  local.tee $2
-  i32.const 16
-  i32.shl
-  i32.const 16
-  i32.sub
-  local.get $0
-  i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 32
-  end
-  local.set $3
-  local.get $2
-  local.get $1
-  local.get $3
   i32.add
   i32.const 65535
   i32.add
@@ -1009,7 +1001,7 @@
    if
     i32.const 0
     i32.const 128
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1024,7 +1016,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1172,7 +1164,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1389,7 +1381,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1405,7 +1397,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/dataview.untouched.wat
+++ b/tests/compiler/std/dataview.untouched.wat
@@ -906,7 +906,7 @@
   if
    i32.const 176
    i32.const 128
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1135,6 +1135,7 @@
   memory.size
   local.set $2
   local.get $1
+  i32.const 16
   local.get $2
   i32.const 16
   i32.shl
@@ -1144,14 +1145,8 @@
   local.set $3
   local.get $3
   i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 16
-   i32.const 1
-   i32.shl
-  end
+  i32.ne
+  i32.shl
   i32.add
   local.set $1
   local.get $1
@@ -1318,7 +1313,7 @@
    if
     i32.const 0
     i32.const 128
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1334,7 +1329,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1713,7 +1708,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3013,7 +3008,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -3033,7 +3028,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/dataview.untouched.wat
+++ b/tests/compiler/std/dataview.untouched.wat
@@ -707,9 +707,9 @@
    return
   end
   local.get $6
-  i32.const 2
   i32.const 16
-  i32.mul
+  i32.const 1
+  i32.shl
   i32.sub
   local.set $7
   local.get $1
@@ -906,7 +906,7 @@
   if
    i32.const 176
    i32.const 128
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1116,8 +1116,44 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $1
+  end
   memory.size
   local.set $2
+  local.get $1
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 16
+   i32.const 1
+   i32.shl
+  end
+  i32.add
+  local.set $1
   local.get $1
   i32.const 65535
   i32.add
@@ -1127,12 +1163,12 @@
   i32.and
   i32.const 16
   i32.shr_u
-  local.set $3
+  local.set $4
   local.get $2
-  local.tee $4
-  local.get $3
-  local.tee $5
+  local.tee $3
   local.get $4
+  local.tee $5
+  local.get $3
   local.get $5
   i32.gt_s
   select
@@ -1142,7 +1178,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $4
    memory.grow
    i32.const 0
    i32.lt_s
@@ -1282,7 +1318,7 @@
    if
     i32.const 0
     i32.const 128
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1298,7 +1334,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1677,7 +1713,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2977,7 +3013,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2997,7 +3033,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -699,7 +699,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -849,9 +849,42 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 11 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  i32.const 1
+  i32.const 27
+  local.get $1
+  i32.clz
+  i32.sub
+  i32.shl
+  i32.const 1
+  i32.sub
+  local.get $1
+  i32.add
+  local.get $1
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  select
+  local.set $1
   memory.size
   local.tee $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 32
+  end
+  local.set $3
+  local.get $2
   local.get $1
+  local.get $3
+  i32.add
   i32.const 65535
   i32.add
   i32.const -65536
@@ -982,7 +1015,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -997,7 +1030,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1332,7 +1365,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1549,7 +1582,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1565,7 +1598,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -699,7 +699,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -849,7 +849,18 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 11 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
-  (local $3 i32)
+  memory.size
+  local.tee $2
+  i32.const 16
+  local.get $0
+  i32.load offset=1568
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  i32.ne
+  i32.shl
   i32.const 1
   i32.const 27
   local.get $1
@@ -865,25 +876,6 @@
   i32.const 536870904
   i32.lt_u
   select
-  local.set $1
-  memory.size
-  local.tee $2
-  i32.const 16
-  i32.shl
-  i32.const 16
-  i32.sub
-  local.get $0
-  i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 32
-  end
-  local.set $3
-  local.get $2
-  local.get $1
-  local.get $3
   i32.add
   i32.const 65535
   i32.add
@@ -1015,7 +1007,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1030,7 +1022,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1365,7 +1357,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1582,7 +1574,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1598,7 +1590,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -907,7 +907,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1136,6 +1136,7 @@
   memory.size
   local.set $2
   local.get $1
+  i32.const 16
   local.get $2
   i32.const 16
   i32.shl
@@ -1145,14 +1146,8 @@
   local.set $3
   local.get $3
   i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 16
-   i32.const 1
-   i32.shl
-  end
+  i32.ne
+  i32.shl
   i32.add
   local.set $1
   local.get $1
@@ -1319,7 +1314,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1335,7 +1330,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1738,7 +1733,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3038,7 +3033,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -3058,7 +3053,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -708,9 +708,9 @@
    return
   end
   local.get $6
-  i32.const 2
   i32.const 16
-  i32.mul
+  i32.const 1
+  i32.shl
   i32.sub
   local.set $7
   local.get $1
@@ -907,7 +907,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1117,8 +1117,44 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $1
+  end
   memory.size
   local.set $2
+  local.get $1
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 16
+   i32.const 1
+   i32.shl
+  end
+  i32.add
+  local.set $1
   local.get $1
   i32.const 65535
   i32.add
@@ -1128,12 +1164,12 @@
   i32.and
   i32.const 16
   i32.shr_u
-  local.set $3
+  local.set $4
   local.get $2
-  local.tee $4
-  local.get $3
-  local.tee $5
+  local.tee $3
   local.get $4
+  local.tee $5
+  local.get $3
   local.get $5
   i32.gt_s
   select
@@ -1143,7 +1179,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $4
    memory.grow
    i32.const 0
    i32.lt_s
@@ -1283,7 +1319,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1299,7 +1335,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1702,7 +1738,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3002,7 +3038,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -3022,7 +3058,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -694,7 +694,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -844,7 +844,18 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 11 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
-  (local $3 i32)
+  memory.size
+  local.tee $2
+  i32.const 16
+  local.get $0
+  i32.load offset=1568
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  i32.ne
+  i32.shl
   i32.const 1
   i32.const 27
   local.get $1
@@ -860,25 +871,6 @@
   i32.const 536870904
   i32.lt_u
   select
-  local.set $1
-  memory.size
-  local.tee $2
-  i32.const 16
-  i32.shl
-  i32.const 16
-  i32.sub
-  local.get $0
-  i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 32
-  end
-  local.set $3
-  local.get $2
-  local.get $1
-  local.get $3
   i32.add
   i32.const 65535
   i32.add
@@ -1010,7 +1002,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1025,7 +1017,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1360,7 +1352,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1577,7 +1569,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1593,7 +1585,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -694,7 +694,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -844,9 +844,42 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 11 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  i32.const 1
+  i32.const 27
+  local.get $1
+  i32.clz
+  i32.sub
+  i32.shl
+  i32.const 1
+  i32.sub
+  local.get $1
+  i32.add
+  local.get $1
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  select
+  local.set $1
   memory.size
   local.tee $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 32
+  end
+  local.set $3
+  local.get $2
   local.get $1
+  local.get $3
+  i32.add
   i32.const 65535
   i32.add
   i32.const -65536
@@ -977,7 +1010,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -992,7 +1025,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1327,7 +1360,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1544,7 +1577,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1560,7 +1593,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -905,7 +905,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1134,6 +1134,7 @@
   memory.size
   local.set $2
   local.get $1
+  i32.const 16
   local.get $2
   i32.const 16
   i32.shl
@@ -1143,14 +1144,8 @@
   local.set $3
   local.get $3
   i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 16
-   i32.const 1
-   i32.shl
-  end
+  i32.ne
+  i32.shl
   i32.add
   local.set $1
   local.get $1
@@ -1317,7 +1312,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1333,7 +1328,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1736,7 +1731,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3036,7 +3031,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -3056,7 +3051,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -706,9 +706,9 @@
    return
   end
   local.get $6
-  i32.const 2
   i32.const 16
-  i32.mul
+  i32.const 1
+  i32.shl
   i32.sub
   local.set $7
   local.get $1
@@ -905,7 +905,7 @@
   if
    i32.const 72
    i32.const 24
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1115,8 +1115,44 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $1
+  end
   memory.size
   local.set $2
+  local.get $1
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 16
+   i32.const 1
+   i32.shl
+  end
+  i32.add
+  local.set $1
   local.get $1
   i32.const 65535
   i32.add
@@ -1126,12 +1162,12 @@
   i32.and
   i32.const 16
   i32.shr_u
-  local.set $3
+  local.set $4
   local.get $2
-  local.tee $4
-  local.get $3
-  local.tee $5
+  local.tee $3
   local.get $4
+  local.tee $5
+  local.get $3
   local.get $5
   i32.gt_s
   select
@@ -1141,7 +1177,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $4
    memory.grow
    i32.const 0
    i32.lt_s
@@ -1281,7 +1317,7 @@
    if
     i32.const 0
     i32.const 24
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1297,7 +1333,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1700,7 +1736,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3000,7 +3036,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -3020,7 +3056,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-encoding.optimized.wat
+++ b/tests/compiler/std/string-encoding.optimized.wat
@@ -553,7 +553,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -793,7 +793,7 @@
   if
    i32.const 248
    i32.const 104
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -943,7 +943,18 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 15 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
-  (local $3 i32)
+  memory.size
+  local.tee $2
+  i32.const 16
+  local.get $0
+  i32.load offset=1568
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  i32.ne
+  i32.shl
   i32.const 1
   i32.const 27
   local.get $1
@@ -959,25 +970,6 @@
   i32.const 536870904
   i32.lt_u
   select
-  local.set $1
-  memory.size
-  local.tee $2
-  i32.const 16
-  i32.shl
-  i32.const 16
-  i32.sub
-  local.get $0
-  i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 32
-  end
-  local.set $3
-  local.get $2
-  local.get $1
-  local.get $3
   i32.add
   i32.const 65535
   i32.add
@@ -1109,7 +1101,7 @@
    if
     i32.const 0
     i32.const 104
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1124,7 +1116,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1346,7 +1338,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1362,7 +1354,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2205,7 +2197,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 506
+   i32.const 504
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -2307,7 +2299,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 570
+   i32.const 568
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2323,7 +2315,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 571
+   i32.const 569
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-encoding.optimized.wat
+++ b/tests/compiler/std/string-encoding.optimized.wat
@@ -553,7 +553,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -793,7 +793,7 @@
   if
    i32.const 248
    i32.const 104
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -943,9 +943,42 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 15 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  i32.const 1
+  i32.const 27
+  local.get $1
+  i32.clz
+  i32.sub
+  i32.shl
+  i32.const 1
+  i32.sub
+  local.get $1
+  i32.add
+  local.get $1
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  select
+  local.set $1
   memory.size
   local.tee $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 32
+  end
+  local.set $3
+  local.get $2
   local.get $1
+  local.get $3
+  i32.add
   i32.const 65535
   i32.add
   i32.const -65536
@@ -1076,7 +1109,7 @@
    if
     i32.const 0
     i32.const 104
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1091,7 +1124,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1313,7 +1346,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1329,7 +1362,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2172,7 +2205,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 495
+   i32.const 506
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -2274,7 +2307,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 559
+   i32.const 570
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2290,7 +2323,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 560
+   i32.const 571
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-encoding.untouched.wat
+++ b/tests/compiler/std/string-encoding.untouched.wat
@@ -675,7 +675,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -819,9 +819,9 @@
    return
   end
   local.get $6
-  i32.const 2
   i32.const 16
-  i32.mul
+  i32.const 1
+  i32.shl
   i32.sub
   local.set $7
   local.get $1
@@ -1018,7 +1018,7 @@
   if
    i32.const 248
    i32.const 104
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1228,8 +1228,44 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $1
+  end
   memory.size
   local.set $2
+  local.get $1
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 16
+   i32.const 1
+   i32.shl
+  end
+  i32.add
+  local.set $1
   local.get $1
   i32.const 65535
   i32.add
@@ -1239,12 +1275,12 @@
   i32.and
   i32.const 16
   i32.shr_u
-  local.set $3
+  local.set $4
   local.get $2
-  local.tee $4
-  local.get $3
-  local.tee $5
+  local.tee $3
   local.get $4
+  local.tee $5
+  local.get $3
   local.get $5
   i32.gt_s
   select
@@ -1254,7 +1290,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $4
    memory.grow
    i32.const 0
    i32.lt_s
@@ -1394,7 +1430,7 @@
    if
     i32.const 0
     i32.const 104
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1410,7 +1446,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2714,7 +2750,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2734,7 +2770,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3715,7 +3751,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 495
+   i32.const 506
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -3829,7 +3865,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 559
+   i32.const 570
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -3849,7 +3885,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 560
+   i32.const 571
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-encoding.untouched.wat
+++ b/tests/compiler/std/string-encoding.untouched.wat
@@ -675,7 +675,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1018,7 +1018,7 @@
   if
    i32.const 248
    i32.const 104
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1247,6 +1247,7 @@
   memory.size
   local.set $2
   local.get $1
+  i32.const 16
   local.get $2
   i32.const 16
   i32.shl
@@ -1256,14 +1257,8 @@
   local.set $3
   local.get $3
   i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 16
-   i32.const 1
-   i32.shl
-  end
+  i32.ne
+  i32.shl
   i32.add
   local.set $1
   local.get $1
@@ -1430,7 +1425,7 @@
    if
     i32.const 0
     i32.const 104
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1446,7 +1441,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2750,7 +2745,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2770,7 +2765,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3751,7 +3746,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 506
+   i32.const 504
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -3865,7 +3860,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 570
+   i32.const 568
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -3885,7 +3880,7 @@
   if
    i32.const 0
    i32.const 104
-   i32.const 571
+   i32.const 569
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -750,7 +750,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -990,7 +990,7 @@
   if
    i32.const 328
    i32.const 184
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1140,9 +1140,42 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 16 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  i32.const 1
+  i32.const 27
+  local.get $1
+  i32.clz
+  i32.sub
+  i32.shl
+  i32.const 1
+  i32.sub
+  local.get $1
+  i32.add
+  local.get $1
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  select
+  local.set $1
   memory.size
   local.tee $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 32
+  end
+  local.set $3
+  local.get $2
   local.get $1
+  local.get $3
+  i32.add
   i32.const 65535
   i32.add
   i32.const -65536
@@ -1273,7 +1306,7 @@
    if
     i32.const 0
     i32.const 184
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1288,7 +1321,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1510,7 +1543,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1526,7 +1559,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -4061,7 +4094,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 495
+   i32.const 506
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -4163,7 +4196,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 559
+   i32.const 570
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -4179,7 +4212,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 560
+   i32.const 571
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -750,7 +750,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -990,7 +990,7 @@
   if
    i32.const 328
    i32.const 184
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1140,7 +1140,18 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 16 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
-  (local $3 i32)
+  memory.size
+  local.tee $2
+  i32.const 16
+  local.get $0
+  i32.load offset=1568
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  i32.ne
+  i32.shl
   i32.const 1
   i32.const 27
   local.get $1
@@ -1156,25 +1167,6 @@
   i32.const 536870904
   i32.lt_u
   select
-  local.set $1
-  memory.size
-  local.tee $2
-  i32.const 16
-  i32.shl
-  i32.const 16
-  i32.sub
-  local.get $0
-  i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 32
-  end
-  local.set $3
-  local.get $2
-  local.get $1
-  local.get $3
   i32.add
   i32.const 65535
   i32.add
@@ -1306,7 +1298,7 @@
    if
     i32.const 0
     i32.const 184
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1321,7 +1313,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1543,7 +1535,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1559,7 +1551,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -4094,7 +4086,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 506
+   i32.const 504
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -4196,7 +4188,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 570
+   i32.const 568
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -4212,7 +4204,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 571
+   i32.const 569
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -901,7 +901,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1045,9 +1045,9 @@
    return
   end
   local.get $6
-  i32.const 2
   i32.const 16
-  i32.mul
+  i32.const 1
+  i32.shl
   i32.sub
   local.set $7
   local.get $1
@@ -1244,7 +1244,7 @@
   if
    i32.const 328
    i32.const 184
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1454,8 +1454,44 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $1
+  end
   memory.size
   local.set $2
+  local.get $1
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 16
+   i32.const 1
+   i32.shl
+  end
+  i32.add
+  local.set $1
   local.get $1
   i32.const 65535
   i32.add
@@ -1465,12 +1501,12 @@
   i32.and
   i32.const 16
   i32.shr_u
-  local.set $3
+  local.set $4
   local.get $2
-  local.tee $4
-  local.get $3
-  local.tee $5
+  local.tee $3
   local.get $4
+  local.tee $5
+  local.get $3
   local.get $5
   i32.gt_s
   select
@@ -1480,7 +1516,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $4
    memory.grow
    i32.const 0
    i32.lt_s
@@ -1620,7 +1656,7 @@
    if
     i32.const 0
     i32.const 184
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1636,7 +1672,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2940,7 +2976,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2960,7 +2996,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -6167,7 +6203,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 495
+   i32.const 506
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -6281,7 +6317,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 559
+   i32.const 570
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -6301,7 +6337,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 560
+   i32.const 571
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -901,7 +901,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1244,7 +1244,7 @@
   if
    i32.const 328
    i32.const 184
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1473,6 +1473,7 @@
   memory.size
   local.set $2
   local.get $1
+  i32.const 16
   local.get $2
   i32.const 16
   i32.shl
@@ -1482,14 +1483,8 @@
   local.set $3
   local.get $3
   i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 16
-   i32.const 1
-   i32.shl
-  end
+  i32.ne
+  i32.shl
   i32.add
   local.set $1
   local.get $1
@@ -1656,7 +1651,7 @@
    if
     i32.const 0
     i32.const 184
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1672,7 +1667,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2976,7 +2971,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -2996,7 +2991,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -6203,7 +6198,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 506
+   i32.const 504
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -6317,7 +6312,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 570
+   i32.const 568
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -6337,7 +6332,7 @@
   if
    i32.const 0
    i32.const 184
-   i32.const 571
+   i32.const 569
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -744,7 +744,7 @@
   if
    i32.const 176
    i32.const 128
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -894,9 +894,42 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 11 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  i32.const 1
+  i32.const 27
+  local.get $1
+  i32.clz
+  i32.sub
+  i32.shl
+  i32.const 1
+  i32.sub
+  local.get $1
+  i32.add
+  local.get $1
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  select
+  local.set $1
   memory.size
   local.tee $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 32
+  end
+  local.set $3
+  local.get $2
   local.get $1
+  local.get $3
+  i32.add
   i32.const 65535
   i32.add
   i32.const -65536
@@ -1027,7 +1060,7 @@
    if
     i32.const 0
     i32.const 128
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1042,7 +1075,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1370,7 +1403,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1587,7 +1620,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1603,7 +1636,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -744,7 +744,7 @@
   if
    i32.const 176
    i32.const 128
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -894,7 +894,18 @@
  )
  (func $~lib/rt/tlsf/growMemory (; 11 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
-  (local $3 i32)
+  memory.size
+  local.tee $2
+  i32.const 16
+  local.get $0
+  i32.load offset=1568
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  i32.ne
+  i32.shl
   i32.const 1
   i32.const 27
   local.get $1
@@ -910,25 +921,6 @@
   i32.const 536870904
   i32.lt_u
   select
-  local.set $1
-  memory.size
-  local.tee $2
-  i32.const 16
-  i32.shl
-  i32.const 16
-  i32.sub
-  local.get $0
-  i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 32
-  end
-  local.set $3
-  local.get $2
-  local.get $1
-  local.get $3
   i32.add
   i32.const 65535
   i32.add
@@ -1060,7 +1052,7 @@
    if
     i32.const 0
     i32.const 128
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1075,7 +1067,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1403,7 +1395,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1620,7 +1612,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1636,7 +1628,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -969,7 +969,7 @@
   if
    i32.const 176
    i32.const 128
-   i32.const 459
+   i32.const 457
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1198,6 +1198,7 @@
   memory.size
   local.set $2
   local.get $1
+  i32.const 16
   local.get $2
   i32.const 16
   i32.shl
@@ -1207,14 +1208,8 @@
   local.set $3
   local.get $3
   i32.load offset=1568
-  i32.eq
-  if (result i32)
-   i32.const 16
-  else   
-   i32.const 16
-   i32.const 1
-   i32.shl
-  end
+  i32.ne
+  i32.shl
   i32.add
   local.set $1
   local.get $1
@@ -1381,7 +1376,7 @@
    if
     i32.const 0
     i32.const 128
-    i32.const 489
+    i32.const 487
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1397,7 +1392,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 491
+   i32.const 489
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1776,7 +1771,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 548
+   i32.const 546
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3076,7 +3071,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 578
+   i32.const 576
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -3096,7 +3091,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 579
+   i32.const 577
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -770,9 +770,9 @@
    return
   end
   local.get $6
-  i32.const 2
   i32.const 16
-  i32.mul
+  i32.const 1
+  i32.shl
   i32.sub
   local.set $7
   local.get $1
@@ -969,7 +969,7 @@
   if
    i32.const 176
    i32.const 128
-   i32.const 448
+   i32.const 459
    i32.const 29
    call $~lib/builtins/abort
    unreachable
@@ -1179,8 +1179,44 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $1
+  end
   memory.size
   local.set $2
+  local.get $1
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.load offset=1568
+  i32.eq
+  if (result i32)
+   i32.const 16
+  else   
+   i32.const 16
+   i32.const 1
+   i32.shl
+  end
+  i32.add
+  local.set $1
   local.get $1
   i32.const 65535
   i32.add
@@ -1190,12 +1226,12 @@
   i32.and
   i32.const 16
   i32.shr_u
-  local.set $3
+  local.set $4
   local.get $2
-  local.tee $4
-  local.get $3
-  local.tee $5
+  local.tee $3
   local.get $4
+  local.tee $5
+  local.get $3
   local.get $5
   i32.gt_s
   select
@@ -1205,7 +1241,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $3
+   local.get $4
    memory.grow
    i32.const 0
    i32.lt_s
@@ -1345,7 +1381,7 @@
    if
     i32.const 0
     i32.const 128
-    i32.const 478
+    i32.const 489
     i32.const 15
     call $~lib/builtins/abort
     unreachable
@@ -1361,7 +1397,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 480
+   i32.const 491
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -1740,7 +1776,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 537
+   i32.const 548
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3040,7 +3076,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 567
+   i32.const 578
    i32.const 13
    call $~lib/builtins/abort
    unreachable
@@ -3060,7 +3096,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 568
+   i32.const 579
    i32.const 2
    call $~lib/builtins/abort
    unreachable


### PR DESCRIPTION
See #701

What happened here is that `growMemory` was called with the size of the next allocation, but it didn't make sure that such an allocation will actually succeed, leading to `searchBlock` searching another list for certain sizes, in turn not finding a block before hitting the respective assertion.

Unfortunately, I don't see a good way to test this except compiling thousands of modules with incrementing initial allocations since this depends on memory being grown. Maybe someone else has an idea? :)