### PR TITLE
Improve stub RT reallocation

### DIFF
--- a/std/assembly/rt/stub.ts
+++ b/std/assembly/rt/stub.ts
@@ -32,10 +32,11 @@ export function __alloc(size: usize, id: u32): usize {
 // @ts-ignore: decorator
 @unsafe @global
 export function __realloc(ref: usize, size: usize): usize {
+  assert(ref != 0 && !(ref & AL_MASK)); // must exist and be aligned
   var block = changetype<BLOCK>(ref - BLOCK_OVERHEAD);
-  var oldSize = <usize>block.rtSize;
+  var oldSize = (<usize>block.rtSize + AL_MASK) & ~AL_MASK;
   if (size > oldSize) {
-    let newRef = __alloc(size, block.rtId);
+    let newRef = __alloc(max<usize>(size, oldSize << 1), block.rtId);
     memory.copy(newRef, ref, oldSize);
     ref = newRef;
   } else {

--- a/tests/compiler/call-super.optimized.wat
+++ b/tests/compiler/call-super.optimized.wat
@@ -2,6 +2,7 @@
  (type $FUNCSIG$v (func))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$i (func (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
@@ -11,11 +12,56 @@
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $start)
- (func $~lib/rt/stub/__alloc (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const -16
+  i32.and
+  local.tee $0
+  memory.size
+  local.tee $2
+  i32.const 16
+  i32.shl
+  local.tee $1
+  i32.gt_u
+  if
+   local.get $2
+   local.get $0
+   local.get $1
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const -65536
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.tee $1
+   local.get $2
+   local.get $1
+   i32.gt_s
+   select
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $1
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 2 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -25,7 +71,7 @@
   global.get $~lib/rt/stub/offset
   i32.const 16
   i32.add
-  local.tee $3
+  local.tee $2
   local.get $0
   i32.const 1
   local.get $0
@@ -33,59 +79,19 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const -16
-  i32.and
-  local.tee $2
-  memory.size
-  local.tee $4
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $4
-   local.get $2
-   local.get $3
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const -65536
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.tee $5
-   local.get $4
-   local.get $5
-   i32.gt_s
-   select
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $5
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $2
-  global.set $~lib/rt/stub/offset
-  local.get $3
   i32.const 16
   i32.sub
-  local.tee $2
+  local.tee $3
   local.get $1
   i32.store offset=8
-  local.get $2
+  local.get $3
   local.get $0
   i32.store offset=12
-  local.get $3
+  local.get $2
  )
- (func $call-super/A#constructor (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $call-super/A#constructor (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -111,7 +117,7 @@
   end
   local.get $0
  )
- (func $call-super/B#constructor (; 3 ;) (type $FUNCSIG$i) (result i32)
+ (func $call-super/B#constructor (; 4 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   i32.const 8
   i32.const 4
@@ -146,7 +152,7 @@
   end
   local.get $0
  )
- (func $call-super/test1 (; 4 ;) (type $FUNCSIG$v)
+ (func $call-super/test1 (; 5 ;) (type $FUNCSIG$v)
   (local $0 i32)
   call $call-super/B#constructor
   local.tee $0
@@ -174,7 +180,7 @@
    unreachable
   end
  )
- (func $call-super/D#constructor (; 5 ;) (type $FUNCSIG$i) (result i32)
+ (func $call-super/D#constructor (; 6 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   i32.const 8
   i32.const 6
@@ -219,7 +225,7 @@
   end
   local.get $0
  )
- (func $call-super/test2 (; 6 ;) (type $FUNCSIG$v)
+ (func $call-super/test2 (; 7 ;) (type $FUNCSIG$v)
   (local $0 i32)
   call $call-super/D#constructor
   local.tee $0
@@ -247,7 +253,7 @@
    unreachable
   end
  )
- (func $call-super/E#constructor (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $call-super/E#constructor (; 8 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -273,7 +279,7 @@
   end
   local.get $0
  )
- (func $call-super/test3 (; 8 ;) (type $FUNCSIG$v)
+ (func $call-super/test3 (; 9 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 8
   i32.const 8
@@ -307,7 +313,7 @@
    unreachable
   end
  )
- (func $call-super/H#constructor (; 9 ;) (type $FUNCSIG$i) (result i32)
+ (func $call-super/H#constructor (; 10 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   i32.const 8
   i32.const 10
@@ -328,7 +334,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $call-super/test4 (; 10 ;) (type $FUNCSIG$v)
+ (func $call-super/test4 (; 11 ;) (type $FUNCSIG$v)
   (local $0 i32)
   call $call-super/H#constructor
   local.tee $0
@@ -356,7 +362,7 @@
    unreachable
   end
  )
- (func $call-super/J#constructor (; 11 ;) (type $FUNCSIG$i) (result i32)
+ (func $call-super/J#constructor (; 12 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   i32.const 8
   i32.const 12
@@ -377,7 +383,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $call-super/test5 (; 12 ;) (type $FUNCSIG$v)
+ (func $call-super/test5 (; 13 ;) (type $FUNCSIG$v)
   (local $0 i32)
   call $call-super/J#constructor
   local.tee $0
@@ -405,7 +411,7 @@
    unreachable
   end
  )
- (func $start (; 13 ;) (type $FUNCSIG$v)
+ (func $start (; 14 ;) (type $FUNCSIG$v)
   i32.const 64
   global.set $~lib/rt/stub/startOffset
   global.get $~lib/rt/stub/startOffset
@@ -416,7 +422,7 @@
   call $call-super/test4
   call $call-super/test5
  )
- (func $null (; 14 ;) (type $FUNCSIG$v)
+ (func $null (; 15 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/call-super.untouched.wat
+++ b/tests/compiler/call-super.untouched.wat
@@ -2,8 +2,8 @@
  (type $FUNCSIG$v (func))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
- (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00c\00a\00l\00l\00-\00s\00u\00p\00e\00r\00.\00t\00s\00")
@@ -14,14 +14,73 @@
  (global $~lib/heap/__heap_base i32 (i32.const 52))
  (export "memory" (memory $0))
  (start $start)
- (func $~lib/rt/stub/__alloc (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $0
+  memory.size
+  local.set $1
+  local.get $1
+  i32.const 16
+  i32.shl
+  local.set $2
+  local.get $0
+  local.get $2
+  i32.gt_u
+  if
+   local.get $0
+   local.get $2
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const 65535
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.set $3
+   local.get $1
+   local.tee $4
+   local.get $3
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_s
+   select
+   local.set $4
+   local.get $4
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $3
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 2 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -42,74 +101,23 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const 15
-  i32.const -1
-  i32.xor
-  i32.and
-  local.set $5
-  memory.size
-  local.set $6
-  local.get $5
-  local.get $6
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $5
-   local.get $2
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const 65535
-   i32.const -1
-   i32.xor
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.set $3
-   local.get $6
-   local.tee $4
-   local.get $3
-   local.tee $7
-   local.get $4
-   local.get $7
-   i32.gt_s
-   select
-   local.set $4
-   local.get $4
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $3
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
-  local.get $5
-  global.set $~lib/rt/stub/offset
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $2
   i32.const 16
   i32.sub
-  local.set $8
-  local.get $8
+  local.set $5
+  local.get $5
   local.get $1
   i32.store offset=8
-  local.get $8
+  local.get $5
   local.get $0
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $call-super/A#constructor (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $call-super/A#constructor (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -137,7 +145,7 @@
   end
   local.get $0
  )
- (func $call-super/B#constructor (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $call-super/B#constructor (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -180,10 +188,10 @@
   end
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 5 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/rt/stub/__release (; 6 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $call-super/test1 (; 6 ;) (type $FUNCSIG$v)
+ (func $call-super/test1 (; 7 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   call $call-super/B#constructor
@@ -217,7 +225,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $call-super/C#constructor (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $call-super/C#constructor (; 8 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -232,7 +240,7 @@
   i32.store
   local.get $0
  )
- (func $call-super/D#constructor (; 8 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $call-super/D#constructor (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -275,7 +283,7 @@
   end
   local.get $0
  )
- (func $call-super/test2 (; 9 ;) (type $FUNCSIG$v)
+ (func $call-super/test2 (; 10 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   call $call-super/D#constructor
@@ -309,7 +317,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $call-super/E#constructor (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $call-super/E#constructor (; 11 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -337,7 +345,7 @@
   end
   local.get $0
  )
- (func $call-super/F#constructor (; 11 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $call-super/F#constructor (; 12 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -355,7 +363,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $call-super/test3 (; 12 ;) (type $FUNCSIG$v)
+ (func $call-super/test3 (; 13 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   call $call-super/F#constructor
@@ -389,7 +397,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $call-super/G#constructor (; 13 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $call-super/G#constructor (; 14 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -404,7 +412,7 @@
   i32.store
   local.get $0
  )
- (func $call-super/H#constructor (; 14 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $call-super/H#constructor (; 15 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -422,7 +430,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $call-super/test4 (; 15 ;) (type $FUNCSIG$v)
+ (func $call-super/test4 (; 16 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   call $call-super/H#constructor
@@ -456,7 +464,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $call-super/I#constructor (; 16 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $call-super/I#constructor (; 17 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -471,7 +479,7 @@
   i32.store
   local.get $0
  )
- (func $call-super/J#constructor (; 17 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $call-super/J#constructor (; 18 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -489,7 +497,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $call-super/test5 (; 18 ;) (type $FUNCSIG$v)
+ (func $call-super/test5 (; 19 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   call $call-super/J#constructor
@@ -523,7 +531,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $start:call-super (; 19 ;) (type $FUNCSIG$v)
+ (func $start:call-super (; 20 ;) (type $FUNCSIG$v)
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -540,9 +548,9 @@
   call $call-super/test4
   call $call-super/test5
  )
- (func $start (; 20 ;) (type $FUNCSIG$v)
+ (func $start (; 21 ;) (type $FUNCSIG$v)
   call $start:call-super
  )
- (func $null (; 21 ;) (type $FUNCSIG$v)
+ (func $null (; 22 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/constructor.optimized.wat
+++ b/tests/compiler/constructor.optimized.wat
@@ -1,5 +1,6 @@
 (module
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$v (func))
  (memory $0 0)
  (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
@@ -17,11 +18,56 @@
  (global $constructor/ctorConditionallyAllocates (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $start)
- (func $~lib/rt/stub/__alloc (; 0 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 0 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const -16
+  i32.and
+  local.tee $0
+  memory.size
+  local.tee $2
+  i32.const 16
+  i32.shl
+  local.tee $1
+  i32.gt_u
+  if
+   local.get $2
+   local.get $0
+   local.get $1
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const -65536
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.tee $1
+   local.get $2
+   local.get $1
+   i32.gt_s
+   select
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $1
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -31,7 +77,7 @@
   global.get $~lib/rt/stub/offset
   i32.const 16
   i32.add
-  local.tee $3
+  local.tee $2
   local.get $0
   i32.const 1
   local.get $0
@@ -39,59 +85,19 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const -16
-  i32.and
-  local.tee $2
-  memory.size
-  local.tee $4
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $4
-   local.get $2
-   local.get $3
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const -65536
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.tee $5
-   local.get $4
-   local.get $5
-   i32.gt_s
-   select
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $5
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $2
-  global.set $~lib/rt/stub/offset
-  local.get $3
   i32.const 16
   i32.sub
-  local.tee $2
+  local.tee $3
   local.get $1
   i32.store offset=8
-  local.get $2
+  local.get $3
   local.get $0
   i32.store offset=12
-  local.get $3
+  local.get $2
  )
- (func $start:constructor (; 1 ;) (type $FUNCSIG$v)
+ (func $start:constructor (; 2 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 16
   global.set $~lib/rt/stub/startOffset
@@ -172,10 +178,10 @@
   local.get $0
   global.set $constructor/ctorConditionallyAllocates
  )
- (func $start (; 2 ;) (type $FUNCSIG$v)
+ (func $start (; 3 ;) (type $FUNCSIG$v)
   call $start:constructor
  )
- (func $null (; 3 ;) (type $FUNCSIG$v)
+ (func $null (; 4 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/constructor.untouched.wat
+++ b/tests/compiler/constructor.untouched.wat
@@ -1,6 +1,7 @@
 (module
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
@@ -21,14 +22,73 @@
  (global $~lib/heap/__heap_base i32 (i32.const 8))
  (export "memory" (memory $0))
  (start $start)
- (func $~lib/rt/stub/__alloc (; 0 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 0 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $0
+  memory.size
+  local.set $1
+  local.get $1
+  i32.const 16
+  i32.shl
+  local.set $2
+  local.get $0
+  local.get $2
+  i32.gt_u
+  if
+   local.get $0
+   local.get $2
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const 65535
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.set $3
+   local.get $1
+   local.tee $4
+   local.get $3
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_s
+   select
+   local.set $4
+   local.get $4
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $3
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -49,74 +109,23 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const 15
-  i32.const -1
-  i32.xor
-  i32.and
-  local.set $5
-  memory.size
-  local.set $6
-  local.get $5
-  local.get $6
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $5
-   local.get $2
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const 65535
-   i32.const -1
-   i32.xor
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.set $3
-   local.get $6
-   local.tee $4
-   local.get $3
-   local.tee $7
-   local.get $4
-   local.get $7
-   i32.gt_s
-   select
-   local.set $4
-   local.get $4
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $3
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
-  local.get $5
-  global.set $~lib/rt/stub/offset
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $2
   i32.const 16
   i32.sub
-  local.set $8
-  local.get $8
+  local.set $5
+  local.get $5
   local.get $1
   i32.store offset=8
-  local.get $8
+  local.get $5
   local.get $0
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $constructor/EmptyCtor#constructor (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $constructor/EmptyCtor#constructor (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -128,7 +137,7 @@
   end
   local.get $0
  )
- (func $constructor/EmptyCtorWithFieldInit#constructor (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $constructor/EmptyCtorWithFieldInit#constructor (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -143,7 +152,7 @@
   i32.store
   local.get $0
  )
- (func $constructor/EmptyCtorWithFieldNoInit#constructor (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $constructor/EmptyCtorWithFieldNoInit#constructor (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -158,7 +167,7 @@
   i32.store
   local.get $0
  )
- (func $constructor/None#constructor (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $constructor/None#constructor (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -170,7 +179,7 @@
   end
   local.get $0
  )
- (func $constructor/JustFieldInit#constructor (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $constructor/JustFieldInit#constructor (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -185,7 +194,7 @@
   i32.store
   local.get $0
  )
- (func $constructor/JustFieldNoInit#constructor (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $constructor/JustFieldNoInit#constructor (; 8 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -200,11 +209,11 @@
   i32.store
   local.get $0
  )
- (func $constructor/CtorReturns#constructor (; 8 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $constructor/CtorReturns#constructor (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   call $~lib/rt/stub/__retain
  )
- (func $constructor/CtorConditionallyReturns#constructor (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $constructor/CtorConditionallyReturns#constructor (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   global.get $constructor/b
   if
    i32.const 0
@@ -222,7 +231,7 @@
   end
   local.get $0
  )
- (func $constructor/CtorAllocates#constructor (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $constructor/CtorAllocates#constructor (; 11 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -236,7 +245,7 @@
   drop
   local.get $0
  )
- (func $constructor/CtorConditionallyAllocates#constructor (; 11 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $constructor/CtorConditionallyAllocates#constructor (; 12 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   global.get $constructor/b
   if
    local.get $0
@@ -262,7 +271,7 @@
   end
   local.get $0
  )
- (func $start:constructor (; 12 ;) (type $FUNCSIG$v)
+ (func $start:constructor (; 13 ;) (type $FUNCSIG$v)
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -304,9 +313,9 @@
   call $constructor/CtorConditionallyAllocates#constructor
   global.set $constructor/ctorConditionallyAllocates
  )
- (func $start (; 13 ;) (type $FUNCSIG$v)
+ (func $start (; 14 ;) (type $FUNCSIG$v)
   call $start:constructor
  )
- (func $null (; 14 ;) (type $FUNCSIG$v)
+ (func $null (; 15 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/exports.optimized.wat
+++ b/tests/compiler/exports.optimized.wat
@@ -1,9 +1,9 @@
 (module
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$vii (func (param i32 i32)))
- (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$v (func))
  (memory $0 0)
  (global $exports/Animal.CAT i32 (i32.const 0))
@@ -60,29 +60,25 @@
  (func $exports/Car.getNumTires (; 2 ;) (type $FUNCSIG$i) (result i32)
   i32.const 4
  )
- (func $~lib/rt/stub/__alloc (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 3 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  global.get $~lib/rt/stub/offset
-  i32.const 16
-  i32.add
-  local.tee $2
-  i32.const 19
+  local.get $0
+  i32.const 15
   i32.add
   i32.const -16
   i32.and
-  local.tee $1
+  local.tee $0
   memory.size
-  local.tee $3
+  local.tee $2
   i32.const 16
   i32.shl
+  local.tee $1
   i32.gt_u
   if
-   local.get $3
-   local.get $1
    local.get $2
+   local.get $0
+   local.get $1
    i32.sub
    i32.const 65535
    i32.add
@@ -90,16 +86,16 @@
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
-   local.get $3
-   local.get $4
+   local.tee $1
+   local.get $2
+   local.get $1
    i32.gt_s
    select
    memory.grow
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $1
     memory.grow
     i32.const 0
     i32.lt_s
@@ -108,41 +104,52 @@
     end
    end
   end
-  local.get $1
+  local.get $0
   global.set $~lib/rt/stub/offset
-  local.get $2
+ )
+ (func $~lib/rt/stub/__alloc (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  global.get $~lib/rt/stub/offset
+  i32.const 16
+  i32.add
+  local.tee $1
+  i32.const 4
+  i32.add
+  call $~lib/rt/stub/maybeGrowMemory
+  local.get $1
   i32.const 16
   i32.sub
-  local.tee $1
+  local.tee $2
   local.get $0
   i32.store offset=8
-  local.get $1
+  local.get $2
   i32.const 4
   i32.store offset=12
-  local.get $2
+  local.get $1
  )
- (func $exports/Car#get:numDoors (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $exports/Car#get:numDoors (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load
  )
- (func $exports/Car#set:numDoors (; 5 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $exports/Car#set:numDoors (; 6 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
  )
- (func $exports/Car#openDoors (; 6 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $exports/Car#openDoors (; 7 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $start (; 7 ;) (type $FUNCSIG$v)
+ (func $start (; 8 ;) (type $FUNCSIG$v)
   i32.const 16
   global.set $~lib/rt/stub/startOffset
   global.get $~lib/rt/stub/startOffset
   global.set $~lib/rt/stub/offset
  )
- (func $null (; 8 ;) (type $FUNCSIG$v)
+ (func $null (; 9 ;) (type $FUNCSIG$v)
   nop
  )
- (func $exports/subOpt|trampoline (; 9 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/subOpt|trampoline (; 10 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -160,11 +167,11 @@
   local.get $1
   call $exports/subOpt
  )
- (func $~lib/setargc (; 10 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/setargc (; 11 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   global.set $~lib/argc
  )
- (func $exports/Car#constructor|trampoline (; 11 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/Car#constructor|trampoline (; 12 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -191,7 +198,7 @@
   i32.store
   local.get $0
  )
- (func $exports/vehicles.Car#constructor|trampoline (; 12 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/vehicles.Car#constructor|trampoline (; 13 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange

--- a/tests/compiler/exports.untouched.wat
+++ b/tests/compiler/exports.untouched.wat
@@ -1,9 +1,9 @@
 (module
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$vii (func (param i32 i32)))
- (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
@@ -68,14 +68,73 @@
  (func $exports/Car.getNumTires (; 3 ;) (type $FUNCSIG$i) (result i32)
   global.get $exports/Car.TIRES
  )
- (func $~lib/rt/stub/__alloc (; 4 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 4 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $0
+  memory.size
+  local.set $1
+  local.get $1
+  i32.const 16
+  i32.shl
+  local.set $2
+  local.get $0
+  local.get $2
+  i32.gt_u
+  if
+   local.get $0
+   local.get $2
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const 65535
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.set $3
+   local.get $1
+   local.tee $4
+   local.get $3
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_s
+   select
+   local.set $4
+   local.get $4
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $3
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 5 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -96,74 +155,23 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const 15
-  i32.const -1
-  i32.xor
-  i32.and
-  local.set $5
-  memory.size
-  local.set $6
-  local.get $5
-  local.get $6
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $5
-   local.get $2
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const 65535
-   i32.const -1
-   i32.xor
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.set $3
-   local.get $6
-   local.tee $4
-   local.get $3
-   local.tee $7
-   local.get $4
-   local.get $7
-   i32.gt_s
-   select
-   local.set $4
-   local.get $4
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $3
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
-  local.get $5
-  global.set $~lib/rt/stub/offset
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $2
   i32.const 16
   i32.sub
-  local.set $8
-  local.get $8
+  local.set $5
+  local.get $5
   local.get $1
   i32.store offset=8
-  local.get $8
+  local.get $5
   local.get $0
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $exports/Car#constructor (; 6 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/Car#constructor (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -181,22 +189,22 @@
   i32.store
   local.get $0
  )
- (func $exports/Car#get:numDoors (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $exports/Car#get:numDoors (; 8 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load
  )
- (func $exports/Car#set:numDoors (; 8 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $exports/Car#set:numDoors (; 9 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
  )
- (func $exports/Car#openDoors (; 9 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $exports/Car#openDoors (; 10 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $exports/vehicles.Car.getNumTires (; 10 ;) (type $FUNCSIG$i) (result i32)
+ (func $exports/vehicles.Car.getNumTires (; 11 ;) (type $FUNCSIG$i) (result i32)
   global.get $exports/vehicles.Car.TIRES
  )
- (func $exports/vehicles.Car#constructor (; 11 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/vehicles.Car#constructor (; 12 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -214,19 +222,19 @@
   i32.store
   local.get $0
  )
- (func $exports/vehicles.Car#get:numDoors (; 12 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $exports/vehicles.Car#get:numDoors (; 13 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load
  )
- (func $exports/vehicles.Car#set:numDoors (; 13 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $exports/vehicles.Car#set:numDoors (; 14 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
  )
- (func $exports/vehicles.Car#openDoors (; 14 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $exports/vehicles.Car#openDoors (; 15 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $start (; 15 ;) (type $FUNCSIG$v)
+ (func $start (; 16 ;) (type $FUNCSIG$v)
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -238,9 +246,9 @@
   global.get $~lib/rt/stub/startOffset
   global.set $~lib/rt/stub/offset
  )
- (func $null (; 16 ;) (type $FUNCSIG$v)
+ (func $null (; 17 ;) (type $FUNCSIG$v)
  )
- (func $exports/subOpt|trampoline (; 17 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/subOpt|trampoline (; 18 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -258,20 +266,20 @@
   local.get $1
   call $exports/subOpt
  )
- (func $~lib/setargc (; 18 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/setargc (; 19 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   global.set $~lib/argc
  )
- (func $Car#get:doors (; 19 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $Car#get:doors (; 20 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load
  )
- (func $Car#set:doors (; 20 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $Car#set:doors (; 21 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
  )
- (func $exports/Car#constructor|trampoline (; 21 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/Car#constructor|trampoline (; 22 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -287,16 +295,16 @@
   local.get $1
   call $exports/Car#constructor
  )
- (func $vehicles.Car#get:doors (; 22 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $vehicles.Car#get:doors (; 23 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load
  )
- (func $vehicles.Car#set:doors (; 23 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $vehicles.Car#set:doors (; 24 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
  )
- (func $exports/vehicles.Car#constructor|trampoline (; 24 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/vehicles.Car#constructor|trampoline (; 25 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange

--- a/tests/compiler/getter-call.optimized.wat
+++ b/tests/compiler/getter-call.optimized.wat
@@ -1,5 +1,6 @@
 (module
  (type $FUNCSIG$i (func (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 2 funcref)
@@ -10,16 +11,11 @@
  (export "memory" (memory $0))
  (export "test" (func $getter-call/test))
  (start $start)
- (func $~lib/rt/stub/__alloc (; 0 ;) (type $FUNCSIG$i) (result i32)
-  (local $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 0 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  global.get $~lib/rt/stub/offset
-  i32.const 16
-  i32.add
-  local.tee $1
-  i32.const 16
+  local.get $0
+  i32.const 15
   i32.add
   i32.const -16
   i32.and
@@ -28,6 +24,7 @@
   local.tee $2
   i32.const 16
   i32.shl
+  local.tee $1
   i32.gt_u
   if
    local.get $2
@@ -40,16 +37,16 @@
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $1
    local.get $2
-   local.get $3
+   local.get $1
    i32.gt_s
    select
    memory.grow
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $1
     memory.grow
     i32.const 0
     i32.lt_s
@@ -60,34 +57,45 @@
   end
   local.get $0
   global.set $~lib/rt/stub/offset
-  local.get $1
+ )
+ (func $~lib/rt/stub/__alloc (; 1 ;) (type $FUNCSIG$i) (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  global.get $~lib/rt/stub/offset
+  i32.const 16
+  i32.add
+  local.tee $0
+  i32.const 1
+  i32.add
+  call $~lib/rt/stub/maybeGrowMemory
+  local.get $0
   i32.const 16
   i32.sub
-  local.tee $0
+  local.tee $1
   i32.const 3
   i32.store offset=8
-  local.get $0
+  local.get $1
   i32.const 0
   i32.store offset=12
-  local.get $1
+  local.get $0
  )
- (func $getter-call/C#get:x~anonymous|0 (; 1 ;) (type $FUNCSIG$i) (result i32)
+ (func $getter-call/C#get:x~anonymous|0 (; 2 ;) (type $FUNCSIG$i) (result i32)
   i32.const 42
  )
- (func $getter-call/test (; 2 ;) (type $FUNCSIG$i) (result i32)
+ (func $getter-call/test (; 3 ;) (type $FUNCSIG$i) (result i32)
   call $~lib/rt/stub/__alloc
   drop
   i32.const 0
   global.set $~lib/argc
   call $getter-call/C#get:x~anonymous|0
  )
- (func $start (; 3 ;) (type $FUNCSIG$v)
+ (func $start (; 4 ;) (type $FUNCSIG$v)
   i32.const 16
   global.set $~lib/rt/stub/startOffset
   global.get $~lib/rt/stub/startOffset
   global.set $~lib/rt/stub/offset
  )
- (func $null (; 4 ;) (type $FUNCSIG$v)
+ (func $null (; 5 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/getter-call.untouched.wat
+++ b/tests/compiler/getter-call.untouched.wat
@@ -1,8 +1,8 @@
 (module
  (type $FUNCSIG$i (func (result i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
- (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 2 funcref)
@@ -14,14 +14,73 @@
  (export "memory" (memory $0))
  (export "test" (func $getter-call/test))
  (start $start)
- (func $~lib/rt/stub/__alloc (; 0 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 0 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $0
+  memory.size
+  local.set $1
+  local.get $1
+  i32.const 16
+  i32.shl
+  local.set $2
+  local.get $0
+  local.get $2
+  i32.gt_u
+  if
+   local.get $0
+   local.get $2
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const 65535
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.set $3
+   local.get $1
+   local.tee $4
+   local.get $3
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_s
+   select
+   local.set $4
+   local.get $4
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $3
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -42,74 +101,23 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const 15
-  i32.const -1
-  i32.xor
-  i32.and
-  local.set $5
-  memory.size
-  local.set $6
-  local.get $5
-  local.get $6
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $5
-   local.get $2
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const 65535
-   i32.const -1
-   i32.xor
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.set $3
-   local.get $6
-   local.tee $4
-   local.get $3
-   local.tee $7
-   local.get $4
-   local.get $7
-   i32.gt_s
-   select
-   local.set $4
-   local.get $4
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $3
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
-  local.get $5
-  global.set $~lib/rt/stub/offset
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $2
   i32.const 16
   i32.sub
-  local.set $8
-  local.get $8
+  local.set $5
+  local.get $5
   local.get $1
   i32.store offset=8
-  local.get $8
+  local.get $5
   local.get $0
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $getter-call/C#constructor (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $getter-call/C#constructor (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -121,16 +129,16 @@
   end
   local.get $0
  )
- (func $getter-call/C#get:x~anonymous|0 (; 3 ;) (type $FUNCSIG$i) (result i32)
+ (func $getter-call/C#get:x~anonymous|0 (; 4 ;) (type $FUNCSIG$i) (result i32)
   i32.const 42
  )
- (func $getter-call/C#get:x (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $getter-call/C#get:x (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
  )
- (func $~lib/rt/stub/__release (; 5 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/rt/stub/__release (; 6 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $getter-call/test (; 6 ;) (type $FUNCSIG$i) (result i32)
+ (func $getter-call/test (; 7 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -146,7 +154,7 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $start (; 7 ;) (type $FUNCSIG$v)
+ (func $start (; 8 ;) (type $FUNCSIG$v)
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -158,6 +166,6 @@
   global.get $~lib/rt/stub/startOffset
   global.set $~lib/rt/stub/offset
  )
- (func $null (; 8 ;) (type $FUNCSIG$v)
+ (func $null (; 9 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/inlining.optimized.wat
+++ b/tests/compiler/inlining.optimized.wat
@@ -3,6 +3,7 @@
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$v (func))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -37,11 +38,56 @@
    unreachable
   end
  )
- (func $~lib/rt/stub/__alloc (; 4 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 4 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const -16
+  i32.and
+  local.tee $0
+  memory.size
+  local.tee $2
+  i32.const 16
+  i32.shl
+  local.tee $1
+  i32.gt_u
+  if
+   local.get $2
+   local.get $0
+   local.get $1
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const -65536
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.tee $1
+   local.get $2
+   local.get $1
+   i32.gt_s
+   select
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $1
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 5 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -51,7 +97,7 @@
   global.get $~lib/rt/stub/offset
   i32.const 16
   i32.add
-  local.tee $3
+  local.tee $2
   local.get $0
   i32.const 1
   local.get $0
@@ -59,59 +105,19 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const -16
-  i32.and
-  local.tee $2
-  memory.size
-  local.tee $4
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $4
-   local.get $2
-   local.get $3
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const -65536
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.tee $5
-   local.get $4
-   local.get $5
-   i32.gt_s
-   select
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $5
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $2
-  global.set $~lib/rt/stub/offset
-  local.get $3
   i32.const 16
   i32.sub
-  local.tee $2
+  local.tee $3
   local.get $1
   i32.store offset=8
-  local.get $2
+  local.get $3
   local.get $0
   i32.store offset=12
-  local.get $3
+  local.get $2
  )
- (func $inlining/test_ctor (; 5 ;) (type $FUNCSIG$v)
+ (func $inlining/test_ctor (; 6 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 16
   i32.const 5
@@ -191,7 +197,7 @@
    unreachable
   end
  )
- (func $start (; 6 ;) (type $FUNCSIG$v)
+ (func $start (; 7 ;) (type $FUNCSIG$v)
   call $inlining/test_funcs
   i32.const 48
   global.set $~lib/rt/stub/startOffset
@@ -199,7 +205,7 @@
   global.set $~lib/rt/stub/offset
   call $inlining/test_ctor
  )
- (func $null (; 7 ;) (type $FUNCSIG$v)
+ (func $null (; 8 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/inlining.untouched.wat
+++ b/tests/compiler/inlining.untouched.wat
@@ -275,14 +275,73 @@
   local.get $7
   call $~lib/rt/stub/__release
  )
- (func $~lib/rt/stub/__alloc (; 6 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 6 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $0
+  memory.size
+  local.set $1
+  local.get $1
+  i32.const 16
+  i32.shl
+  local.set $2
+  local.get $0
+  local.get $2
+  i32.gt_u
+  if
+   local.get $0
+   local.get $2
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const 65535
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.set $3
+   local.get $1
+   local.tee $4
+   local.get $3
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_s
+   select
+   local.set $4
+   local.get $4
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $3
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -303,71 +362,20 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const 15
-  i32.const -1
-  i32.xor
-  i32.and
-  local.set $5
-  memory.size
-  local.set $6
-  local.get $5
-  local.get $6
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $5
-   local.get $2
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const 65535
-   i32.const -1
-   i32.xor
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.set $3
-   local.get $6
-   local.tee $4
-   local.get $3
-   local.tee $7
-   local.get $4
-   local.get $7
-   i32.gt_s
-   select
-   local.set $4
-   local.get $4
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $3
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
-  local.get $5
-  global.set $~lib/rt/stub/offset
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $2
   i32.const 16
   i32.sub
-  local.set $8
-  local.get $8
+  local.set $5
+  local.get $5
   local.get $1
   i32.store offset=8
-  local.get $8
+  local.get $5
   local.get $0
   i32.store offset=12
   local.get $2
  )
- (func $inlining/test_ctor (; 7 ;) (type $FUNCSIG$v)
+ (func $inlining/test_ctor (; 8 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -475,7 +483,7 @@
   local.get $4
   call $~lib/rt/stub/__release
  )
- (func $start:inlining (; 8 ;) (type $FUNCSIG$v)
+ (func $start:inlining (; 9 ;) (type $FUNCSIG$v)
   call $inlining/test
   i32.const 3
   i32.eq
@@ -501,9 +509,9 @@
   global.set $~lib/rt/stub/offset
   call $inlining/test_ctor
  )
- (func $start (; 9 ;) (type $FUNCSIG$v)
+ (func $start (; 10 ;) (type $FUNCSIG$v)
   call $start:inlining
  )
- (func $null (; 10 ;) (type $FUNCSIG$v)
+ (func $null (; 11 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/number.optimized.wat
+++ b/tests/compiler/number.optimized.wat
@@ -1,6 +1,7 @@
 (module
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$viii (func (param i32 i32 i32)))
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$id (func (param f64) (result i32)))
@@ -91,11 +92,56 @@
   i32.lt_u
   select
  )
- (func $~lib/rt/stub/__alloc (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 2 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const -16
+  i32.and
+  local.tee $0
+  memory.size
+  local.tee $2
+  i32.const 16
+  i32.shl
+  local.tee $1
+  i32.gt_u
+  if
+   local.get $2
+   local.get $0
+   local.get $1
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const -65536
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.tee $1
+   local.get $2
+   local.get $1
+   i32.gt_s
+   select
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $1
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -105,7 +151,7 @@
   global.get $~lib/rt/stub/offset
   i32.const 16
   i32.add
-  local.tee $2
+  local.tee $1
   local.get $0
   i32.const 1
   local.get $0
@@ -113,59 +159,19 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const -16
-  i32.and
-  local.tee $1
-  memory.size
-  local.tee $3
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $3
-   local.get $1
-   local.get $2
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const -65536
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.tee $4
-   local.get $3
-   local.get $4
-   i32.gt_s
-   select
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $4
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $1
-  global.set $~lib/rt/stub/offset
-  local.get $2
   i32.const 16
   i32.sub
-  local.tee $1
+  local.tee $2
   i32.const 1
   i32.store offset=8
-  local.get $1
+  local.get $2
   local.get $0
   i32.store offset=12
-  local.get $2
+  local.get $1
  )
- (func $~lib/util/number/utoa_simple<u32> (; 3 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u32> (; 4 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   loop $continue|0
    local.get $1
@@ -192,7 +198,7 @@
    br_if $continue|0
   end
  )
- (func $~lib/util/number/itoa32 (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -232,7 +238,7 @@
   end
   local.get $2
  )
- (func $~lib/string/String#get:length (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -240,7 +246,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 6 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/compareImpl (; 7 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   loop $continue|0
    local.get $2
@@ -273,7 +279,7 @@
   end
   local.get $3
  )
- (func $~lib/string/String.__eq (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 8 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -305,19 +311,19 @@
   end
   i32.const 0
  )
- (func $~lib/number/isFinite<f64> (; 8 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/number/isFinite<f64> (; 9 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   local.get $0
   f64.sub
   f64.const 0
   f64.eq
  )
- (func $~lib/number/isNaN<f64> (; 9 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/number/isNaN<f64> (; 10 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   local.get $0
   f64.ne
  )
- (func $~lib/util/number/genDigits (; 10 ;) (type $FUNCSIG$iijijij) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (result i32)
+ (func $~lib/util/number/genDigits (; 11 ;) (type $FUNCSIG$iijijij) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (result i32)
   (local $6 i32)
   (local $7 i32)
   (local $8 i64)
@@ -717,7 +723,7 @@
   i32.store16
   local.get $2
  )
- (func $~lib/memory/memory.copy (; 11 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 12 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -892,7 +898,7 @@
    end
   end
  )
- (func $~lib/util/number/prettify (; 12 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (; 13 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
@@ -1139,7 +1145,7 @@
    end
   end
  )
- (func $~lib/util/number/dtoa_core (; 13 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/dtoa_core (; 14 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -1316,7 +1322,7 @@
   global.get $~lib/util/number/_K
   call $~lib/util/number/prettify
  )
- (func $~lib/string/String#substring (; 14 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#substring (; 15 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 0
@@ -1389,7 +1395,7 @@
   call $~lib/memory/memory.copy
   local.get $1
  )
- (func $~lib/util/number/dtoa (; 15 ;) (type $FUNCSIG$i) (result i32)
+ (func $~lib/util/number/dtoa (; 16 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   (local $1 i32)
   f64.const 2
@@ -1420,13 +1426,13 @@
   local.get $1
   call $~lib/string/String#substring
  )
- (func $~lib/number/Bool#toString (; 16 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/number/Bool#toString (; 17 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1424
   i32.const 1448
   local.get $0
   select
  )
- (func $~lib/number/F32.isSafeInteger (; 17 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
+ (func $~lib/number/F32.isSafeInteger (; 18 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
   local.get $0
   f32.trunc
   local.get $0
@@ -1438,7 +1444,7 @@
   f32.le
   select
  )
- (func $~lib/number/F32.isInteger (; 18 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
+ (func $~lib/number/F32.isInteger (; 19 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
   local.get $0
   f32.trunc
   local.get $0
@@ -1451,7 +1457,7 @@
   f32.eq
   select
  )
- (func $~lib/number/F64.isSafeInteger (; 19 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/number/F64.isSafeInteger (; 20 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   f64.trunc
   local.get $0
@@ -1463,7 +1469,7 @@
   f64.le
   select
  )
- (func $~lib/number/F64.isInteger (; 20 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/number/F64.isInteger (; 21 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   call $~lib/number/isFinite<f64>
   if (result i32)
@@ -1475,7 +1481,7 @@
    i32.const 0
   end
  )
- (func $start:number (; 21 ;) (type $FUNCSIG$v)
+ (func $start:number (; 22 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 1472
   global.set $~lib/rt/stub/startOffset
@@ -2093,10 +2099,10 @@
    unreachable
   end
  )
- (func $start (; 22 ;) (type $FUNCSIG$v)
+ (func $start (; 23 ;) (type $FUNCSIG$v)
   call $start:number
  )
- (func $null (; 23 ;) (type $FUNCSIG$v)
+ (func $null (; 24 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/number.untouched.wat
+++ b/tests/compiler/number.untouched.wat
@@ -1,8 +1,8 @@
 (module
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
- (type $FUNCSIG$viii (func (param i32 i32 i32)))
  (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
  (type $FUNCSIG$iiiiii (func (param i32 i32 i32 i32 i32) (result i32)))
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$idi (func (param f64 i32) (result i32)))
@@ -130,14 +130,73 @@
   end
   unreachable
  )
- (func $~lib/rt/stub/__alloc (; 3 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 3 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $0
+  memory.size
+  local.set $1
+  local.get $1
+  i32.const 16
+  i32.shl
+  local.set $2
+  local.get $0
+  local.get $2
+  i32.gt_u
+  if
+   local.get $0
+   local.get $2
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const 65535
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.set $3
+   local.get $1
+   local.tee $4
+   local.get $3
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_s
+   select
+   local.set $4
+   local.get $4
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $3
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 4 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -158,71 +217,20 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const 15
-  i32.const -1
-  i32.xor
-  i32.and
-  local.set $5
-  memory.size
-  local.set $6
-  local.get $5
-  local.get $6
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $5
-   local.get $2
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const 65535
-   i32.const -1
-   i32.xor
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.set $3
-   local.get $6
-   local.tee $4
-   local.get $3
-   local.tee $7
-   local.get $4
-   local.get $7
-   i32.gt_s
-   select
-   local.set $4
-   local.get $4
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $3
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
-  local.get $5
-  global.set $~lib/rt/stub/offset
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $2
   i32.const 16
   i32.sub
-  local.set $8
-  local.get $8
+  local.set $5
+  local.get $5
   local.get $1
   i32.store offset=8
-  local.get $8
+  local.get $5
   local.get $0
   i32.store offset=12
   local.get $2
  )
- (func $~lib/util/number/utoa32_lut (; 4 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa32_lut (; 5 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -364,7 +372,7 @@
    i32.store16
   end
  )
- (func $~lib/util/number/itoa32 (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -419,15 +427,15 @@
   local.get $3
   call $~lib/rt/stub/__retain
  )
- (func $~lib/util/number/itoa<i32> (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<i32> (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/itoa32
   return
  )
- (func $~lib/rt/stub/__release (; 7 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/rt/stub/__release (; 8 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $~lib/number/I32#toString (; 8 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/number/I32#toString (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -439,7 +447,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/string/String#get:length (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -447,7 +455,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 10 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (; 11 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -512,7 +520,7 @@
   call $~lib/rt/stub/__release
   local.get $8
  )
- (func $~lib/string/String.__eq (; 11 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 12 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -585,19 +593,19 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/number/isFinite<f64> (; 12 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/number/isFinite<f64> (; 13 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   local.get $0
   f64.sub
   f64.const 0
   f64.eq
  )
- (func $~lib/number/isNaN<f64> (; 13 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/number/isNaN<f64> (; 14 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   local.get $0
   f64.ne
  )
- (func $~lib/array/Array<u64>#__unchecked_get (; 14 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__unchecked_get (; 15 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -606,7 +614,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<i16>#__unchecked_get (; 15 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__unchecked_get (; 16 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -615,7 +623,7 @@
   i32.add
   i32.load16_s
  )
- (func $~lib/util/number/genDigits (; 16 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (; 17 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -1117,7 +1125,7 @@
   end
   unreachable
  )
- (func $~lib/util/memory/memcpy (; 17 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (; 18 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2145,7 +2153,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 18 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 19 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2370,7 +2378,7 @@
    end
   end
  )
- (func $~lib/util/number/prettify (; 19 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (; 20 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2689,7 +2697,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/dtoa_core (; 20 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (; 21 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3111,7 +3119,7 @@
   local.get $2
   i32.add
  )
- (func $~lib/string/String#substring (; 21 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substring (; 22 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3218,10 +3226,10 @@
   local.get $10
   call $~lib/rt/stub/__retain
  )
- (func $~lib/rt/stub/__free (; 22 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/rt/stub/__free (; 23 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $~lib/util/number/dtoa (; 23 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/util/number/dtoa (; 24 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3280,11 +3288,11 @@
   call $~lib/rt/stub/__free
   local.get $3
  )
- (func $~lib/number/F64#toString (; 24 ;) (type $FUNCSIG$idi) (param $0 f64) (param $1 i32) (result i32)
+ (func $~lib/number/F64#toString (; 25 ;) (type $FUNCSIG$idi) (param $0 f64) (param $1 i32) (result i32)
   local.get $0
   call $~lib/util/number/dtoa
  )
- (func $~lib/number/Bool#toString (; 25 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/number/Bool#toString (; 26 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -3299,12 +3307,12 @@
   end
   call $~lib/rt/stub/__retain
  )
- (func $~lib/number/isNaN<f32> (; 26 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
+ (func $~lib/number/isNaN<f32> (; 27 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
   local.get $0
   local.get $0
   f32.ne
  )
- (func $~lib/number/F32.isSafeInteger (; 27 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
+ (func $~lib/number/F32.isSafeInteger (; 28 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
   local.get $0
   f32.abs
   global.get $~lib/builtins/f32.MAX_SAFE_INTEGER
@@ -3318,14 +3326,14 @@
    i32.const 0
   end
  )
- (func $~lib/number/isFinite<f32> (; 28 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
+ (func $~lib/number/isFinite<f32> (; 29 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
   local.get $0
   local.get $0
   f32.sub
   f32.const 0
   f32.eq
  )
- (func $~lib/number/F32.isInteger (; 29 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
+ (func $~lib/number/F32.isInteger (; 30 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
   local.get $0
   call $~lib/number/isFinite<f32>
   if (result i32)
@@ -3337,7 +3345,7 @@
    i32.const 0
   end
  )
- (func $~lib/number/F64.isSafeInteger (; 30 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/number/F64.isSafeInteger (; 31 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   f64.abs
   global.get $~lib/builtins/f64.MAX_SAFE_INTEGER
@@ -3351,7 +3359,7 @@
    i32.const 0
   end
  )
- (func $~lib/number/F64.isInteger (; 31 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/number/F64.isInteger (; 32 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   call $~lib/number/isFinite<f64>
   if (result i32)
@@ -3363,7 +3371,7 @@
    i32.const 0
   end
  )
- (func $start:number (; 32 ;) (type $FUNCSIG$v)
+ (func $start:number (; 33 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -4123,9 +4131,9 @@
   local.get $10
   call $~lib/rt/stub/__release
  )
- (func $start (; 33 ;) (type $FUNCSIG$v)
+ (func $start (; 34 ;) (type $FUNCSIG$v)
   call $start:number
  )
- (func $null (; 34 ;) (type $FUNCSIG$v)
+ (func $null (; 35 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/optional-typeparameters.optimized.wat
+++ b/tests/compiler/optional-typeparameters.optimized.wat
@@ -1,4 +1,5 @@
 (module
+ (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$v (func))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (memory $0 0)
@@ -8,29 +9,25 @@
  (global $optional-typeparameters/tDerived (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $start)
- (func $~lib/rt/stub/__alloc (; 0 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 0 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  global.get $~lib/rt/stub/offset
-  i32.const 16
-  i32.add
-  local.tee $2
-  i32.const 16
+  local.get $0
+  i32.const 15
   i32.add
   i32.const -16
   i32.and
-  local.tee $1
+  local.tee $0
   memory.size
-  local.tee $3
+  local.tee $2
   i32.const 16
   i32.shl
+  local.tee $1
   i32.gt_u
   if
-   local.get $3
-   local.get $1
    local.get $2
+   local.get $0
+   local.get $1
    i32.sub
    i32.const 65535
    i32.add
@@ -38,16 +35,16 @@
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
-   local.get $3
-   local.get $4
+   local.tee $1
+   local.get $2
+   local.get $1
    i32.gt_s
    select
    memory.grow
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $1
     memory.grow
     i32.const 0
     i32.lt_s
@@ -56,20 +53,31 @@
     end
    end
   end
-  local.get $1
+  local.get $0
   global.set $~lib/rt/stub/offset
-  local.get $2
+ )
+ (func $~lib/rt/stub/__alloc (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  global.get $~lib/rt/stub/offset
+  i32.const 16
+  i32.add
+  local.tee $1
+  i32.const 1
+  i32.add
+  call $~lib/rt/stub/maybeGrowMemory
+  local.get $1
   i32.const 16
   i32.sub
-  local.tee $1
+  local.tee $2
   local.get $0
   i32.store offset=8
-  local.get $1
+  local.get $2
   i32.const 0
   i32.store offset=12
-  local.get $2
+  local.get $1
  )
- (func $start (; 1 ;) (type $FUNCSIG$v)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   i32.const 16
   global.set $~lib/rt/stub/startOffset
   global.get $~lib/rt/stub/startOffset
@@ -81,7 +89,7 @@
   call $~lib/rt/stub/__alloc
   global.set $optional-typeparameters/tDerived
  )
- (func $null (; 2 ;) (type $FUNCSIG$v)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/optional-typeparameters.untouched.wat
+++ b/tests/compiler/optional-typeparameters.untouched.wat
@@ -1,6 +1,7 @@
 (module
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
  (type $FUNCSIG$didd (func (param i32 f64 f64) (result f64)))
  (type $FUNCSIG$v (func))
@@ -20,14 +21,73 @@
  (func $optional-typeparameters/testDerived<i32,i32> (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/__alloc (; 2 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 2 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $0
+  memory.size
+  local.set $1
+  local.get $1
+  i32.const 16
+  i32.shl
+  local.set $2
+  local.get $0
+  local.get $2
+  i32.gt_u
+  if
+   local.get $0
+   local.get $2
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const 65535
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.set $3
+   local.get $1
+   local.tee $4
+   local.get $3
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_s
+   select
+   local.set $4
+   local.get $4
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $3
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 3 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -48,74 +108,23 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const 15
-  i32.const -1
-  i32.xor
-  i32.and
-  local.set $5
-  memory.size
-  local.set $6
-  local.get $5
-  local.get $6
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $5
-   local.get $2
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const 65535
-   i32.const -1
-   i32.xor
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.set $3
-   local.get $6
-   local.tee $4
-   local.get $3
-   local.tee $7
-   local.get $4
-   local.get $7
-   i32.gt_s
-   select
-   local.set $4
-   local.get $4
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $3
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
-  local.get $5
-  global.set $~lib/rt/stub/offset
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $2
   i32.const 16
   i32.sub
-  local.set $8
-  local.get $8
+  local.set $5
+  local.get $5
   local.get $1
   i32.store offset=8
-  local.get $8
+  local.get $5
   local.get $0
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $optional-typeparameters/TestConcrete<i32,i32>#constructor (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $optional-typeparameters/TestConcrete<i32,i32>#constructor (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -127,12 +136,12 @@
   end
   local.get $0
  )
- (func $optional-typeparameters/TestConcrete<i32,i32>#test<i32> (; 5 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $optional-typeparameters/TestConcrete<i32,i32>#test<i32> (; 6 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   local.get $2
   i32.add
  )
- (func $optional-typeparameters/TestDerived<f64,f64>#constructor (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $optional-typeparameters/TestDerived<f64,f64>#constructor (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -144,12 +153,12 @@
   end
   local.get $0
  )
- (func $optional-typeparameters/TestDerived<f64,f64>#test<f64> (; 7 ;) (type $FUNCSIG$didd) (param $0 i32) (param $1 f64) (param $2 f64) (result f64)
+ (func $optional-typeparameters/TestDerived<f64,f64>#test<f64> (; 8 ;) (type $FUNCSIG$didd) (param $0 i32) (param $1 f64) (param $2 f64) (result f64)
   local.get $1
   local.get $2
   f64.add
  )
- (func $start:optional-typeparameters (; 8 ;) (type $FUNCSIG$v)
+ (func $start:optional-typeparameters (; 9 ;) (type $FUNCSIG$v)
   i32.const 1
   call $optional-typeparameters/testConcrete<i32,i32>
   drop
@@ -183,9 +192,9 @@
   call $optional-typeparameters/TestDerived<f64,f64>#test<f64>
   drop
  )
- (func $start (; 9 ;) (type $FUNCSIG$v)
+ (func $start (; 10 ;) (type $FUNCSIG$v)
   call $start:optional-typeparameters
  )
- (func $null (; 10 ;) (type $FUNCSIG$v)
+ (func $null (; 11 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/resolve-access.optimized.wat
+++ b/tests/compiler/resolve-access.optimized.wat
@@ -1,13 +1,13 @@
 (module
  (type $FUNCSIG$i (func (result i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$viii (func (param i32 i32 i32)))
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$ij (func (param i64) (result i32)))
  (type $FUNCSIG$viji (func (param i32 i64 i32)))
  (type $FUNCSIG$v (func))
- (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$ji (func (param i32) (result i64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -22,11 +22,56 @@
  (export "fieldAccess" (func $resolve-access/fieldAccess))
  (export "propertyAccess" (func $resolve-access/propertyAccess))
  (start $start)
- (func $~lib/rt/stub/__alloc (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const -16
+  i32.and
+  local.tee $0
+  memory.size
+  local.tee $2
+  i32.const 16
+  i32.shl
+  local.tee $1
+  i32.gt_u
+  if
+   local.get $2
+   local.get $0
+   local.get $1
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const -65536
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.tee $1
+   local.get $2
+   local.get $1
+   i32.gt_s
+   select
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $1
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 2 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -36,7 +81,7 @@
   global.get $~lib/rt/stub/offset
   i32.const 16
   i32.add
-  local.tee $3
+  local.tee $2
   local.get $0
   i32.const 1
   local.get $0
@@ -44,59 +89,19 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const -16
-  i32.and
-  local.tee $2
-  memory.size
-  local.tee $4
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $4
-   local.get $2
-   local.get $3
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const -65536
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.tee $5
-   local.get $4
-   local.get $5
-   i32.gt_s
-   select
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $5
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $2
-  global.set $~lib/rt/stub/offset
-  local.get $3
   i32.const 16
   i32.sub
-  local.tee $2
+  local.tee $3
   local.get $1
   i32.store offset=8
-  local.get $2
+  local.get $3
   local.get $0
   i32.store offset=12
-  local.get $3
+  local.get $2
  )
- (func $~lib/memory/memory.copy (; 2 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/memory/memory.copy (; 3 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -267,7 +272,7 @@
    end
   end
  )
- (func $~lib/rt/__allocArray (; 3 ;) (type $FUNCSIG$i) (result i32)
+ (func $~lib/rt/__allocArray (; 4 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   (local $1 i32)
   i32.const 16
@@ -292,7 +297,7 @@
   call $~lib/memory/memory.copy
   local.get $0
  )
- (func $~lib/array/Array<u64>#__get (; 4 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
+ (func $~lib/array/Array<u64>#__get (; 5 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
   i32.const 0
   local.get $0
   i32.load offset=8
@@ -311,7 +316,7 @@
   i32.load offset=4
   i64.load
  )
- (func $~lib/util/number/decimalCount32 (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   i32.const 2
   local.get $0
@@ -359,7 +364,7 @@
   i32.lt_u
   select
  )
- (func $~lib/util/number/utoa_simple<u32> (; 6 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u32> (; 7 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   loop $continue|0
    local.get $1
@@ -386,7 +391,7 @@
    br_if $continue|0
   end
  )
- (func $~lib/util/number/decimalCount64 (; 7 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64 (; 8 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   i32.const 10
   i32.const 11
   i32.const 12
@@ -439,7 +444,7 @@
   i64.lt_u
   select
  )
- (func $~lib/util/number/utoa_simple<u64> (; 8 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u64> (; 9 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   loop $continue|0
    local.get $1
@@ -469,7 +474,7 @@
    br_if $continue|0
   end
  )
- (func $~lib/util/number/utoa64 (; 9 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/utoa64 (; 10 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -511,12 +516,12 @@
   end
   local.get $2
  )
- (func $resolve-access/arrayAccess (; 10 ;) (type $FUNCSIG$i) (result i32)
+ (func $resolve-access/arrayAccess (; 11 ;) (type $FUNCSIG$i) (result i32)
   call $~lib/rt/__allocArray
   call $~lib/array/Array<u64>#__get
   call $~lib/util/number/utoa64
  )
- (func $resolve-access/Container#constructor (; 11 ;) (type $FUNCSIG$i) (result i32)
+ (func $resolve-access/Container#constructor (; 12 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   i32.const 8
   i32.const 5
@@ -526,7 +531,7 @@
   i64.store
   local.get $0
  )
- (func $resolve-access/fieldAccess (; 12 ;) (type $FUNCSIG$i) (result i32)
+ (func $resolve-access/fieldAccess (; 13 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   call $resolve-access/Container#constructor
   local.tee $0
@@ -536,7 +541,7 @@
   i64.load
   call $~lib/util/number/utoa64
  )
- (func $~lib/util/number/utoa32 (; 13 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/utoa32 (; 14 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -558,7 +563,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $2
  )
- (func $resolve-access/propertyAccess (; 14 ;) (type $FUNCSIG$i) (result i32)
+ (func $resolve-access/propertyAccess (; 15 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   call $resolve-access/Container#constructor
   local.tee $0
@@ -569,13 +574,13 @@
   i32.wrap_i64
   call $~lib/util/number/utoa32
  )
- (func $start (; 15 ;) (type $FUNCSIG$v)
+ (func $start (; 16 ;) (type $FUNCSIG$v)
   i32.const 160
   global.set $~lib/rt/stub/startOffset
   global.get $~lib/rt/stub/startOffset
   global.set $~lib/rt/stub/offset
  )
- (func $null (; 16 ;) (type $FUNCSIG$v)
+ (func $null (; 17 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/retain-release.optimized.wat
+++ b/tests/compiler/retain-release.optimized.wat
@@ -1,9 +1,9 @@
 (module
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$v (func))
  (type $FUNCSIG$i (func (result i32)))
- (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -54,11 +54,56 @@
  (export "provideRefIndirect" (func $retain-release/provideRefIndirect))
  (export "receiveRefIndirect" (func $retain-release/receiveRefIndirect))
  (export "receiveRefIndirectDrop" (func $retain-release/receiveRefIndirect))
- (func $~lib/rt/stub/__alloc (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const -16
+  i32.and
+  local.tee $0
+  memory.size
+  local.tee $2
+  i32.const 16
+  i32.shl
+  local.tee $1
+  i32.gt_u
+  if
+   local.get $2
+   local.get $0
+   local.get $1
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const -65536
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.tee $1
+   local.get $2
+   local.get $1
+   i32.gt_s
+   select
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $1
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 2 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -68,7 +113,7 @@
   global.get $~lib/rt/stub/offset
   i32.const 16
   i32.add
-  local.tee $3
+  local.tee $2
   local.get $0
   i32.const 1
   local.get $0
@@ -76,85 +121,45 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const -16
-  i32.and
-  local.tee $2
-  memory.size
-  local.tee $4
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $4
-   local.get $2
-   local.get $3
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const -65536
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.tee $5
-   local.get $4
-   local.get $5
-   i32.gt_s
-   select
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $5
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $2
-  global.set $~lib/rt/stub/offset
-  local.get $3
   i32.const 16
   i32.sub
-  local.tee $2
+  local.tee $3
   local.get $1
   i32.store offset=8
-  local.get $2
+  local.get $3
   local.get $0
   i32.store offset=12
-  local.get $3
+  local.get $2
  )
- (func $retain-release/Ref#constructor (; 2 ;) (type $FUNCSIG$i) (result i32)
+ (func $retain-release/Ref#constructor (; 3 ;) (type $FUNCSIG$i) (result i32)
   i32.const 0
   i32.const 3
   call $~lib/rt/stub/__alloc
  )
- (func $retain-release/returnRef (; 3 ;) (type $FUNCSIG$i) (result i32)
+ (func $retain-release/returnRef (; 4 ;) (type $FUNCSIG$i) (result i32)
   global.get $retain-release/REF
  )
- (func $retain-release/receiveRef (; 4 ;) (type $FUNCSIG$v)
+ (func $retain-release/receiveRef (; 5 ;) (type $FUNCSIG$v)
   nop
  )
- (func $retain-release/takeRef (; 5 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $retain-release/takeRef (; 6 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $retain-release/takeReturnRef (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $retain-release/takeReturnRef (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $retain-release/newRef (; 7 ;) (type $FUNCSIG$v)
+ (func $retain-release/newRef (; 8 ;) (type $FUNCSIG$v)
   call $retain-release/Ref#constructor
   drop
  )
- (func $retain-release/assignGlobal (; 8 ;) (type $FUNCSIG$v)
+ (func $retain-release/assignGlobal (; 9 ;) (type $FUNCSIG$v)
   (local $0 i32)
   global.get $retain-release/REF
   global.set $retain-release/glo
  )
- (func $retain-release/assignField (; 9 ;) (type $FUNCSIG$v)
+ (func $retain-release/assignField (; 10 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   global.get $retain-release/REF
@@ -168,11 +173,11 @@
   local.get $0
   i32.store
  )
- (func $retain-release/scopeBlockToConditional (; 10 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $retain-release/scopeBlockToConditional (; 11 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   nop
  )
- (func $retain-release/scopeThrow (; 11 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $retain-release/scopeThrow (; 12 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   if
    i32.const 24
@@ -183,27 +188,27 @@
    unreachable
   end
  )
- (func $retain-release/scopeUnreachable (; 12 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $retain-release/scopeUnreachable (; 13 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   if
    unreachable
   end
  )
- (func $retain-release/provideRefIndirect (; 13 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $retain-release/provideRefIndirect (; 14 ;) (type $FUNCSIG$vi) (param $0 i32)
   i32.const 1
   global.set $~lib/argc
   global.get $retain-release/REF
   local.get $0
   call_indirect (type $FUNCSIG$vi)
  )
- (func $retain-release/receiveRefIndirect (; 14 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $retain-release/receiveRefIndirect (; 15 ;) (type $FUNCSIG$vi) (param $0 i32)
   i32.const 0
   global.set $~lib/argc
   local.get $0
   call_indirect (type $FUNCSIG$i)
   drop
  )
- (func $start (; 15 ;) (type $FUNCSIG$v)
+ (func $start (; 16 ;) (type $FUNCSIG$v)
   (local $0 i32)
   global.get $~lib/started
   if

--- a/tests/compiler/retain-release.untouched.wat
+++ b/tests/compiler/retain-release.untouched.wat
@@ -1,9 +1,9 @@
 (module
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$v (func))
  (type $FUNCSIG$i (func (result i32)))
- (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -55,14 +55,73 @@
  (export "provideRefIndirect" (func $retain-release/provideRefIndirect))
  (export "receiveRefIndirect" (func $retain-release/receiveRefIndirect))
  (export "receiveRefIndirectDrop" (func $retain-release/receiveRefIndirectDrop))
- (func $~lib/rt/stub/__alloc (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $0
+  memory.size
+  local.set $1
+  local.get $1
+  i32.const 16
+  i32.shl
+  local.set $2
+  local.get $0
+  local.get $2
+  i32.gt_u
+  if
+   local.get $0
+   local.get $2
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const 65535
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.set $3
+   local.get $1
+   local.tee $4
+   local.get $3
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_s
+   select
+   local.set $4
+   local.get $4
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $3
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 2 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -83,74 +142,23 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const 15
-  i32.const -1
-  i32.xor
-  i32.and
-  local.set $5
-  memory.size
-  local.set $6
-  local.get $5
-  local.get $6
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $5
-   local.get $2
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const 65535
-   i32.const -1
-   i32.xor
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.set $3
-   local.get $6
-   local.tee $4
-   local.get $3
-   local.tee $7
-   local.get $4
-   local.get $7
-   i32.gt_s
-   select
-   local.set $4
-   local.get $4
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $3
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
-  local.get $5
-  global.set $~lib/rt/stub/offset
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $2
   i32.const 16
   i32.sub
-  local.set $8
-  local.get $8
+  local.set $5
+  local.get $5
   local.get $1
   i32.store offset=8
-  local.get $8
+  local.get $5
   local.get $0
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $retain-release/Ref#constructor (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $retain-release/Ref#constructor (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -162,7 +170,7 @@
   end
   local.get $0
  )
- (func $retain-release/Target#constructor (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $retain-release/Target#constructor (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -177,7 +185,7 @@
   i32.store
   local.get $0
  )
- (func $start:retain-release (; 5 ;) (type $FUNCSIG$v)
+ (func $start:retain-release (; 6 ;) (type $FUNCSIG$v)
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -195,14 +203,14 @@
   call $retain-release/Target#constructor
   global.set $retain-release/TARGET
  )
- (func $retain-release/returnRef (; 6 ;) (type $FUNCSIG$i) (result i32)
+ (func $retain-release/returnRef (; 7 ;) (type $FUNCSIG$i) (result i32)
   global.get $retain-release/REF
   call $~lib/rt/stub/__retain
  )
- (func $~lib/rt/stub/__release (; 7 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/rt/stub/__release (; 8 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $retain-release/receiveRef (; 8 ;) (type $FUNCSIG$v)
+ (func $retain-release/receiveRef (; 9 ;) (type $FUNCSIG$v)
   (local $0 i32)
   call $retain-release/returnRef
   local.tee $0
@@ -211,35 +219,35 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $retain-release/receiveRefDrop (; 9 ;) (type $FUNCSIG$v)
+ (func $retain-release/receiveRefDrop (; 10 ;) (type $FUNCSIG$v)
   call $retain-release/returnRef
   call $~lib/rt/stub/__release
  )
- (func $retain-release/receiveRefRetain (; 10 ;) (type $FUNCSIG$v)
+ (func $retain-release/receiveRefRetain (; 11 ;) (type $FUNCSIG$v)
   (local $0 i32)
   call $retain-release/returnRef
   local.set $0
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $retain-release/takeRef (; 11 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $retain-release/takeRef (; 12 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   drop
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $retain-release/provideRef (; 12 ;) (type $FUNCSIG$v)
+ (func $retain-release/provideRef (; 13 ;) (type $FUNCSIG$v)
   global.get $retain-release/REF
   call $retain-release/takeRef
  )
- (func $retain-release/takeReturnRef (; 13 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $retain-release/takeReturnRef (; 14 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/rt/stub/__retain
   drop
   local.get $0
  )
- (func $retain-release/provideReceiveRef (; 14 ;) (type $FUNCSIG$v)
+ (func $retain-release/provideReceiveRef (; 15 ;) (type $FUNCSIG$v)
   (local $0 i32)
   global.get $retain-release/REF
   call $retain-release/takeReturnRef
@@ -249,12 +257,12 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $retain-release/newRef (; 15 ;) (type $FUNCSIG$v)
+ (func $retain-release/newRef (; 16 ;) (type $FUNCSIG$v)
   i32.const 0
   call $retain-release/Ref#constructor
   call $~lib/rt/stub/__release
  )
- (func $retain-release/assignGlobal (; 16 ;) (type $FUNCSIG$v)
+ (func $retain-release/assignGlobal (; 17 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   global.get $retain-release/REF
@@ -272,7 +280,7 @@
   local.get $0
   global.set $retain-release/glo
  )
- (func $retain-release/assignField (; 17 ;) (type $FUNCSIG$v)
+ (func $retain-release/assignField (; 18 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   global.get $retain-release/TARGET
@@ -293,7 +301,7 @@
   local.get $1
   i32.store
  )
- (func $retain-release/scopeBlock (; 18 ;) (type $FUNCSIG$v)
+ (func $retain-release/scopeBlock (; 19 ;) (type $FUNCSIG$v)
   (local $0 i32)
   global.get $retain-release/REF
   call $~lib/rt/stub/__retain
@@ -301,7 +309,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $retain-release/scopeBlockToUninitialized (; 19 ;) (type $FUNCSIG$v)
+ (func $retain-release/scopeBlockToUninitialized (; 20 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -330,7 +338,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $retain-release/scopeBlockToInitialized (; 20 ;) (type $FUNCSIG$v)
+ (func $retain-release/scopeBlockToInitialized (; 21 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -360,7 +368,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $retain-release/scopeBlockToConditional (; 21 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $retain-release/scopeBlockToConditional (; 22 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -406,14 +414,14 @@
   local.get $1
   call $~lib/rt/stub/__release
  )
- (func $retain-release/scopeTopLevelUninitialized (; 22 ;) (type $FUNCSIG$v)
+ (func $retain-release/scopeTopLevelUninitialized (; 23 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 0
   local.set $0
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $retain-release/scopeTopLevelInitialized (; 23 ;) (type $FUNCSIG$v)
+ (func $retain-release/scopeTopLevelInitialized (; 24 ;) (type $FUNCSIG$v)
   (local $0 i32)
   global.get $retain-release/REF
   call $~lib/rt/stub/__retain
@@ -421,7 +429,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $retain-release/scopeTopLevelConditional (; 24 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $retain-release/scopeTopLevelConditional (; 25 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -447,7 +455,7 @@
   local.get $1
   call $~lib/rt/stub/__release
  )
- (func $retain-release/scopeIf (; 25 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $retain-release/scopeIf (; 26 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   local.get $0
   if
@@ -458,7 +466,7 @@
    call $~lib/rt/stub/__release
   end
  )
- (func $retain-release/scopeIfElse (; 26 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $retain-release/scopeIfElse (; 27 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   local.get $0
   if
@@ -475,7 +483,7 @@
    call $~lib/rt/stub/__release
   end
  )
- (func $retain-release/scopeWhile (; 27 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $retain-release/scopeWhile (; 28 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   block $break|0
    loop $continue|0
@@ -492,7 +500,7 @@
    unreachable
   end
  )
- (func $retain-release/scopeDo (; 28 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $retain-release/scopeDo (; 29 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   loop $continue|0
    global.get $retain-release/REF
@@ -502,7 +510,7 @@
    br_if $continue|0
   end
  )
- (func $retain-release/scopeFor (; 29 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $retain-release/scopeFor (; 30 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   block $break|0
    loop $loop|0
@@ -519,7 +527,7 @@
    unreachable
   end
  )
- (func $retain-release/scopeBreak (; 30 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $retain-release/scopeBreak (; 31 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   block $break|0
    local.get $0
@@ -533,7 +541,7 @@
    br $break|0
   end
  )
- (func $retain-release/scopeContinue (; 31 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $retain-release/scopeContinue (; 32 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   block $break|0
    loop $continue|0
@@ -550,7 +558,7 @@
    unreachable
   end
  )
- (func $retain-release/scopeThrow (; 32 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $retain-release/scopeThrow (; 33 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   block $break|0
    local.get $0
@@ -569,7 +577,7 @@
    unreachable
   end
  )
- (func $retain-release/scopeUnreachable (; 33 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $retain-release/scopeUnreachable (; 34 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   block $break|0
    loop $continue|0
@@ -584,7 +592,7 @@
    unreachable
   end
  )
- (func $retain-release/callInline (; 34 ;) (type $FUNCSIG$v)
+ (func $retain-release/callInline (; 35 ;) (type $FUNCSIG$v)
   (local $0 i32)
   global.get $retain-release/REF
   call $~lib/rt/stub/__retain
@@ -592,7 +600,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $retain-release/provideRefInline (; 35 ;) (type $FUNCSIG$v)
+ (func $retain-release/provideRefInline (; 36 ;) (type $FUNCSIG$v)
   (local $0 i32)
   global.get $retain-release/REF
   call $~lib/rt/stub/__retain
@@ -600,7 +608,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $retain-release/receiveRefInline (; 36 ;) (type $FUNCSIG$v)
+ (func $retain-release/receiveRefInline (; 37 ;) (type $FUNCSIG$v)
   (local $0 i32)
   global.get $retain-release/REF
   call $~lib/rt/stub/__retain
@@ -610,19 +618,19 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $retain-release/receiveRefInlineDrop (; 37 ;) (type $FUNCSIG$v)
+ (func $retain-release/receiveRefInlineDrop (; 38 ;) (type $FUNCSIG$v)
   global.get $retain-release/REF
   call $~lib/rt/stub/__retain
   call $~lib/rt/stub/__release
  )
- (func $retain-release/provideRefIndirect (; 38 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $retain-release/provideRefIndirect (; 39 ;) (type $FUNCSIG$vi) (param $0 i32)
   i32.const 1
   global.set $~lib/argc
   global.get $retain-release/REF
   local.get $0
   call_indirect (type $FUNCSIG$vi)
  )
- (func $retain-release/receiveRefIndirect (; 39 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $retain-release/receiveRefIndirect (; 40 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   i32.const 0
   global.set $~lib/argc
@@ -634,14 +642,14 @@
   local.get $1
   call $~lib/rt/stub/__release
  )
- (func $retain-release/receiveRefIndirectDrop (; 40 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $retain-release/receiveRefIndirectDrop (; 41 ;) (type $FUNCSIG$vi) (param $0 i32)
   i32.const 0
   global.set $~lib/argc
   local.get $0
   call_indirect (type $FUNCSIG$i)
   call $~lib/rt/stub/__release
  )
- (func $start (; 41 ;) (type $FUNCSIG$v)
+ (func $start (; 42 ;) (type $FUNCSIG$v)
   global.get $~lib/started
   if
    return
@@ -651,6 +659,6 @@
   end
   call $start:retain-release
  )
- (func $null (; 42 ;) (type $FUNCSIG$v)
+ (func $null (; 43 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/rt/instanceof.optimized.wat
+++ b/tests/compiler/rt/instanceof.optimized.wat
@@ -1,5 +1,6 @@
 (module
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$v (func))
@@ -22,29 +23,25 @@
  (global $~lib/started (mut i32) (i32.const 0))
  (export "__start" (func $start))
  (export "memory" (memory $0))
- (func $~lib/rt/stub/__alloc (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  global.get $~lib/rt/stub/offset
-  i32.const 16
-  i32.add
-  local.tee $2
-  i32.const 16
+  local.get $0
+  i32.const 15
   i32.add
   i32.const -16
   i32.and
-  local.tee $1
+  local.tee $0
   memory.size
-  local.tee $3
+  local.tee $2
   i32.const 16
   i32.shl
+  local.tee $1
   i32.gt_u
   if
-   local.get $3
-   local.get $1
    local.get $2
+   local.get $0
+   local.get $1
    i32.sub
    i32.const 65535
    i32.add
@@ -52,16 +49,16 @@
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
-   local.get $3
-   local.get $4
+   local.tee $1
+   local.get $2
+   local.get $1
    i32.gt_s
    select
    memory.grow
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $1
     memory.grow
     i32.const 0
     i32.lt_s
@@ -70,20 +67,31 @@
     end
    end
   end
-  local.get $1
+  local.get $0
   global.set $~lib/rt/stub/offset
-  local.get $2
+ )
+ (func $~lib/rt/stub/__alloc (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  global.get $~lib/rt/stub/offset
+  i32.const 16
+  i32.add
+  local.tee $1
+  i32.const 1
+  i32.add
+  call $~lib/rt/stub/maybeGrowMemory
+  local.get $1
   i32.const 16
   i32.sub
-  local.tee $1
+  local.tee $2
   local.get $0
   i32.store offset=8
-  local.get $1
+  local.get $2
   i32.const 0
   i32.store offset=12
-  local.get $2
+  local.get $1
  )
- (func $rt/instanceof/Animal#constructor (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $rt/instanceof/Animal#constructor (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -93,7 +101,7 @@
   end
   local.get $0
  )
- (func $rt/instanceof/Cat#constructor (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $rt/instanceof/Cat#constructor (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -104,12 +112,12 @@
   local.get $0
   call $rt/instanceof/Animal#constructor
  )
- (func $rt/instanceof/BlackCat#constructor (; 4 ;) (type $FUNCSIG$i) (result i32)
+ (func $rt/instanceof/BlackCat#constructor (; 5 ;) (type $FUNCSIG$i) (result i32)
   i32.const 5
   call $~lib/rt/stub/__alloc
   call $rt/instanceof/Cat#constructor
  )
- (func $~lib/rt/__instanceof (; 5 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/__instanceof (; 6 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -139,7 +147,7 @@
   end
   i32.const 0
  )
- (func $start:rt/instanceof (; 6 ;) (type $FUNCSIG$v)
+ (func $start:rt/instanceof (; 7 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 112
   global.set $~lib/rt/stub/startOffset
@@ -531,7 +539,7 @@
    unreachable
   end
  )
- (func $start (; 7 ;) (type $FUNCSIG$v)
+ (func $start (; 8 ;) (type $FUNCSIG$v)
   global.get $~lib/started
   if
    return
@@ -541,7 +549,7 @@
   end
   call $start:rt/instanceof
  )
- (func $null (; 8 ;) (type $FUNCSIG$v)
+ (func $null (; 9 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/rt/instanceof.untouched.wat
+++ b/tests/compiler/rt/instanceof.untouched.wat
@@ -1,5 +1,6 @@
 (module
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$v (func))
@@ -25,14 +26,73 @@
  (global $~lib/heap/__heap_base i32 (i32.const 108))
  (export "__start" (func $start))
  (export "memory" (memory $0))
- (func $~lib/rt/stub/__alloc (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $0
+  memory.size
+  local.set $1
+  local.get $1
+  i32.const 16
+  i32.shl
+  local.set $2
+  local.get $0
+  local.get $2
+  i32.gt_u
+  if
+   local.get $0
+   local.get $2
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const 65535
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.set $3
+   local.get $1
+   local.tee $4
+   local.get $3
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_s
+   select
+   local.set $4
+   local.get $4
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $3
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 2 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -53,74 +113,23 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const 15
-  i32.const -1
-  i32.xor
-  i32.and
-  local.set $5
-  memory.size
-  local.set $6
-  local.get $5
-  local.get $6
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $5
-   local.get $2
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const 65535
-   i32.const -1
-   i32.xor
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.set $3
-   local.get $6
-   local.tee $4
-   local.get $3
-   local.tee $7
-   local.get $4
-   local.get $7
-   i32.gt_s
-   select
-   local.set $4
-   local.get $4
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $3
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
-  local.get $5
-  global.set $~lib/rt/stub/offset
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $2
   i32.const 16
   i32.sub
-  local.set $8
-  local.get $8
+  local.set $5
+  local.get $5
   local.get $1
   i32.store offset=8
-  local.get $8
+  local.get $5
   local.get $0
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $rt/instanceof/Animal#constructor (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $rt/instanceof/Animal#constructor (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -132,7 +141,7 @@
   end
   local.get $0
  )
- (func $rt/instanceof/Cat#constructor (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $rt/instanceof/Cat#constructor (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -147,7 +156,7 @@
   local.set $0
   local.get $0
  )
- (func $rt/instanceof/BlackCat#constructor (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $rt/instanceof/BlackCat#constructor (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -162,7 +171,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/rt/__instanceof (; 6 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/__instanceof (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -199,7 +208,7 @@
   end
   i32.const 0
  )
- (func $start:rt/instanceof (; 7 ;) (type $FUNCSIG$v)
+ (func $start:rt/instanceof (; 8 ;) (type $FUNCSIG$v)
   (local $0 i32)
   global.get $~lib/heap/__heap_base
   i32.const 15
@@ -659,7 +668,7 @@
    unreachable
   end
  )
- (func $start (; 8 ;) (type $FUNCSIG$v)
+ (func $start (; 9 ;) (type $FUNCSIG$v)
   global.get $~lib/started
   if
    return
@@ -669,6 +678,6 @@
   end
   call $start:rt/instanceof
  )
- (func $null (; 9 ;) (type $FUNCSIG$v)
+ (func $null (; 10 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/rt/stub-realloc.json
+++ b/tests/compiler/rt/stub-realloc.json
@@ -1,0 +1,6 @@
+{
+  "asc_flags": [
+    "--runtime stub",
+    "--explicitStart"
+  ]
+}

--- a/tests/compiler/rt/stub-realloc.optimized.wat
+++ b/tests/compiler/rt/stub-realloc.optimized.wat
@@ -1,0 +1,515 @@
+(module
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
+ (memory $0 1)
+ (data (i32.const 8) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00s\00t\00u\00b\00.\00t\00s")
+ (data (i32.const 56) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00r\00t\00/\00s\00t\00u\00b\00-\00r\00e\00a\00l\00l\00o\00c\00.\00t\00s")
+ (data (i32.const 112) "\03\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10")
+ (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
+ (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
+ (global $rt/stub-realloc/ptr (mut i32) (i32.const 0))
+ (global $rt/stub-realloc/originalPtr (mut i32) (i32.const 0))
+ (global $rt/stub-realloc/newLastPtr (mut i32) (i32.const 0))
+ (global $~lib/started (mut i32) (i32.const 0))
+ (global $~lib/rt/__rtti_base i32 (i32.const 112))
+ (export "__start" (func $start))
+ (export "memory" (memory $0))
+ (export "__alloc" (func $~lib/rt/stub/__alloc))
+ (export "__retain" (func $~lib/rt/stub/__retain))
+ (export "__release" (func $~lib/rt/stub/__release))
+ (export "__collect" (func $~lib/rt/stub/__collect))
+ (export "__rtti_base" (global $~lib/rt/__rtti_base))
+ (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const -16
+  i32.and
+  local.tee $0
+  memory.size
+  local.tee $2
+  i32.const 16
+  i32.shl
+  local.tee $1
+  i32.gt_u
+  if
+   local.get $2
+   local.get $0
+   local.get $1
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const -65536
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.tee $1
+   local.get $2
+   local.get $1
+   i32.gt_s
+   select
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $1
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 2 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  i32.const 1073741808
+  i32.gt_u
+  if
+   unreachable
+  end
+  global.get $~lib/rt/stub/offset
+  i32.const 16
+  i32.add
+  local.tee $2
+  local.get $0
+  i32.const 1
+  local.get $0
+  i32.const 1
+  i32.gt_u
+  select
+  i32.add
+  call $~lib/rt/stub/maybeGrowMemory
+  local.get $2
+  i32.const 16
+  i32.sub
+  local.tee $3
+  local.get $1
+  i32.store offset=8
+  local.get $3
+  local.get $0
+  i32.store offset=12
+  local.get $2
+ )
+ (func $~lib/rt/stub/__retain (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+ )
+ (func $~lib/rt/stub/__release (; 4 ;) (type $FUNCSIG$vi) (param $0 i32)
+  nop
+ )
+ (func $~lib/rt/stub/__collect (; 5 ;) (type $FUNCSIG$v)
+  nop
+ )
+ (func $~lib/memory/memory.copy (; 6 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  block $~lib/util/memory/memmove|inlined.0
+   local.get $2
+   local.set $3
+   local.get $0
+   local.get $1
+   i32.eq
+   br_if $~lib/util/memory/memmove|inlined.0
+   local.get $0
+   local.get $1
+   i32.lt_u
+   if
+    local.get $1
+    i32.const 7
+    i32.and
+    local.get $0
+    i32.const 7
+    i32.and
+    i32.eq
+    if
+     loop $continue|0
+      local.get $0
+      i32.const 7
+      i32.and
+      if
+       local.get $3
+       i32.eqz
+       br_if $~lib/util/memory/memmove|inlined.0
+       local.get $3
+       i32.const 1
+       i32.sub
+       local.set $3
+       local.get $0
+       local.tee $2
+       i32.const 1
+       i32.add
+       local.set $0
+       local.get $1
+       local.tee $4
+       i32.const 1
+       i32.add
+       local.set $1
+       local.get $2
+       local.get $4
+       i32.load8_u
+       i32.store8
+       br $continue|0
+      end
+     end
+     loop $continue|1
+      local.get $3
+      i32.const 8
+      i32.lt_u
+      i32.eqz
+      if
+       local.get $0
+       local.get $1
+       i64.load
+       i64.store
+       local.get $3
+       i32.const 8
+       i32.sub
+       local.set $3
+       local.get $0
+       i32.const 8
+       i32.add
+       local.set $0
+       local.get $1
+       i32.const 8
+       i32.add
+       local.set $1
+       br $continue|1
+      end
+     end
+    end
+    loop $continue|2
+     local.get $3
+     if
+      local.get $0
+      local.tee $2
+      i32.const 1
+      i32.add
+      local.set $0
+      local.get $1
+      local.tee $4
+      i32.const 1
+      i32.add
+      local.set $1
+      local.get $2
+      local.get $4
+      i32.load8_u
+      i32.store8
+      local.get $3
+      i32.const 1
+      i32.sub
+      local.set $3
+      br $continue|2
+     end
+    end
+   else    
+    local.get $1
+    i32.const 7
+    i32.and
+    local.get $0
+    i32.const 7
+    i32.and
+    i32.eq
+    if
+     loop $continue|3
+      local.get $0
+      local.get $3
+      i32.add
+      i32.const 7
+      i32.and
+      if
+       local.get $3
+       i32.eqz
+       br_if $~lib/util/memory/memmove|inlined.0
+       local.get $0
+       local.get $3
+       i32.const 1
+       i32.sub
+       local.tee $3
+       i32.add
+       local.get $1
+       local.get $3
+       i32.add
+       i32.load8_u
+       i32.store8
+       br $continue|3
+      end
+     end
+     loop $continue|4
+      local.get $3
+      i32.const 8
+      i32.lt_u
+      i32.eqz
+      if
+       local.get $0
+       local.get $3
+       i32.const 8
+       i32.sub
+       local.tee $3
+       i32.add
+       local.get $1
+       local.get $3
+       i32.add
+       i64.load
+       i64.store
+       br $continue|4
+      end
+     end
+    end
+    loop $continue|5
+     local.get $3
+     if
+      local.get $0
+      local.get $3
+      i32.const 1
+      i32.sub
+      local.tee $3
+      i32.add
+      local.get $1
+      local.get $3
+      i32.add
+      i32.load8_u
+      i32.store8
+      br $continue|5
+     end
+    end
+   end
+  end
+ )
+ (func $~lib/rt/stub/__realloc (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  local.get $0
+  i32.const 15
+  i32.and
+  i32.eqz
+  i32.const 0
+  local.get $0
+  select
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 40
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/rt/stub/offset
+  local.get $0
+  i32.const 16
+  i32.sub
+  local.tee $2
+  i32.load offset=12
+  i32.const 15
+  i32.add
+  i32.const -16
+  i32.and
+  local.tee $4
+  local.get $0
+  i32.add
+  i32.eq
+  local.set $3
+  local.get $1
+  local.get $4
+  i32.gt_u
+  if
+   local.get $3
+   if
+    local.get $1
+    i32.const 1073741808
+    i32.gt_u
+    if
+     unreachable
+    end
+    local.get $0
+    local.get $1
+    i32.add
+    call $~lib/rt/stub/maybeGrowMemory
+   else    
+    local.get $1
+    local.get $4
+    i32.const 1
+    i32.shl
+    local.tee $3
+    local.get $1
+    local.get $3
+    i32.gt_u
+    select
+    local.get $2
+    i32.load offset=8
+    call $~lib/rt/stub/__alloc
+    local.tee $2
+    local.get $0
+    local.get $4
+    call $~lib/memory/memory.copy
+    local.get $2
+    local.tee $0
+    i32.const 16
+    i32.sub
+    local.set $2
+   end
+  else   
+   local.get $3
+   if
+    local.get $0
+    local.get $1
+    i32.add
+    i32.const 15
+    i32.add
+    i32.const -16
+    i32.and
+    global.set $~lib/rt/stub/offset
+   end
+  end
+  local.get $2
+  local.get $1
+  i32.store offset=12
+  local.get $0
+ )
+ (func $start:rt/stub-realloc (; 8 ;) (type $FUNCSIG$v)
+  i32.const 10
+  i32.const 0
+  call $~lib/rt/stub/__alloc
+  global.set $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/ptr
+  global.set $rt/stub-realloc/originalPtr
+  global.get $rt/stub-realloc/ptr
+  i32.const 12
+  call $~lib/rt/stub/__realloc
+  global.set $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/originalPtr
+  i32.ne
+  if
+   i32.const 0
+   i32.const 72
+   i32.const 7
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $rt/stub-realloc/ptr
+  i32.const 16
+  call $~lib/rt/stub/__realloc
+  global.set $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/originalPtr
+  i32.ne
+  if
+   i32.const 0
+   i32.const 72
+   i32.const 10
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $rt/stub-realloc/ptr
+  i32.const 33
+  call $~lib/rt/stub/__realloc
+  global.set $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/originalPtr
+  i32.ne
+  if
+   i32.const 0
+   i32.const 72
+   i32.const 13
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $rt/stub-realloc/ptr
+  i32.const 20
+  call $~lib/rt/stub/__realloc
+  global.set $rt/stub-realloc/ptr
+  i32.const 1
+  i32.const 0
+  call $~lib/rt/stub/__alloc
+  global.set $rt/stub-realloc/newLastPtr
+  global.get $rt/stub-realloc/newLastPtr
+  global.get $rt/stub-realloc/originalPtr
+  i32.const 48
+  i32.add
+  i32.ne
+  if
+   i32.const 0
+   i32.const 72
+   i32.const 18
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $rt/stub-realloc/ptr
+  i32.const 24
+  call $~lib/rt/stub/__realloc
+  global.set $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/originalPtr
+  i32.ne
+  if
+   i32.const 0
+   i32.const 72
+   i32.const 21
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $rt/stub-realloc/ptr
+  i32.const 32
+  call $~lib/rt/stub/__realloc
+  global.set $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/originalPtr
+  i32.ne
+  if
+   i32.const 0
+   i32.const 72
+   i32.const 24
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $rt/stub-realloc/ptr
+  i32.const 33
+  call $~lib/rt/stub/__realloc
+  global.set $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/originalPtr
+  i32.le_u
+  if
+   i32.const 0
+   i32.const 72
+   i32.const 27
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $start (; 9 ;) (type $FUNCSIG$v)
+  global.get $~lib/started
+  if
+   return
+  else   
+   i32.const 1
+   global.set $~lib/started
+  end
+  i32.const 144
+  global.set $~lib/rt/stub/startOffset
+  global.get $~lib/rt/stub/startOffset
+  global.set $~lib/rt/stub/offset
+  call $start:rt/stub-realloc
+ )
+)

--- a/tests/compiler/rt/stub-realloc.ts
+++ b/tests/compiler/rt/stub-realloc.ts
@@ -1,0 +1,27 @@
+import { BLOCK_OVERHEAD } from "rt/common";
+
+var ptr = __alloc(10, 0); // initial allocation
+var originalPtr = ptr;
+
+ptr = __realloc(ptr, 12); // just resizes (<= 16)
+assert(ptr == originalPtr);
+
+ptr = __realloc(ptr, 16); // just resizes (<= 16)
+assert(ptr == originalPtr);
+
+ptr = __realloc(ptr, 33); // last: resizes checking for grow (<= 48)
+assert(ptr == originalPtr);
+
+ptr = __realloc(ptr, 20); // last: shrinks again (<= 32, see *)
+
+var newLastPtr = __alloc(1, 0);
+assert(newLastPtr == originalPtr + 32 + BLOCK_OVERHEAD); // *
+
+ptr = __realloc(ptr, 24); // just resizes (<= 32)
+assert(ptr == originalPtr);
+
+ptr = __realloc(ptr, 32); // just resizes (<= 32)
+assert(ptr == originalPtr);
+
+ptr = __realloc(ptr, 33); // not last anymore: copies
+assert(ptr > originalPtr);

--- a/tests/compiler/rt/stub-realloc.untouched.wat
+++ b/tests/compiler/rt/stub-realloc.untouched.wat
@@ -1,35 +1,33 @@
 (module
- (type $FUNCSIG$i (func (result i32)))
- (type $FUNCSIG$iiiii (func (param i32 i32 i32 i32) (result i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
- (type $FUNCSIG$viii (func (param i32 i32 i32)))
- (type $FUNCSIG$jii (func (param i32 i32) (result i64)))
- (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
- (type $FUNCSIG$ij (func (param i64) (result i32)))
- (type $FUNCSIG$viji (func (param i32 i64 i32)))
  (type $FUNCSIG$v (func))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
- (data (i32.const 8) "\08\00\00\00\01\00\00\00\00\00\00\00\08\00\00\00\01\00\00\00\00\00\00\00")
- (data (i32.const 32) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e\00")
- (data (i32.const 88) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s\00")
- (data (i32.const 136) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\000\00")
- (data (i32.const 160) "\90\01\00\00\01\00\00\00\00\00\00\00\90\01\00\000\000\000\001\000\002\000\003\000\004\000\005\000\006\000\007\000\008\000\009\001\000\001\001\001\002\001\003\001\004\001\005\001\006\001\007\001\008\001\009\002\000\002\001\002\002\002\003\002\004\002\005\002\006\002\007\002\008\002\009\003\000\003\001\003\002\003\003\003\004\003\005\003\006\003\007\003\008\003\009\004\000\004\001\004\002\004\003\004\004\004\005\004\006\004\007\004\008\004\009\005\000\005\001\005\002\005\003\005\004\005\005\005\006\005\007\005\008\005\009\006\000\006\001\006\002\006\003\006\004\006\005\006\006\006\007\006\008\006\009\007\000\007\001\007\002\007\003\007\004\007\005\007\006\007\007\007\008\007\009\008\000\008\001\008\002\008\003\008\004\008\005\008\006\008\007\008\008\008\009\009\000\009\001\009\002\009\003\009\004\009\005\009\006\009\007\009\008\009\009\00")
- (data (i32.const 576) "\10\00\00\00\01\00\00\00\05\00\00\00\10\00\00\00\b0\00\00\00\b0\00\00\00\90\01\00\00d\00\00\00")
+ (data (i32.const 8) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00s\00t\00u\00b\00.\00t\00s\00")
+ (data (i32.const 56) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00r\00t\00/\00s\00t\00u\00b\00-\00r\00e\00a\00l\00l\00o\00c\00.\00t\00s\00")
+ (data (i32.const 112) "\03\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00")
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
+ (global $rt/stub-realloc/ptr (mut i32) (i32.const 0))
+ (global $rt/stub-realloc/originalPtr (mut i32) (i32.const 0))
  (global $~lib/ASC_SHRINK_LEVEL i32 (i32.const 0))
- (global $~lib/builtins/u32.MAX_VALUE i32 (i32.const -1))
- (global $~lib/heap/__heap_base i32 (i32.const 608))
+ (global $rt/stub-realloc/newLastPtr (mut i32) (i32.const 0))
+ (global $~lib/started (mut i32) (i32.const 0))
+ (global $~lib/rt/__rtti_base i32 (i32.const 112))
+ (global $~lib/heap/__heap_base i32 (i32.const 140))
+ (export "__start" (func $start))
  (export "memory" (memory $0))
- (export "arrayAccess" (func $resolve-access/arrayAccess))
- (export "fieldAccess" (func $resolve-access/fieldAccess))
- (export "propertyAccess" (func $resolve-access/propertyAccess))
- (start $start)
+ (export "__alloc" (func $~lib/rt/stub/__alloc))
+ (export "__retain" (func $~lib/rt/stub/__retain))
+ (export "__release" (func $~lib/rt/stub/__release))
+ (export "__collect" (func $~lib/rt/stub/__collect))
+ (export "__rtti_base" (global $~lib/rt/__rtti_base))
  (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -133,7 +131,13 @@
  (func $~lib/rt/stub/__retain (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/util/memory/memcpy (; 4 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/stub/__release (; 4 ;) (type $FUNCSIG$vi) (param $0 i32)
+  nop
+ )
+ (func $~lib/rt/stub/__collect (; 5 ;) (type $FUNCSIG$v)
+  nop
+ )
+ (func $~lib/util/memory/memcpy (; 6 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1161,7 +1165,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 5 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 7 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1386,696 +1390,248 @@
    end
   end
  )
- (func $~lib/rt/__allocArray (; 6 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/rt/stub/__realloc (; 8 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
-  i32.const 16
-  local.get $2
-  call $~lib/rt/stub/__alloc
-  local.set $4
   local.get $0
-  local.get $1
-  i32.shl
-  local.set $5
-  local.get $5
   i32.const 0
-  call $~lib/rt/stub/__alloc
-  local.set $6
-  local.get $4
-  local.get $6
-  call $~lib/rt/stub/__retain
-  i32.store
-  local.get $4
-  local.get $6
-  i32.store offset=4
-  local.get $4
-  local.get $5
-  i32.store offset=8
-  local.get $4
-  local.get $0
-  i32.store offset=12
-  local.get $3
-  if
-   local.get $6
-   local.get $3
-   local.get $5
-   call $~lib/memory/memory.copy
+  i32.ne
+  if (result i32)
+   local.get $0
+   i32.const 15
+   i32.and
+   i32.eqz
+  else   
+   i32.const 0
   end
-  local.get $4
- )
- (func $~lib/array/Array<u64>#__unchecked_get (; 7 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
-  local.get $0
-  i32.load offset=4
-  local.get $1
-  i32.const 3
-  i32.shl
-  i32.add
-  i64.load
- )
- (func $~lib/array/Array<u64>#__get (; 8 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
-  local.get $1
-  local.get $0
-  i32.load offset=8
-  i32.const 3
-  i32.shr_u
-  i32.ge_u
+  i32.eqz
   if
-   i32.const 48
-   i32.const 104
-   i32.const 109
-   i32.const 61
+   i32.const 0
+   i32.const 24
+   i32.const 40
+   i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  local.get $1
-  call $~lib/array/Array<u64>#__unchecked_get
- )
- (func $~lib/util/number/decimalCount32 (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  local.get $0
-  i32.const 100000
-  i32.lt_u
-  if
-   local.get $0
-   i32.const 100
-   i32.lt_u
-   if
-    i32.const 1
-    i32.const 2
-    local.get $0
-    i32.const 10
-    i32.lt_u
-    select
-    return
-   else    
-    i32.const 4
-    i32.const 5
-    local.get $0
-    i32.const 10000
-    i32.lt_u
-    select
-    local.set $1
-    i32.const 3
-    local.get $1
-    local.get $0
-    i32.const 1000
-    i32.lt_u
-    select
-    return
-   end
-   unreachable
-  else   
-   local.get $0
-   i32.const 10000000
-   i32.lt_u
-   if
-    i32.const 6
-    i32.const 7
-    local.get $0
-    i32.const 1000000
-    i32.lt_u
-    select
-    return
-   else    
-    i32.const 9
-    i32.const 10
-    local.get $0
-    i32.const 1000000000
-    i32.lt_u
-    select
-    local.set $1
-    i32.const 8
-    local.get $1
-    local.get $0
-    i32.const 100000000
-    i32.lt_u
-    select
-    return
-   end
-   unreachable
-  end
-  unreachable
- )
- (func $~lib/util/number/utoa32_lut (; 10 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i64)
-  (local $9 i64)
-  i32.const 592
-  i32.load offset=4
+  i32.const 16
+  i32.sub
+  local.set $2
+  local.get $2
+  i32.load offset=12
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
   local.set $3
-  block $break|0
-   loop $continue|0
-    local.get $1
-    i32.const 10000
-    i32.ge_u
-    i32.eqz
-    br_if $break|0
-    local.get $1
-    i32.const 10000
-    i32.div_u
-    local.set $4
-    local.get $1
-    i32.const 10000
-    i32.rem_u
-    local.set $5
-    local.get $4
-    local.set $1
-    local.get $5
-    i32.const 100
-    i32.div_u
-    local.set $6
-    local.get $5
-    i32.const 100
-    i32.rem_u
-    local.set $7
-    local.get $3
-    local.get $6
-    i32.const 2
-    i32.shl
-    i32.add
-    i64.load32_u
-    local.set $8
-    local.get $3
-    local.get $7
-    i32.const 2
-    i32.shl
-    i32.add
-    i64.load32_u
-    local.set $9
-    local.get $2
-    i32.const 4
-    i32.sub
-    local.set $2
-    local.get $0
-    local.get $2
-    i32.const 1
-    i32.shl
-    i32.add
-    local.get $8
-    local.get $9
-    i64.const 32
-    i64.shl
-    i64.or
-    i64.store
-    br $continue|0
-   end
-   unreachable
-  end
-  local.get $1
-  i32.const 100
-  i32.ge_u
-  if
-   local.get $1
-   i32.const 100
-   i32.div_u
-   local.set $7
-   local.get $1
-   i32.const 100
-   i32.rem_u
-   local.set $6
-   local.get $7
-   local.set $1
-   local.get $2
-   i32.const 2
-   i32.sub
-   local.set $2
-   local.get $3
-   local.get $6
-   i32.const 2
-   i32.shl
-   i32.add
-   i32.load
-   local.set $5
-   local.get $0
-   local.get $2
-   i32.const 1
-   i32.shl
-   i32.add
-   local.get $5
-   i32.store
-  end
-  local.get $1
-  i32.const 10
-  i32.ge_u
-  if
-   local.get $2
-   i32.const 2
-   i32.sub
-   local.set $2
-   local.get $3
-   local.get $1
-   i32.const 2
-   i32.shl
-   i32.add
-   i32.load
-   local.set $5
-   local.get $0
-   local.get $2
-   i32.const 1
-   i32.shl
-   i32.add
-   local.get $5
-   i32.store
-  else   
-   local.get $2
-   i32.const 1
-   i32.sub
-   local.set $2
-   i32.const 48
-   local.get $1
-   i32.add
-   local.set $5
-   local.get $0
-   local.get $2
-   i32.const 1
-   i32.shl
-   i32.add
-   local.get $5
-   i32.store16
-  end
- )
- (func $~lib/util/number/decimalCount64 (; 11 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
-  (local $1 i32)
   local.get $0
-  i64.const 1000000000000000
-  i64.lt_u
-  if
-   local.get $0
-   i64.const 1000000000000
-   i64.lt_u
-   if
-    i32.const 11
-    i32.const 12
-    local.get $0
-    i64.const 100000000000
-    i64.lt_u
-    select
-    local.set $1
-    i32.const 10
-    local.get $1
-    local.get $0
-    i64.const 10000000000
-    i64.lt_u
-    select
-    return
-   else    
-    i32.const 14
-    i32.const 15
-    local.get $0
-    i64.const 100000000000000
-    i64.lt_u
-    select
-    local.set $1
-    i32.const 13
-    local.get $1
-    local.get $0
-    i64.const 10000000000000
-    i64.lt_u
-    select
-    return
-   end
-   unreachable
-  else   
-   local.get $0
-   i64.const 100000000000000000
-   i64.lt_u
-   if
-    i32.const 16
-    i32.const 17
-    local.get $0
-    i64.const 10000000000000000
-    i64.lt_u
-    select
-    return
-   else    
-    i32.const 19
-    i32.const 20
-    local.get $0
-    i64.const -8446744073709551616
-    i64.lt_u
-    select
-    local.set $1
-    i32.const 18
-    local.get $1
-    local.get $0
-    i64.const 1000000000000000000
-    i64.lt_u
-    select
-    return
-   end
-   unreachable
-  end
-  unreachable
- )
- (func $~lib/util/number/utoa64_lut (; 12 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
-  (local $3 i32)
-  (local $4 i64)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i64)
-  (local $13 i64)
-  i32.const 592
-  i32.load offset=4
-  local.set $3
-  block $break|0
-   loop $continue|0
-    local.get $1
-    i64.const 100000000
-    i64.ge_u
-    i32.eqz
-    br_if $break|0
-    local.get $1
-    i64.const 100000000
-    i64.div_u
-    local.set $4
-    local.get $1
-    local.get $4
-    i64.const 100000000
-    i64.mul
-    i64.sub
-    i32.wrap_i64
-    local.set $5
-    local.get $4
-    local.set $1
-    local.get $5
-    i32.const 10000
-    i32.div_u
-    local.set $6
-    local.get $5
-    i32.const 10000
-    i32.rem_u
-    local.set $7
-    local.get $6
-    i32.const 100
-    i32.div_u
-    local.set $8
-    local.get $6
-    i32.const 100
-    i32.rem_u
-    local.set $9
-    local.get $7
-    i32.const 100
-    i32.div_u
-    local.set $10
-    local.get $7
-    i32.const 100
-    i32.rem_u
-    local.set $11
-    local.get $3
-    local.get $10
-    i32.const 2
-    i32.shl
-    i32.add
-    i64.load32_u
-    local.set $12
-    local.get $3
-    local.get $11
-    i32.const 2
-    i32.shl
-    i32.add
-    i64.load32_u
-    local.set $13
-    local.get $2
-    i32.const 4
-    i32.sub
-    local.set $2
-    local.get $0
-    local.get $2
-    i32.const 1
-    i32.shl
-    i32.add
-    local.get $12
-    local.get $13
-    i64.const 32
-    i64.shl
-    i64.or
-    i64.store
-    local.get $3
-    local.get $8
-    i32.const 2
-    i32.shl
-    i32.add
-    i64.load32_u
-    local.set $12
-    local.get $3
-    local.get $9
-    i32.const 2
-    i32.shl
-    i32.add
-    i64.load32_u
-    local.set $13
-    local.get $2
-    i32.const 4
-    i32.sub
-    local.set $2
-    local.get $0
-    local.get $2
-    i32.const 1
-    i32.shl
-    i32.add
-    local.get $12
-    local.get $13
-    i64.const 32
-    i64.shl
-    i64.or
-    i64.store
-    br $continue|0
-   end
-   unreachable
-  end
-  local.get $0
-  local.get $1
-  i32.wrap_i64
-  local.get $2
-  call $~lib/util/number/utoa32_lut
- )
- (func $~lib/util/number/utoa64 (; 13 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i64)
-  local.get $0
-  i64.eqz
-  if
-   i32.const 152
-   call $~lib/rt/stub/__retain
-   return
-  end
-  local.get $0
-  i64.const 4294967295
-  i64.le_u
-  if
-   local.get $0
-   i32.wrap_i64
-   local.set $2
-   local.get $2
-   call $~lib/util/number/decimalCount32
-   local.set $3
-   local.get $3
-   i32.const 1
-   i32.shl
-   i32.const 1
-   call $~lib/rt/stub/__alloc
-   local.set $1
-   local.get $1
-   local.set $6
-   local.get $2
-   local.set $5
-   local.get $3
-   local.set $4
-   local.get $6
-   local.get $5
-   local.get $4
-   call $~lib/util/number/utoa32_lut
-  else   
-   local.get $0
-   call $~lib/util/number/decimalCount64
-   local.set $3
-   local.get $3
-   i32.const 1
-   i32.shl
-   i32.const 1
-   call $~lib/rt/stub/__alloc
-   local.set $1
-   local.get $1
-   local.set $5
-   local.get $0
-   local.set $7
-   local.get $3
-   local.set $4
-   local.get $5
-   local.get $7
-   local.get $4
-   call $~lib/util/number/utoa64_lut
-  end
-  local.get $1
-  call $~lib/rt/stub/__retain
- )
- (func $~lib/util/number/itoa<u64> (; 14 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
-  local.get $0
-  call $~lib/util/number/utoa64
-  return
- )
- (func $~lib/rt/stub/__release (; 15 ;) (type $FUNCSIG$vi) (param $0 i32)
-  nop
- )
- (func $~lib/number/U64#toString (; 16 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/util/number/itoa<u64>
-  local.tee $1
-  call $~lib/rt/stub/__retain
-  local.set $2
-  local.get $1
-  call $~lib/rt/stub/__release
-  local.get $2
- )
- (func $resolve-access/arrayAccess (; 17 ;) (type $FUNCSIG$i) (result i32)
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  i32.const 1
-  i32.const 3
-  i32.const 3
-  i32.const 24
-  call $~lib/rt/__allocArray
-  call $~lib/rt/stub/__retain
-  local.tee $1
-  call $~lib/rt/stub/__retain
-  local.set $0
-  local.get $0
-  i32.const 0
-  call $~lib/array/Array<u64>#__get
-  call $~lib/number/U64#toString
-  local.set $2
-  local.get $1
-  call $~lib/rt/stub/__release
-  local.get $0
-  call $~lib/rt/stub/__release
-  local.get $2
- )
- (func $resolve-access/Container#constructor (; 18 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  local.get $0
-  i32.eqz
-  if
-   i32.const 8
-   i32.const 6
-   call $~lib/rt/stub/__alloc
-   call $~lib/rt/stub/__retain
-   local.set $0
-  end
-  local.get $0
-  i64.const 0
-  i64.store
-  local.get $0
- )
- (func $resolve-access/fieldAccess (; 19 ;) (type $FUNCSIG$i) (result i32)
-  (local $0 i32)
-  (local $1 i32)
-  i32.const 0
-  call $resolve-access/Container#constructor
-  local.set $0
-  local.get $0
-  i64.const 1
-  i64.store
-  local.get $0
-  i64.load
-  call $~lib/number/U64#toString
-  local.set $1
-  local.get $0
-  call $~lib/rt/stub/__release
-  local.get $1
- )
- (func $resolve-access/Container#toU32 (; 20 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  local.get $0
-  i64.load
-  i32.wrap_i64
- )
- (func $~lib/util/number/utoa32 (; 21 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  local.get $0
-  i32.eqz
-  if
-   i32.const 152
-   call $~lib/rt/stub/__retain
-   return
-  end
-  local.get $0
-  call $~lib/util/number/decimalCount32
-  local.set $1
-  local.get $1
-  i32.const 1
-  i32.shl
-  i32.const 1
-  call $~lib/rt/stub/__alloc
-  local.set $2
-  local.get $2
-  local.set $5
-  local.get $0
+  local.get $3
+  i32.add
+  global.get $~lib/rt/stub/offset
+  i32.eq
   local.set $4
   local.get $1
-  local.set $3
-  local.get $5
-  local.get $4
   local.get $3
-  call $~lib/util/number/utoa32_lut
+  i32.gt_u
+  if
+   local.get $4
+   if
+    local.get $1
+    i32.const 1073741808
+    i32.gt_u
+    if
+     unreachable
+    end
+    local.get $0
+    local.get $1
+    i32.add
+    call $~lib/rt/stub/maybeGrowMemory
+   else    
+    local.get $1
+    local.tee $5
+    local.get $3
+    i32.const 1
+    i32.shl
+    local.tee $6
+    local.get $5
+    local.get $6
+    i32.gt_u
+    select
+    local.get $2
+    i32.load offset=8
+    call $~lib/rt/stub/__alloc
+    local.set $5
+    local.get $5
+    local.get $0
+    local.get $3
+    call $~lib/memory/memory.copy
+    local.get $5
+    local.tee $0
+    i32.const 16
+    i32.sub
+    local.set $2
+   end
+  else   
+   local.get $4
+   if
+    local.get $0
+    local.get $1
+    i32.add
+    i32.const 15
+    i32.add
+    i32.const 15
+    i32.const -1
+    i32.xor
+    i32.and
+    global.set $~lib/rt/stub/offset
+   end
+  end
   local.get $2
-  call $~lib/rt/stub/__retain
- )
- (func $~lib/util/number/itoa<u32> (; 22 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  local.get $0
-  call $~lib/util/number/utoa32
-  return
- )
- (func $~lib/number/U32#toString (; 23 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  call $~lib/util/number/itoa<u32>
-  local.tee $1
-  call $~lib/rt/stub/__retain
-  local.set $2
   local.get $1
-  call $~lib/rt/stub/__release
-  local.get $2
+  i32.store offset=12
+  local.get $0
  )
- (func $resolve-access/propertyAccess (; 24 ;) (type $FUNCSIG$i) (result i32)
-  (local $0 i32)
-  (local $1 i32)
+ (func $start:rt/stub-realloc (; 9 ;) (type $FUNCSIG$v)
+  i32.const 10
   i32.const 0
-  call $resolve-access/Container#constructor
-  local.set $0
-  local.get $0
-  i64.const 1
-  i64.store
-  local.get $0
-  call $resolve-access/Container#toU32
-  call $~lib/number/U32#toString
-  local.set $1
-  local.get $0
-  call $~lib/rt/stub/__release
-  local.get $1
+  call $~lib/rt/stub/__alloc
+  global.set $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/ptr
+  global.set $rt/stub-realloc/originalPtr
+  global.get $rt/stub-realloc/ptr
+  i32.const 12
+  call $~lib/rt/stub/__realloc
+  global.set $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/originalPtr
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 72
+   i32.const 7
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $rt/stub-realloc/ptr
+  i32.const 16
+  call $~lib/rt/stub/__realloc
+  global.set $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/originalPtr
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 72
+   i32.const 10
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $rt/stub-realloc/ptr
+  i32.const 33
+  call $~lib/rt/stub/__realloc
+  global.set $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/originalPtr
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 72
+   i32.const 13
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $rt/stub-realloc/ptr
+  i32.const 20
+  call $~lib/rt/stub/__realloc
+  global.set $rt/stub-realloc/ptr
+  i32.const 1
+  i32.const 0
+  call $~lib/rt/stub/__alloc
+  global.set $rt/stub-realloc/newLastPtr
+  global.get $rt/stub-realloc/newLastPtr
+  global.get $rt/stub-realloc/originalPtr
+  i32.const 32
+  i32.add
+  i32.const 16
+  i32.add
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 72
+   i32.const 18
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $rt/stub-realloc/ptr
+  i32.const 24
+  call $~lib/rt/stub/__realloc
+  global.set $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/originalPtr
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 72
+   i32.const 21
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $rt/stub-realloc/ptr
+  i32.const 32
+  call $~lib/rt/stub/__realloc
+  global.set $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/originalPtr
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 72
+   i32.const 24
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $rt/stub-realloc/ptr
+  i32.const 33
+  call $~lib/rt/stub/__realloc
+  global.set $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/ptr
+  global.get $rt/stub-realloc/originalPtr
+  i32.gt_u
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 72
+   i32.const 27
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
  )
- (func $start (; 25 ;) (type $FUNCSIG$v)
+ (func $start (; 10 ;) (type $FUNCSIG$v)
+  global.get $~lib/started
+  if
+   return
+  else   
+   i32.const 1
+   global.set $~lib/started
+  end
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -2086,7 +1642,8 @@
   global.set $~lib/rt/stub/startOffset
   global.get $~lib/rt/stub/startOffset
   global.set $~lib/rt/stub/offset
+  call $start:rt/stub-realloc
  )
- (func $null (; 26 ;) (type $FUNCSIG$v)
+ (func $null (; 11 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/runtime-stub.optimized.wat
+++ b/tests/compiler/runtime-stub.optimized.wat
@@ -1,7 +1,7 @@
 (module
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
- (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$v (func))
  (memory $0 1)
  (data (i32.const 8) "\03\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10")
@@ -15,11 +15,56 @@
  (export "__collect" (func $~lib/rt/stub/__collect))
  (export "__rtti_base" (global $~lib/rt/__rtti_base))
  (start $start)
- (func $~lib/rt/stub/__alloc (; 0 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 0 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const -16
+  i32.and
+  local.tee $0
+  memory.size
+  local.tee $2
+  i32.const 16
+  i32.shl
+  local.tee $1
+  i32.gt_u
+  if
+   local.get $2
+   local.get $0
+   local.get $1
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const -65536
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.tee $1
+   local.get $2
+   local.get $1
+   i32.gt_s
+   select
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $1
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -29,7 +74,7 @@
   global.get $~lib/rt/stub/offset
   i32.const 16
   i32.add
-  local.tee $3
+  local.tee $2
   local.get $0
   i32.const 1
   local.get $0
@@ -37,68 +82,28 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const -16
-  i32.and
-  local.tee $2
-  memory.size
-  local.tee $4
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $4
-   local.get $2
-   local.get $3
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const -65536
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.tee $5
-   local.get $4
-   local.get $5
-   i32.gt_s
-   select
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $5
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $2
-  global.set $~lib/rt/stub/offset
-  local.get $3
   i32.const 16
   i32.sub
-  local.tee $2
+  local.tee $3
   local.get $1
   i32.store offset=8
-  local.get $2
+  local.get $3
   local.get $0
   i32.store offset=12
-  local.get $3
+  local.get $2
  )
- (func $~lib/rt/stub/__retain (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 2 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/rt/stub/__release (; 3 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $~lib/rt/stub/__collect (; 3 ;) (type $FUNCSIG$v)
+ (func $~lib/rt/stub/__collect (; 4 ;) (type $FUNCSIG$v)
   nop
  )
- (func $start (; 4 ;) (type $FUNCSIG$v)
+ (func $start (; 5 ;) (type $FUNCSIG$v)
   i32.const 48
   global.set $~lib/rt/stub/startOffset
   global.get $~lib/rt/stub/startOffset

--- a/tests/compiler/runtime-stub.untouched.wat
+++ b/tests/compiler/runtime-stub.untouched.wat
@@ -1,7 +1,7 @@
 (module
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
- (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$v (func))
  (memory $0 1)
  (data (i32.const 8) "\03\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00")
@@ -18,14 +18,73 @@
  (export "__collect" (func $~lib/rt/stub/__collect))
  (export "__rtti_base" (global $~lib/rt/__rtti_base))
  (start $start)
- (func $~lib/rt/stub/__alloc (; 0 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 0 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $0
+  memory.size
+  local.set $1
+  local.get $1
+  i32.const 16
+  i32.shl
+  local.set $2
+  local.get $0
+  local.get $2
+  i32.gt_u
+  if
+   local.get $0
+   local.get $2
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const 65535
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.set $3
+   local.get $1
+   local.tee $4
+   local.get $3
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_s
+   select
+   local.set $4
+   local.get $4
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $3
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -46,80 +105,29 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const 15
-  i32.const -1
-  i32.xor
-  i32.and
-  local.set $5
-  memory.size
-  local.set $6
-  local.get $5
-  local.get $6
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $5
-   local.get $2
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const 65535
-   i32.const -1
-   i32.xor
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.set $3
-   local.get $6
-   local.tee $4
-   local.get $3
-   local.tee $7
-   local.get $4
-   local.get $7
-   i32.gt_s
-   select
-   local.set $4
-   local.get $4
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $3
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
-  local.get $5
-  global.set $~lib/rt/stub/offset
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $2
   i32.const 16
   i32.sub
-  local.set $8
-  local.get $8
+  local.set $5
+  local.get $5
   local.get $1
   i32.store offset=8
-  local.get $8
+  local.get $5
   local.get $0
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 2 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/rt/stub/__release (; 3 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $~lib/rt/stub/__collect (; 3 ;) (type $FUNCSIG$v)
+ (func $~lib/rt/stub/__collect (; 4 ;) (type $FUNCSIG$v)
   nop
  )
- (func $start (; 4 ;) (type $FUNCSIG$v)
+ (func $start (; 5 ;) (type $FUNCSIG$v)
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -131,6 +139,6 @@
   global.get $~lib/rt/stub/startOffset
   global.set $~lib/rt/stub/offset
  )
- (func $null (; 5 ;) (type $FUNCSIG$v)
+ (func $null (; 6 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/date.optimized.wat
+++ b/tests/compiler/std/date.optimized.wat
@@ -2,6 +2,7 @@
  (type $FUNCSIG$diiiiiid (func (param i32 i32 i32 i32 i32 i32 f64) (result f64)))
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$d (func (result f64)))
+ (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$v (func))
  (type $FUNCSIG$i (func (result i32)))
  (import "Date" "UTC" (func $~lib/bindings/Date/UTC (param i32 i32 i32 i32 i32 i32 f64) (result f64)))
@@ -15,16 +16,11 @@
  (global $std/date/date (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $start)
- (func $~lib/rt/stub/__alloc (; 3 ;) (type $FUNCSIG$i) (result i32)
-  (local $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 3 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  global.get $~lib/rt/stub/offset
-  i32.const 16
-  i32.add
-  local.tee $1
-  i32.const 23
+  local.get $0
+  i32.const 15
   i32.add
   i32.const -16
   i32.and
@@ -33,6 +29,7 @@
   local.tee $2
   i32.const 16
   i32.shl
+  local.tee $1
   i32.gt_u
   if
    local.get $2
@@ -45,16 +42,16 @@
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $1
    local.get $2
-   local.get $3
+   local.get $1
    i32.gt_s
    select
    memory.grow
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $1
     memory.grow
     i32.const 0
     i32.lt_s
@@ -65,18 +62,29 @@
   end
   local.get $0
   global.set $~lib/rt/stub/offset
-  local.get $1
+ )
+ (func $~lib/rt/stub/__alloc (; 4 ;) (type $FUNCSIG$i) (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  global.get $~lib/rt/stub/offset
+  i32.const 16
+  i32.add
+  local.tee $0
+  i32.const 8
+  i32.add
+  call $~lib/rt/stub/maybeGrowMemory
+  local.get $0
   i32.const 16
   i32.sub
-  local.tee $0
+  local.tee $1
   i32.const 3
   i32.store offset=8
-  local.get $0
+  local.get $1
   i32.const 8
   i32.store offset=12
-  local.get $1
+  local.get $0
  )
- (func $start:std/date (; 4 ;) (type $FUNCSIG$v)
+ (func $start:std/date (; 5 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i64)
   i32.const 1970
@@ -197,10 +205,10 @@
    unreachable
   end
  )
- (func $start (; 5 ;) (type $FUNCSIG$v)
+ (func $start (; 6 ;) (type $FUNCSIG$v)
   call $start:std/date
  )
- (func $null (; 6 ;) (type $FUNCSIG$v)
+ (func $null (; 7 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -4,6 +4,7 @@
  (type $FUNCSIG$d (func (result f64)))
  (type $FUNCSIG$iij (func (param i32 i64) (result i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$ji (func (param i32) (result i64)))
  (type $FUNCSIG$jij (func (param i32 i64) (result i64)))
@@ -22,14 +23,73 @@
  (global $~lib/heap/__heap_base i32 (i32.const 48))
  (export "memory" (memory $0))
  (start $start)
- (func $~lib/rt/stub/__alloc (; 3 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 3 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $0
+  memory.size
+  local.set $1
+  local.get $1
+  i32.const 16
+  i32.shl
+  local.set $2
+  local.get $0
+  local.get $2
+  i32.gt_u
+  if
+   local.get $0
+   local.get $2
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const 65535
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.set $3
+   local.get $1
+   local.tee $4
+   local.get $3
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_s
+   select
+   local.set $4
+   local.get $4
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $3
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 4 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -50,74 +110,23 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const 15
-  i32.const -1
-  i32.xor
-  i32.and
-  local.set $5
-  memory.size
-  local.set $6
-  local.get $5
-  local.get $6
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $5
-   local.get $2
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const 65535
-   i32.const -1
-   i32.xor
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.set $3
-   local.get $6
-   local.tee $4
-   local.get $3
-   local.tee $7
-   local.get $4
-   local.get $7
-   i32.gt_s
-   select
-   local.set $4
-   local.get $4
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $3
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
-  local.get $5
-  global.set $~lib/rt/stub/offset
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $2
   i32.const 16
   i32.sub
-  local.set $8
-  local.get $8
+  local.set $5
+  local.get $5
   local.get $1
   i32.store offset=8
-  local.get $8
+  local.get $5
   local.get $0
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/date/Date#constructor (; 5 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/date/Date#constructor (; 6 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   local.get $0
   i32.eqz
   if
@@ -135,17 +144,17 @@
   i64.store
   local.get $0
  )
- (func $~lib/date/Date#getTime (; 6 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
+ (func $~lib/date/Date#getTime (; 7 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
   local.get $0
   i64.load
  )
- (func $~lib/date/Date#setTime (; 7 ;) (type $FUNCSIG$jij) (param $0 i32) (param $1 i64) (result i64)
+ (func $~lib/date/Date#setTime (; 8 ;) (type $FUNCSIG$jij) (param $0 i32) (param $1 i64) (result i64)
   local.get $0
   local.get $1
   i64.store
   local.get $1
  )
- (func $start:std/date (; 8 ;) (type $FUNCSIG$v)
+ (func $start:std/date (; 9 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -322,9 +331,9 @@
    unreachable
   end
  )
- (func $start (; 9 ;) (type $FUNCSIG$v)
+ (func $start (; 10 ;) (type $FUNCSIG$v)
   call $start:std/date
  )
- (func $null (; 10 ;) (type $FUNCSIG$v)
+ (func $null (; 11 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/new.optimized.wat
+++ b/tests/compiler/std/new.optimized.wat
@@ -1,4 +1,5 @@
 (module
+ (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$v (func))
  (type $FUNCSIG$i (func (result i32)))
  (memory $0 0)
@@ -7,16 +8,11 @@
  (global $std/new/aClass (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $start)
- (func $~lib/rt/stub/__alloc (; 0 ;) (type $FUNCSIG$i) (result i32)
-  (local $0 i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 0 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  global.get $~lib/rt/stub/offset
-  i32.const 16
-  i32.add
-  local.tee $1
-  i32.const 23
+  local.get $0
+  i32.const 15
   i32.add
   i32.const -16
   i32.and
@@ -25,6 +21,7 @@
   local.tee $2
   i32.const 16
   i32.shl
+  local.tee $1
   i32.gt_u
   if
    local.get $2
@@ -37,16 +34,16 @@
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $3
+   local.tee $1
    local.get $2
-   local.get $3
+   local.get $1
    i32.gt_s
    select
    memory.grow
    i32.const 0
    i32.lt_s
    if
-    local.get $3
+    local.get $1
     memory.grow
     i32.const 0
     i32.lt_s
@@ -57,18 +54,29 @@
   end
   local.get $0
   global.set $~lib/rt/stub/offset
-  local.get $1
+ )
+ (func $~lib/rt/stub/__alloc (; 1 ;) (type $FUNCSIG$i) (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  global.get $~lib/rt/stub/offset
+  i32.const 16
+  i32.add
+  local.tee $0
+  i32.const 8
+  i32.add
+  call $~lib/rt/stub/maybeGrowMemory
+  local.get $0
   i32.const 16
   i32.sub
-  local.tee $0
+  local.tee $1
   i32.const 3
   i32.store offset=8
-  local.get $0
+  local.get $1
   i32.const 8
   i32.store offset=12
-  local.get $1
+  local.get $0
  )
- (func $std/new/AClass#constructor (; 1 ;) (type $FUNCSIG$i) (result i32)
+ (func $std/new/AClass#constructor (; 2 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   call $~lib/rt/stub/__alloc
   local.tee $0
@@ -88,7 +96,7 @@
   f32.store offset=4
   local.get $0
  )
- (func $start (; 2 ;) (type $FUNCSIG$v)
+ (func $start (; 3 ;) (type $FUNCSIG$v)
   i32.const 16
   global.set $~lib/rt/stub/startOffset
   global.get $~lib/rt/stub/startOffset
@@ -96,7 +104,7 @@
   call $std/new/AClass#constructor
   global.set $std/new/aClass
  )
- (func $null (; 3 ;) (type $FUNCSIG$v)
+ (func $null (; 4 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/new.untouched.wat
+++ b/tests/compiler/std/new.untouched.wat
@@ -1,6 +1,7 @@
 (module
  (type $FUNCSIG$iif (func (param i32 f32) (result i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$v (func))
  (memory $0 0)
@@ -13,14 +14,73 @@
  (global $~lib/heap/__heap_base i32 (i32.const 8))
  (export "memory" (memory $0))
  (start $start)
- (func $~lib/rt/stub/__alloc (; 0 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 0 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $0
+  memory.size
+  local.set $1
+  local.get $1
+  i32.const 16
+  i32.shl
+  local.set $2
+  local.get $0
+  local.get $2
+  i32.gt_u
+  if
+   local.get $0
+   local.get $2
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const 65535
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.set $3
+   local.get $1
+   local.tee $4
+   local.get $3
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_s
+   select
+   local.set $4
+   local.get $4
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $3
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -41,74 +101,23 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const 15
-  i32.const -1
-  i32.xor
-  i32.and
-  local.set $5
-  memory.size
-  local.set $6
-  local.get $5
-  local.get $6
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $5
-   local.get $2
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const 65535
-   i32.const -1
-   i32.xor
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.set $3
-   local.get $6
-   local.tee $4
-   local.get $3
-   local.tee $7
-   local.get $4
-   local.get $7
-   i32.gt_s
-   select
-   local.set $4
-   local.get $4
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $3
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
-  local.get $5
-  global.set $~lib/rt/stub/offset
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $2
   i32.const 16
   i32.sub
-  local.set $8
-  local.get $8
+  local.set $5
+  local.get $5
   local.get $1
   i32.store offset=8
-  local.get $8
+  local.get $5
   local.get $0
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $std/new/AClass#constructor (; 2 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
+ (func $std/new/AClass#constructor (; 3 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
   local.get $0
   local.get $0
   i32.eqz
@@ -135,7 +144,7 @@
   f32.store offset=4
   local.get $0
  )
- (func $start:std/new (; 3 ;) (type $FUNCSIG$v)
+ (func $start:std/new (; 4 ;) (type $FUNCSIG$v)
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -151,9 +160,9 @@
   call $std/new/AClass#constructor
   global.set $std/new/aClass
  )
- (func $start (; 4 ;) (type $FUNCSIG$v)
+ (func $start (; 5 ;) (type $FUNCSIG$v)
   call $start:std/new
  )
- (func $null (; 5 ;) (type $FUNCSIG$v)
+ (func $null (; 6 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/object-literal.optimized.wat
+++ b/tests/compiler/std/object-literal.optimized.wat
@@ -1,7 +1,7 @@
 (module
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
- (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
@@ -12,11 +12,56 @@
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $start)
- (func $~lib/rt/stub/__alloc (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const -16
+  i32.and
+  local.tee $0
+  memory.size
+  local.tee $2
+  i32.const 16
+  i32.shl
+  local.tee $1
+  i32.gt_u
+  if
+   local.get $2
+   local.get $0
+   local.get $1
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const -65536
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.tee $1
+   local.get $2
+   local.get $1
+   i32.gt_s
+   select
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $1
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 2 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -26,7 +71,7 @@
   global.get $~lib/rt/stub/offset
   i32.const 16
   i32.add
-  local.tee $3
+  local.tee $2
   local.get $0
   i32.const 1
   local.get $0
@@ -34,59 +79,19 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const -16
-  i32.and
-  local.tee $2
-  memory.size
-  local.tee $4
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $4
-   local.get $2
-   local.get $3
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const -65536
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.tee $5
-   local.get $4
-   local.get $5
-   i32.gt_s
-   select
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $5
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $2
-  global.set $~lib/rt/stub/offset
-  local.get $3
   i32.const 16
   i32.sub
-  local.tee $2
+  local.tee $3
   local.get $1
   i32.store offset=8
-  local.get $2
+  local.get $3
   local.get $0
   i32.store offset=12
-  local.get $3
+  local.get $2
  )
- (func $~lib/string/String#get:length (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -94,7 +99,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 3 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/compareImpl (; 4 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 24
@@ -130,7 +135,7 @@
   end
   local.get $3
  )
- (func $~lib/string/String.__eq (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/string/String.__eq (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 24
@@ -160,7 +165,7 @@
   end
   i32.const 0
  )
- (func $std/object-literal/bar (; 5 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $std/object-literal/bar (; 6 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.load
   i32.const 1
@@ -186,7 +191,7 @@
    unreachable
   end
  )
- (func $start:std/object-literal (; 6 ;) (type $FUNCSIG$v)
+ (func $start:std/object-literal (; 7 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 112
   global.set $~lib/rt/stub/startOffset
@@ -240,10 +245,10 @@
    unreachable
   end
  )
- (func $start (; 7 ;) (type $FUNCSIG$v)
+ (func $start (; 8 ;) (type $FUNCSIG$v)
   call $start:std/object-literal
  )
- (func $null (; 8 ;) (type $FUNCSIG$v)
+ (func $null (; 9 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/object-literal.untouched.wat
+++ b/tests/compiler/std/object-literal.untouched.wat
@@ -1,7 +1,7 @@
 (module
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
- (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$iiiiii (func (param i32 i32 i32 i32 i32) (result i32)))
  (type $FUNCSIG$v (func))
@@ -16,14 +16,73 @@
  (global $~lib/heap/__heap_base i32 (i32.const 108))
  (export "memory" (memory $0))
  (start $start)
- (func $~lib/rt/stub/__alloc (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $0
+  memory.size
+  local.set $1
+  local.get $1
+  i32.const 16
+  i32.shl
+  local.set $2
+  local.get $0
+  local.get $2
+  i32.gt_u
+  if
+   local.get $0
+   local.get $2
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const 65535
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.set $3
+   local.get $1
+   local.tee $4
+   local.get $3
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_s
+   select
+   local.set $4
+   local.get $4
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $3
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 2 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -44,77 +103,26 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const 15
-  i32.const -1
-  i32.xor
-  i32.and
-  local.set $5
-  memory.size
-  local.set $6
-  local.get $5
-  local.get $6
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $5
-   local.get $2
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const 65535
-   i32.const -1
-   i32.xor
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.set $3
-   local.get $6
-   local.tee $4
-   local.get $3
-   local.tee $7
-   local.get $4
-   local.get $7
-   i32.gt_s
-   select
-   local.set $4
-   local.get $4
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $3
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
-  local.get $5
-  global.set $~lib/rt/stub/offset
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $2
   i32.const 16
   i32.sub
-  local.set $8
-  local.get $8
+  local.set $5
+  local.get $5
   local.get $1
   i32.store offset=8
-  local.get $8
+  local.get $5
   local.get $0
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 3 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/rt/stub/__release (; 4 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $~lib/string/String#get:length (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -122,7 +130,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 5 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (; 6 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -187,7 +195,7 @@
   call $~lib/rt/stub/__release
   local.get $8
  )
- (func $~lib/string/String.__eq (; 6 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -260,7 +268,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/object-literal/bar (; 7 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $std/object-literal/bar (; 8 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   drop
@@ -293,7 +301,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $std/object-literal/bar2 (; 8 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $std/object-literal/bar2 (; 9 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   call $~lib/rt/stub/__retain
   drop
@@ -313,7 +321,7 @@
   local.get $0
   call $~lib/rt/stub/__release
  )
- (func $std/object-literal/Foo2#test (; 9 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $std/object-literal/Foo2#test (; 10 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   i32.load
   i32.const 3
@@ -328,7 +336,7 @@
    unreachable
   end
  )
- (func $start:std/object-literal (; 10 ;) (type $FUNCSIG$v)
+ (func $start:std/object-literal (; 11 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -382,9 +390,9 @@
   local.get $2
   call $~lib/rt/stub/__release
  )
- (func $start (; 11 ;) (type $FUNCSIG$v)
+ (func $start (; 12 ;) (type $FUNCSIG$v)
   call $start:std/object-literal
  )
- (func $null (; 12 ;) (type $FUNCSIG$v)
+ (func $null (; 13 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/operator-overloading.optimized.wat
+++ b/tests/compiler/std/operator-overloading.optimized.wat
@@ -1,5 +1,6 @@
 (module
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))
  (type $FUNCSIG$ddi (func (param f64 i32) (result f64)))
@@ -78,29 +79,25 @@
  (global $std/operator-overloading/aii (mut i32) (i32.const 0))
  (export "memory" (memory $0))
  (start $start)
- (func $~lib/rt/stub/__alloc (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  global.get $~lib/rt/stub/offset
-  i32.const 16
-  i32.add
-  local.tee $2
-  i32.const 23
+  local.get $0
+  i32.const 15
   i32.add
   i32.const -16
   i32.and
-  local.tee $1
+  local.tee $0
   memory.size
-  local.tee $3
+  local.tee $2
   i32.const 16
   i32.shl
+  local.tee $1
   i32.gt_u
   if
-   local.get $3
-   local.get $1
    local.get $2
+   local.get $0
+   local.get $1
    i32.sub
    i32.const 65535
    i32.add
@@ -108,16 +105,16 @@
    i32.and
    i32.const 16
    i32.shr_u
-   local.tee $4
-   local.get $3
-   local.get $4
+   local.tee $1
+   local.get $2
+   local.get $1
    i32.gt_s
    select
    memory.grow
    i32.const 0
    i32.lt_s
    if
-    local.get $4
+    local.get $1
     memory.grow
     i32.const 0
     i32.lt_s
@@ -126,20 +123,31 @@
     end
    end
   end
-  local.get $1
+  local.get $0
   global.set $~lib/rt/stub/offset
-  local.get $2
+ )
+ (func $~lib/rt/stub/__alloc (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  global.get $~lib/rt/stub/offset
+  i32.const 16
+  i32.add
+  local.tee $1
+  i32.const 8
+  i32.add
+  call $~lib/rt/stub/maybeGrowMemory
+  local.get $1
   i32.const 16
   i32.sub
-  local.tee $1
+  local.tee $2
   local.get $0
   i32.store offset=8
-  local.get $1
+  local.get $2
   i32.const 8
   i32.store offset=12
-  local.get $2
+  local.get $1
  )
- (func $std/operator-overloading/Tester#constructor (; 2 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester#constructor (; 3 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   i32.const 3
   call $~lib/rt/stub/__alloc
@@ -151,7 +159,7 @@
   i32.store offset=4
   local.get $2
  )
- (func $~lib/math/NativeMath.scalbn (; 3 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/NativeMath.scalbn (; 4 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
   local.get $1
   i32.const 1023
   i32.gt_s
@@ -228,7 +236,7 @@
   f64.reinterpret_i64
   f64.mul
  )
- (func $~lib/math/NativeMath.pow (; 4 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.pow (; 5 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 f64)
   (local $4 i32)
@@ -1136,7 +1144,7 @@
   f64.const 1e-300
   f64.mul
  )
- (func $std/operator-overloading/Tester.pow (; 5 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.pow (; 6 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load
   f64.convert_i32_s
@@ -1155,7 +1163,7 @@
   i32.trunc_f64_s
   call $std/operator-overloading/Tester#constructor
  )
- (func $std/operator-overloading/Tester.equals (; 6 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.equals (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load
   local.get $1
@@ -1171,7 +1179,7 @@
    i32.const 0
   end
  )
- (func $std/operator-overloading/Tester.notEquals (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.notEquals (; 8 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load
   local.get $1
@@ -1187,7 +1195,7 @@
    i32.const 0
   end
  )
- (func $std/operator-overloading/TesterInlineStatic#constructor (; 8 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/TesterInlineStatic#constructor (; 9 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   i32.const 4
   call $~lib/rt/stub/__alloc
@@ -1199,7 +1207,7 @@
   i32.store offset=4
   local.get $2
  )
- (func $std/operator-overloading/TesterInlineInstance#constructor (; 9 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/TesterInlineInstance#constructor (; 10 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   i32.const 5
   call $~lib/rt/stub/__alloc
@@ -1211,7 +1219,7 @@
   i32.store offset=4
   local.get $2
  )
- (func $start:std/operator-overloading (; 10 ;) (type $FUNCSIG$v)
+ (func $start:std/operator-overloading (; 11 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 80
@@ -2372,10 +2380,10 @@
    unreachable
   end
  )
- (func $start (; 11 ;) (type $FUNCSIG$v)
+ (func $start (; 12 ;) (type $FUNCSIG$v)
   call $start:std/operator-overloading
  )
- (func $null (; 12 ;) (type $FUNCSIG$v)
+ (func $null (; 13 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/operator-overloading.untouched.wat
+++ b/tests/compiler/std/operator-overloading.untouched.wat
@@ -1,8 +1,8 @@
 (module
  (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
- (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))
  (type $FUNCSIG$ddi (func (param f64 i32) (result f64)))
@@ -84,14 +84,73 @@
  (global $~lib/heap/__heap_base i32 (i32.const 80))
  (export "memory" (memory $0))
  (start $start)
- (func $~lib/rt/stub/__alloc (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $0
+  memory.size
+  local.set $1
+  local.get $1
+  i32.const 16
+  i32.shl
+  local.set $2
+  local.get $0
+  local.get $2
+  i32.gt_u
+  if
+   local.get $0
+   local.get $2
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const 65535
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.set $3
+   local.get $1
+   local.tee $4
+   local.get $3
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_s
+   select
+   local.set $4
+   local.get $4
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $3
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 2 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -112,74 +171,23 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const 15
-  i32.const -1
-  i32.xor
-  i32.and
-  local.set $5
-  memory.size
-  local.set $6
-  local.get $5
-  local.get $6
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $5
-   local.get $2
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const 65535
-   i32.const -1
-   i32.xor
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.set $3
-   local.get $6
-   local.tee $4
-   local.get $3
-   local.tee $7
-   local.get $4
-   local.get $7
-   i32.gt_s
-   select
-   local.set $4
-   local.get $4
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $3
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
-  local.get $5
-  global.set $~lib/rt/stub/offset
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $2
   i32.const 16
   i32.sub
-  local.set $8
-  local.get $8
+  local.set $5
+  local.get $5
   local.get $1
   i32.store offset=8
-  local.get $8
+  local.get $5
   local.get $0
   i32.store offset=12
   local.get $2
  )
- (func $~lib/rt/stub/__retain (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $std/operator-overloading/Tester#constructor (; 3 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/operator-overloading/Tester#constructor (; 4 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -197,10 +205,10 @@
   i32.store offset=4
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 4 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/rt/stub/__release (; 5 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $std/operator-overloading/Tester.add (; 5 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.add (; 6 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -227,7 +235,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.sub (; 6 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.sub (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -254,7 +262,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.mul (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.mul (; 8 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -281,7 +289,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.div (; 8 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.div (; 9 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -308,7 +316,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.mod (; 9 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.mod (; 10 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -335,7 +343,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/math/NativeMath.scalbn (; 10 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/NativeMath.scalbn (; 11 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
@@ -426,7 +434,7 @@
   f64.reinterpret_i64
   f64.mul
  )
- (func $~lib/math/NativeMath.pow (; 11 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.pow (; 12 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -1506,7 +1514,7 @@
   local.get $16
   f64.mul
  )
- (func $std/operator-overloading/Tester.pow (; 12 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.pow (; 13 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1539,7 +1547,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.and (; 13 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.and (; 14 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1566,7 +1574,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.or (; 14 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.or (; 15 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1593,7 +1601,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.xor (; 15 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.xor (; 16 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1620,7 +1628,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.equals (; 16 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.equals (; 17 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1649,7 +1657,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.notEquals (; 17 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.notEquals (; 18 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1678,7 +1686,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.greater (; 18 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.greater (; 19 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1707,7 +1715,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.greaterEquals (; 19 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.greaterEquals (; 20 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1736,7 +1744,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.less (; 20 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.less (; 21 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1765,7 +1773,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.lessEquals (; 21 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.lessEquals (; 22 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1794,7 +1802,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.shr (; 22 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.shr (; 23 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1814,7 +1822,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.shu (; 23 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.shu (; 24 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1834,7 +1842,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.shl (; 24 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/operator-overloading/Tester.shl (; 25 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1854,7 +1862,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $std/operator-overloading/Tester.pos (; 25 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/operator-overloading/Tester.pos (; 26 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1870,7 +1878,7 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $std/operator-overloading/Tester.neg (; 26 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/operator-overloading/Tester.neg (; 27 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1890,7 +1898,7 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $std/operator-overloading/Tester.not (; 27 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/operator-overloading/Tester.not (; 28 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1910,7 +1918,7 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $std/operator-overloading/Tester.excl (; 28 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/operator-overloading/Tester.excl (; 29 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -1930,7 +1938,7 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $std/operator-overloading/Tester#inc (; 29 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/operator-overloading/Tester#inc (; 30 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   local.get $0
   i32.load
@@ -1946,7 +1954,7 @@
   local.get $0
   call $~lib/rt/stub/__retain
  )
- (func $std/operator-overloading/Tester#dec (; 30 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/operator-overloading/Tester#dec (; 31 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   local.get $0
   i32.load
@@ -1962,7 +1970,7 @@
   local.get $0
   call $~lib/rt/stub/__retain
  )
- (func $std/operator-overloading/Tester#postInc (; 31 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/operator-overloading/Tester#postInc (; 32 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load
@@ -1974,7 +1982,7 @@
   i32.add
   call $std/operator-overloading/Tester#constructor
  )
- (func $std/operator-overloading/Tester#postDec (; 32 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/operator-overloading/Tester#postDec (; 33 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   local.get $0
   i32.load
@@ -1986,7 +1994,7 @@
   i32.sub
   call $std/operator-overloading/Tester#constructor
  )
- (func $std/operator-overloading/TesterInlineStatic#constructor (; 33 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/operator-overloading/TesterInlineStatic#constructor (; 34 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -2004,7 +2012,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $std/operator-overloading/TesterInlineInstance#constructor (; 34 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/operator-overloading/TesterInlineInstance#constructor (; 35 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -2022,7 +2030,7 @@
   i32.store offset=4
   local.get $0
  )
- (func $start:std/operator-overloading (; 35 ;) (type $FUNCSIG$v)
+ (func $start:std/operator-overloading (; 36 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -3274,9 +3282,9 @@
   local.get $22
   call $~lib/rt/stub/__release
  )
- (func $start (; 36 ;) (type $FUNCSIG$v)
+ (func $start (; 37 ;) (type $FUNCSIG$v)
   call $start:std/operator-overloading
  )
- (func $null (; 37 ;) (type $FUNCSIG$v)
+ (func $null (; 38 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -2,6 +2,7 @@
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$v (func))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$vii (func (param i32 i32)))
@@ -51,11 +52,56 @@
   i32.add
   i32.load
  )
- (func $~lib/rt/stub/__alloc (; 2 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 2 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const -16
+  i32.and
+  local.tee $0
+  memory.size
+  local.tee $2
+  i32.const 16
+  i32.shl
+  local.tee $1
+  i32.gt_u
+  if
+   local.get $2
+   local.get $0
+   local.get $1
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const -65536
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.tee $1
+   local.get $2
+   local.get $1
+   i32.gt_s
+   select
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $1
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 3 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -65,7 +111,7 @@
   global.get $~lib/rt/stub/offset
   i32.const 16
   i32.add
-  local.tee $3
+  local.tee $2
   local.get $0
   i32.const 1
   local.get $0
@@ -73,59 +119,19 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const -16
-  i32.and
-  local.tee $2
-  memory.size
-  local.tee $4
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $4
-   local.get $2
-   local.get $3
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const -65536
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.tee $5
-   local.get $4
-   local.get $5
-   i32.gt_s
-   select
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $5
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $2
-  global.set $~lib/rt/stub/offset
-  local.get $3
   i32.const 16
   i32.sub
-  local.tee $2
+  local.tee $3
   local.get $1
   i32.store offset=8
-  local.get $2
+  local.get $3
   local.get $0
   i32.store offset=12
-  local.get $3
+  local.get $2
  )
- (func $~lib/memory/memory.copy (; 3 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 4 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -300,7 +306,7 @@
    end
   end
  )
- (func $~lib/rt/stub/__realloc (; 4 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__realloc (; 5 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -315,12 +321,12 @@
   if
    i32.const 0
    i32.const 472
-   i32.const 35
+   i32.const 40
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  global.get $~lib/rt/stub/offset
   local.get $0
   i32.const 16
   i32.sub
@@ -330,35 +336,69 @@
   i32.add
   i32.const -16
   i32.and
-  local.tee $3
+  local.tee $4
+  local.get $0
+  i32.add
+  i32.eq
+  local.set $3
+  local.get $1
+  local.get $4
   i32.gt_u
   if
-   local.get $1
    local.get $3
-   i32.const 1
-   i32.shl
-   local.tee $4
-   local.get $1
-   local.get $4
-   i32.gt_u
-   select
-   local.get $2
-   i32.load offset=8
-   call $~lib/rt/stub/__alloc
-   local.tee $1
-   local.get $0
-   local.get $3
-   call $~lib/memory/memory.copy
-   local.get $1
-   local.set $0
+   if
+    local.get $1
+    i32.const 1073741808
+    i32.gt_u
+    if
+     unreachable
+    end
+    local.get $0
+    local.get $1
+    i32.add
+    call $~lib/rt/stub/maybeGrowMemory
+   else    
+    local.get $1
+    local.get $4
+    i32.const 1
+    i32.shl
+    local.tee $3
+    local.get $1
+    local.get $3
+    i32.gt_u
+    select
+    local.get $2
+    i32.load offset=8
+    call $~lib/rt/stub/__alloc
+    local.tee $2
+    local.get $0
+    local.get $4
+    call $~lib/memory/memory.copy
+    local.get $2
+    local.tee $0
+    i32.const 16
+    i32.sub
+    local.set $2
+   end
   else   
-   local.get $2
-   local.get $1
-   i32.store offset=12
+   local.get $3
+   if
+    local.get $0
+    local.get $1
+    i32.add
+    i32.const 15
+    i32.add
+    i32.const -16
+    i32.and
+    global.set $~lib/rt/stub/offset
+   end
   end
+  local.get $2
+  local.get $1
+  i32.store offset=12
   local.get $0
  )
- (func $~lib/memory/memory.fill (; 5 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/memory/memory.fill (; 6 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $1
@@ -567,7 +607,7 @@
    end
   end
  )
- (func $~lib/array/ensureSize (; 6 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/ensureSize (; 7 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -623,7 +663,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<i32>#__set (; 7 ;) (type $FUNCSIG$v)
+ (func $~lib/array/Array<i32>#__set (; 8 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 60
   i32.load
@@ -644,7 +684,7 @@
    i32.store
   end
  )
- (func $~lib/array/Array<i64>#__get (; 8 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
+ (func $~lib/array/Array<i64>#__get (; 9 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
   local.get $0
   i32.const 120
   i32.load
@@ -667,7 +707,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<i64>#__set (; 9 ;) (type $FUNCSIG$v)
+ (func $~lib/array/Array<i64>#__set (; 10 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 124
   i32.load
@@ -688,7 +728,7 @@
    i32.store
   end
  )
- (func $~lib/array/Array<f32>#__get (; 10 ;) (type $FUNCSIG$fi) (param $0 i32) (result f32)
+ (func $~lib/array/Array<f32>#__get (; 11 ;) (type $FUNCSIG$fi) (param $0 i32) (result f32)
   local.get $0
   i32.const 176
   i32.load
@@ -711,7 +751,7 @@
   i32.add
   f32.load
  )
- (func $~lib/array/Array<f32>#__set (; 11 ;) (type $FUNCSIG$v)
+ (func $~lib/array/Array<f32>#__set (; 12 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 180
   i32.load
@@ -732,7 +772,7 @@
    i32.store
   end
  )
- (func $~lib/array/Array<f64>#__get (; 12 ;) (type $FUNCSIG$di) (param $0 i32) (result f64)
+ (func $~lib/array/Array<f64>#__get (; 13 ;) (type $FUNCSIG$di) (param $0 i32) (result f64)
   local.get $0
   i32.const 240
   i32.load
@@ -755,7 +795,7 @@
   i32.add
   f64.load
  )
- (func $~lib/array/Array<f64>#__set (; 13 ;) (type $FUNCSIG$v)
+ (func $~lib/array/Array<f64>#__set (; 14 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 244
   i32.load
@@ -776,7 +816,7 @@
    i32.store
   end
  )
- (func $start:std/static-array (; 14 ;) (type $FUNCSIG$v)
+ (func $start:std/static-array (; 15 ;) (type $FUNCSIG$v)
   i32.const 60
   i32.load
   i32.const 2
@@ -978,10 +1018,10 @@
    unreachable
   end
  )
- (func $start (; 15 ;) (type $FUNCSIG$v)
+ (func $start (; 16 ;) (type $FUNCSIG$v)
   call $start:std/static-array
  )
- (func $null (; 16 ;) (type $FUNCSIG$v)
+ (func $null (; 17 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -23,6 +23,7 @@
  (data (i32.const 304) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e")
  (data (i32.const 360) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s")
  (data (i32.const 408) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
+ (data (i32.const 456) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00s\00t\00u\00b\00.\00t\00s")
  (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (export "memory" (memory $0))
@@ -302,16 +303,45 @@
  (func $~lib/rt/stub/__realloc (; 4 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  local.get $0
+  i32.const 15
+  i32.and
+  i32.eqz
+  i32.const 0
+  local.get $0
+  select
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 472
+   i32.const 35
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
   local.get $1
   local.get $0
   i32.const 16
   i32.sub
   local.tee $2
   i32.load offset=12
+  i32.const 15
+  i32.add
+  i32.const -16
+  i32.and
   local.tee $3
   i32.gt_u
   if
    local.get $1
+   local.get $3
+   i32.const 1
+   i32.shl
+   local.tee $4
+   local.get $1
+   local.get $4
+   i32.gt_u
+   select
    local.get $2
    i32.load offset=8
    call $~lib/rt/stub/__alloc
@@ -783,7 +813,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 464
+  i32.const 512
   global.set $~lib/rt/stub/startOffset
   global.get $~lib/rt/stub/startOffset
   global.set $~lib/rt/stub/offset

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -24,6 +24,7 @@
  (data (i32.const 304) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e\00")
  (data (i32.const 360) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s\00")
  (data (i32.const 408) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
+ (data (i32.const 456) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00s\00t\00u\00b\00.\00t\00s\00")
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (global $std/static-array/i i32 (i32.const 48))
@@ -33,7 +34,7 @@
  (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (global $~lib/ASC_SHRINK_LEVEL i32 (i32.const 0))
- (global $~lib/heap/__heap_base i32 (i32.const 452))
+ (global $~lib/heap/__heap_base i32 (i32.const 504))
  (export "memory" (memory $0))
  (start $start)
  (func $~lib/array/Array<i32>#get:length (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
@@ -1417,18 +1418,54 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  i32.const 0
+  i32.ne
+  if (result i32)
+   local.get $0
+   i32.const 15
+   i32.and
+   i32.eqz
+  else   
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 472
+   i32.const 35
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
   local.get $0
   i32.const 16
   i32.sub
   local.set $2
   local.get $2
   i32.load offset=12
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
   local.set $3
   local.get $1
   local.get $3
   i32.gt_u
   if
    local.get $1
+   local.tee $4
+   local.get $3
+   i32.const 1
+   i32.shl
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_u
+   select
    local.get $2
    i32.load offset=8
    call $~lib/rt/stub/__alloc

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -3,6 +3,7 @@
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$jii (func (param i32 i32) (result i64)))
  (type $FUNCSIG$viij (func (param i32 i32 i64)))
  (type $FUNCSIG$fii (func (param i32 i32) (result f32)))
@@ -69,14 +70,73 @@
   local.get $1
   call $~lib/array/Array<i32>#__unchecked_get
  )
- (func $~lib/rt/stub/__alloc (; 4 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 4 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $0
+  memory.size
+  local.set $1
+  local.get $1
+  i32.const 16
+  i32.shl
+  local.set $2
+  local.get $0
+  local.get $2
+  i32.gt_u
+  if
+   local.get $0
+   local.get $2
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const 65535
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.set $3
+   local.get $1
+   local.tee $4
+   local.get $3
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_s
+   select
+   local.set $4
+   local.get $4
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $3
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 5 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -97,71 +157,20 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const 15
-  i32.const -1
-  i32.xor
-  i32.and
-  local.set $5
-  memory.size
-  local.set $6
-  local.get $5
-  local.get $6
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $5
-   local.get $2
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const 65535
-   i32.const -1
-   i32.xor
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.set $3
-   local.get $6
-   local.tee $4
-   local.get $3
-   local.tee $7
-   local.get $4
-   local.get $7
-   i32.gt_s
-   select
-   local.set $4
-   local.get $4
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $3
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
-  local.get $5
-  global.set $~lib/rt/stub/offset
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $2
   i32.const 16
   i32.sub
-  local.set $8
-  local.get $8
+  local.set $5
+  local.get $5
   local.get $1
   i32.store offset=8
-  local.get $8
+  local.get $5
   local.get $0
   i32.store offset=12
   local.get $2
  )
- (func $~lib/util/memory/memcpy (; 5 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (; 6 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1189,7 +1198,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 6 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 7 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1414,11 +1423,12 @@
    end
   end
  )
- (func $~lib/rt/stub/__realloc (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__realloc (; 8 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.const 0
   i32.ne
@@ -1434,7 +1444,7 @@
   if
    i32.const 0
    i32.const 472
-   i32.const 35
+   i32.const 40
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1452,38 +1462,74 @@
   i32.xor
   i32.and
   local.set $3
+  local.get $0
+  local.get $3
+  i32.add
+  global.get $~lib/rt/stub/offset
+  i32.eq
+  local.set $4
   local.get $1
   local.get $3
   i32.gt_u
   if
-   local.get $1
-   local.tee $4
-   local.get $3
-   i32.const 1
-   i32.shl
-   local.tee $5
    local.get $4
-   local.get $5
-   i32.gt_u
-   select
-   local.get $2
-   i32.load offset=8
-   call $~lib/rt/stub/__alloc
-   local.set $4
-   local.get $4
-   local.get $0
-   local.get $3
-   call $~lib/memory/memory.copy
-   local.get $4
-   local.set $0
+   if
+    local.get $1
+    i32.const 1073741808
+    i32.gt_u
+    if
+     unreachable
+    end
+    local.get $0
+    local.get $1
+    i32.add
+    call $~lib/rt/stub/maybeGrowMemory
+   else    
+    local.get $1
+    local.tee $5
+    local.get $3
+    i32.const 1
+    i32.shl
+    local.tee $6
+    local.get $5
+    local.get $6
+    i32.gt_u
+    select
+    local.get $2
+    i32.load offset=8
+    call $~lib/rt/stub/__alloc
+    local.set $5
+    local.get $5
+    local.get $0
+    local.get $3
+    call $~lib/memory/memory.copy
+    local.get $5
+    local.tee $0
+    i32.const 16
+    i32.sub
+    local.set $2
+   end
   else   
-   local.get $2
-   local.get $1
-   i32.store offset=12
+   local.get $4
+   if
+    local.get $0
+    local.get $1
+    i32.add
+    i32.const 15
+    i32.add
+    i32.const 15
+    i32.const -1
+    i32.xor
+    i32.and
+    global.set $~lib/rt/stub/offset
+   end
   end
+  local.get $2
+  local.get $1
+  i32.store offset=12
   local.get $0
  )
- (func $~lib/memory/memory.fill (; 8 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.fill (; 9 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1747,10 +1793,10 @@
    end
   end
  )
- (func $~lib/rt/stub/__retain (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/array/ensureSize (; 10 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureSize (; 11 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1813,7 +1859,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<i32>#__unchecked_set (; 11 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__unchecked_set (; 12 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -1823,7 +1869,7 @@
   local.get $2
   i32.store
  )
- (func $~lib/array/Array<i32>#__set (; 12 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__set (; 13 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $0
   i32.load offset=12
@@ -1849,11 +1895,11 @@
    i32.store offset=12
   end
  )
- (func $~lib/array/Array<i64>#get:length (; 13 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i64>#get:length (; 14 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i64>#__unchecked_get (; 14 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<i64>#__unchecked_get (; 15 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -1862,7 +1908,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<i64>#__get (; 15 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<i64>#__get (; 16 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1881,7 +1927,7 @@
   local.get $1
   call $~lib/array/Array<i64>#__unchecked_get
  )
- (func $~lib/array/Array<i64>#__unchecked_set (; 16 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<i64>#__unchecked_set (; 17 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -1891,7 +1937,7 @@
   local.get $2
   i64.store
  )
- (func $~lib/array/Array<i64>#__set (; 17 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<i64>#__set (; 18 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   local.get $0
   i32.load offset=12
@@ -1917,11 +1963,11 @@
    i32.store offset=12
   end
  )
- (func $~lib/array/Array<f32>#get:length (; 18 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f32>#get:length (; 19 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<f32>#__unchecked_get (; 19 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__unchecked_get (; 20 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -1930,7 +1976,7 @@
   i32.add
   f32.load
  )
- (func $~lib/array/Array<f32>#__get (; 20 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__get (; 21 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -1949,7 +1995,7 @@
   local.get $1
   call $~lib/array/Array<f32>#__unchecked_get
  )
- (func $~lib/array/Array<f32>#__unchecked_set (; 21 ;) (type $FUNCSIG$viif) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/array/Array<f32>#__unchecked_set (; 22 ;) (type $FUNCSIG$viif) (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -1959,7 +2005,7 @@
   local.get $2
   f32.store
  )
- (func $~lib/array/Array<f32>#__set (; 22 ;) (type $FUNCSIG$viif) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/array/Array<f32>#__set (; 23 ;) (type $FUNCSIG$viif) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   local.get $0
   i32.load offset=12
@@ -1985,11 +2031,11 @@
    i32.store offset=12
   end
  )
- (func $~lib/array/Array<f64>#get:length (; 23 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f64>#get:length (; 24 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<f64>#__unchecked_get (; 24 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__unchecked_get (; 25 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -1998,7 +2044,7 @@
   i32.add
   f64.load
  )
- (func $~lib/array/Array<f64>#__get (; 25 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__get (; 26 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
   local.get $1
   local.get $0
   i32.load offset=8
@@ -2017,7 +2063,7 @@
   local.get $1
   call $~lib/array/Array<f64>#__unchecked_get
  )
- (func $~lib/array/Array<f64>#__unchecked_set (; 26 ;) (type $FUNCSIG$viid) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/array/Array<f64>#__unchecked_set (; 27 ;) (type $FUNCSIG$viid) (param $0 i32) (param $1 i32) (param $2 f64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -2027,7 +2073,7 @@
   local.get $2
   f64.store
  )
- (func $~lib/array/Array<f64>#__set (; 27 ;) (type $FUNCSIG$viid) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/array/Array<f64>#__set (; 28 ;) (type $FUNCSIG$viid) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   local.get $0
   i32.load offset=12
@@ -2053,7 +2099,7 @@
    i32.store offset=12
   end
  )
- (func $start:std/static-array (; 28 ;) (type $FUNCSIG$v)
+ (func $start:std/static-array (; 29 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 48
@@ -2303,9 +2349,9 @@
    unreachable
   end
  )
- (func $start (; 29 ;) (type $FUNCSIG$v)
+ (func $start (; 30 ;) (type $FUNCSIG$v)
   call $start:std/static-array
  )
- (func $null (; 30 ;) (type $FUNCSIG$v)
+ (func $null (; 31 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/symbol.optimized.wat
+++ b/tests/compiler/std/symbol.optimized.wat
@@ -65,11 +65,56 @@
   end
   local.get $0
  )
- (func $~lib/rt/stub/__alloc (; 2 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 2 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const -16
+  i32.and
+  local.tee $0
+  memory.size
+  local.tee $2
+  i32.const 16
+  i32.shl
+  local.tee $1
+  i32.gt_u
+  if
+   local.get $2
+   local.get $0
+   local.get $1
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const -65536
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.tee $1
+   local.get $2
+   local.get $1
+   i32.gt_s
+   select
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $1
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 3 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -79,7 +124,7 @@
   global.get $~lib/rt/stub/offset
   i32.const 16
   i32.add
-  local.tee $3
+  local.tee $2
   local.get $0
   i32.const 1
   local.get $0
@@ -87,59 +132,19 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const -16
-  i32.and
-  local.tee $2
-  memory.size
-  local.tee $4
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $4
-   local.get $2
-   local.get $3
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const -65536
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.tee $5
-   local.get $4
-   local.get $5
-   i32.gt_s
-   select
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $5
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $2
-  global.set $~lib/rt/stub/offset
-  local.get $3
   i32.const 16
   i32.sub
-  local.tee $2
+  local.tee $3
   local.get $1
   i32.store offset=8
-  local.get $2
+  local.get $3
   local.get $0
   i32.store offset=12
-  local.get $3
+  local.get $2
  )
- (func $~lib/memory/memory.fill (; 3 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/memory/memory.fill (; 4 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $1
@@ -348,7 +353,7 @@
    end
   end
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 1073741808
@@ -369,7 +374,7 @@
   call $~lib/memory/memory.fill
   local.get $1
  )
- (func $~lib/map/Map<~lib/string/String,usize>#clear (; 5 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#clear (; 6 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   i32.const 16
   call $~lib/arraybuffer/ArrayBuffer#constructor
@@ -402,7 +407,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<~lib/string/String,usize>#constructor (; 6 ;) (type $FUNCSIG$i) (result i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#constructor (; 7 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 3
@@ -429,7 +434,7 @@
   call $~lib/map/Map<~lib/string/String,usize>#clear
   local.get $0
  )
- (func $~lib/map/Map<usize,~lib/string/String>#constructor (; 7 ;) (type $FUNCSIG$i) (result i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#constructor (; 8 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 4
@@ -456,7 +461,7 @@
   call $~lib/map/Map<~lib/string/String,usize>#clear
   local.get $0
  )
- (func $~lib/string/String#get:length (; 8 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -464,7 +469,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/hash/hashStr (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hashStr (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -503,7 +508,7 @@
   end
   local.get $1
  )
- (func $~lib/util/string/compareImpl (; 10 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/compareImpl (; 11 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   loop $continue|0
    local.get $2
@@ -536,7 +541,7 @@
   end
   local.get $3
  )
- (func $~lib/string/String.__eq (; 11 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 12 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -568,7 +573,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<~lib/string/String,usize>#find (; 12 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#find (; 13 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -611,7 +616,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<~lib/string/String,usize>#get (; 13 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#get (; 14 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 24
   call $~lib/util/hash/hashStr
@@ -629,7 +634,7 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/map/Map<~lib/string/String,usize>#rehash (; 14 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#rehash (; 15 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -736,7 +741,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<~lib/string/String,usize>#set (; 15 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#set (; 16 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -825,7 +830,7 @@
    i32.store
   end
  )
- (func $~lib/util/hash/hash32 (; 16 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash32 (; 17 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -856,7 +861,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/map/Map<usize,~lib/string/String>#find (; 17 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#find (; 18 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -899,7 +904,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<usize,~lib/string/String>#rehash (; 18 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#rehash (; 19 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1006,7 +1011,7 @@
   i32.load offset=20
   i32.store offset=16
  )
- (func $~lib/map/Map<usize,~lib/string/String>#set (; 19 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#set (; 20 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1102,7 +1107,7 @@
    i32.store
   end
  )
- (func $~lib/symbol/_Symbol.for (; 20 ;) (type $FUNCSIG$i) (result i32)
+ (func $~lib/symbol/_Symbol.for (; 21 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   global.get $~lib/symbol/stringToId
   if
@@ -1139,7 +1144,7 @@
   call $~lib/map/Map<usize,~lib/string/String>#set
   local.get $0
  )
- (func $~lib/map/Map<usize,~lib/string/String>#has (; 21 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#has (; 22 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -1148,7 +1153,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<usize,~lib/string/String>#get (; 22 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#get (; 23 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -1167,7 +1172,7 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/symbol/_Symbol.keyFor (; 23 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/symbol/_Symbol.keyFor (; 24 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   global.get $~lib/symbol/idToString
   if (result i32)
    global.get $~lib/symbol/idToString
@@ -1184,7 +1189,7 @@
    i32.const 0
   end
  )
- (func $~lib/memory/memory.copy (; 24 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 25 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -1359,7 +1364,7 @@
    end
   end
  )
- (func $~lib/string/String#concat (; 25 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#concat (; 26 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1399,7 +1404,7 @@
   call $~lib/memory/memory.copy
   local.get $2
  )
- (func $~lib/string/String.__concat (; 26 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (; 27 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.const 752
   local.get $0
@@ -1407,7 +1412,7 @@
   local.get $1
   call $~lib/string/String#concat
  )
- (func $~lib/symbol/_Symbol#toString (; 27 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/symbol/_Symbol#toString (; 28 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 720
   block $break|0 (result i32)
    block $case11|0
@@ -1490,7 +1495,7 @@
   i32.const 776
   call $~lib/string/String.__concat
  )
- (func $start:std/symbol (; 28 ;) (type $FUNCSIG$v)
+ (func $start:std/symbol (; 29 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 24
   call $~lib/symbol/Symbol
@@ -1652,10 +1657,10 @@
    unreachable
   end
  )
- (func $start (; 29 ;) (type $FUNCSIG$v)
+ (func $start (; 30 ;) (type $FUNCSIG$v)
   call $start:std/symbol
  )
- (func $null (; 30 ;) (type $FUNCSIG$v)
+ (func $null (; 31 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/symbol.untouched.wat
+++ b/tests/compiler/std/symbol.untouched.wat
@@ -88,14 +88,73 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $~lib/rt/stub/__alloc (; 4 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/maybeGrowMemory (; 4 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $0
+  memory.size
+  local.set $1
+  local.get $1
+  i32.const 16
+  i32.shl
+  local.set $2
+  local.get $0
+  local.get $2
+  i32.gt_u
+  if
+   local.get $0
+   local.get $2
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const 65535
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.set $3
+   local.get $1
+   local.tee $4
+   local.get $3
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_s
+   select
+   local.set $4
+   local.get $4
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $3
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 5 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   local.get $0
   i32.const 1073741808
   i32.gt_u
@@ -116,71 +175,20 @@
   i32.gt_u
   select
   i32.add
-  i32.const 15
-  i32.add
-  i32.const 15
-  i32.const -1
-  i32.xor
-  i32.and
-  local.set $5
-  memory.size
-  local.set $6
-  local.get $5
-  local.get $6
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $5
-   local.get $2
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const 65535
-   i32.const -1
-   i32.xor
-   i32.and
-   i32.const 16
-   i32.shr_u
-   local.set $3
-   local.get $6
-   local.tee $4
-   local.get $3
-   local.tee $7
-   local.get $4
-   local.get $7
-   i32.gt_s
-   select
-   local.set $4
-   local.get $4
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $3
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
-  local.get $5
-  global.set $~lib/rt/stub/offset
+  call $~lib/rt/stub/maybeGrowMemory
   local.get $2
   i32.const 16
   i32.sub
-  local.set $8
-  local.get $8
+  local.set $5
+  local.get $5
   local.get $1
   i32.store offset=8
-  local.get $8
+  local.get $5
   local.get $0
   i32.store offset=12
   local.get $2
  )
- (func $~lib/memory/memory.fill (; 5 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.fill (; 6 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -444,7 +452,7 @@
    end
   end
  )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (; 6 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   i32.const 1073741808
@@ -468,7 +476,7 @@
   local.get $2
   call $~lib/rt/stub/__retain
  )
- (func $~lib/map/Map<~lib/string/String,usize>#clear (; 7 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#clear (; 8 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -508,7 +516,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<~lib/string/String,usize>#constructor (; 8 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#constructor (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -540,7 +548,7 @@
   call $~lib/map/Map<~lib/string/String,usize>#clear
   local.get $0
  )
- (func $~lib/map/Map<usize,~lib/string/String>#clear (; 9 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#clear (; 10 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -580,7 +588,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<usize,~lib/string/String>#constructor (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#constructor (; 11 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -612,7 +620,7 @@
   call $~lib/map/Map<usize,~lib/string/String>#clear
   local.get $0
  )
- (func $~lib/string/String#get:length (; 11 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (; 12 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -620,7 +628,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/hash/hashStr (; 12 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hashStr (; 13 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -671,7 +679,7 @@
   call $~lib/rt/stub/__release
   local.get $3
  )
- (func $~lib/util/string/compareImpl (; 13 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (; 14 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -736,7 +744,7 @@
   call $~lib/rt/stub/__release
   local.get $8
  )
- (func $~lib/string/String.__eq (; 14 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 15 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -809,7 +817,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/map/Map<~lib/string/String,usize>#find (; 15 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#find (; 16 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -869,7 +877,7 @@
   call $~lib/rt/stub/__release
   local.get $4
  )
- (func $~lib/map/Map<~lib/string/String,usize>#has (; 16 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#has (; 17 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -897,7 +905,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/map/Map<~lib/string/String,usize>#get (; 17 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#get (; 18 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -939,7 +947,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/map/Map<~lib/string/String,usize>#rehash (; 18 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#rehash (; 19 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1101,7 +1109,7 @@
   local.get $5
   call $~lib/rt/stub/__release
  )
- (func $~lib/map/Map<~lib/string/String,usize>#set (; 19 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<~lib/string/String,usize>#set (; 20 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1215,7 +1223,7 @@
   local.get $1
   call $~lib/rt/stub/__release
  )
- (func $~lib/util/hash/hash32 (; 20 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash32 (; 21 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   i32.const -2128831035
   local.set $1
@@ -1257,7 +1265,7 @@
   local.set $1
   local.get $1
  )
- (func $~lib/map/Map<usize,~lib/string/String>#find (; 21 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#find (; 22 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -1305,7 +1313,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<usize,~lib/string/String>#rehash (; 22 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#rehash (; 23 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1462,7 +1470,7 @@
   local.get $5
   call $~lib/rt/stub/__release
  )
- (func $~lib/map/Map<usize,~lib/string/String>#set (; 23 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#set (; 24 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1582,7 +1590,7 @@
   local.get $2
   call $~lib/rt/stub/__release
  )
- (func $~lib/symbol/_Symbol.for (; 24 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/symbol/_Symbol.for (; 25 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -1646,7 +1654,7 @@
   call $~lib/rt/stub/__release
   local.get $1
  )
- (func $~lib/map/Map<usize,~lib/string/String>#has (; 25 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#has (; 26 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -1661,7 +1669,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<usize,~lib/string/String>#get (; 26 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<usize,~lib/string/String>#get (; 27 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -1689,7 +1697,7 @@
   i32.load offset=4
   call $~lib/rt/stub/__retain
  )
- (func $~lib/symbol/_Symbol.keyFor (; 27 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/symbol/_Symbol.keyFor (; 28 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   global.get $~lib/symbol/idToString
   i32.const 0
   i32.ne
@@ -1709,7 +1717,7 @@
    call $~lib/rt/stub/__retain
   end
  )
- (func $~lib/util/memory/memcpy (; 28 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (; 29 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2737,7 +2745,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 29 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 30 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2962,7 +2970,7 @@
    end
   end
  )
- (func $~lib/string/String#concat (; 30 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#concat (; 31 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3038,7 +3046,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/string/String.__concat (; 31 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (; 32 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -3061,7 +3069,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/symbol/_Symbol#toString (; 32 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/symbol/_Symbol#toString (; 33 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3348,7 +3356,7 @@
   call $~lib/rt/stub/__release
   local.get $5
  )
- (func $start:std/symbol (; 33 ;) (type $FUNCSIG$v)
+ (func $start:std/symbol (; 34 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -3547,9 +3555,9 @@
   local.get $3
   call $~lib/rt/stub/__release
  )
- (func $start (; 34 ;) (type $FUNCSIG$v)
+ (func $start (; 35 ;) (type $FUNCSIG$v)
   call $start:std/symbol
  )
- (func $null (; 35 ;) (type $FUNCSIG$v)
+ (func $null (; 36 ;) (type $FUNCSIG$v)
  )
 )


### PR DESCRIPTION
potentially fixes https://github.com/AssemblyScript/assemblyscript/issues/788
potentially fixes https://github.com/AssemblyScript/assemblyscript/pull/789

Previously, if a memory block didn't fit anymore upon __realloc, the stub RT would reallocate to exactly the requested size, which is super inefficient since stub can't free and would waste lots of memory in any scenario reallocating multiple times (e.g. when filling a buffer). Instead, it now tries to at least double the capacity when wasting memory, to subsequently waste less.