### PR TITLE
Fix missing TS1110 on function signatures with one parameter

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -459,7 +459,7 @@ export class Parser extends DiagnosticEmitter {
           if (!suppressErrors) {
             this.error(
               DiagnosticCode._0_expected,
-              tn.range(tn.pos), "}"
+              tn.range(tn.pos), ")"
             );
           }
           return null;
@@ -684,11 +684,28 @@ export class Parser extends DiagnosticEmitter {
             if (!parameters) parameters = [ param ];
             else parameters.push(param);
           } else {
+            if (!isSignature) {
+              let next = tn.peek();
+              if (next == Token.COMMA || next == Token.CLOSEPAREN) {
+                isSignature = true;
+                tn.discard(state);
+              }
+            }
             if (isSignature) {
+              let param = new ParameterNode();
+              param.parameterKind = kind;
+              param.name = name;
+              param.type = Node.createOmittedType(tn.range().atEnd);
+              if (!parameters) parameters = [ param ];
+              else parameters.push(param);
               this.error(
                 DiagnosticCode.Type_expected,
-                tn.range()
+                param.type.range
               ); // recoverable
+            } else {
+              tn.reset(state);
+              this.tryParseSignatureIsSignature = false;
+              return null;
             }
           }
         } else {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -744,16 +744,16 @@ export class Parser extends DiagnosticEmitter {
         isSignature = true;
         tn.discard(state);
         if (firstParamNameNoType) { // now we know
-          this.error(
-            DiagnosticCode.Type_expected,
-            firstParamNameNoType.range.atEnd
-          ); // recoverable
           let param = new ParameterNode();
           param.parameterKind = firstParamKind;
           param.name = firstParamNameNoType;
           param.type = Node.createOmittedType(firstParamNameNoType.range.atEnd);
           if (!parameters) parameters = [ param ];
           else parameters.push(param);
+          this.error(
+            DiagnosticCode.Type_expected,
+            param.type.range
+          ); // recoverable
         }
       }
       returnType = this.parseType(tn);

--- a/tests/parser/function-type.ts
+++ b/tests/parser/function-type.ts
@@ -1,0 +1,4 @@
+var a: () => void;
+var b: (a: i32, b: i32) => void;
+var c: (a: i32, b: i32) => (a: i32, b: i32) => void;
+var d: (a) => void; // TS1110

--- a/tests/parser/function-type.ts.fixture.ts
+++ b/tests/parser/function-type.ts.fixture.ts
@@ -1,0 +1,5 @@
+var a: () => void;
+var b: (a: i32, b: i32) => void;
+var c: (a: i32, b: i32) => (a: i32, b: i32) => void;
+var d: (a) => void;
+// ERROR 1110: "Type expected." in function-type.ts:4:9


### PR DESCRIPTION
potentially fixes #822

As mentioned in https://github.com/AssemblyScript/assemblyscript/issues/822#issuecomment-528880236 we were missing a diagnostic here in the `(identifier)` case, which is ambiguous in that it can be either a parenthesized or a function type without parsing further. The fix is a bit awkward because the parser cannot look ahead more than one token, so it remembers the potentially erroneous parameter and issues the diagnostic once it is sure that it is dealing with a function type. Also adds parameters with an omitted type to the AST fwiw (serialization purposes maybe).