### PR TITLE
[Implement] isVoid<T>()

### DIFF
--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -102,6 +102,7 @@ export namespace BuiltinSymbols {
   export const isDefined = "~lib/builtins/isDefined";
   export const isConstant = "~lib/builtins/isConstant";
   export const isManaged = "~lib/builtins/isManaged";
+  export const isVoid = "~lib/builtins/isVoid";
 
   export const clz = "~lib/builtins/clz";
   export const ctz = "~lib/builtins/ctz";
@@ -657,6 +658,12 @@ export function compileCall(
       compiler.currentType = Type.bool;
       if (!type) return module.unreachable();
       return module.i32(type.isManaged ? 1 : 0);
+    }
+    case BuiltinSymbols.isVoid: { // isVoid<T>() -> bool
+      let type = evaluateConstantType(compiler, typeArguments, operands, reportNode);
+      compiler.currentType = Type.bool;
+      if (!type) return module.unreachable();
+      return module.i32(type.kind === TypeKind.VOID ? 1 : 0);
     }
     case BuiltinSymbols.sizeof: { // sizeof<T!>() -> usize
       compiler.currentType = compiler.options.usizeType;

--- a/std/assembly/builtins.ts
+++ b/std/assembly/builtins.ts
@@ -52,6 +52,10 @@ export declare function isManaged<T>(value?: T): bool;
 
 // @ts-ignore: decorator
 @builtin
+export declare function isVoid<T>(): boolean;
+
+// @ts-ignore: decorator
+@builtin
 export declare function clz<T>(value: T): T;
 
 // @ts-ignore: decorator

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -158,6 +158,8 @@ declare function isDefined(expression: any): bool;
 declare function isConstant(expression: any): bool;
 /** Tests if the specified type *or* expression is of a managed type. Compiles to a constant. */
 declare function isManaged<T>(value?: any): bool;
+/** Tests if the specified type is void. Compiles to a constant. */
+declare function isVoid<T>(): bool;
 /** Traps if the specified value is not true-ish, otherwise returns the (non-nullable) value. */
 declare function assert<T>(isTrueish: T, message?: string): T & object; // any better way to model `: T != null`?
 /** Parses an integer string to a 64-bit float. */

--- a/tests/compiler/builtins.ts
+++ b/tests/compiler/builtins.ts
@@ -418,3 +418,18 @@ f64.store(8, 1.0);
 
 f32.trunc(1.0);
 f64.trunc(1.0);
+
+assert(isVoid<void>());
+assert(!isVoid<i8>());
+assert(!isVoid<u8>());
+assert(!isVoid<i16>());
+assert(!isVoid<u16>());
+assert(!isVoid<i32>());
+assert(!isVoid<u32>());
+assert(!isVoid<f32>());
+assert(!isVoid<i64>());
+assert(!isVoid<u64>());
+assert(!isVoid<f64>());
+assert(!isVoid<C>());
+assert(!isVoid<string>());
+// assert(!isVoid<v128>());


### PR DESCRIPTION
For combined use with `ReturnType`.

```ts
if (isFunction<T>()) {
  if (isVoid<ReturnType<T>>())  {
    call_indirect(func, ...props)
  } else {
    let value: ReturnType<T> = call_indirect(func, ...props);
    // do something with value
  }
}
```