### PR TITLE
fix errors when generating definitions for export alias

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -509,7 +509,7 @@ export class TSDBuilder extends ExportsWalker {
     indent(sb, this.indentLevel);
     sb.push("export const ");
     sb.push(name);
-    sb.push(" = typeof ");
+    sb.push(": typeof ");
     sb.push(originalName);
     sb.push(";\n");
   }


### PR DESCRIPTION
the generated d.ts for
```ts
export function add(x: i32, y: i32): i32 {
  return x + y;
}

export { add as addI32 }
```

was

```ts
declare module ASModule {
  type i8 = number;
  type i16 = number;
  type i32 = number;
  type u8 = number;
  type u16 = number;
  type u32 = number;
  type f32 = number;
  type f64 = number;
  type bool = any;
  export function add(x: i32, y: i32): i32;
  export const addI32 = typeof add; // ERROR!
}
export default ASModule;
```

but it should be

```ts
declare module ASModule {
  // ...
  export function add(x: i32, y: i32): i32;
  export const addI32: typeof add;
}
export default ASModule;
```

This pull request fixes this error.