### PR TITLE
[Implement] ParameterCount

### DIFF
--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -662,7 +662,15 @@ export function compileCall(
     case BuiltinSymbols.ParameterCount: {
       let type = evaluateConstantType(compiler, typeArguments, operands, reportNode);
       compiler.currentType = Type.i32;
-      if (!type || !type.signatureReference) {
+      if (type === null) {
+        compiler.error(
+          DiagnosticCode.Expected_0_type_arguments_but_got_1,
+          reportNode.range, "1", (typeArguments ? typeArguments.length : 1).toString(10)
+        );
+        return module.unreachable();
+      }
+
+      if (type.signatureReference === null) {
         compiler.error(
           DiagnosticCode.Type_0_has_no_call_signatures,
           reportNode.range, "1", (typeArguments ? typeArguments.length : 1).toString(10)

--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -102,6 +102,7 @@ export namespace BuiltinSymbols {
   export const isDefined = "~lib/builtins/isDefined";
   export const isConstant = "~lib/builtins/isConstant";
   export const isManaged = "~lib/builtins/isManaged";
+  export const ParameterCount = "~lib/builtins/ParameterCount";
 
   export const clz = "~lib/builtins/clz";
   export const ctz = "~lib/builtins/ctz";
@@ -657,6 +658,20 @@ export function compileCall(
       compiler.currentType = Type.bool;
       if (!type) return module.unreachable();
       return module.i32(type.isManaged ? 1 : 0);
+    }
+    case BuiltinSymbols.ParameterCount: {
+      let type = evaluateConstantType(compiler, typeArguments, operands, reportNode);
+      compiler.currentType = Type.i32;
+      if (!type || !type.signatureReference) {
+        compiler.error(
+          DiagnosticCode.Type_0_has_no_call_signatures,
+          reportNode.range, "1", (typeArguments ? typeArguments.length : 1).toString(10)
+        );
+        return module.unreachable();
+      }
+      return type.signatureReference.parameterNames === null
+        ? module.i32(0)
+        : module.i32(type.signatureReference.parameterNames.length);
     }
     case BuiltinSymbols.sizeof: { // sizeof<T!>() -> usize
       compiler.currentType = compiler.options.usizeType;

--- a/src/diagnosticMessages.generated.ts
+++ b/src/diagnosticMessages.generated.ts
@@ -136,6 +136,7 @@ export enum DiagnosticCode {
   Namespace_0_has_no_exported_member_1 = 2694,
   Required_type_parameters_may_not_follow_optional_type_parameters = 2706,
   Duplicate_property_0 = 2718,
+  Type_0_has_no_call_signatures = 2757,
   File_0_not_found = 6054,
   Numeric_separators_are_not_allowed_here = 6188,
   Multiple_consecutive_numeric_separators_are_not_permitted = 6189,
@@ -275,6 +276,7 @@ export function diagnosticCodeToString(code: DiagnosticCode): string {
     case 2694: return "Namespace '{0}' has no exported member '{1}'.";
     case 2706: return "Required type parameters may not follow optional type parameters.";
     case 2718: return "Duplicate property '{0}'.";
+    case 2757: return "Type '{0}' has no call signatures.";
     case 6054: return "File '{0}' not found.";
     case 6188: return "Numeric separators are not allowed here.";
     case 6189: return "Multiple consecutive numeric separators are not permitted.";

--- a/src/diagnosticMessages.json
+++ b/src/diagnosticMessages.json
@@ -130,6 +130,7 @@
   "Namespace '{0}' has no exported member '{1}'.": 2694,
   "Required type parameters may not follow optional type parameters.": 2706,
   "Duplicate property '{0}'.": 2718,
+  "Type '{0}' has no call signatures.": 2757,
 
   "File '{0}' not found.": 6054,
   "Numeric separators are not allowed here.": 6188,

--- a/std/assembly/builtins.ts
+++ b/std/assembly/builtins.ts
@@ -52,6 +52,10 @@ export declare function isManaged<T>(value?: T): bool;
 
 // @ts-ignore: decorator
 @builtin
+export declare function ParameterCount<T>(func?: T): i32;
+
+// @ts-ignore: decorator
+@builtin
 export declare function clz<T>(value: T): T;
 
 // @ts-ignore: decorator

--- a/tests/compiler/builtins.ts
+++ b/tests/compiler/builtins.ts
@@ -418,3 +418,8 @@ f64.store(8, 1.0);
 
 f32.trunc(1.0);
 f64.trunc(1.0);
+
+assert(ParameterCount<() => void>() == 0);
+assert(ParameterCount<(a: i32) => void>() == 1);
+assert(ParameterCount<(a: i32, b: C) => void>() == 2);
+assert(ParameterCount<(a: i32, b: C, c: string) => void>() == 3);


### PR DESCRIPTION
Usage:

```ts
switch(ParameterCount<CallbackType>()) {
  case 1: call_indirect(func, arg0); break;
  case 2: call_indirect(func, arg0, arg1); break;
  case 3: call_indirect(func, arg0, arg1, arg2); break; // etc
}
```

Useful for `EventEmitter.prototype.emit()` and `EventEmitter.on()`.