### PR TITLE
Fix v128.store input type

### DIFF
--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -3877,7 +3877,7 @@ function tryDeferASM(
     switch (prototype.internalName) {
 
       case BuiltinSymbols.v128_load: return deferASM(BuiltinSymbols.load, compiler, Type.v128, operands, Type.v128, reportNode);
-      case BuiltinSymbols.v128_store: return deferASM(BuiltinSymbols.store, compiler, Type.v128, operands, Type.void, reportNode);
+      case BuiltinSymbols.v128_store: return deferASM(BuiltinSymbols.store, compiler, Type.v128, operands, Type.v128, reportNode);
 
       case BuiltinSymbols.i8x16_splat: return deferASM(BuiltinSymbols.v128_splat, compiler, Type.i8, operands, Type.v128, reportNode);
       case BuiltinSymbols.i8x16_extract_lane_s: return deferASM(BuiltinSymbols.v128_extract_lane, compiler, Type.i8, operands, Type.i8, reportNode);


### PR DESCRIPTION
fixes #808

Hasn't been caught earlier because the respective test is disabled, since the instructions errors on various versions of node.