### PR TITLE
Asyncify Support

### DIFF
--- a/lib/bysyncify/as-pect.config.js
+++ b/lib/bysyncify/as-pect.config.js
@@ -1,0 +1,70 @@
+module.exports = {
+  /**
+   * A set of globs passed to the glob package that qualify typescript files for testing.
+   */
+  include: ["assembly/__tests__/**/*.spec.ts"],
+  /**
+   * A set of globs passed to the glob package that quality files to be added to each test.
+   */
+  add: ["assembly/__tests__/**/*.include.ts"],
+  /**
+   * All the compiler flags needed for this test suite. Make sure that a binary file is output.
+   */
+  flags: {
+    /** To output a wat file, uncomment the following line. */
+    "--textFile": ["output.wat"],
+    /** A runtime must be provided here. */
+    "--runtime": ["stub"], // Acceptable values are: full, half, stub (arena), and none
+    "--runPasses": ["asyncify,dce"]
+  },
+  /**
+   * A set of regexp that will disclude source files from testing.
+   */
+  disclude: [/node_modules/],
+  /**
+   * Add your required AssemblyScript imports here.
+   */
+  imports: {},
+  /**
+   * All performance statistics reporting can be configured here.
+   */
+  performance: {
+    /** Enable performance statistics gathering for every test. */
+    enabled: false,
+    /** Set the maximum number of samples to run for every test. */
+    maxSamples: 10000,
+    /** Set the maximum test run time in milliseconds for every test. */
+    maxTestRunTime: 5000,
+    /** Report the median time in the default reporter for every test. */
+    reportMedian: true,
+    /** Report the average time in milliseconds for every test. */
+    reportAverage: true,
+    /** Report the standard deviation for every test. */
+    reportStandardDeviation: false,
+    /** Report the maximum run time in milliseconds for every test. */
+    reportMax: false,
+    /** Report the minimum run time in milliseconds for every test. */
+    reportMin: false,
+  },
+  /**
+   * Add a custom reporter here if you want one. The following example is in typescript.
+   *
+   * @example
+   * import { TestReporter, TestGroup, TestResult, TestContext } from "as-pect";
+   *
+   * export class CustomReporter extends TestReporter {
+   *   // implement each abstract method here
+   *   public abstract onStart(suite: TestContext): void;
+   *   public abstract onGroupStart(group: TestGroup): void;
+   *   public abstract onGroupFinish(group: TestGroup): void;
+   *   public abstract onTestStart(group: TestGroup, result: TestResult): void;
+   *   public abstract onTestFinish(group: TestGroup, result: TestResult): void;
+   *   public abstract onFinish(suite: TestContext): void;
+   * }
+   */
+  // reporter: new CustomReporter(),
+  /**
+   * Specify if the binary wasm file should be written to the file system.
+   */
+  outputBinary: false,
+};

--- a/lib/bysyncify/assembly/__tests__/as-pect.d.ts
+++ b/lib/bysyncify/assembly/__tests__/as-pect.d.ts
@@ -1,0 +1,865 @@
+/**
+ * This function creates a test group in the test loader.
+ *
+ * @param {string} description  - This is the name of the test group.
+ * @param {() => void} callback - A function that contains all of the closures for this test group.
+ *
+ * @example
+ *
+ * ```ts
+ * describe("my test suite", (): void => {
+ *   // put your tests here
+ * });
+ * ```
+ */
+declare function describe(description: string, callback: () => void): void;
+
+/**
+ * This function creates a test inside the given test group. It must be placed inside a describe
+ * block.
+ *
+ * @param {string} description - This is the name of the test, and should describe a behavior.
+ * @param {() => void} callback - A function that contains a set of expectations for this test.
+ *
+ * @example
+ *
+ * ```ts
+ * describe("the meaning of life", (): void => {
+ *   it("should be 42", (): void => {
+ *     // put your expectations here
+ *     expect<i32>(29 + 13).toBe(42);
+ *   });
+ * });
+ * ```
+ */
+declare function it(description: string, callback: () => void): void;
+
+/**
+ * A test that does not run, and is longhand equivalent to using todo function without a
+ * callback. This test does not get run and is reported like a todo.
+ *
+ * @param {string} description - This is the name of the test, and should describe a behavior.
+ * @param {() => void} callback - A function that contains a set of expectations for this test.
+ */
+declare function xit(description: string, callback: () => void): void;
+
+/**
+ * A test that does not run, and is longhand equivalent to using todo function without a
+ * callback. This test does not get run and is reported like a todo.
+ *
+ * @param {string} description - This is the name of the test, and should describe a behavior.
+ * @param {() => void} callback - A function that contains a set of expectations for this test.
+ */
+declare function xtest(description: string, callback: () => void): void;
+
+/**
+ * This function creates a test inside the given test group. It must be placed inside a describe
+ * block.
+ *
+ * @param {string} description - This is the name of the test, and should describe a behavior.
+ * @param {() => void} callback - A function that contains a set of expectations for this test.
+ *
+ * @example
+ * ```ts
+ * describe("the meaning of life", (): void => {
+ *   test("the value should be 42", (): void => {
+ *     // put your expectations here
+ *     expect<i32>(29 + 13).toBe(42);
+ *   });
+ * });
+ * ```
+ */
+declare function test(description: string, callback: () => void): void;
+
+/**
+ * This function creates a test that is expected to fail. This is useful to verify if a given
+ * behavior is expected to throw.
+ *
+ * @param {string} description - This is the name of the test, and should describe a behavior.
+ * @param {() => void} callback - A function that contains a set of expectations for this test.
+ * @param {string?} message - A message that describes why the test should fail.
+ *
+ * @example
+ *
+ * ```ts
+ * describe("the meaning of life", (): void => {
+ *   throws("the value should be 42", (): void => {
+ *     // put your expectations here
+ *     expect<i32>(29 + 13).not.toBe(42);
+ *   });
+ * });
+ * ```
+ */
+declare function throws(description: string, callback: () => void, message?: string): void;
+
+
+/**
+ * This function creates a test that is expected to fail. This is useful to verify if a given
+ * behavior is expected to throw.
+ *
+ * @param {string} description - This is the name of the test, and should describe a behavior.
+ * @param {() => void} callback - A function that contains a set of expectations for this test.
+ * @param {string?} message - A message that describes why the test should fail.
+ *
+ * @example
+ *
+ * ```ts
+ * describe("the meaning of life", (): void => {
+ *   itThrows("when the value should be 42", (): void => {
+ *     // put your expectations here
+ *     expect<i32>(29 + 13).not.toBe(42);
+ *   }, "The value is actually 42.");
+ * });
+ * ```
+ */
+declare function itThrows(description: string, callback: () => void, message?: string): void;
+
+/**
+ * This function creates a callback that is called before each individual test is run in this test
+ * group.
+ *
+ * @param {function} callback - The function to be run before each test in the current test group.
+ *
+ * @example
+ *
+ * ```ts
+ * // create a global
+ * var cat: Cat = new Cat();
+ *
+ * describe("cats", (): void => {
+ *   beforeEach((): void => {
+ *     cat.meow(1); // meow once per test
+ *   });
+ * });
+ * ```
+ */
+declare function beforeEach(callback: () => void): void;
+
+/**
+ * This function creates a callback that is called before the whole test group is run, and only
+ * once.
+ *
+ * @param {function} callback - The function to be run before each test in the current test group.
+ *
+ * @example
+ *
+ * ```ts
+ * // create a global
+ * var dog: Dog = null;
+ * describe("dogs", (): void => {
+ *   beforeAll((): void => {
+ *     dog = new Dog(); // create a single dog once before the tests start
+ *   });
+ * });
+ * ```
+ */
+declare function beforeAll(callback: () => void): void;
+
+/**
+ * This function creates a callback that is called after each individual test is run in this test
+ * group.
+ *
+ * @param {function} callback - The function to be run after each test in the current test group.
+ *
+ * @example
+ *
+ * ```ts
+ * // create a global
+ * var cat: Cat = new Cat();
+ *
+ * describe("cats", (): void => {
+ *   afterEach((): void => {
+ *     cat.sleep(12); // cats sleep a lot
+ *   });
+ * });
+ * ```
+ */
+declare function afterEach(callback: () => void): void;
+
+/**
+ * This function creates a callback that is called after the whole test group is run, and only
+ * once.
+ *
+ * @param {function} callback - The function to be run after each test in the current test group.
+ *
+ * @example
+ *
+ * ```ts
+ * // create a global
+ * var dog: Dog = null;
+ * describe("dogs", (): void => {
+ *   afterAll((): void => {
+ *     memory.free(changetype<usize>(dog)); // free some memory
+ *   });
+ * });
+ * ```
+ */
+declare function afterAll(callback: () => void): void;
+
+/**
+ * Describes a value and returns an expectation to test the value.
+ *
+ * @type {T} - The expectation's type.
+ * @param {T} actual - The value being tested.
+ *
+ * @example
+ *
+ * ```ts
+ * expect<i32>(42).not.toBe(-1, "42 should not be -1");
+ * expect<i32>(19 + 23).toBe(42, "19 + 23 should equal 42");
+ * ```
+ */
+declare function expect<T>(actual: T | null): Expectation<T>;
+
+/**
+ * Describes a void function and returns an expectation to test the function.
+ *
+ * @param {() => void} callback - The callback being tested.
+ *
+ * @example
+ *
+ * ```ts
+ * expectFn((): void => unreachable()).toThrow("unreachables do not throw");
+ * expectFn((): void => {
+ *   cat.meow();
+ * }).not.toThrow("Uhoh, cats can't meow!");;
+ * ```
+ */
+declare function expectFn(cb: () => void): Expectation<() => void>;
+
+/**
+ * Describes a test that needs to be written.
+ *
+ * @param {string} description - The description of the test that needs to be written.
+ */
+declare function todo(description: string): void;
+
+/**
+ * Logs a single value to the logger, and is stringified. It works for references, values, and
+ * strings.
+ *
+ * @type {T} - The type to be logged.
+ * @param {T | null} value - The value to be logged.
+ *
+ * @example
+ *
+ * ```ts
+ * log<string>("This is a logged value.");
+ * log<i32>(42);
+ * log<Vec3>(new Vec(1, 2, 3));
+ * log<Vec3>(null);
+ * ```
+ */
+declare function log<T>(value: T | null): void;
+
+/**
+ * An expectation for a value.
+ */
+// @ts-ignore
+declare class Expectation<T> {
+
+  /**
+   * Create a new expectation.
+   *
+   * @param {T | null} actual - The actual value of the expectation.
+   */
+  constructor(actual: T | null);
+
+  /**
+   * This expectation performs a strict equality on value types and reference types.
+   *
+   * @param {T | null} expected - The value to be compared.
+   * @param {string} message - The optional message that describes the expectation.
+   *
+   * @example
+   *
+   * ```ts
+   * expect<i32>(42).not.toBe(-1, "42 should not be -1");
+   * expect<i32>(19 + 23).toBe(42, "19 + 23 should equal 42");
+   * ```
+   */
+  toBe(expected: T | null, message?: string): void;
+
+  /**
+   * This expectation performs a strict equality on value types and performs a memcompare on
+   * reference types. If the reference type `T` has reference types as properties, the comparison does
+   * not perform property traversal. It will only compare the pointer values in the memory block, and
+   * only compare `offsetof<T>()` bytes, regardless of the allocated block size.
+   *
+   * @param {T | null} expected - The value to be compared.
+   * @param {string} message - The optional message that describes the expectation.
+   *
+   * @example
+   *
+   * ```ts
+   * expect<Vec3>(new Vec3(1, 2, 3)).toStrictEqual(new Vec(1, 2, 3), "Vectors of the same shape should be equal");
+   * ```
+   */
+  toStrictEqual(expected: T | null, message?: string): void;
+
+  /**
+   * This expectation performs a strict memory block equality based on the allocated block sizes.
+   *
+   * @param {T | null} expected - The value to be compared.
+   * @param {string} message - The optional message that describes the expectation.
+   *
+   * @example
+   *
+   * ```ts
+   * expect<Vec3>(new Vec3(1, 2, 3)).toBlockEqual(new Vec(1, 2, 3), "Vectors of the same shape should be equal");
+   * ```
+   */
+  toBlockEqual(expected: T | null, message?: string): void;
+
+  /**
+   * If the value is callable, it calls the function, and fails the expectation if it throws, or hits
+   * an unreachable().
+   *
+   * @param {string} message - The optional message that describes the expectation.
+   *
+   * @example
+   *
+   * ```ts
+   * expectFn((): void => unreachable()).toThrow("unreachable() should throw.");
+   * expectFn((): void => {
+   *   cat.sleep(100); // cats can sleep quite a lot
+   * }).not.toThrow("cats should sleep, not throw");
+   * ```
+   */
+  toThrow(message?: string): void;
+
+  /**
+   * This expecation asserts that the value is truthy, like in javascript. If the value is a string,
+   * then strings of length 0 are not truthy.
+   *
+   * @param {string} message - The optional message that describes the expectation.
+   *
+   * @example
+   *
+   * ```ts
+   * expect<bool>(true).toBeTruthy("true is truthy.");
+   * expect<i32>(1).toBeTruthy("numeric values that are not 0 are truthy.");
+   * expect<Vec3>(new Vec3(1, 2, 3)).toBeTruthy("reference types that aren't null are truthy.");
+   * expect<bool>(false).not.toBeTruthy("false is not truthy.");
+   * expect<i32>(0).not.toBeTruthy("0 is not truthy.");
+   * expect<Vec3>(null).not.toBeTruthy("null is not truthy.");
+   * ```
+   */
+  toBeTruthy(message?: string): void;
+
+  /**
+   * This expectation tests the value to see if it is null. If the value is a value type, it is
+   * never null. If the value is a reference type, it performs a strict null comparison.
+   *
+   * @param {string} message - The optional message that describes the expectation.
+   *
+   * @example
+   *
+   * ```ts
+   * expect<i32>(0).not.toBeNull("numbers are never null");
+   * expect<Vec3>(null).toBeNull("null reference types are null.");
+   * ```
+   */
+  toBeNull(message?: string): void;
+
+  /**
+   * This expecation assert that the value is falsy, like in javascript. If the value is a string,
+   * then strings of length 0 are falsy.
+   *
+   * @param {string} message - The optional message that describes the expectation.
+   *
+   * @example
+   *
+   * ```ts
+   * expect<bool>(false).toBeFalsy("false is falsy.");
+   * expect<i32>(0).toBeFalsy("0 is falsy.");
+   * expect<Vec3>(null).toBeFalsy("null is falsy.");
+   * expect<bool>(true).not.toBeFalsy("true is not falsy.");
+   * expect<i32>(1).not.toBeFalsy("numeric values that are not 0 are not falsy.");
+   * expect<Vec3>(new Vec3(1, 2, 3)).not.toBeFalsy("reference types that aren't null are not falsy.");
+   * ```
+   */
+  toBeFalsy(message?: string): void;
+
+  /**
+   * This expectation asserts that the value is greater than the expected value. Since operators can
+   * be overloaded in assemblyscript, it's possible for this to work on reference types.
+   *
+   * @param {T | null} expected - The expected value that the actual value should be greater than.
+   * @param {string} message - The optional message that describes this expectation.
+   *
+   * @example
+   *
+   * ```ts
+   * expect<i32>(10).toBeGreaterThan(4);
+   * expect<i32>(12).not.toBeGreaterThan(42);
+   * ```
+   */
+  toBeGreaterThan(expected: T | null, message?: string): void;
+
+  /**
+   * This expectation asserts that the value is less than the expected value. Since operators can
+   * be overloaded in assemblyscript, it's possible for this to work on reference types.
+   *
+   * @param {T | null} value - The expected value that the actual value should be less than.
+   * @param {string} message - The optional message that describes this expectation.
+   *
+   * @example
+   *
+   * ```ts
+   * expect<i32>(10).not.toBeLessThan(4);
+   * expect<i32>(12).toBeLessThan(42);
+   * ```
+   */
+  toBeLessThan(expected: T | null, message?: string): void;
+
+  /**
+   * This expectation asserts that the value is greater than or equal to the expected value. Since
+   * operators can be overloaded in assemblyscript, it's possible for this to work on reference
+   * types.
+   *
+   * @param {T | null} value - The expected value that the actual value should be greater than or
+   * equal to.
+   * @param {string} message - The optional message that describes this expectation.
+   *
+   * @example
+   *
+   * ```ts
+   * expect<i32>(42).toBeGreaterThanOrEqual(42);
+   * expect<i32>(10).toBeGreaterThanOrEqual(4);
+   * expect<i32>(12).not.toBeGreaterThanOrEqual(42);
+   * ```
+   */
+  toBeGreaterThanOrEqual(expected: T | null, message?: string): void;
+
+  /**
+   * This expectation asserts that the value is less than or equal to the expected value. Since
+   * operators can be overloaded in assemblyscript, it's possible for this to work on reference
+   * types.
+   *
+   * @param {T | null} value - The expected value that the actual value should be less than or equal
+   * to.
+   * @param {string} message - The optional message that describes this expectation.
+   *
+   * @example
+   *
+   * ```ts
+   * expect<i32>(42).toBeLessThanOrEqual(42);
+   * expect<i32>(10).not.toBeLessThanOrEqual(4);
+   * expect<i32>(12).toBeLessThanOrEqual(42);
+   * ```
+   */
+  toBeLessThanOrEqual(expected: T | null, message?: string): void;
+
+  /**
+   * This expectation asserts that the value is close to another value. Both numbers must be finite,
+   * and T must extend f64 or f32.
+   *
+   * @param {T extends f64 | f32} value - The expected value to be close to.
+   * @param {i32} decimalPlaces - The number of decimal places used to calculate epsilon. Default is
+   * 2.
+   * @param {string} message - The optional message that describes this expectation.
+   *
+   * @example
+   *
+   * ```ts
+   * expect<f64>(0.1 + 0.2).toBeCloseTo(0.3);
+   * ```
+   */
+  toBeCloseTo(expected: T, decimalPlaces?: number, message?: string): void;
+
+  /**
+   * This function asserts the float type value is NaN.
+   *
+   * @param {string} message - The optional message the describes this expectation.
+   *
+   * @example
+   *
+   * ```ts
+   * expect<f64>(NaN).toBeNaN();
+   * expect<f32>(42).not.toBeNaN();
+   * ```
+   */
+  toBeNaN(message?: string): void;
+
+  /**
+   * This function asserts a float is finite.
+   *
+   * @param {string} message - The optional message the describes this expectation.
+   * @example
+   *
+   * ```ts
+   * expect<f32>(42).toBeFinite();
+   * expect<f64>(Infinity).not.toBeFinite();
+   * ```
+   */
+  toBeFinite(message?: string): void;
+
+  /**
+   * This method asserts the item has the expected length.
+   *
+   * @param {i32} expected - The expected length.
+   * @param {string} message - The optional message the describes this expectation.
+   *
+   * ```ts
+   * expect<i32[]>([1, 2, 3]).toHaveLength(3);
+   * ```
+   */
+  toHaveLength(expected: i32, message?: string): void;
+
+  /**
+   * This method asserts that a given T that extends `Array<U>` has a value/reference included.
+   *
+   * @param {valueof<T>} expected - The expected item to be included in the Array.
+   * @param {string} message - The optional message the describes this expectation.
+   *
+   * @example
+   *
+   * ```ts
+   * expect<i32[]>([1, 2, 3]).toInclude(3);
+   * ```
+   */
+  // @ts-ignore: expected value should be known at compile time
+  toInclude(expected: valueof<T>, message?: string): void;
+
+  /**
+   * This method asserts that a given T that extends `Array<U>` has a value/reference included.
+   *
+   * @param {valueof<T>} expected - The expected item to be included in the Array.
+   * @param {string} message - The optional message the describes this expectation.
+   *
+   * @example
+   *
+   * ```ts
+   * expect<i32[]>([1, 2, 3]).toContain(3);
+   * ```
+   */
+   // @ts-ignore: expected value should be known at compile time
+  toContain(expected: valueof<T>, message?: string): void;
+
+  /**
+   * This method asserts that a given T that extends `Array<U>` has a value/reference included and
+   * compared via memory.compare().
+   *
+   * @param {i32} expected - The expected item to be included in the Array.
+   * @param {string} message - The optional message the describes this expectation.
+   *
+   * @example
+   * ```ts
+   * expect<Vec3[]>([new Vec3(1, 2, 3)]).toInclude(new Vec3(1, 2, 3));
+   * ```
+   */
+  // @ts-ignore: expected value should be known at compile time
+  toIncludeEqual(expected: valueof<T>, message?: string): void;
+
+  /**
+   * This method asserts that a given T that extends `Array<U>` has a value/reference included and
+   * compared via memory.compare().
+   *
+   * @param {i32} expected - The expected item to be included in the Array.
+   * @param {string} message - The optional message the describes this expectation.
+   *
+   * @example
+   * ```ts
+   * expect<Vec3[]>([new Vec3(1, 2, 3)]).toInclude(new Vec3(1, 2, 3));
+   * ```
+   */
+  // @ts-ignore: expected value should be known at compile time
+  toContainEqual(expected: valueof<T>, message?: string): void;
+
+  /**
+   * This computed property is chainable, and negates the existing expectation. It returns itself.
+   *
+   * @example
+   * ```ts
+   * expect<i32>(42).not.toBe(0, "42 is not 0");
+   */
+  not: Expectation<T>;
+
+  /**
+   * The actual value of the expectation.
+   */
+  actual: T | null;
+}
+
+/**
+ * This is called to stop the debugger.  e.g. `node --inspect-brk asp`.
+ */
+declare function debug(): void;
+
+/**
+ * This class contains a set of methods related to performance configuration.
+ */
+// @ts-ignore
+declare class Performance {
+  /**
+   * This function call enables performance statistics gathering for the following test.
+   *
+   * @param {bool} enabled - The bool to indicate if performance statistics should be gathered.
+   */
+  public static enabled(enabled: bool): void;
+
+  /**
+   * This function call sets the maximum number of samples to complete the following test.
+   *
+   * @param {f64} count - The maximum number of samples required.
+   */
+  public static maxSamples(count: f64): void;
+
+  /**
+   * This function call sets the number of decimal places to round to for the following test.
+   *
+   * @param {i32} deicmalPlaces - The number of decimal places to round to
+   */
+  public static roundDecimalPlaces(count: i32): void;
+
+  /**
+   * This function call will set the maximum amount of time that should pass before it can stop
+   * gathering samples for the following test.
+   *
+   * @param {f64} time - The ammount of time in milliseconds.
+   */
+  public static maxTestRunTime(time: f64): void;
+
+  /**
+   * This function call enables gathering the average/mean run time of each sample for the following
+   * test.
+   *
+   * @param {bool} enabled - The bool to indicate if the average/mean should be gathered.
+   */
+  public static reportAverage(enabled: bool): void;
+
+  /**
+   * This function call enables gathering the median run time of each sample for the following test.
+   *
+   * @param {bool} enabled - The bool to indicate if the median should be gathered.
+   */
+  public static reportMedian(value: bool): void;
+
+  /**
+   * This function call enables gathering the standard deviation of the run times of the samples
+   * collected for the following test.
+   *
+   * @param {bool} enabled - The bool to indicate if the standard deviation should be gathered.
+   */
+  public static reportStdDev(value: bool): void;
+
+  /**
+   * This function call enables gathering the largest run time of the samples collected for the
+   * following test.
+   *
+   * @param {bool} enabled - The bool to indicate if the max should be gathered.
+   */
+  public static reportMax(value: bool): void;
+
+  /**
+   * This function call enables gathering the smallest run time of the samples collected for the
+   * following test.
+   *
+   * @param {bool} enabled - The bool to indicate if the min should be gathered.
+   */
+  public static reportMin(value: bool): void;
+
+  /**
+   * This function call enables gathering the varaince of the samples collected for the following test.
+   *
+   * @param {bool} enabled - The bool to indicate if the variance should be calculated.
+   */
+  public static reportVariance(value: bool): void;
+}
+/**
+ * Assemblyscript uses reference counting to perform garbage collection.  This means when you 
+ * allocate a managed object and return it, it's reference count is one.  If another variable aliases
+ * it then the reference count goes up. This static class contains a few convenience methods for 
+ * developers to test the current number of blocks allocated on the heap to make sure you aren't leaking
+ * references, e.i. keeping references to objects you expect to be collected.
+ */
+declare class RTrace {
+  /**
+   * This bool indicates if `RTrace` should call into JavaScript to obtain reference counts.
+   */
+  public static enabled: bool;
+
+  /**
+   * This method returns the current number of active references on the heap.
+   */
+  public static count(): i32;
+
+  /**
+   * This method starts a new refcounting group, and causes the next call to `RTrace.end(label)` to
+   * return a delta in reference counts on the heap.
+   *
+   * @param {i32} label - The numeric label for this refcounting group.
+   */
+  public static start(label: i32): void;
+
+  /**
+   * This method returns a delta of how many new (positive) or collected (negative) are on the heap.
+   *
+   * @param {i32} label - The numeric label for this refcounting group.
+   */
+  public static end(label: i32): i32;
+
+  /**
+   * This method returns the number of increments that have occurred over the course of a test
+   * file.
+   */
+  public static increments(): i32;
+
+  /**
+   * This method returns the number of decrements that have occurred over the course of a test
+   * file.
+   */
+  public static decrements(): i32;
+
+  /**
+   * This method returns the number of increments that have occurred over the course of a test
+   * group.
+   */
+  public static groupIncrements(): i32;
+
+  /**
+   * This method returns the number of decrements that have occurred over the course of a test
+   * group.
+   */
+  public static groupDecrements(): i32;
+
+  /**
+   * This method returns the number of increments that have occurred over the course of a test
+   * group.
+   */
+  public static testIncrements(): i32;
+
+  /**
+   * This method returns the number of decrements that have occurred over the course of a test
+   * group.
+   */
+  public static testDecrements(): i32;
+
+  /**
+   * This method returns the number of allocations that have occurred over the course of a test
+   * file.
+   */
+  public static allocations(): i32;
+
+  /**
+   * This method returns the number of frees that have occurred over the course of a test
+   * file.
+   */
+  public static frees(): i32;
+
+  /**
+   * This method returns the number of allocations that have occurred over the course of a test
+   * group.
+   */
+  public static groupAllocations(): i32;
+
+  /**
+   * This method returns the number of frees that have occurred over the course of a test
+   * group.
+   */
+  public static groupFrees(): i32;
+
+  /**
+   * This method returns the number of allocations that have occurred over the course of a test
+   * group.
+   */
+  public static testAllocations(): i32;
+
+  /**
+   * This method returns the number of frees that have occurred over the course of a test
+   * group.
+   */
+  public static testFrees(): i32;
+
+  /**
+   * This method triggers a garbage collection.
+   */
+  public static collect(): void;
+
+  /**
+   * Get the class id of the pointer.
+   *
+   * @param {usize} pointer - The pointer.
+   * @returns {u32} - The class id of the allocated block.
+   */
+  public static classIdOf(pointer: usize): u32;
+
+  /**
+   * Get the size of a block or buffer.
+   *
+   * @param {T} reference - The reference.
+   * @returns {u32} - The size of the allocated block.
+   */
+  public static sizeOf<T>(reference: T): u32;
+
+  /**
+   * Get the currently allocated blocks.
+   */
+  public static activeBlocks(): usize[];
+
+  /**
+   * Get the current groups allocated blocks.
+   */
+  public static activeGroupBlocks(): usize[];
+
+  /**
+   * Get the current tests allocated blocks.
+   */
+  public static activeTestBlocks(): usize[];
+}
+
+
+/**
+ * This class is static and contains private global values that contain metadata about the Actual
+ * value.
+ *
+ * @example
+ * ```ts
+ * Actual.report<string>("This is an expected string.");
+ * Actual.report<i32[]>([1, 2, 3]);
+ * Actual.report<u8>(42);
+ * ```
+ */
+declare class Actual {
+  /**
+   * This function performs reporting to javascript what the actual value of this expectation is.
+   *
+   * @param {T} actual - The actual value to be reported.
+   */
+  public static report<T>(value: T): void;
+
+  /**
+   * Clear the actual value and release any private memory stored as a global.
+   */
+  public static clear(): void;
+}
+
+
+/**
+ * This class is static and contains private global values that contain metadata about the Expected
+ * value.
+ *
+ * @example
+ * ```ts
+ * Expected.report<string>("This is an expected string.");
+ * Expected.report<i32[]>([1, 2, 3]);
+ * Expected.report<u8>(42, i32(true)); // not 42
+ * ```
+ */
+declare class Expected {
+  /**
+   * This function performs reporting to javascript what the expected value of this expectation is.
+   * It notifies javascript if the expectation is negated.
+   *
+   * @param {T} value - The actual value to be reported.
+   * @param {i32} negated - An indicator if the expectation is negated. Pass `1` to negate the
+   * expectation. (default: 0)
+   */
+  public static report<T>(value: T, negated?: i32): void;
+
+  /**
+   * Clear the expected value and release any private memory stored as a global.
+   */
+  public static clear(): void;
+}

--- a/lib/bysyncify/assembly/__tests__/example.spec.ts
+++ b/lib/bysyncify/assembly/__tests__/example.spec.ts
@@ -1,0 +1,111 @@
+// tslint:disable: no-unsafe-any
+// * bysyncify_start_unwind(data : i32): call this to start unwinding the
+//    stack from the current location. "data" must point to a data
+//    structure as described above (with fields containing valid data).
+//
+//  * bysyncify_start_rewind(data : i32): call this to start rewinding the
+//    stack vack up to the location stored in the provided data. This prepares
+//    for the rewind; to start it, you must call the first function in the
+//    call stack to be unwound.
+//
+//  * bysyncify_stop_rewind(): call this to note that rewinding has
+//    concluded, and normal execution can resume.
+@unmanaged
+class asyncify_data {
+  /* current bysyncify stack location */
+  location: i32;
+  /* bysyncify stack end */
+  end: i32;
+
+  @inline
+  constructor(location: i32, end: i32){
+    this.location = location;
+    this.end = end;
+  }
+}
+
+declare var __asyncify_data: i32;
+declare var __asyncify_state: i32;
+
+const enum asyncify_state {
+  //   0: normal execution
+  //   1: unwinding the stack
+  //   2: rewinding the stack
+  NormalExecution = 0,
+  UnwindingStack = 1,
+  RewindingStack = 2
+}
+
+// declare function log<T>(x: T): void;
+//@ts-ignore
+@external("asyncify", "start_unwind")
+declare function asyncify_start_unwind(data: asyncify_data): void;
+
+//@ts-ignore
+@external("asyncify", "stop_unwind")
+declare function asyncify_stop_unwind(): void;
+
+//@ts-ignore
+@external("asyncify", "start_rewind")
+declare function asyncify_start_rewind(data: asyncify_data): void;
+//@ts-ignore
+@external("asyncify", "stop_unwind")
+declare function asyncify_stop_rewind(): void;
+
+var global_var: i32 = 42;
+var generator = new asyncify_data(16, 1024);
+var sleeping: boolean = false;
+
+var  print = (x: i32): void => { log<i32>(x); };
+
+function sleep(): void {
+  print(1000);
+  if (!sleeping) {
+    print(2000);
+    sleeping = true;
+    asyncify_start_unwind(generator);
+  } else {
+    print(3000);
+    asyncify_stop_rewind();
+    sleeping = false;
+  }
+  print(4000);
+}
+
+function before(): void {
+  print(1);
+}
+function after(): void {
+  print(2);
+}
+
+function main(): void {
+  print(10);
+  before();
+  print(20);
+  sleep();
+  print(30);
+  after();
+  print(40);
+}
+
+function start(): void {
+  print(100);
+  main();
+  print(200);
+  asyncify_stop_unwind();
+  print(300);
+
+  log("could now be doing async stuff");
+
+  asyncify_start_rewind(generator);
+  print(400);
+  main();
+  print(500);
+}
+
+describe("asyncify", (): void => {
+  it("should print correctly", (): void => {
+    start();
+  })
+})

--- a/lib/bysyncify/assembly/__tests__/example.spec.wat
+++ b/lib/bysyncify/assembly/__tests__/example.spec.wat
@@ -1,0 +1,4666 @@
+(module
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$vdii (func (param f64 i32 i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$vdiii (func (param f64 i32 i32 i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$i (func (result i32)))
+ (import "__aspect" "logValue" (func $node_modules/@as-pect/assembly/assembly/internal/log/logInteger (param i32 i32)))
+ (import "__aspect" "logString" (func $node_modules/@as-pect/assembly/assembly/internal/log/logString (param i32)))
+ (import "__aspect" "reportTest" (func $node_modules/@as-pect/assembly/assembly/internal/Test/reportTest (param i32 i32)))
+ (import "__aspect" "reportDescribe" (func $node_modules/@as-pect/assembly/assembly/internal/Describe/reportDescribe (param i32)))
+ (import "__aspect" "reportEndDescribe" (func $node_modules/@as-pect/assembly/assembly/internal/Describe/reportEndDescribe))
+ (import "__aspect" "reportActualArray" (func $node_modules/@as-pect/assembly/assembly/internal/report/Actual/reportActualArray (param i32 i32)))
+ (import "__aspect" "reportActualValue" (func $node_modules/@as-pect/assembly/assembly/internal/report/Actual/reportActualFloat (param f64 i32 i32)))
+ (import "__aspect" "reportActualValue" (func $node_modules/@as-pect/assembly/assembly/internal/report/Actual/reportActualInteger (param i32 i32 i32)))
+ (import "__aspect" "reportActualNull" (func $node_modules/@as-pect/assembly/assembly/internal/report/Actual/reportActualNull (param i32)))
+ (import "__aspect" "reportActualReference" (func $node_modules/@as-pect/assembly/assembly/internal/report/Actual/reportActualReferenceExternal (param i32 i32 i32)))
+ (import "__aspect" "reportActualString" (func $node_modules/@as-pect/assembly/assembly/internal/report/Actual/reportActualString (param i32 i32)))
+ (import "__aspect" "reportActualLong" (func $node_modules/@as-pect/assembly/assembly/internal/report/Actual/reportActualLong (param i32 i32 i32)))
+ (import "__aspect" "reportActualBool" (func $node_modules/@as-pect/assembly/assembly/internal/report/Actual/reportActualBool (param i32 i32)))
+ (import "__aspect" "reportExpectedArray" (func $node_modules/@as-pect/assembly/assembly/internal/report/Expected/reportExpectedArray (param i32 i32 i32)))
+ (import "__aspect" "reportExpectedValue" (func $node_modules/@as-pect/assembly/assembly/internal/report/Expected/reportExpectedFloat (param f64 i32 i32 i32)))
+ (import "__aspect" "reportExpectedValue" (func $node_modules/@as-pect/assembly/assembly/internal/report/Expected/reportExpectedInteger (param i32 i32 i32 i32)))
+ (import "__aspect" "reportExpectedNull" (func $node_modules/@as-pect/assembly/assembly/internal/report/Expected/reportExpectedNull (param i32 i32)))
+ (import "__aspect" "reportExpectedReference" (func $node_modules/@as-pect/assembly/assembly/internal/report/Expected/reportExpectedReferenceExternal (param i32 i32 i32 i32)))
+ (import "__aspect" "reportExpectedString" (func $node_modules/@as-pect/assembly/assembly/internal/report/Expected/reportExpectedString (param i32 i32 i32)))
+ (import "__aspect" "reportExpectedFalsy" (func $node_modules/@as-pect/assembly/assembly/internal/report/Expected/reportExpectedFalsy (param i32 i32)))
+ (import "__aspect" "reportExpectedFinite" (func $node_modules/@as-pect/assembly/assembly/internal/report/Expected/reportExpectedFinite (param i32 i32)))
+ (import "__aspect" "reportExpectedTruthy" (func $node_modules/@as-pect/assembly/assembly/internal/report/Expected/reportExpectedTruthy (param i32 i32)))
+ (import "__aspect" "reportExpectedLong" (func $node_modules/@as-pect/assembly/assembly/internal/report/Expected/reportExpectedLong (param i32 i32 i32 i32)))
+ (import "__aspect" "reportExpectedBool" (func $node_modules/@as-pect/assembly/assembly/internal/report/Expected/reportExpectedBool (param i32 i32 i32)))
+ (memory $0 1)
+ (data (i32.const 8) "\10\00\00\00\01\00\00\00\01\00\00\00\10\00\00\00a\00s\00y\00n\00c\00i\00f\00y\00")
+ (data (i32.const 40) ",\00\00\00\01\00\00\00\01\00\00\00,\00\00\00s\00h\00o\00u\00l\00d\00 \00p\00r\00i\00n\00t\00 \00c\00o\00r\00r\00e\00c\00t\00l\00y\00")
+ (data (i32.const 104) "<\00\00\00\01\00\00\00\01\00\00\00<\00\00\00c\00o\00u\00l\00d\00 \00n\00o\00w\00 \00b\00e\00 \00d\00o\00i\00n\00g\00 \00a\00s\00y\00n\00c\00 \00s\00t\00u\00f\00f\00")
+ (data (i32.const 184) "\04\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\93\00\00\00\02\00\00\00")
+ (table $0 5 funcref)
+ (elem (i32.const 0) $null $start:assembly/__tests__/example.spec~anonymous|0 $start:assembly/__tests__/example.spec~anonymous|1~anonymous|0 $start:assembly/__tests__/example.spec~anonymous|1 $start:node_modules/@as-pect/assembly/assembly/internal/noOp~anonymous|0)
+ (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
+ (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
+ (global $assembly/__tests__/example.spec/global_var (mut i32) (i32.const 42))
+ (global $assembly/__tests__/example.spec/generator (mut i32) (i32.const 0))
+ (global $assembly/__tests__/example.spec/sleeping (mut i32) (i32.const 0))
+ (global $node_modules/@as-pect/assembly/assembly/internal/log/ignoreLogs (mut i32) (i32.const 0))
+ (global $assembly/__tests__/example.spec/print (mut i32) (i32.const 1))
+ (global $~lib/argc (mut i32) (i32.const 0))
+ (global $node_modules/@as-pect/assembly/assembly/internal/noOp/noOp i32 (i32.const 4))
+ (global $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.type (mut i32) (i32.const 0))
+ (global $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.signed (mut i32) (i32.const 0))
+ (global $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.float (mut f64) (f64.const 0))
+ (global $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.integer (mut i32) (i32.const 0))
+ (global $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.reference (mut i32) (i32.const 0))
+ (global $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.offset (mut i32) (i32.const 0))
+ (global $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.stackTrace (mut i32) (i32.const -1))
+ (global $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.ready (mut i32) (i32.const 0))
+ (global $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.type (mut i32) (i32.const 0))
+ (global $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.signed (mut i32) (i32.const 0))
+ (global $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.float (mut f64) (f64.const 0))
+ (global $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.integer (mut i32) (i32.const 0))
+ (global $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.reference (mut i32) (i32.const 0))
+ (global $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.offset (mut i32) (i32.const 0))
+ (global $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.negated (mut i32) (i32.const 0))
+ (global $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.stackTrace (mut i32) (i32.const 0))
+ (global $node_modules/@as-pect/assembly/assembly/internal/RTrace/RTrace.enabled (mut i32) (i32.const 1))
+ (global $~lib/started (mut i32) (i32.const 0))
+ (global $~lib/rt/__rtti_base i32 (i32.const 184))
+ (global $~lib/heap/__heap_base i32 (i32.const 220))
+ (global $__asyncify_state (mut i32) (i32.const 0))
+ (global $__asyncify_data (mut i32) (i32.const 0))
+ (export "__start" (func $start))
+ (export "memory" (memory $0))
+ (export "__alloc" (func $~lib/rt/stub/__alloc))
+ (export "__retain" (func $~lib/rt/stub/__retain))
+ (export "__release" (func $~lib/rt/stub/__release))
+ (export "__collect" (func $~lib/rt/stub/__collect))
+ (export "__rtti_base" (global $~lib/rt/__rtti_base))
+ (export "__ready" (func $node_modules/@as-pect/assembly/assembly/index/__ready))
+ (export "__call" (func $node_modules/@as-pect/assembly/assembly/internal/call/__call))
+ (export "__sendActual" (func $node_modules/@as-pect/assembly/assembly/internal/report/Actual/__sendActual))
+ (export "__sendExpected" (func $node_modules/@as-pect/assembly/assembly/internal/report/Expected/__sendExpected))
+ (export "__ignoreLogs" (func $node_modules/@as-pect/assembly/assembly/internal/log/__ignoreLogs))
+ (export "__disableRTrace" (func $node_modules/@as-pect/assembly/assembly/internal/RTrace/__disableRTrace))
+ (export "__getUsizeArrayId" (func $node_modules/@as-pect/assembly/assembly/internal/RTrace/__getUsizeArrayId))
+ (export "__cleanup" (func $node_modules/@as-pect/assembly/assembly/internal/Expectation/__cleanup))
+ (export "asyncify_start_unwind" (func $asyncify_start_unwind))
+ (export "asyncify_stop_unwind" (func $asyncify_stop_unwind))
+ (export "asyncify_start_rewind" (func $asyncify_start_rewind))
+ (export "asyncify_stop_rewind" (func $asyncify_stop_rewind))
+ (func $~lib/rt/stub/__alloc (; 24 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  (local $60 i32)
+  local.get $0
+  local.set $9
+  local.get $9
+  i32.const 1073741808
+  i32.gt_u
+  local.set $10
+  local.get $10
+  if
+   unreachable
+  end
+  nop
+  global.get $~lib/rt/stub/offset
+  local.set $11
+  local.get $11
+  i32.const 16
+  i32.add
+  local.set $12
+  local.get $12
+  local.set $2
+  nop
+  local.get $2
+  local.set $13
+  local.get $0
+  local.set $14
+  local.get $14
+  local.set $3
+  local.get $3
+  local.set $15
+  i32.const 1
+  local.set $4
+  local.get $4
+  local.set $16
+  local.get $3
+  local.set $17
+  local.get $4
+  local.set $18
+  local.get $17
+  local.get $18
+  i32.gt_u
+  local.set $19
+  local.get $15
+  local.get $16
+  local.get $19
+  select
+  local.set $20
+  local.get $13
+  local.get $20
+  i32.add
+  local.set $21
+  local.get $21
+  i32.const 15
+  i32.add
+  local.set $22
+  i32.const 15
+  i32.const -1
+  i32.xor
+  local.set $23
+  local.get $22
+  local.get $23
+  i32.and
+  local.set $24
+  local.get $24
+  local.set $5
+  nop
+  memory.size
+  local.set $25
+  local.get $25
+  local.set $6
+  nop
+  local.get $5
+  local.set $26
+  local.get $6
+  local.set $27
+  local.get $27
+  i32.const 16
+  i32.shl
+  local.set $28
+  local.get $26
+  local.get $28
+  i32.gt_u
+  local.set $29
+  local.get $29
+  if
+   local.get $5
+   local.set $30
+   local.get $2
+   local.set $31
+   local.get $30
+   local.get $31
+   i32.sub
+   local.set $32
+   local.get $32
+   i32.const 65535
+   i32.add
+   local.set $33
+   i32.const 65535
+   i32.const -1
+   i32.xor
+   local.set $34
+   local.get $33
+   local.get $34
+   i32.and
+   local.set $35
+   local.get $35
+   i32.const 16
+   i32.shr_u
+   local.set $36
+   local.get $36
+   local.set $3
+   nop
+   local.get $6
+   local.set $37
+   local.get $37
+   local.set $4
+   local.get $4
+   local.set $38
+   local.get $3
+   local.set $39
+   local.get $39
+   local.set $7
+   local.get $7
+   local.set $40
+   local.get $4
+   local.set $41
+   local.get $7
+   local.set $42
+   local.get $41
+   local.get $42
+   i32.gt_s
+   local.set $43
+   local.get $38
+   local.get $40
+   local.get $43
+   select
+   local.set $44
+   local.get $44
+   local.set $4
+   nop
+   local.get $4
+   local.set $45
+   local.get $45
+   memory.grow
+   local.set $46
+   local.get $46
+   i32.const 0
+   i32.lt_s
+   local.set $47
+   local.get $47
+   if
+    local.get $3
+    local.set $48
+    local.get $48
+    memory.grow
+    local.set $49
+    local.get $49
+    i32.const 0
+    i32.lt_s
+    local.set $50
+    local.get $50
+    if
+     unreachable
+    end
+    nop
+   end
+   nop
+   nop
+  end
+  nop
+  local.get $5
+  local.set $51
+  local.get $51
+  global.set $~lib/rt/stub/offset
+  nop
+  local.get $2
+  local.set $52
+  local.get $52
+  i32.const 16
+  i32.sub
+  local.set $53
+  local.get $53
+  local.set $8
+  nop
+  local.get $8
+  local.set $54
+  local.get $1
+  local.set $55
+  local.get $54
+  local.get $55
+  i32.store offset=8
+  nop
+  local.get $8
+  local.set $56
+  local.get $0
+  local.set $57
+  local.get $56
+  local.get $57
+  i32.store offset=12
+  nop
+  local.get $2
+  local.set $58
+  local.get $58
+  local.set $59
+  local.get $59
+  local.set $60
+  local.get $60
+  return
+ )
+ (func $~lib/rt/stub/__retain (; 25 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  local.get $0
+  local.set $1
+  local.get $1
+  return
+ )
+ (func $~lib/rt/stub/__release (; 26 ;) (type $FUNCSIG$vi) (param $0 i32)
+  nop
+ )
+ (func $~lib/rt/stub/__collect (; 27 ;) (type $FUNCSIG$v)
+  nop
+ )
+ (func $node_modules/@as-pect/assembly/assembly/internal/log/log<i32> (; 28 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  global.get $__asyncify_state
+  i32.const 2
+  i32.eq
+  if
+   global.get $__asyncify_data
+   global.get $__asyncify_data
+   i32.load
+   i32.const -64
+   i32.add
+   i32.store
+   global.get $__asyncify_data
+   i32.load
+   local.set $18
+   local.get $18
+   i32.load
+   local.set $0
+   local.get $18
+   i32.load offset=4
+   local.set $1
+   local.get $18
+   i32.load offset=8
+   local.set $2
+   local.get $18
+   i32.load offset=12
+   local.set $3
+   local.get $18
+   i32.load offset=16
+   local.set $4
+   local.get $18
+   i32.load offset=20
+   local.set $5
+   local.get $18
+   i32.load offset=24
+   local.set $6
+   local.get $18
+   i32.load offset=28
+   local.set $7
+   local.get $18
+   i32.load offset=32
+   local.set $8
+   local.get $18
+   i32.load offset=36
+   local.set $9
+   local.get $18
+   i32.load offset=40
+   local.set $10
+   local.get $18
+   i32.load offset=44
+   local.set $11
+   local.get $18
+   i32.load offset=48
+   local.set $12
+   local.get $18
+   i32.load offset=52
+   local.set $13
+   local.get $18
+   i32.load offset=56
+   local.set $14
+   local.get $18
+   i32.load offset=60
+   local.set $15
+  end
+  block $__asyncify_unwind (result i32)
+   global.get $__asyncify_state
+   i32.const 2
+   i32.eq
+   if
+    global.get $__asyncify_data
+    global.get $__asyncify_data
+    i32.load
+    i32.const -4
+    i32.add
+    i32.store
+    global.get $__asyncify_data
+    i32.load
+    i32.load
+    local.set $17
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    global.get $node_modules/@as-pect/assembly/assembly/internal/log/ignoreLogs
+    local.set $1
+    local.get $1
+    if
+     return
+    end
+    nop
+    local.get $0
+    local.set $2
+    local.get $0
+    local.set $3
+    local.get $3
+    drop
+    nop
+    i32.const 1
+    local.set $4
+    local.get $4
+    local.set $5
+    local.get $5
+    if
+     i32.const 1
+     local.set $9
+    else     
+     local.get $0
+     local.set $6
+     local.get $6
+     drop
+     nop
+     i32.const 0
+     local.set $7
+     local.get $7
+     local.set $8
+     local.get $8
+     local.set $9
+    end
+    local.get $9
+    local.set $10
+    local.get $10
+    if
+     i32.const 1
+     local.set $14
+    else     
+     local.get $0
+     local.set $11
+     local.get $11
+     drop
+     nop
+     i32.const 0
+     local.set $12
+     local.get $12
+     local.set $13
+     local.get $13
+     local.set $14
+    end
+    local.get $14
+    local.set $15
+   end
+   nop
+   nop
+   nop
+   nop
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 1
+   else    
+    local.get $17
+    i32.const 0
+    i32.eq
+   end
+   if
+    local.get $2
+    local.get $15
+    call $node_modules/@as-pect/assembly/assembly/internal/log/logInteger
+    global.get $__asyncify_state
+    i32.const 1
+    i32.eq
+    if
+     i32.const 0
+     br $__asyncify_unwind
+    end
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+   end
+   return
+  end
+  local.set $16
+  global.get $__asyncify_data
+  i32.load
+  local.get $16
+  i32.store
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 4
+  i32.add
+  i32.store
+  global.get $__asyncify_data
+  i32.load
+  local.set $19
+  local.get $19
+  local.get $0
+  i32.store
+  local.get $19
+  local.get $1
+  i32.store offset=4
+  local.get $19
+  local.get $2
+  i32.store offset=8
+  local.get $19
+  local.get $3
+  i32.store offset=12
+  local.get $19
+  local.get $4
+  i32.store offset=16
+  local.get $19
+  local.get $5
+  i32.store offset=20
+  local.get $19
+  local.get $6
+  i32.store offset=24
+  local.get $19
+  local.get $7
+  i32.store offset=28
+  local.get $19
+  local.get $8
+  i32.store offset=32
+  local.get $19
+  local.get $9
+  i32.store offset=36
+  local.get $19
+  local.get $10
+  i32.store offset=40
+  local.get $19
+  local.get $11
+  i32.store offset=44
+  local.get $19
+  local.get $12
+  i32.store offset=48
+  local.get $19
+  local.get $13
+  i32.store offset=52
+  local.get $19
+  local.get $14
+  i32.store offset=56
+  local.get $19
+  local.get $15
+  i32.store offset=60
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 64
+  i32.add
+  i32.store
+ )
+ (func $start:assembly/__tests__/example.spec~anonymous|0 (; 29 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  global.get $__asyncify_state
+  i32.const 2
+  i32.eq
+  if
+   global.get $__asyncify_data
+   global.get $__asyncify_data
+   i32.load
+   i32.const -8
+   i32.add
+   i32.store
+   global.get $__asyncify_data
+   i32.load
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $0
+   local.get $4
+   i32.load offset=4
+   local.set $1
+  end
+  block $__asyncify_unwind (result i32)
+   global.get $__asyncify_state
+   i32.const 2
+   i32.eq
+   if
+    global.get $__asyncify_data
+    global.get $__asyncify_data
+    i32.load
+    i32.const -4
+    i32.add
+    i32.store
+    global.get $__asyncify_data
+    i32.load
+    i32.load
+    local.set $3
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    local.get $0
+    local.set $1
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 1
+   else    
+    local.get $3
+    i32.const 0
+    i32.eq
+   end
+   if
+    local.get $1
+    call $node_modules/@as-pect/assembly/assembly/internal/log/log<i32>
+    global.get $__asyncify_state
+    i32.const 1
+    i32.eq
+    if
+     i32.const 0
+     br $__asyncify_unwind
+    end
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+   end
+   return
+  end
+  local.set $2
+  global.get $__asyncify_data
+  i32.load
+  local.get $2
+  i32.store
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 4
+  i32.add
+  i32.store
+  global.get $__asyncify_data
+  i32.load
+  local.set $5
+  local.get $5
+  local.get $0
+  i32.store
+  local.get $5
+  local.get $1
+  i32.store offset=4
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 8
+  i32.add
+  i32.store
+ )
+ (func $assembly/__tests__/example.spec/before (; 30 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  global.get $__asyncify_state
+  i32.const 2
+  i32.eq
+  if
+   global.get $__asyncify_data
+   global.get $__asyncify_data
+   i32.load
+   i32.const -4
+   i32.add
+   i32.store
+   global.get $__asyncify_data
+   i32.load
+   local.set $3
+   local.get $3
+   i32.load
+   local.set $0
+  end
+  block $__asyncify_unwind (result i32)
+   global.get $__asyncify_state
+   i32.const 2
+   i32.eq
+   if
+    global.get $__asyncify_data
+    global.get $__asyncify_data
+    i32.load
+    i32.const -4
+    i32.add
+    i32.store
+    global.get $__asyncify_data
+    i32.load
+    i32.load
+    local.set $2
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    i32.const 1
+    global.set $~lib/argc
+    nop
+    global.get $assembly/__tests__/example.spec/print
+    local.set $0
+   end
+   nop
+   nop
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 1
+   else    
+    local.get $2
+    i32.const 0
+    i32.eq
+   end
+   if
+    i32.const 1
+    local.get $0
+    call_indirect (type $FUNCSIG$vi)
+    global.get $__asyncify_state
+    i32.const 1
+    i32.eq
+    if
+     i32.const 0
+     br $__asyncify_unwind
+    end
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+   end
+   return
+  end
+  local.set $1
+  global.get $__asyncify_data
+  i32.load
+  local.get $1
+  i32.store
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 4
+  i32.add
+  i32.store
+  global.get $__asyncify_data
+  i32.load
+  local.set $4
+  local.get $4
+  local.get $0
+  i32.store
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 4
+  i32.add
+  i32.store
+ )
+ (func $assembly/__tests__/example.spec/sleep (; 31 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  i32.const 1
+  global.set $~lib/argc
+  nop
+  global.get $assembly/__tests__/example.spec/print
+  local.set $0
+  i32.const 1000
+  local.get $0
+  call_indirect (type $FUNCSIG$vi)
+  nop
+  global.get $assembly/__tests__/example.spec/sleeping
+  local.set $1
+  local.get $1
+  i32.eqz
+  local.set $2
+  local.get $2
+  if
+   i32.const 1
+   global.set $~lib/argc
+   nop
+   global.get $assembly/__tests__/example.spec/print
+   local.set $3
+   i32.const 2000
+   local.get $3
+   call_indirect (type $FUNCSIG$vi)
+   nop
+   i32.const 1
+   global.set $assembly/__tests__/example.spec/sleeping
+   nop
+   global.get $assembly/__tests__/example.spec/generator
+   local.set $4
+   local.get $4
+   call $asyncify_start_unwind
+   nop
+   nop
+  else   
+   i32.const 1
+   global.set $~lib/argc
+   nop
+   global.get $assembly/__tests__/example.spec/print
+   local.set $5
+   i32.const 3000
+   local.get $5
+   call_indirect (type $FUNCSIG$vi)
+   nop
+   call $asyncify_stop_unwind
+   nop
+   i32.const 0
+   global.set $assembly/__tests__/example.spec/sleeping
+   nop
+   nop
+  end
+  nop
+  i32.const 1
+  global.set $~lib/argc
+  nop
+  global.get $assembly/__tests__/example.spec/print
+  local.set $6
+  i32.const 4000
+  local.get $6
+  call_indirect (type $FUNCSIG$vi)
+  nop
+  nop
+ )
+ (func $assembly/__tests__/example.spec/after (; 32 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  global.get $__asyncify_state
+  i32.const 2
+  i32.eq
+  if
+   global.get $__asyncify_data
+   global.get $__asyncify_data
+   i32.load
+   i32.const -4
+   i32.add
+   i32.store
+   global.get $__asyncify_data
+   i32.load
+   local.set $3
+   local.get $3
+   i32.load
+   local.set $0
+  end
+  block $__asyncify_unwind (result i32)
+   global.get $__asyncify_state
+   i32.const 2
+   i32.eq
+   if
+    global.get $__asyncify_data
+    global.get $__asyncify_data
+    i32.load
+    i32.const -4
+    i32.add
+    i32.store
+    global.get $__asyncify_data
+    i32.load
+    i32.load
+    local.set $2
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    i32.const 1
+    global.set $~lib/argc
+    nop
+    global.get $assembly/__tests__/example.spec/print
+    local.set $0
+   end
+   nop
+   nop
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 1
+   else    
+    local.get $2
+    i32.const 0
+    i32.eq
+   end
+   if
+    i32.const 2
+    local.get $0
+    call_indirect (type $FUNCSIG$vi)
+    global.get $__asyncify_state
+    i32.const 1
+    i32.eq
+    if
+     i32.const 0
+     br $__asyncify_unwind
+    end
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+   end
+   return
+  end
+  local.set $1
+  global.get $__asyncify_data
+  i32.load
+  local.get $1
+  i32.store
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 4
+  i32.add
+  i32.store
+  global.get $__asyncify_data
+  i32.load
+  local.set $4
+  local.get $4
+  local.get $0
+  i32.store
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 4
+  i32.add
+  i32.store
+ )
+ (func $assembly/__tests__/example.spec/main (; 33 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  global.get $__asyncify_state
+  i32.const 2
+  i32.eq
+  if
+   global.get $__asyncify_data
+   global.get $__asyncify_data
+   i32.load
+   i32.const -16
+   i32.add
+   i32.store
+   global.get $__asyncify_data
+   i32.load
+   local.set $6
+   local.get $6
+   i32.load
+   local.set $0
+   local.get $6
+   i32.load offset=4
+   local.set $1
+   local.get $6
+   i32.load offset=8
+   local.set $2
+   local.get $6
+   i32.load offset=12
+   local.set $3
+  end
+  block $__asyncify_unwind (result i32)
+   global.get $__asyncify_state
+   i32.const 2
+   i32.eq
+   if
+    global.get $__asyncify_data
+    global.get $__asyncify_data
+    i32.load
+    i32.const -4
+    i32.add
+    i32.store
+    global.get $__asyncify_data
+    i32.load
+    i32.load
+    local.set $5
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    i32.const 1
+    global.set $~lib/argc
+    nop
+    global.get $assembly/__tests__/example.spec/print
+    local.set $0
+   end
+   nop
+   nop
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 1
+   else    
+    local.get $5
+    i32.const 0
+    i32.eq
+   end
+   if
+    i32.const 10
+    local.get $0
+    call_indirect (type $FUNCSIG$vi)
+    global.get $__asyncify_state
+    i32.const 1
+    i32.eq
+    if
+     i32.const 0
+     br $__asyncify_unwind
+    end
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 1
+   else    
+    local.get $5
+    i32.const 1
+    i32.eq
+   end
+   if
+    call $assembly/__tests__/example.spec/before
+    global.get $__asyncify_state
+    i32.const 1
+    i32.eq
+    if
+     i32.const 1
+     br $__asyncify_unwind
+    end
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+    i32.const 1
+    global.set $~lib/argc
+    nop
+    global.get $assembly/__tests__/example.spec/print
+    local.set $1
+   end
+   nop
+   nop
+   nop
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 1
+   else    
+    local.get $5
+    i32.const 2
+    i32.eq
+   end
+   if
+    i32.const 20
+    local.get $1
+    call_indirect (type $FUNCSIG$vi)
+    global.get $__asyncify_state
+    i32.const 1
+    i32.eq
+    if
+     i32.const 2
+     br $__asyncify_unwind
+    end
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+    call $assembly/__tests__/example.spec/sleep
+    nop
+    i32.const 1
+    global.set $~lib/argc
+    nop
+    global.get $assembly/__tests__/example.spec/print
+    local.set $2
+   end
+   nop
+   nop
+   nop
+   nop
+   nop
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 1
+   else    
+    local.get $5
+    i32.const 3
+    i32.eq
+   end
+   if
+    i32.const 30
+    local.get $2
+    call_indirect (type $FUNCSIG$vi)
+    global.get $__asyncify_state
+    i32.const 1
+    i32.eq
+    if
+     i32.const 3
+     br $__asyncify_unwind
+    end
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 1
+   else    
+    local.get $5
+    i32.const 4
+    i32.eq
+   end
+   if
+    call $assembly/__tests__/example.spec/after
+    global.get $__asyncify_state
+    i32.const 1
+    i32.eq
+    if
+     i32.const 4
+     br $__asyncify_unwind
+    end
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+    i32.const 1
+    global.set $~lib/argc
+    nop
+    global.get $assembly/__tests__/example.spec/print
+    local.set $3
+   end
+   nop
+   nop
+   nop
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 1
+   else    
+    local.get $5
+    i32.const 5
+    i32.eq
+   end
+   if
+    i32.const 40
+    local.get $3
+    call_indirect (type $FUNCSIG$vi)
+    global.get $__asyncify_state
+    i32.const 1
+    i32.eq
+    if
+     i32.const 5
+     br $__asyncify_unwind
+    end
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+   end
+   return
+  end
+  local.set $4
+  global.get $__asyncify_data
+  i32.load
+  local.get $4
+  i32.store
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 4
+  i32.add
+  i32.store
+  global.get $__asyncify_data
+  i32.load
+  local.set $7
+  local.get $7
+  local.get $0
+  i32.store
+  local.get $7
+  local.get $1
+  i32.store offset=4
+  local.get $7
+  local.get $2
+  i32.store offset=8
+  local.get $7
+  local.get $3
+  i32.store offset=12
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 16
+  i32.add
+  i32.store
+ )
+ (func $node_modules/@as-pect/assembly/assembly/internal/log/log<~lib/string/String> (; 34 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  global.get $__asyncify_state
+  i32.const 2
+  i32.eq
+  if
+   global.get $__asyncify_data
+   global.get $__asyncify_data
+   i32.load
+   i32.const -28
+   i32.add
+   i32.store
+   global.get $__asyncify_data
+   i32.load
+   local.set $9
+   local.get $9
+   i32.load
+   local.set $0
+   local.get $9
+   i32.load offset=4
+   local.set $1
+   local.get $9
+   i32.load offset=8
+   local.set $2
+   local.get $9
+   i32.load offset=12
+   local.set $3
+   local.get $9
+   i32.load offset=16
+   local.set $4
+   local.get $9
+   i32.load offset=20
+   local.set $5
+   local.get $9
+   i32.load offset=24
+   local.set $6
+  end
+  block $__asyncify_unwind (result i32)
+   global.get $__asyncify_state
+   i32.const 2
+   i32.eq
+   if
+    global.get $__asyncify_data
+    global.get $__asyncify_data
+    i32.load
+    i32.const -4
+    i32.add
+    i32.store
+    global.get $__asyncify_data
+    i32.load
+    i32.load
+    local.set $8
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    local.get $0
+    local.set $1
+    local.get $1
+    call $~lib/rt/stub/__retain
+    local.set $2
+    local.get $2
+    drop
+    nop
+    global.get $node_modules/@as-pect/assembly/assembly/internal/log/ignoreLogs
+    local.set $3
+    local.get $3
+    if
+     local.get $0
+     local.set $4
+     local.get $4
+     call $~lib/rt/stub/__release
+     nop
+     return
+    end
+    nop
+    local.get $0
+    local.set $5
+   end
+   nop
+   nop
+   nop
+   nop
+   nop
+   nop
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 1
+   else    
+    local.get $8
+    i32.const 0
+    i32.eq
+   end
+   if
+    local.get $5
+    call $node_modules/@as-pect/assembly/assembly/internal/log/logString
+    global.get $__asyncify_state
+    i32.const 1
+    i32.eq
+    if
+     i32.const 0
+     br $__asyncify_unwind
+    end
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+    local.get $0
+    local.set $6
+    local.get $6
+    call $~lib/rt/stub/__release
+    nop
+   end
+   nop
+   nop
+   nop
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+   end
+   return
+  end
+  local.set $7
+  global.get $__asyncify_data
+  i32.load
+  local.get $7
+  i32.store
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 4
+  i32.add
+  i32.store
+  global.get $__asyncify_data
+  i32.load
+  local.set $10
+  local.get $10
+  local.get $0
+  i32.store
+  local.get $10
+  local.get $1
+  i32.store offset=4
+  local.get $10
+  local.get $2
+  i32.store offset=8
+  local.get $10
+  local.get $3
+  i32.store offset=12
+  local.get $10
+  local.get $4
+  i32.store offset=16
+  local.get $10
+  local.get $5
+  i32.store offset=20
+  local.get $10
+  local.get $6
+  i32.store offset=24
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 28
+  i32.add
+  i32.store
+ )
+ (func $assembly/__tests__/example.spec/start (; 35 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  i32.const 1
+  global.set $~lib/argc
+  nop
+  global.get $assembly/__tests__/example.spec/print
+  local.set $0
+  i32.const 100
+  local.get $0
+  call_indirect (type $FUNCSIG$vi)
+  nop
+  call $assembly/__tests__/example.spec/main
+  nop
+  i32.const 1
+  global.set $~lib/argc
+  nop
+  global.get $assembly/__tests__/example.spec/print
+  local.set $1
+  i32.const 200
+  local.get $1
+  call_indirect (type $FUNCSIG$vi)
+  nop
+  call $asyncify_stop_unwind
+  nop
+  i32.const 1
+  global.set $~lib/argc
+  nop
+  global.get $assembly/__tests__/example.spec/print
+  local.set $2
+  i32.const 300
+  local.get $2
+  call_indirect (type $FUNCSIG$vi)
+  nop
+  i32.const 120
+  call $node_modules/@as-pect/assembly/assembly/internal/log/log<~lib/string/String>
+  nop
+  global.get $assembly/__tests__/example.spec/generator
+  local.set $3
+  local.get $3
+  call $asyncify_start_rewind
+  nop
+  i32.const 1
+  global.set $~lib/argc
+  nop
+  global.get $assembly/__tests__/example.spec/print
+  local.set $4
+  i32.const 400
+  local.get $4
+  call_indirect (type $FUNCSIG$vi)
+  nop
+  call $assembly/__tests__/example.spec/main
+  nop
+  i32.const 1
+  global.set $~lib/argc
+  nop
+  global.get $assembly/__tests__/example.spec/print
+  local.set $5
+  i32.const 500
+  local.get $5
+  call_indirect (type $FUNCSIG$vi)
+  nop
+  nop
+ )
+ (func $start:assembly/__tests__/example.spec~anonymous|1~anonymous|0 (; 36 ;) (type $FUNCSIG$v)
+  call $assembly/__tests__/example.spec/start
+  nop
+ )
+ (func $node_modules/@as-pect/assembly/assembly/internal/Test/it (; 37 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  global.get $__asyncify_state
+  i32.const 2
+  i32.eq
+  if
+   global.get $__asyncify_data
+   global.get $__asyncify_data
+   i32.load
+   i32.const -28
+   i32.add
+   i32.store
+   global.get $__asyncify_data
+   i32.load
+   local.set $9
+   local.get $9
+   i32.load
+   local.set $0
+   local.get $9
+   i32.load offset=4
+   local.set $1
+   local.get $9
+   i32.load offset=8
+   local.set $2
+   local.get $9
+   i32.load offset=12
+   local.set $3
+   local.get $9
+   i32.load offset=16
+   local.set $4
+   local.get $9
+   i32.load offset=20
+   local.set $5
+   local.get $9
+   i32.load offset=24
+   local.set $6
+  end
+  block $__asyncify_unwind (result i32)
+   global.get $__asyncify_state
+   i32.const 2
+   i32.eq
+   if
+    global.get $__asyncify_data
+    global.get $__asyncify_data
+    i32.load
+    i32.const -4
+    i32.add
+    i32.store
+    global.get $__asyncify_data
+    i32.load
+    i32.load
+    local.set $8
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    local.get $0
+    local.set $2
+    local.get $2
+    call $~lib/rt/stub/__retain
+    local.set $3
+    local.get $3
+    drop
+    nop
+    local.get $0
+    local.set $4
+    local.get $1
+    local.set $5
+   end
+   nop
+   nop
+   nop
+   nop
+   nop
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 1
+   else    
+    local.get $8
+    i32.const 0
+    i32.eq
+   end
+   if
+    local.get $4
+    local.get $5
+    call $node_modules/@as-pect/assembly/assembly/internal/Test/reportTest
+    global.get $__asyncify_state
+    i32.const 1
+    i32.eq
+    if
+     i32.const 0
+     br $__asyncify_unwind
+    end
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+    local.get $0
+    local.set $6
+    local.get $6
+    call $~lib/rt/stub/__release
+    nop
+   end
+   nop
+   nop
+   nop
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+   end
+   return
+  end
+  local.set $7
+  global.get $__asyncify_data
+  i32.load
+  local.get $7
+  i32.store
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 4
+  i32.add
+  i32.store
+  global.get $__asyncify_data
+  i32.load
+  local.set $10
+  local.get $10
+  local.get $0
+  i32.store
+  local.get $10
+  local.get $1
+  i32.store offset=4
+  local.get $10
+  local.get $2
+  i32.store offset=8
+  local.get $10
+  local.get $3
+  i32.store offset=12
+  local.get $10
+  local.get $4
+  i32.store offset=16
+  local.get $10
+  local.get $5
+  i32.store offset=20
+  local.get $10
+  local.get $6
+  i32.store offset=24
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 28
+  i32.add
+  i32.store
+ )
+ (func $start:assembly/__tests__/example.spec~anonymous|1 (; 38 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  global.get $__asyncify_state
+  i32.const 2
+  i32.eq
+  if
+   nop
+  end
+  block $__asyncify_unwind (result i32)
+   global.get $__asyncify_state
+   i32.const 2
+   i32.eq
+   if
+    global.get $__asyncify_data
+    global.get $__asyncify_data
+    i32.load
+    i32.const -4
+    i32.add
+    i32.store
+    global.get $__asyncify_data
+    i32.load
+    i32.load
+    local.set $1
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 1
+   else    
+    local.get $1
+    i32.const 0
+    i32.eq
+   end
+   if
+    i32.const 56
+    i32.const 2
+    call $node_modules/@as-pect/assembly/assembly/internal/Test/it
+    global.get $__asyncify_state
+    i32.const 1
+    i32.eq
+    if
+     i32.const 0
+     br $__asyncify_unwind
+    end
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+   end
+   return
+  end
+  local.set $0
+  global.get $__asyncify_data
+  i32.load
+  local.get $0
+  i32.store
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 4
+  i32.add
+  i32.store
+  nop
+ )
+ (func $start:node_modules/@as-pect/assembly/assembly/internal/noOp~anonymous|0 (; 39 ;) (type $FUNCSIG$v)
+  nop
+ )
+ (func $node_modules/@as-pect/assembly/assembly/internal/Describe/describe (; 40 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  global.get $__asyncify_state
+  i32.const 2
+  i32.eq
+  if
+   global.get $__asyncify_data
+   global.get $__asyncify_data
+   i32.load
+   i32.const -28
+   i32.add
+   i32.store
+   global.get $__asyncify_data
+   i32.load
+   local.set $9
+   local.get $9
+   i32.load
+   local.set $0
+   local.get $9
+   i32.load offset=4
+   local.set $1
+   local.get $9
+   i32.load offset=8
+   local.set $2
+   local.get $9
+   i32.load offset=12
+   local.set $3
+   local.get $9
+   i32.load offset=16
+   local.set $4
+   local.get $9
+   i32.load offset=20
+   local.set $5
+   local.get $9
+   i32.load offset=24
+   local.set $6
+  end
+  block $__asyncify_unwind (result i32)
+   global.get $__asyncify_state
+   i32.const 2
+   i32.eq
+   if
+    global.get $__asyncify_data
+    global.get $__asyncify_data
+    i32.load
+    i32.const -4
+    i32.add
+    i32.store
+    global.get $__asyncify_data
+    i32.load
+    i32.load
+    local.set $8
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    local.get $0
+    local.set $2
+    local.get $2
+    call $~lib/rt/stub/__retain
+    local.set $3
+    local.get $3
+    drop
+    nop
+    local.get $0
+    local.set $4
+   end
+   nop
+   nop
+   nop
+   nop
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 1
+   else    
+    local.get $8
+    i32.const 0
+    i32.eq
+   end
+   if
+    local.get $4
+    call $node_modules/@as-pect/assembly/assembly/internal/Describe/reportDescribe
+    global.get $__asyncify_state
+    i32.const 1
+    i32.eq
+    if
+     i32.const 0
+     br $__asyncify_unwind
+    end
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+    i32.const 0
+    global.set $~lib/argc
+    nop
+    local.get $1
+    local.set $5
+   end
+   nop
+   nop
+   nop
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 1
+   else    
+    local.get $8
+    i32.const 1
+    i32.eq
+   end
+   if
+    local.get $5
+    call_indirect (type $FUNCSIG$v)
+    global.get $__asyncify_state
+    i32.const 1
+    i32.eq
+    if
+     i32.const 1
+     br $__asyncify_unwind
+    end
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 1
+   else    
+    local.get $8
+    i32.const 2
+    i32.eq
+   end
+   if
+    call $node_modules/@as-pect/assembly/assembly/internal/Describe/reportEndDescribe
+    global.get $__asyncify_state
+    i32.const 1
+    i32.eq
+    if
+     i32.const 2
+     br $__asyncify_unwind
+    end
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+    local.get $0
+    local.set $6
+    local.get $6
+    call $~lib/rt/stub/__release
+    nop
+   end
+   nop
+   nop
+   nop
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+   end
+   return
+  end
+  local.set $7
+  global.get $__asyncify_data
+  i32.load
+  local.get $7
+  i32.store
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 4
+  i32.add
+  i32.store
+  global.get $__asyncify_data
+  i32.load
+  local.set $10
+  local.get $10
+  local.get $0
+  i32.store
+  local.get $10
+  local.get $1
+  i32.store offset=4
+  local.get $10
+  local.get $2
+  i32.store offset=8
+  local.get $10
+  local.get $3
+  i32.store offset=12
+  local.get $10
+  local.get $4
+  i32.store offset=16
+  local.get $10
+  local.get $5
+  i32.store offset=20
+  local.get $10
+  local.get $6
+  i32.store offset=24
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 28
+  i32.add
+  i32.store
+ )
+ (func $start:assembly/__tests__/example.spec (; 41 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  global.get $__asyncify_state
+  i32.const 2
+  i32.eq
+  if
+   global.get $__asyncify_data
+   global.get $__asyncify_data
+   i32.load
+   i32.const -72
+   i32.add
+   i32.store
+   global.get $__asyncify_data
+   i32.load
+   local.set $20
+   local.get $20
+   i32.load
+   local.set $0
+   local.get $20
+   i32.load offset=4
+   local.set $1
+   local.get $20
+   i32.load offset=8
+   local.set $2
+   local.get $20
+   i32.load offset=12
+   local.set $3
+   local.get $20
+   i32.load offset=16
+   local.set $4
+   local.get $20
+   i32.load offset=20
+   local.set $5
+   local.get $20
+   i32.load offset=24
+   local.set $6
+   local.get $20
+   i32.load offset=28
+   local.set $7
+   local.get $20
+   i32.load offset=32
+   local.set $8
+   local.get $20
+   i32.load offset=36
+   local.set $9
+   local.get $20
+   i32.load offset=40
+   local.set $10
+   local.get $20
+   i32.load offset=44
+   local.set $11
+   local.get $20
+   i32.load offset=48
+   local.set $12
+   local.get $20
+   i32.load offset=52
+   local.set $13
+   local.get $20
+   i32.load offset=56
+   local.set $14
+   local.get $20
+   i32.load offset=60
+   local.set $15
+   local.get $20
+   i32.load offset=64
+   local.set $16
+   local.get $20
+   i32.load offset=68
+   local.set $17
+  end
+  block $__asyncify_unwind (result i32)
+   global.get $__asyncify_state
+   i32.const 2
+   i32.eq
+   if
+    global.get $__asyncify_data
+    global.get $__asyncify_data
+    i32.load
+    i32.const -4
+    i32.add
+    i32.store
+    global.get $__asyncify_data
+    i32.load
+    i32.load
+    local.set $19
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    i32.const 0
+    local.set $2
+    nop
+    i32.const 16
+    local.set $1
+    nop
+    i32.const 1024
+    local.set $0
+    nop
+    local.get $2
+    local.set $3
+    local.get $3
+    i32.eqz
+    local.set $4
+    local.get $4
+    if
+     i32.const 8
+     i32.const 0
+     call $~lib/rt/stub/__alloc
+     local.set $5
+     local.get $5
+     call $~lib/rt/stub/__retain
+     local.set $6
+     local.get $6
+     local.set $2
+     nop
+    end
+    nop
+    local.get $2
+    local.set $7
+    local.get $7
+    i32.const 0
+    i32.store
+    nop
+    local.get $2
+    local.set $8
+    local.get $8
+    i32.const 0
+    i32.store offset=4
+    nop
+    local.get $2
+    local.set $9
+    local.get $9
+    local.set $10
+    local.get $10
+    local.set $11
+    local.get $1
+    local.set $12
+    local.get $11
+    local.get $12
+    i32.store
+    nop
+    local.get $2
+    local.set $13
+    local.get $0
+    local.set $14
+    local.get $13
+    local.get $14
+    i32.store offset=4
+    nop
+    local.get $2
+    local.set $15
+    local.get $15
+    local.set $16
+    local.get $16
+    local.set $17
+    local.get $17
+    global.set $assembly/__tests__/example.spec/generator
+    nop
+   end
+   nop
+   nop
+   nop
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 1
+   else    
+    local.get $19
+    i32.const 0
+    i32.eq
+   end
+   if
+    i32.const 24
+    i32.const 3
+    call $node_modules/@as-pect/assembly/assembly/internal/Describe/describe
+    global.get $__asyncify_state
+    i32.const 1
+    i32.eq
+    if
+     i32.const 0
+     br $__asyncify_unwind
+    end
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+   end
+   return
+  end
+  local.set $18
+  global.get $__asyncify_data
+  i32.load
+  local.get $18
+  i32.store
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 4
+  i32.add
+  i32.store
+  global.get $__asyncify_data
+  i32.load
+  local.set $21
+  local.get $21
+  local.get $0
+  i32.store
+  local.get $21
+  local.get $1
+  i32.store offset=4
+  local.get $21
+  local.get $2
+  i32.store offset=8
+  local.get $21
+  local.get $3
+  i32.store offset=12
+  local.get $21
+  local.get $4
+  i32.store offset=16
+  local.get $21
+  local.get $5
+  i32.store offset=20
+  local.get $21
+  local.get $6
+  i32.store offset=24
+  local.get $21
+  local.get $7
+  i32.store offset=28
+  local.get $21
+  local.get $8
+  i32.store offset=32
+  local.get $21
+  local.get $9
+  i32.store offset=36
+  local.get $21
+  local.get $10
+  i32.store offset=40
+  local.get $21
+  local.get $11
+  i32.store offset=44
+  local.get $21
+  local.get $12
+  i32.store offset=48
+  local.get $21
+  local.get $13
+  i32.store offset=52
+  local.get $21
+  local.get $14
+  i32.store offset=56
+  local.get $21
+  local.get $15
+  i32.store offset=60
+  local.get $21
+  local.get $16
+  i32.store offset=64
+  local.get $21
+  local.get $17
+  i32.store offset=68
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 72
+  i32.add
+  i32.store
+ )
+ (func $node_modules/@as-pect/assembly/assembly/index/__ready (; 42 ;) (type $FUNCSIG$v)
+  i32.const 1
+  global.set $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.ready
+  nop
+ )
+ (func $node_modules/@as-pect/assembly/assembly/internal/call/__call (; 43 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  global.get $__asyncify_state
+  i32.const 2
+  i32.eq
+  if
+   global.get $__asyncify_data
+   global.get $__asyncify_data
+   i32.load
+   i32.const -8
+   i32.add
+   i32.store
+   global.get $__asyncify_data
+   i32.load
+   local.set $4
+   local.get $4
+   i32.load
+   local.set $0
+   local.get $4
+   i32.load offset=4
+   local.set $1
+  end
+  block $__asyncify_unwind (result i32)
+   global.get $__asyncify_state
+   i32.const 2
+   i32.eq
+   if
+    global.get $__asyncify_data
+    global.get $__asyncify_data
+    i32.load
+    i32.const -4
+    i32.add
+    i32.store
+    global.get $__asyncify_data
+    i32.load
+    i32.load
+    local.set $3
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    i32.const 0
+    global.set $~lib/argc
+    nop
+    local.get $0
+    local.set $1
+   end
+   nop
+   nop
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 1
+   else    
+    local.get $3
+    i32.const 0
+    i32.eq
+   end
+   if
+    local.get $1
+    call_indirect (type $FUNCSIG$v)
+    global.get $__asyncify_state
+    i32.const 1
+    i32.eq
+    if
+     i32.const 0
+     br $__asyncify_unwind
+    end
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+   end
+   return
+  end
+  local.set $2
+  global.get $__asyncify_data
+  i32.load
+  local.get $2
+  i32.store
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 4
+  i32.add
+  i32.store
+  global.get $__asyncify_data
+  i32.load
+  local.set $5
+  local.get $5
+  local.get $0
+  i32.store
+  local.get $5
+  local.get $1
+  i32.store offset=4
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 8
+  i32.add
+  i32.store
+ )
+ (func $node_modules/@as-pect/assembly/assembly/internal/report/Actual/__sendActual (; 44 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 f64)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 i32)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  global.get $__asyncify_state
+  i32.const 2
+  i32.eq
+  if
+   global.get $__asyncify_data
+   global.get $__asyncify_data
+   i32.load
+   i32.const -156
+   i32.add
+   i32.store
+   global.get $__asyncify_data
+   i32.load
+   local.set $40
+   local.get $40
+   i32.load
+   local.set $0
+   local.get $40
+   i32.load offset=4
+   local.set $1
+   local.get $40
+   i32.load offset=8
+   local.set $2
+   local.get $40
+   i32.load offset=12
+   local.set $3
+   local.get $40
+   i32.load offset=16
+   local.set $4
+   local.get $40
+   i32.load offset=20
+   local.set $5
+   local.get $40
+   i32.load offset=24
+   local.set $6
+   local.get $40
+   i32.load offset=28
+   local.set $7
+   local.get $40
+   i32.load offset=32
+   local.set $8
+   local.get $40
+   i32.load offset=36
+   local.set $9
+   local.get $40
+   i32.load offset=40
+   local.set $10
+   local.get $40
+   i32.load offset=44
+   local.set $11
+   local.get $40
+   i32.load offset=48
+   local.set $12
+   local.get $40
+   i32.load offset=52
+   local.set $13
+   local.get $40
+   i32.load offset=56
+   local.set $14
+   local.get $40
+   i32.load offset=60
+   local.set $15
+   local.get $40
+   i32.load offset=64
+   local.set $16
+   local.get $40
+   i32.load offset=68
+   local.set $17
+   local.get $40
+   i32.load offset=72
+   local.set $18
+   local.get $40
+   i32.load offset=76
+   local.set $19
+   local.get $40
+   i32.load offset=80
+   local.set $20
+   local.get $40
+   i32.load offset=84
+   local.set $21
+   local.get $40
+   f64.load offset=88 align=4
+   local.set $22
+   local.get $40
+   i32.load offset=96
+   local.set $23
+   local.get $40
+   i32.load offset=100
+   local.set $24
+   local.get $40
+   i32.load offset=104
+   local.set $25
+   local.get $40
+   i32.load offset=108
+   local.set $26
+   local.get $40
+   i32.load offset=112
+   local.set $27
+   local.get $40
+   i32.load offset=116
+   local.set $28
+   local.get $40
+   i32.load offset=120
+   local.set $29
+   local.get $40
+   i32.load offset=124
+   local.set $30
+   local.get $40
+   i32.load offset=128
+   local.set $31
+   local.get $40
+   i32.load offset=132
+   local.set $32
+   local.get $40
+   i32.load offset=136
+   local.set $33
+   local.get $40
+   i32.load offset=140
+   local.set $34
+   local.get $40
+   i32.load offset=144
+   local.set $35
+   local.get $40
+   i32.load offset=148
+   local.set $36
+   local.get $40
+   i32.load offset=152
+   local.set $37
+  end
+  block $__asyncify_unwind (result i32)
+   global.get $__asyncify_state
+   i32.const 2
+   i32.eq
+   if
+    global.get $__asyncify_data
+    global.get $__asyncify_data
+    i32.load
+    i32.const -4
+    i32.add
+    i32.store
+    global.get $__asyncify_data
+    i32.load
+    i32.load
+    local.set $39
+   end
+   block $break|0
+    block $case8|0
+     block $case7|0
+      block $case6|0
+       block $case5|0
+        block $case4|0
+         block $case3|0
+          block $case2|0
+           global.get $__asyncify_state
+           i32.const 0
+           i32.eq
+           if
+            block $case1|0
+             block $case0|0
+              global.get $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.type
+              local.set $1
+              local.get $1
+              local.set $0
+              nop
+              local.get $0
+              local.set $2
+              local.get $2
+              i32.const 0
+              i32.eq
+              local.set $3
+              local.get $3
+              br_if $case0|0
+              nop
+              local.get $0
+              local.set $4
+              local.get $4
+              i32.const 6
+              i32.eq
+              local.set $5
+              local.get $5
+              br_if $case1|0
+              nop
+              local.get $0
+              local.set $6
+              local.get $6
+              i32.const 2
+              i32.eq
+              local.set $7
+              local.get $7
+              br_if $case2|0
+              nop
+              local.get $0
+              local.set $8
+              local.get $8
+              i32.const 3
+              i32.eq
+              local.set $9
+              local.get $9
+              br_if $case3|0
+              nop
+              local.get $0
+              local.set $10
+              local.get $10
+              i32.const 1
+              i32.eq
+              local.set $11
+              local.get $11
+              br_if $case4|0
+              nop
+              local.get $0
+              local.set $12
+              local.get $12
+              i32.const 4
+              i32.eq
+              local.set $13
+              local.get $13
+              br_if $case5|0
+              nop
+              local.get $0
+              local.set $14
+              local.get $14
+              i32.const 5
+              i32.eq
+              local.set $15
+              local.get $15
+              br_if $case6|0
+              nop
+              local.get $0
+              local.set $16
+              local.get $16
+              i32.const 10
+              i32.eq
+              local.set $17
+              local.get $17
+              br_if $case7|0
+              nop
+              local.get $0
+              local.set $18
+              local.get $18
+              i32.const 11
+              i32.eq
+              local.set $19
+              local.get $19
+              br_if $case8|0
+              nop
+              br $break|0
+             end
+             nop
+             return
+            end
+            nop
+            global.get $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.reference
+            local.set $20
+            global.get $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.stackTrace
+            local.set $21
+           end
+           nop
+           nop
+           nop
+           global.get $__asyncify_state
+           i32.const 0
+           i32.eq
+           if (result i32)
+            i32.const 1
+           else            
+            local.get $39
+            i32.const 0
+            i32.eq
+           end
+           if
+            local.get $20
+            local.get $21
+            call $node_modules/@as-pect/assembly/assembly/internal/report/Actual/reportActualArray
+            global.get $__asyncify_state
+            i32.const 1
+            i32.eq
+            if
+             i32.const 0
+             br $__asyncify_unwind
+            end
+           end
+           global.get $__asyncify_state
+           i32.const 0
+           i32.eq
+           if
+            nop
+            br $break|0
+           end
+           nop
+          end
+          global.get $__asyncify_state
+          i32.const 0
+          i32.eq
+          if
+           nop
+           global.get $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.float
+           local.set $22
+           global.get $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.stackTrace
+           local.set $23
+          end
+          nop
+          nop
+          global.get $__asyncify_state
+          i32.const 0
+          i32.eq
+          if (result i32)
+           i32.const 1
+          else           
+           local.get $39
+           i32.const 1
+           i32.eq
+          end
+          if
+           local.get $22
+           i32.const 1
+           local.get $23
+           call $node_modules/@as-pect/assembly/assembly/internal/report/Actual/reportActualFloat
+           global.get $__asyncify_state
+           i32.const 1
+           i32.eq
+           if
+            i32.const 1
+            br $__asyncify_unwind
+           end
+          end
+          global.get $__asyncify_state
+          i32.const 0
+          i32.eq
+          if
+           nop
+           br $break|0
+          end
+          nop
+         end
+         global.get $__asyncify_state
+         i32.const 0
+         i32.eq
+         if
+          nop
+          global.get $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.integer
+          local.set $24
+          global.get $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.signed
+          local.set $25
+          global.get $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.stackTrace
+          local.set $26
+         end
+         nop
+         nop
+         nop
+         global.get $__asyncify_state
+         i32.const 0
+         i32.eq
+         if (result i32)
+          i32.const 1
+         else          
+          local.get $39
+          i32.const 2
+          i32.eq
+         end
+         if
+          local.get $24
+          local.get $25
+          local.get $26
+          call $node_modules/@as-pect/assembly/assembly/internal/report/Actual/reportActualInteger
+          global.get $__asyncify_state
+          i32.const 1
+          i32.eq
+          if
+           i32.const 2
+           br $__asyncify_unwind
+          end
+         end
+         global.get $__asyncify_state
+         i32.const 0
+         i32.eq
+         if
+          nop
+          br $break|0
+         end
+         nop
+        end
+        global.get $__asyncify_state
+        i32.const 0
+        i32.eq
+        if
+         nop
+         global.get $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.stackTrace
+         local.set $27
+        end
+        nop
+        global.get $__asyncify_state
+        i32.const 0
+        i32.eq
+        if (result i32)
+         i32.const 1
+        else         
+         local.get $39
+         i32.const 3
+         i32.eq
+        end
+        if
+         local.get $27
+         call $node_modules/@as-pect/assembly/assembly/internal/report/Actual/reportActualNull
+         global.get $__asyncify_state
+         i32.const 1
+         i32.eq
+         if
+          i32.const 3
+          br $__asyncify_unwind
+         end
+        end
+        global.get $__asyncify_state
+        i32.const 0
+        i32.eq
+        if
+         nop
+         br $break|0
+        end
+        nop
+       end
+       global.get $__asyncify_state
+       i32.const 0
+       i32.eq
+       if
+        nop
+        global.get $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.reference
+        local.set $28
+        global.get $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.offset
+        local.set $29
+        global.get $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.stackTrace
+        local.set $30
+       end
+       nop
+       nop
+       nop
+       global.get $__asyncify_state
+       i32.const 0
+       i32.eq
+       if (result i32)
+        i32.const 1
+       else        
+        local.get $39
+        i32.const 4
+        i32.eq
+       end
+       if
+        local.get $28
+        local.get $29
+        local.get $30
+        call $node_modules/@as-pect/assembly/assembly/internal/report/Actual/reportActualReferenceExternal
+        global.get $__asyncify_state
+        i32.const 1
+        i32.eq
+        if
+         i32.const 4
+         br $__asyncify_unwind
+        end
+       end
+       global.get $__asyncify_state
+       i32.const 0
+       i32.eq
+       if
+        nop
+        br $break|0
+       end
+       nop
+      end
+      global.get $__asyncify_state
+      i32.const 0
+      i32.eq
+      if
+       nop
+       global.get $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.reference
+       local.set $31
+       global.get $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.stackTrace
+       local.set $32
+      end
+      nop
+      nop
+      global.get $__asyncify_state
+      i32.const 0
+      i32.eq
+      if (result i32)
+       i32.const 1
+      else       
+       local.get $39
+       i32.const 5
+       i32.eq
+      end
+      if
+       local.get $31
+       local.get $32
+       call $node_modules/@as-pect/assembly/assembly/internal/report/Actual/reportActualString
+       global.get $__asyncify_state
+       i32.const 1
+       i32.eq
+       if
+        i32.const 5
+        br $__asyncify_unwind
+       end
+      end
+      global.get $__asyncify_state
+      i32.const 0
+      i32.eq
+      if
+       nop
+       br $break|0
+      end
+      nop
+     end
+     global.get $__asyncify_state
+     i32.const 0
+     i32.eq
+     if
+      nop
+      global.get $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.reference
+      local.set $33
+      global.get $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.signed
+      local.set $34
+      global.get $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.stackTrace
+      local.set $35
+     end
+     nop
+     nop
+     nop
+     global.get $__asyncify_state
+     i32.const 0
+     i32.eq
+     if (result i32)
+      i32.const 1
+     else      
+      local.get $39
+      i32.const 6
+      i32.eq
+     end
+     if
+      local.get $33
+      local.get $34
+      local.get $35
+      call $node_modules/@as-pect/assembly/assembly/internal/report/Actual/reportActualLong
+      global.get $__asyncify_state
+      i32.const 1
+      i32.eq
+      if
+       i32.const 6
+       br $__asyncify_unwind
+      end
+     end
+     global.get $__asyncify_state
+     i32.const 0
+     i32.eq
+     if
+      nop
+      br $break|0
+     end
+     nop
+    end
+    global.get $__asyncify_state
+    i32.const 0
+    i32.eq
+    if
+     nop
+     global.get $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.integer
+     local.set $36
+     global.get $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.stackTrace
+     local.set $37
+    end
+    nop
+    nop
+    global.get $__asyncify_state
+    i32.const 0
+    i32.eq
+    if (result i32)
+     i32.const 1
+    else     
+     local.get $39
+     i32.const 7
+     i32.eq
+    end
+    if
+     local.get $36
+     local.get $37
+     call $node_modules/@as-pect/assembly/assembly/internal/report/Actual/reportActualBool
+     global.get $__asyncify_state
+     i32.const 1
+     i32.eq
+     if
+      i32.const 7
+      br $__asyncify_unwind
+     end
+    end
+    global.get $__asyncify_state
+    i32.const 0
+    i32.eq
+    if
+     nop
+     br $break|0
+    end
+    nop
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+   end
+   return
+  end
+  local.set $38
+  global.get $__asyncify_data
+  i32.load
+  local.get $38
+  i32.store
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 4
+  i32.add
+  i32.store
+  global.get $__asyncify_data
+  i32.load
+  local.set $41
+  local.get $41
+  local.get $0
+  i32.store
+  local.get $41
+  local.get $1
+  i32.store offset=4
+  local.get $41
+  local.get $2
+  i32.store offset=8
+  local.get $41
+  local.get $3
+  i32.store offset=12
+  local.get $41
+  local.get $4
+  i32.store offset=16
+  local.get $41
+  local.get $5
+  i32.store offset=20
+  local.get $41
+  local.get $6
+  i32.store offset=24
+  local.get $41
+  local.get $7
+  i32.store offset=28
+  local.get $41
+  local.get $8
+  i32.store offset=32
+  local.get $41
+  local.get $9
+  i32.store offset=36
+  local.get $41
+  local.get $10
+  i32.store offset=40
+  local.get $41
+  local.get $11
+  i32.store offset=44
+  local.get $41
+  local.get $12
+  i32.store offset=48
+  local.get $41
+  local.get $13
+  i32.store offset=52
+  local.get $41
+  local.get $14
+  i32.store offset=56
+  local.get $41
+  local.get $15
+  i32.store offset=60
+  local.get $41
+  local.get $16
+  i32.store offset=64
+  local.get $41
+  local.get $17
+  i32.store offset=68
+  local.get $41
+  local.get $18
+  i32.store offset=72
+  local.get $41
+  local.get $19
+  i32.store offset=76
+  local.get $41
+  local.get $20
+  i32.store offset=80
+  local.get $41
+  local.get $21
+  i32.store offset=84
+  local.get $41
+  local.get $22
+  f64.store offset=88 align=4
+  local.get $41
+  local.get $23
+  i32.store offset=96
+  local.get $41
+  local.get $24
+  i32.store offset=100
+  local.get $41
+  local.get $25
+  i32.store offset=104
+  local.get $41
+  local.get $26
+  i32.store offset=108
+  local.get $41
+  local.get $27
+  i32.store offset=112
+  local.get $41
+  local.get $28
+  i32.store offset=116
+  local.get $41
+  local.get $29
+  i32.store offset=120
+  local.get $41
+  local.get $30
+  i32.store offset=124
+  local.get $41
+  local.get $31
+  i32.store offset=128
+  local.get $41
+  local.get $32
+  i32.store offset=132
+  local.get $41
+  local.get $33
+  i32.store offset=136
+  local.get $41
+  local.get $34
+  i32.store offset=140
+  local.get $41
+  local.get $35
+  i32.store offset=144
+  local.get $41
+  local.get $36
+  i32.store offset=148
+  local.get $41
+  local.get $37
+  i32.store offset=152
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 156
+  i32.add
+  i32.store
+ )
+ (func $node_modules/@as-pect/assembly/assembly/internal/report/Expected/__sendExpected (; 45 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  (local $26 i32)
+  (local $27 f64)
+  (local $28 i32)
+  (local $29 i32)
+  (local $30 i32)
+  (local $31 i32)
+  (local $32 i32)
+  (local $33 i32)
+  (local $34 i32)
+  (local $35 i32)
+  (local $36 i32)
+  (local $37 i32)
+  (local $38 i32)
+  (local $39 i32)
+  (local $40 i32)
+  (local $41 i32)
+  (local $42 i32)
+  (local $43 i32)
+  (local $44 i32)
+  (local $45 i32)
+  (local $46 i32)
+  (local $47 i32)
+  (local $48 i32)
+  (local $49 i32)
+  (local $50 i32)
+  (local $51 i32)
+  (local $52 i32)
+  (local $53 i32)
+  (local $54 i32)
+  (local $55 i32)
+  (local $56 i32)
+  (local $57 i32)
+  (local $58 i32)
+  (local $59 i32)
+  global.get $__asyncify_state
+  i32.const 2
+  i32.eq
+  if
+   global.get $__asyncify_data
+   global.get $__asyncify_data
+   i32.load
+   i32.const -228
+   i32.add
+   i32.store
+   global.get $__asyncify_data
+   i32.load
+   local.set $58
+   local.get $58
+   i32.load
+   local.set $0
+   local.get $58
+   i32.load offset=4
+   local.set $1
+   local.get $58
+   i32.load offset=8
+   local.set $2
+   local.get $58
+   i32.load offset=12
+   local.set $3
+   local.get $58
+   i32.load offset=16
+   local.set $4
+   local.get $58
+   i32.load offset=20
+   local.set $5
+   local.get $58
+   i32.load offset=24
+   local.set $6
+   local.get $58
+   i32.load offset=28
+   local.set $7
+   local.get $58
+   i32.load offset=32
+   local.set $8
+   local.get $58
+   i32.load offset=36
+   local.set $9
+   local.get $58
+   i32.load offset=40
+   local.set $10
+   local.get $58
+   i32.load offset=44
+   local.set $11
+   local.get $58
+   i32.load offset=48
+   local.set $12
+   local.get $58
+   i32.load offset=52
+   local.set $13
+   local.get $58
+   i32.load offset=56
+   local.set $14
+   local.get $58
+   i32.load offset=60
+   local.set $15
+   local.get $58
+   i32.load offset=64
+   local.set $16
+   local.get $58
+   i32.load offset=68
+   local.set $17
+   local.get $58
+   i32.load offset=72
+   local.set $18
+   local.get $58
+   i32.load offset=76
+   local.set $19
+   local.get $58
+   i32.load offset=80
+   local.set $20
+   local.get $58
+   i32.load offset=84
+   local.set $21
+   local.get $58
+   i32.load offset=88
+   local.set $22
+   local.get $58
+   i32.load offset=92
+   local.set $23
+   local.get $58
+   i32.load offset=96
+   local.set $24
+   local.get $58
+   i32.load offset=100
+   local.set $25
+   local.get $58
+   i32.load offset=104
+   local.set $26
+   local.get $58
+   f64.load offset=108 align=4
+   local.set $27
+   local.get $58
+   i32.load offset=116
+   local.set $28
+   local.get $58
+   i32.load offset=120
+   local.set $29
+   local.get $58
+   i32.load offset=124
+   local.set $30
+   local.get $58
+   i32.load offset=128
+   local.set $31
+   local.get $58
+   i32.load offset=132
+   local.set $32
+   local.get $58
+   i32.load offset=136
+   local.set $33
+   local.get $58
+   i32.load offset=140
+   local.set $34
+   local.get $58
+   i32.load offset=144
+   local.set $35
+   local.get $58
+   i32.load offset=148
+   local.set $36
+   local.get $58
+   i32.load offset=152
+   local.set $37
+   local.get $58
+   i32.load offset=156
+   local.set $38
+   local.get $58
+   i32.load offset=160
+   local.set $39
+   local.get $58
+   i32.load offset=164
+   local.set $40
+   local.get $58
+   i32.load offset=168
+   local.set $41
+   local.get $58
+   i32.load offset=172
+   local.set $42
+   local.get $58
+   i32.load offset=176
+   local.set $43
+   local.get $58
+   i32.load offset=180
+   local.set $44
+   local.get $58
+   i32.load offset=184
+   local.set $45
+   local.get $58
+   i32.load offset=188
+   local.set $46
+   local.get $58
+   i32.load offset=192
+   local.set $47
+   local.get $58
+   i32.load offset=196
+   local.set $48
+   local.get $58
+   i32.load offset=200
+   local.set $49
+   local.get $58
+   i32.load offset=204
+   local.set $50
+   local.get $58
+   i32.load offset=208
+   local.set $51
+   local.get $58
+   i32.load offset=212
+   local.set $52
+   local.get $58
+   i32.load offset=216
+   local.set $53
+   local.get $58
+   i32.load offset=220
+   local.set $54
+   local.get $58
+   i32.load offset=224
+   local.set $55
+  end
+  block $__asyncify_unwind (result i32)
+   global.get $__asyncify_state
+   i32.const 2
+   i32.eq
+   if
+    global.get $__asyncify_data
+    global.get $__asyncify_data
+    i32.load
+    i32.const -4
+    i32.add
+    i32.store
+    global.get $__asyncify_data
+    i32.load
+    i32.load
+    local.set $57
+   end
+   block $break|0
+    block $case10|0
+     block $case9|0
+      block $case8|0
+       block $case7|0
+        block $case6|0
+         block $case5|0
+          block $case4|0
+           block $case3|0
+            block $case2|0
+             block $case1|0
+              global.get $__asyncify_state
+              i32.const 0
+              i32.eq
+              if
+               block $case0|0
+                global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.type
+                local.set $1
+                local.get $1
+                local.set $0
+                nop
+                local.get $0
+                local.set $2
+                local.get $2
+                i32.const 6
+                i32.eq
+                local.set $3
+                local.get $3
+                br_if $case0|0
+                nop
+                local.get $0
+                local.set $4
+                local.get $4
+                i32.const 2
+                i32.eq
+                local.set $5
+                local.get $5
+                br_if $case1|0
+                nop
+                local.get $0
+                local.set $6
+                local.get $6
+                i32.const 3
+                i32.eq
+                local.set $7
+                local.get $7
+                br_if $case2|0
+                nop
+                local.get $0
+                local.set $8
+                local.get $8
+                i32.const 1
+                i32.eq
+                local.set $9
+                local.get $9
+                br_if $case3|0
+                nop
+                local.get $0
+                local.set $10
+                local.get $10
+                i32.const 4
+                i32.eq
+                local.set $11
+                local.get $11
+                br_if $case4|0
+                nop
+                local.get $0
+                local.set $12
+                local.get $12
+                i32.const 5
+                i32.eq
+                local.set $13
+                local.get $13
+                br_if $case5|0
+                nop
+                local.get $0
+                local.set $14
+                local.get $14
+                i32.const 7
+                i32.eq
+                local.set $15
+                local.get $15
+                br_if $case6|0
+                nop
+                local.get $0
+                local.set $16
+                local.get $16
+                i32.const 9
+                i32.eq
+                local.set $17
+                local.get $17
+                br_if $case7|0
+                nop
+                local.get $0
+                local.set $18
+                local.get $18
+                i32.const 8
+                i32.eq
+                local.set $19
+                local.get $19
+                br_if $case8|0
+                nop
+                local.get $0
+                local.set $20
+                local.get $20
+                i32.const 10
+                i32.eq
+                local.set $21
+                local.get $21
+                br_if $case9|0
+                nop
+                local.get $0
+                local.set $22
+                local.get $22
+                i32.const 11
+                i32.eq
+                local.set $23
+                local.get $23
+                br_if $case10|0
+                nop
+                br $break|0
+               end
+               nop
+               global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.reference
+               local.set $24
+               global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.negated
+               local.set $25
+               global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.stackTrace
+               local.set $26
+              end
+              nop
+              nop
+              nop
+              nop
+              global.get $__asyncify_state
+              i32.const 0
+              i32.eq
+              if (result i32)
+               i32.const 1
+              else               
+               local.get $57
+               i32.const 0
+               i32.eq
+              end
+              if
+               local.get $24
+               local.get $25
+               local.get $26
+               call $node_modules/@as-pect/assembly/assembly/internal/report/Expected/reportExpectedArray
+               global.get $__asyncify_state
+               i32.const 1
+               i32.eq
+               if
+                i32.const 0
+                br $__asyncify_unwind
+               end
+              end
+              global.get $__asyncify_state
+              i32.const 0
+              i32.eq
+              if
+               nop
+               br $break|0
+              end
+              nop
+             end
+             global.get $__asyncify_state
+             i32.const 0
+             i32.eq
+             if
+              nop
+              global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.float
+              local.set $27
+              global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.negated
+              local.set $28
+              global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.stackTrace
+              local.set $29
+             end
+             nop
+             nop
+             nop
+             global.get $__asyncify_state
+             i32.const 0
+             i32.eq
+             if (result i32)
+              i32.const 1
+             else              
+              local.get $57
+              i32.const 1
+              i32.eq
+             end
+             if
+              local.get $27
+              i32.const 1
+              local.get $28
+              local.get $29
+              call $node_modules/@as-pect/assembly/assembly/internal/report/Expected/reportExpectedFloat
+              global.get $__asyncify_state
+              i32.const 1
+              i32.eq
+              if
+               i32.const 1
+               br $__asyncify_unwind
+              end
+             end
+             global.get $__asyncify_state
+             i32.const 0
+             i32.eq
+             if
+              nop
+              br $break|0
+             end
+             nop
+            end
+            global.get $__asyncify_state
+            i32.const 0
+            i32.eq
+            if
+             nop
+             global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.integer
+             local.set $30
+             global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.signed
+             local.set $31
+             global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.negated
+             local.set $32
+             global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.stackTrace
+             local.set $33
+            end
+            nop
+            nop
+            nop
+            nop
+            global.get $__asyncify_state
+            i32.const 0
+            i32.eq
+            if (result i32)
+             i32.const 1
+            else             
+             local.get $57
+             i32.const 2
+             i32.eq
+            end
+            if
+             local.get $30
+             local.get $31
+             local.get $32
+             local.get $33
+             call $node_modules/@as-pect/assembly/assembly/internal/report/Expected/reportExpectedInteger
+             global.get $__asyncify_state
+             i32.const 1
+             i32.eq
+             if
+              i32.const 2
+              br $__asyncify_unwind
+             end
+            end
+            global.get $__asyncify_state
+            i32.const 0
+            i32.eq
+            if
+             nop
+             br $break|0
+            end
+            nop
+           end
+           global.get $__asyncify_state
+           i32.const 0
+           i32.eq
+           if
+            nop
+            global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.negated
+            local.set $34
+            global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.stackTrace
+            local.set $35
+           end
+           nop
+           nop
+           global.get $__asyncify_state
+           i32.const 0
+           i32.eq
+           if (result i32)
+            i32.const 1
+           else            
+            local.get $57
+            i32.const 3
+            i32.eq
+           end
+           if
+            local.get $34
+            local.get $35
+            call $node_modules/@as-pect/assembly/assembly/internal/report/Expected/reportExpectedNull
+            global.get $__asyncify_state
+            i32.const 1
+            i32.eq
+            if
+             i32.const 3
+             br $__asyncify_unwind
+            end
+           end
+           global.get $__asyncify_state
+           i32.const 0
+           i32.eq
+           if
+            nop
+            br $break|0
+           end
+           nop
+          end
+          global.get $__asyncify_state
+          i32.const 0
+          i32.eq
+          if
+           nop
+           global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.reference
+           local.set $36
+           global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.offset
+           local.set $37
+           global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.negated
+           local.set $38
+           global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.stackTrace
+           local.set $39
+          end
+          nop
+          nop
+          nop
+          nop
+          global.get $__asyncify_state
+          i32.const 0
+          i32.eq
+          if (result i32)
+           i32.const 1
+          else           
+           local.get $57
+           i32.const 4
+           i32.eq
+          end
+          if
+           local.get $36
+           local.get $37
+           local.get $38
+           local.get $39
+           call $node_modules/@as-pect/assembly/assembly/internal/report/Expected/reportExpectedReferenceExternal
+           global.get $__asyncify_state
+           i32.const 1
+           i32.eq
+           if
+            i32.const 4
+            br $__asyncify_unwind
+           end
+          end
+          global.get $__asyncify_state
+          i32.const 0
+          i32.eq
+          if
+           nop
+           br $break|0
+          end
+          nop
+         end
+         global.get $__asyncify_state
+         i32.const 0
+         i32.eq
+         if
+          nop
+          global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.reference
+          local.set $40
+          global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.negated
+          local.set $41
+          global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.stackTrace
+          local.set $42
+         end
+         nop
+         nop
+         nop
+         global.get $__asyncify_state
+         i32.const 0
+         i32.eq
+         if (result i32)
+          i32.const 1
+         else          
+          local.get $57
+          i32.const 5
+          i32.eq
+         end
+         if
+          local.get $40
+          local.get $41
+          local.get $42
+          call $node_modules/@as-pect/assembly/assembly/internal/report/Expected/reportExpectedString
+          global.get $__asyncify_state
+          i32.const 1
+          i32.eq
+          if
+           i32.const 5
+           br $__asyncify_unwind
+          end
+         end
+         global.get $__asyncify_state
+         i32.const 0
+         i32.eq
+         if
+          nop
+          br $break|0
+         end
+         nop
+        end
+        global.get $__asyncify_state
+        i32.const 0
+        i32.eq
+        if
+         nop
+         global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.negated
+         local.set $43
+         global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.stackTrace
+         local.set $44
+        end
+        nop
+        nop
+        global.get $__asyncify_state
+        i32.const 0
+        i32.eq
+        if (result i32)
+         i32.const 1
+        else         
+         local.get $57
+         i32.const 6
+         i32.eq
+        end
+        if
+         local.get $43
+         local.get $44
+         call $node_modules/@as-pect/assembly/assembly/internal/report/Expected/reportExpectedFalsy
+         global.get $__asyncify_state
+         i32.const 1
+         i32.eq
+         if
+          i32.const 6
+          br $__asyncify_unwind
+         end
+        end
+        global.get $__asyncify_state
+        i32.const 0
+        i32.eq
+        if
+         nop
+         br $break|0
+        end
+        nop
+       end
+       global.get $__asyncify_state
+       i32.const 0
+       i32.eq
+       if
+        nop
+        global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.negated
+        local.set $45
+        global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.stackTrace
+        local.set $46
+       end
+       nop
+       nop
+       global.get $__asyncify_state
+       i32.const 0
+       i32.eq
+       if (result i32)
+        i32.const 1
+       else        
+        local.get $57
+        i32.const 7
+        i32.eq
+       end
+       if
+        local.get $45
+        local.get $46
+        call $node_modules/@as-pect/assembly/assembly/internal/report/Expected/reportExpectedFinite
+        global.get $__asyncify_state
+        i32.const 1
+        i32.eq
+        if
+         i32.const 7
+         br $__asyncify_unwind
+        end
+       end
+       global.get $__asyncify_state
+       i32.const 0
+       i32.eq
+       if
+        nop
+        br $break|0
+       end
+       nop
+      end
+      global.get $__asyncify_state
+      i32.const 0
+      i32.eq
+      if
+       nop
+       global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.negated
+       local.set $47
+       global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.stackTrace
+       local.set $48
+      end
+      nop
+      nop
+      global.get $__asyncify_state
+      i32.const 0
+      i32.eq
+      if (result i32)
+       i32.const 1
+      else       
+       local.get $57
+       i32.const 8
+       i32.eq
+      end
+      if
+       local.get $47
+       local.get $48
+       call $node_modules/@as-pect/assembly/assembly/internal/report/Expected/reportExpectedTruthy
+       global.get $__asyncify_state
+       i32.const 1
+       i32.eq
+       if
+        i32.const 8
+        br $__asyncify_unwind
+       end
+      end
+      global.get $__asyncify_state
+      i32.const 0
+      i32.eq
+      if
+       nop
+       br $break|0
+      end
+      nop
+     end
+     global.get $__asyncify_state
+     i32.const 0
+     i32.eq
+     if
+      nop
+      global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.reference
+      local.set $49
+      global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.signed
+      local.set $50
+      global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.negated
+      local.set $51
+      global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.stackTrace
+      local.set $52
+     end
+     nop
+     nop
+     nop
+     nop
+     global.get $__asyncify_state
+     i32.const 0
+     i32.eq
+     if (result i32)
+      i32.const 1
+     else      
+      local.get $57
+      i32.const 9
+      i32.eq
+     end
+     if
+      local.get $49
+      local.get $50
+      local.get $51
+      local.get $52
+      call $node_modules/@as-pect/assembly/assembly/internal/report/Expected/reportExpectedLong
+      global.get $__asyncify_state
+      i32.const 1
+      i32.eq
+      if
+       i32.const 9
+       br $__asyncify_unwind
+      end
+     end
+     global.get $__asyncify_state
+     i32.const 0
+     i32.eq
+     if
+      nop
+      br $break|0
+     end
+     nop
+    end
+    global.get $__asyncify_state
+    i32.const 0
+    i32.eq
+    if
+     nop
+     global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.integer
+     local.set $53
+     global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.negated
+     local.set $54
+     global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.stackTrace
+     local.set $55
+    end
+    nop
+    nop
+    nop
+    global.get $__asyncify_state
+    i32.const 0
+    i32.eq
+    if (result i32)
+     i32.const 1
+    else     
+     local.get $57
+     i32.const 10
+     i32.eq
+    end
+    if
+     local.get $53
+     local.get $54
+     local.get $55
+     call $node_modules/@as-pect/assembly/assembly/internal/report/Expected/reportExpectedBool
+     global.get $__asyncify_state
+     i32.const 1
+     i32.eq
+     if
+      i32.const 10
+      br $__asyncify_unwind
+     end
+    end
+    global.get $__asyncify_state
+    i32.const 0
+    i32.eq
+    if
+     nop
+     br $break|0
+    end
+    nop
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+   end
+   return
+  end
+  local.set $56
+  global.get $__asyncify_data
+  i32.load
+  local.get $56
+  i32.store
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 4
+  i32.add
+  i32.store
+  global.get $__asyncify_data
+  i32.load
+  local.set $59
+  local.get $59
+  local.get $0
+  i32.store
+  local.get $59
+  local.get $1
+  i32.store offset=4
+  local.get $59
+  local.get $2
+  i32.store offset=8
+  local.get $59
+  local.get $3
+  i32.store offset=12
+  local.get $59
+  local.get $4
+  i32.store offset=16
+  local.get $59
+  local.get $5
+  i32.store offset=20
+  local.get $59
+  local.get $6
+  i32.store offset=24
+  local.get $59
+  local.get $7
+  i32.store offset=28
+  local.get $59
+  local.get $8
+  i32.store offset=32
+  local.get $59
+  local.get $9
+  i32.store offset=36
+  local.get $59
+  local.get $10
+  i32.store offset=40
+  local.get $59
+  local.get $11
+  i32.store offset=44
+  local.get $59
+  local.get $12
+  i32.store offset=48
+  local.get $59
+  local.get $13
+  i32.store offset=52
+  local.get $59
+  local.get $14
+  i32.store offset=56
+  local.get $59
+  local.get $15
+  i32.store offset=60
+  local.get $59
+  local.get $16
+  i32.store offset=64
+  local.get $59
+  local.get $17
+  i32.store offset=68
+  local.get $59
+  local.get $18
+  i32.store offset=72
+  local.get $59
+  local.get $19
+  i32.store offset=76
+  local.get $59
+  local.get $20
+  i32.store offset=80
+  local.get $59
+  local.get $21
+  i32.store offset=84
+  local.get $59
+  local.get $22
+  i32.store offset=88
+  local.get $59
+  local.get $23
+  i32.store offset=92
+  local.get $59
+  local.get $24
+  i32.store offset=96
+  local.get $59
+  local.get $25
+  i32.store offset=100
+  local.get $59
+  local.get $26
+  i32.store offset=104
+  local.get $59
+  local.get $27
+  f64.store offset=108 align=4
+  local.get $59
+  local.get $28
+  i32.store offset=116
+  local.get $59
+  local.get $29
+  i32.store offset=120
+  local.get $59
+  local.get $30
+  i32.store offset=124
+  local.get $59
+  local.get $31
+  i32.store offset=128
+  local.get $59
+  local.get $32
+  i32.store offset=132
+  local.get $59
+  local.get $33
+  i32.store offset=136
+  local.get $59
+  local.get $34
+  i32.store offset=140
+  local.get $59
+  local.get $35
+  i32.store offset=144
+  local.get $59
+  local.get $36
+  i32.store offset=148
+  local.get $59
+  local.get $37
+  i32.store offset=152
+  local.get $59
+  local.get $38
+  i32.store offset=156
+  local.get $59
+  local.get $39
+  i32.store offset=160
+  local.get $59
+  local.get $40
+  i32.store offset=164
+  local.get $59
+  local.get $41
+  i32.store offset=168
+  local.get $59
+  local.get $42
+  i32.store offset=172
+  local.get $59
+  local.get $43
+  i32.store offset=176
+  local.get $59
+  local.get $44
+  i32.store offset=180
+  local.get $59
+  local.get $45
+  i32.store offset=184
+  local.get $59
+  local.get $46
+  i32.store offset=188
+  local.get $59
+  local.get $47
+  i32.store offset=192
+  local.get $59
+  local.get $48
+  i32.store offset=196
+  local.get $59
+  local.get $49
+  i32.store offset=200
+  local.get $59
+  local.get $50
+  i32.store offset=204
+  local.get $59
+  local.get $51
+  i32.store offset=208
+  local.get $59
+  local.get $52
+  i32.store offset=212
+  local.get $59
+  local.get $53
+  i32.store offset=216
+  local.get $59
+  local.get $54
+  i32.store offset=220
+  local.get $59
+  local.get $55
+  i32.store offset=224
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 228
+  i32.add
+  i32.store
+ )
+ (func $node_modules/@as-pect/assembly/assembly/internal/log/__ignoreLogs (; 46 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.set $1
+  local.get $1
+  i32.const 0
+  i32.ne
+  local.set $2
+  local.get $2
+  global.set $node_modules/@as-pect/assembly/assembly/internal/log/ignoreLogs
+  nop
+ )
+ (func $node_modules/@as-pect/assembly/assembly/internal/RTrace/__disableRTrace (; 47 ;) (type $FUNCSIG$v)
+  i32.const 0
+  global.set $node_modules/@as-pect/assembly/assembly/internal/RTrace/RTrace.enabled
+  nop
+ )
+ (func $node_modules/@as-pect/assembly/assembly/internal/RTrace/__getUsizeArrayId (; 48 ;) (type $FUNCSIG$i) (result i32)
+  i32.const 3
+  return
+ )
+ (func $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.clear (; 49 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  global.set $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.type
+  nop
+  global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.reference
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.gt_u
+  local.set $1
+  local.get $1
+  if
+   global.get $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.reference
+   local.set $2
+   local.get $2
+   call $~lib/rt/stub/__release
+   nop
+   i32.const 0
+   global.set $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.reference
+   nop
+   nop
+  end
+  nop
+  nop
+ )
+ (func $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.clear (; 50 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  i32.const 0
+  global.set $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.type
+  nop
+  global.get $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.reference
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.gt_u
+  local.set $1
+  local.get $1
+  if
+   global.get $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.reference
+   local.set $2
+   local.get $2
+   call $~lib/rt/stub/__release
+   nop
+   i32.const 0
+   global.set $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.reference
+   nop
+   nop
+  end
+  nop
+  i32.const -1
+  global.set $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.stackTrace
+  nop
+  nop
+ )
+ (func $node_modules/@as-pect/assembly/assembly/internal/Expectation/__cleanup (; 51 ;) (type $FUNCSIG$v)
+  call $node_modules/@as-pect/assembly/assembly/internal/report/Expected/Expected.clear
+  nop
+  call $node_modules/@as-pect/assembly/assembly/internal/report/Actual/Actual.clear
+  nop
+  nop
+ )
+ (func $start (; 52 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  global.get $__asyncify_state
+  i32.const 2
+  i32.eq
+  if
+   global.get $__asyncify_data
+   global.get $__asyncify_data
+   i32.load
+   i32.const -24
+   i32.add
+   i32.store
+   global.get $__asyncify_data
+   i32.load
+   local.set $8
+   local.get $8
+   i32.load
+   local.set $0
+   local.get $8
+   i32.load offset=4
+   local.set $1
+   local.get $8
+   i32.load offset=8
+   local.set $2
+   local.get $8
+   i32.load offset=12
+   local.set $3
+   local.get $8
+   i32.load offset=16
+   local.set $4
+   local.get $8
+   i32.load offset=20
+   local.set $5
+  end
+  block $__asyncify_unwind (result i32)
+   global.get $__asyncify_state
+   i32.const 2
+   i32.eq
+   if
+    global.get $__asyncify_data
+    global.get $__asyncify_data
+    i32.load
+    i32.const -4
+    i32.add
+    i32.store
+    global.get $__asyncify_data
+    i32.load
+    i32.load
+    local.set $7
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    global.get $~lib/started
+    local.set $0
+    local.get $0
+    if
+     return
+    else     
+     i32.const 1
+     global.set $~lib/started
+     nop
+    end
+    nop
+    global.get $~lib/heap/__heap_base
+    local.set $1
+    local.get $1
+    i32.const 15
+    i32.add
+    local.set $2
+    i32.const 15
+    i32.const -1
+    i32.xor
+    local.set $3
+    local.get $2
+    local.get $3
+    i32.and
+    local.set $4
+    local.get $4
+    global.set $~lib/rt/stub/startOffset
+    nop
+    global.get $~lib/rt/stub/startOffset
+    local.set $5
+    local.get $5
+    global.set $~lib/rt/stub/offset
+    nop
+   end
+   nop
+   nop
+   nop
+   nop
+   nop
+   nop
+   nop
+   nop
+   nop
+   nop
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if (result i32)
+    i32.const 1
+   else    
+    local.get $7
+    i32.const 0
+    i32.eq
+   end
+   if
+    call $start:assembly/__tests__/example.spec
+    global.get $__asyncify_state
+    i32.const 1
+    i32.eq
+    if
+     i32.const 0
+     br $__asyncify_unwind
+    end
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+   end
+   global.get $__asyncify_state
+   i32.const 0
+   i32.eq
+   if
+    nop
+   end
+   return
+  end
+  local.set $6
+  global.get $__asyncify_data
+  i32.load
+  local.get $6
+  i32.store
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 4
+  i32.add
+  i32.store
+  global.get $__asyncify_data
+  i32.load
+  local.set $9
+  local.get $9
+  local.get $0
+  i32.store
+  local.get $9
+  local.get $1
+  i32.store offset=4
+  local.get $9
+  local.get $2
+  i32.store offset=8
+  local.get $9
+  local.get $3
+  i32.store offset=12
+  local.get $9
+  local.get $4
+  i32.store offset=16
+  local.get $9
+  local.get $5
+  i32.store offset=20
+  global.get $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  i32.const 24
+  i32.add
+  i32.store
+ )
+ (func $null (; 53 ;) (type $FUNCSIG$v)
+  nop
+ )
+ (func $asyncify_start_unwind (; 54 ;) (type $FUNCSIG$vi) (param $0 i32)
+  i32.const 1
+  global.set $__asyncify_state
+  local.get $0
+  global.set $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  global.get $__asyncify_data
+  i32.load offset=4
+  i32.gt_u
+  if
+   unreachable
+  end
+ )
+ (func $asyncify_stop_unwind (; 55 ;) (type $FUNCSIG$v)
+  i32.const 0
+  global.set $__asyncify_state
+  global.get $__asyncify_data
+  i32.load
+  global.get $__asyncify_data
+  i32.load offset=4
+  i32.gt_u
+  if
+   unreachable
+  end
+ )
+ (func $asyncify_start_rewind (; 56 ;) (type $FUNCSIG$vi) (param $0 i32)
+  i32.const 2
+  global.set $__asyncify_state
+  local.get $0
+  global.set $__asyncify_data
+  global.get $__asyncify_data
+  i32.load
+  global.get $__asyncify_data
+  i32.load offset=4
+  i32.gt_u
+  if
+   unreachable
+  end
+ )
+ (func $asyncify_stop_rewind (; 57 ;) (type $FUNCSIG$v)
+  i32.const 0
+  global.set $__asyncify_state
+  global.get $__asyncify_data
+  i32.load
+  global.get $__asyncify_data
+  i32.load offset=4
+  i32.gt_u
+  if
+   unreachable
+  end
+ )
+)

--- a/lib/bysyncify/assembly/index.ts
+++ b/lib/bysyncify/assembly/index.ts
@@ -1,0 +1,5 @@
+// The entry file of your WebAssembly module.
+
+export function add(a: i32, b: i32): i32 {
+  return a + b;
+}

--- a/lib/bysyncify/assembly/tsconfig.json
+++ b/lib/bysyncify/assembly/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../std/assembly.json",
+  "include": [
+    "./**/*.ts"
+  ]
+}

--- a/lib/bysyncify/build/.gitignore
+++ b/lib/bysyncify/build/.gitignore
@@ -1,0 +1,3 @@
+*.wasm
+*.wasm.map
+*.asm.js

--- a/lib/bysyncify/index.js
+++ b/lib/bysyncify/index.js
@@ -1,0 +1,12 @@
+const fs = require("fs");
+const compiled = new WebAssembly.Module(fs.readFileSync(__dirname + "/build/optimized.wasm"));
+const imports = {
+  env: {
+    abort(_msg, _file, line, column) {
+       console.error("abort called at index.ts:" + line + ":" + column);
+    }
+  }
+};
+Object.defineProperty(module, "exports", {
+  get: () => new WebAssembly.Instance(compiled, imports).exports
+});

--- a/lib/bysyncify/package-lock.json
+++ b/lib/bysyncify/package-lock.json
@@ -1,0 +1,190 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@as-pect/assembly": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@as-pect/assembly/-/assembly-2.3.1.tgz",
+      "integrity": "sha512-KYBhyTEnaVcJjN/1EpzLhpbUHKT3pJjCPxm+Mdc7obnZ9EdVz6vN/lw+BQjeL4cUi1YLsnvgl8ftXcup5jVbQA=="
+    },
+    "@as-pect/cli": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@as-pect/cli/-/cli-2.3.1.tgz",
+      "integrity": "sha512-ipcxrXnK9Xj1Foy92nSRsganapB+yxFe4HJ/RuwnjRQ9s8bqu0UwH12XbiHktcK7bJMs1H77/sqbQVxqoYHQcA==",
+      "requires": {
+        "@as-pect/assembly": "^2.3.1",
+        "@as-pect/core": "^2.3.1",
+        "chalk": "^2.4.2",
+        "glob": "^7.1.4"
+      }
+    },
+    "@as-pect/core": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@as-pect/core/-/core-2.3.1.tgz",
+      "integrity": "sha512-iwd4MkGuO1wZqo9/sPlT567XYK0PkMLzBvwfkXOM2zq1wwuc5GZQrKoofgYorA40KI0edJW39djtOmPwIhx2vA==",
+      "requires": {
+        "@as-pect/assembly": "^2.3.1",
+        "chalk": "^2.4.2",
+        "csv-stringify": "^5.3.0",
+        "long": "^4.0.0"
+      }
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "assemblyscript": {
+      "version": "file:../..",
+      "requires": {
+        "@protobufjs/utf8": "^1.1.0",
+        "binaryen": "87.0.0-nightly.20190716",
+        "glob": "^7.1.4",
+        "long": "^4.0.0",
+        "opencollective-postinstall": "^2.0.0",
+        "source-map-support": "^0.5.12"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "csv-stringify": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.3.0.tgz",
+      "integrity": "sha512-VMYPbE8zWz475smwqb9VbX9cj0y4J0PBl59UdcqzLkzXHZZ8dh4Rmbb0ZywsWEtUml4A96Hn7Q5MW9ppVghYzg==",
+      "optional": true,
+      "requires": {
+        "lodash.get": "~4.4.2"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "optional": true
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  }
+}

--- a/lib/bysyncify/package.json
+++ b/lib/bysyncify/package.json
@@ -1,0 +1,11 @@
+{
+  "scripts": {
+    "asbuild:untouched": "asc assembly/index.ts -b build/untouched.wasm -t build/untouched.wat --sourceMap --validate --debug",
+    "asbuild:optimized": "asc assembly/index.ts -b build/optimized.wasm -t build/optimized.wat --sourceMap --validate --optimize",
+    "asbuild": "npm run asbuild:untouched && npm run asbuild:optimized"
+  },
+  "dependencies": {
+    "@as-pect/cli": "^2.3.1",
+    "assemblyscript": "file:../.."
+  }
+}


### PR DESCRIPTION
This is an experiment to use the new [async/await pass for binaryen](https://github.com/WebAssembly/binaryen/blob/master/src/passes/Asyncify.cpp).  Essentially four functions allow you to unwind and rewind the stack allowing for "pauses" a function by storing the stack in memory.

By default all functions will be instrumented to track the stack.  So the async keyword can be used to distinguish functions to be instrumented.

This will also update the loader since the paused functions can return to the host runtime, there will need to add a run loop.