### PR TITLE
Fix missing argument when specifying a --lib directory

### DIFF
--- a/cli/asc.js
+++ b/cli/asc.js
@@ -259,7 +259,7 @@ exports.main = function main(argv, options, callback) {
         libFiles = [ path.basename(libDir) ];
         libDir = path.dirname(libDir);
       } else {
-        libFiles = listFiles(libDir) || [];
+        libFiles = listFiles(libDir, baseDir) || [];
       }
       for (let j = 0, l = libFiles.length; j < l; ++j) {
         let libPath = libFiles[j];


### PR DESCRIPTION
As discovered in https://github.com/AssemblyScript/assemblyscript/issues/714 the respective call to `listFiles` in asc when a directory was provided with `--lib` missed the necessary second parameter, leading to the described issue.