### PR TITLE
1. Asc command supported absolute path.

### DIFF
--- a/cli/asc.js
+++ b/cli/asc.js
@@ -380,6 +380,8 @@ exports.main = function main(argv, options, callback) {
     const filename = argv[i];
 
     let sourcePath = String(filename).replace(/\\/g, "/").replace(/(\.ts|\/)$/, "");
+    // Setting the path to relative path
+    sourcePath = sourcePath.indexOf(baseDir) == 0 ? sourcePath.slice(baseDir.length) : sourcePath;
 
     // Try entryPath.ts, then entryPath/index.ts
     let sourceText = readFile(sourcePath + ".ts", baseDir);

--- a/cli/asc.js
+++ b/cli/asc.js
@@ -381,7 +381,7 @@ exports.main = function main(argv, options, callback) {
 
     let sourcePath = String(filename).replace(/\\/g, "/").replace(/(\.ts|\/)$/, "");
     // Setting the path to relative path
-    sourcePath = sourcePath.indexOf(baseDir) == 0 ? sourcePath.slice(baseDir.length) : sourcePath;
+    sourcePath = path.isAbsolute(sourcePath) ? path.relative(baseDir, sourcePath) : sourcePath;
 
     // Try entryPath.ts, then entryPath/index.ts
     let sourceText = readFile(sourcePath + ".ts", baseDir);


### PR DESCRIPTION
Got the below errors, when executed command asc /Workspace/assemblyscript/tests/compiler/for.ts -t for.wast

The reason is that the asc command works improperly when using absolute path.

```typescript
 asc /Workspace/assemblyscript/tests/compiler/for.ts -t for.wast
ERROR: Entry file '/Workspace/assemblyscript/tests/compiler/for.ts' not found.
    at Object.main (/Users/peng/Workspace/assemblyscript/cli/asc.js:391:25)
    at Object.<anonymous> (/Users/peng/Workspace/assemblyscript/bin/asc:21:26)
    at Module._compile (internal/modules/cjs/loader.js:774:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:785:10)
    at Module.load (internal/modules/cjs/loader.js:641:32)
    at Function.Module._load (internal/modules/cjs/loader.js:556:12)
    at Function.Module.runMain (internal/modules/cjs/loader.js:837:10)
    at internal/main/run_main_module.js:17:11
```