### PR TITLE
[Loader] Speedup __getArray

### DIFF
--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -199,7 +199,11 @@ function postInstantiate(baseModule, instance) {
 
   /** Reads (copies) the values of an array from the module's memory. */
   function __getArray(arr) {
-    return Array.from(__getArrayView(arr));
+    const input = __getArrayView(arr);
+    const len = input.length;
+    const out = new Array(len);
+    for (let i = 0; i < len; i++) out[i] = input[i];
+    return out;
   }
 
   baseModule.__getArray = __getArray;


### PR DESCRIPTION
Benchmark results.
Firefox 69:
<img width="683" alt="Firefox" src="https://user-images.githubusercontent.com/1301959/64259341-91531880-cf31-11e9-917f-8f58ed725b7b.png">

Chrome 77.0.3865.56:
<img width="761" alt="Chrome" src="https://user-images.githubusercontent.com/1301959/64259383-a29c2500-cf31-11e9-9782-eb5973df7d19.png">

Bench link: https://esbench.com/bench/5d6fb7144cd7e6009ef62769
* Note: unset Babel transpiration check button before run tests