### PR TITLE
Implement typeof expressions

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -8736,11 +8736,7 @@ export class Compiler extends DiagnosticEmitter {
         break;
       }
       case Token.TYPEOF: {
-        this.error(
-          DiagnosticCode.Operation_not_supported,
-          expression.range
-        );
-        return module.unreachable();
+        return this.compileTypeof(expression, contextualType, constraints);
       }
       default: {
         assert(false);
@@ -8759,6 +8755,71 @@ export class Compiler extends DiagnosticEmitter {
       resolver.currentElementExpression,
       contextualType != Type.void
     );
+  }
+
+  compileTypeof(
+    expression: UnaryPrefixExpression,
+    contextualType: Type,
+    constraints: Constraints
+  ): ExpressionRef {
+    var operand = expression.operand;
+    var expr: ExpressionRef = 0;
+    var stringInstance = this.program.stringInstance;
+    var typeString: string;
+    if (operand.kind == NodeKind.NULL) {
+      typeString = "object"; // special since `null` without type context is usize
+    } else {
+      let element = this.resolver.lookupExpression(operand, this.currentFlow, Type.auto, ReportMode.SWALLOW);
+      if (!element) {
+        typeString = "undefined";
+      } else {
+        switch (element.kind) {
+          case ElementKind.CLASS_PROTOTYPE:
+          case ElementKind.NAMESPACE:
+          case ElementKind.ENUM: {
+            typeString = "object";
+            break;
+          }
+          case ElementKind.FUNCTION_PROTOTYPE: {
+            typeString = "function";
+            break;
+          }
+          default: {
+            expr = this.compileExpression(operand, Type.auto);
+            let type = this.currentType;
+            expr = this.convertExpression(expr, type, Type.void, true, false, operand);
+            if (type.is(TypeFlags.REFERENCE)) {
+              let signatureReference = type.signatureReference;
+              if (signatureReference) {
+                typeString = "function";
+              } else {
+                let classReference = type.classReference;
+                if (classReference) {
+                  if (classReference.prototype === stringInstance.prototype) {
+                    typeString = "string";
+                  } else {
+                    typeString = "object";
+                  }
+                } else {
+                  typeString = "anyref"; // TODO?
+                }
+              }
+            } else if (type == Type.bool) {
+              typeString = "boolean";
+            } else if (type.isAny(TypeFlags.FLOAT | TypeFlags.INTEGER)) {
+              typeString = "number";
+            } else {
+              typeString = "undefined"; // failed to compile?
+            }
+            break;
+          }
+        }
+      }
+    }
+    this.currentType = stringInstance.type;
+    return expr
+      ? this.module.block(null, [ expr, this.ensureStaticString(typeString) ], this.options.nativeSizeType)
+      : this.ensureStaticString(typeString);
   }
 
   /** Makes sure that a 32-bit integer value is wrapped to a valid value of the specified type. */

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -8771,6 +8771,20 @@ export class Compiler extends DiagnosticEmitter {
     } else {
       let element = this.resolver.lookupExpression(operand, this.currentFlow, Type.auto, ReportMode.SWALLOW);
       if (!element) {
+        switch (operand.kind) {
+          case NodeKind.PROPERTYACCESS:
+          case NodeKind.ELEMENTACCESS: {
+            operand = operand.kind == NodeKind.PROPERTYACCESS
+              ? (<PropertyAccessExpression>operand).expression
+              : (<ElementAccessExpression>operand).expression;
+            let targetType = this.resolver.resolveExpression(operand, this.currentFlow, Type.auto, ReportMode.REPORT);
+            if (!targetType) {
+              this.currentType = stringInstance.type;
+              return this.module.unreachable();
+            }
+            expr = this.compileExpression(operand, Type.auto); // might have side-effects
+          }
+        }
         typeString = "undefined";
       } else {
         switch (element.kind) {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -8783,7 +8783,10 @@ export class Compiler extends DiagnosticEmitter {
               return this.module.unreachable();
             }
             expr = this.compileExpression(operand, Type.auto); // might have side-effects
+            break;
           }
+          case NodeKind.IDENTIFIER: break; // ignore error
+          default: expr = this.compileExpression(operand, Type.auto); // trigger error
         }
         typeString = "undefined";
       } else {

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1063,6 +1063,14 @@ export class Resolver extends DiagnosticEmitter {
     /** How to proceed with eventual diagnostics. */
     reportMode: ReportMode = ReportMode.REPORT
   ): Element | null {
+    switch (node.kind) {
+      case NodeKind.TRUE:
+      case NodeKind.FALSE:
+      case NodeKind.NULL: {
+        let type = this.resolveIdentifierExpression(node, ctxFlow, Type.auto, ctxElement, reportMode);
+        return type ? this.getElementOfType(type) : null;
+      }
+    }
     var name = node.text;
     var element: Element | null;
     if (element = ctxFlow.lookup(name)) {

--- a/tests/compiler/typeof.json
+++ b/tests/compiler/typeof.json
@@ -1,0 +1,6 @@
+{
+  "asc_flags": [
+    "--runtime none",
+    "--explicitStart"
+  ]
+}

--- a/tests/compiler/typeof.optimized.wat
+++ b/tests/compiler/typeof.optimized.wat
@@ -15,6 +15,7 @@
  (data (i32.const 144) "\0e\00\00\00\01\00\00\00\01\00\00\00\0e\00\00\00b\00o\00o\00l\00e\00a\00n")
  (data (i32.const 176) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\001")
  (data (i32.const 200) "\0c\00\00\00\01\00\00\00\01\00\00\00\0c\00\00\00s\00t\00r\00i\00n\00g")
+ (data (i32.const 232) "\12\00\00\00\01\00\00\00\01\00\00\00\12\00\00\00u\00n\00d\00e\00f\00i\00n\00e\00d")
  (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (global $typeof/c (mut i32) (i32.const 0))
@@ -383,9 +384,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 240
+  i32.const 272
   global.set $~lib/rt/stub/startOffset
-  i32.const 240
+  i32.const 272
   global.set $~lib/rt/stub/offset
   call $~lib/rt/stub/__alloc
   global.set $typeof/c
@@ -409,6 +410,30 @@
    i32.const 0
    i32.const 88
    i32.const 42
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 248
+  i32.const 248
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 43
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 248
+  i32.const 248
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 44
    i32.const 0
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/typeof.optimized.wat
+++ b/tests/compiler/typeof.optimized.wat
@@ -1,0 +1,427 @@
+(module
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$i (func (result i32)))
+ (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
+ (memory $0 1)
+ (data (i32.const 8) "\0c\00\00\00\01\00\00\00\01\00\00\00\0c\00\00\00n\00u\00m\00b\00e\00r")
+ (data (i32.const 40) "\0c\00\00\00\01\00\00\00\01\00\00\00\0c\00\00\00o\00b\00j\00e\00c\00t")
+ (data (i32.const 72) "\12\00\00\00\01\00\00\00\01\00\00\00\12\00\00\00t\00y\00p\00e\00o\00f\00.\00t\00s")
+ (data (i32.const 112) "\10\00\00\00\01\00\00\00\01\00\00\00\10\00\00\00f\00u\00n\00c\00t\00i\00o\00n")
+ (data (i32.const 144) "\0e\00\00\00\01\00\00\00\01\00\00\00\0e\00\00\00b\00o\00o\00l\00e\00a\00n")
+ (data (i32.const 176) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\001")
+ (data (i32.const 200) "\0c\00\00\00\01\00\00\00\01\00\00\00\0c\00\00\00s\00t\00r\00i\00n\00g")
+ (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
+ (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
+ (global $typeof/c (mut i32) (i32.const 0))
+ (global $~lib/started (mut i32) (i32.const 0))
+ (export "__start" (func $start))
+ (export "memory" (memory $0))
+ (func $~lib/string/String#get:length (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.const 16
+  i32.sub
+  i32.load offset=12
+  i32.const 1
+  i32.shr_u
+ )
+ (func $~lib/util/string/compareImpl (; 2 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  loop $continue|0
+   local.get $2
+   if (result i32)
+    local.get $0
+    i32.load16_u
+    local.get $1
+    i32.load16_u
+    i32.sub
+    local.tee $3
+    i32.eqz
+   else
+    i32.const 0
+   end
+   if
+    local.get $2
+    i32.const 1
+    i32.sub
+    local.set $2
+    local.get $0
+    i32.const 2
+    i32.add
+    local.set $0
+    local.get $1
+    i32.const 2
+    i32.add
+    local.set $1
+    br $continue|0
+   end
+  end
+  local.get $3
+ )
+ (func $~lib/string/String.__eq (; 3 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $0
+  local.get $1
+  i32.eq
+  if
+   i32.const 1
+   return
+  end
+  block $folding-inner0
+   local.get $1
+   i32.eqz
+   i32.const 1
+   local.get $0
+   select
+   br_if $folding-inner0
+   local.get $0
+   call $~lib/string/String#get:length
+   local.tee $2
+   local.get $1
+   call $~lib/string/String#get:length
+   i32.ne
+   br_if $folding-inner0
+   local.get $0
+   local.get $1
+   local.get $2
+   call $~lib/util/string/compareImpl
+   i32.eqz
+   return
+  end
+  i32.const 0
+ )
+ (func $start:typeof~anonymous|0 (; 4 ;) (type $FUNCSIG$v)
+  nop
+ )
+ (func $~lib/rt/stub/maybeGrowMemory (; 5 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  memory.size
+  local.tee $2
+  i32.const 16
+  i32.shl
+  local.tee $1
+  i32.gt_u
+  if
+   local.get $2
+   local.get $0
+   local.get $1
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const -65536
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.tee $1
+   local.get $2
+   local.get $1
+   i32.gt_s
+   select
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $1
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 6 ;) (type $FUNCSIG$i) (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  global.get $~lib/rt/stub/offset
+  i32.const 16
+  i32.add
+  local.tee $1
+  i32.const 16
+  i32.add
+  call $~lib/rt/stub/maybeGrowMemory
+  local.get $1
+  i32.const 16
+  i32.sub
+  local.tee $0
+  i32.const 16
+  i32.store
+  local.get $0
+  i32.const -1
+  i32.store offset=4
+  local.get $0
+  i32.const 3
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+ )
+ (func $start:typeof (; 7 ;) (type $FUNCSIG$v)
+  i32.const 56
+  i32.const 56
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 13
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 56
+  i32.const 56
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 14
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 56
+  i32.const 56
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 15
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 128
+  i32.const 128
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 16
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 128
+  i32.const 128
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 17
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 160
+  i32.const 160
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 19
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 56
+  i32.const 56
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 20
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 24
+  i32.const 24
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 21
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 24
+  i32.const 24
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 22
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 24
+  i32.const 24
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 23
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 216
+  i32.const 216
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 24
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 160
+  i32.const 160
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 27
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 24
+  i32.const 24
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 29
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 24
+  i32.const 24
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 31
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 24
+  i32.const 24
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 33
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 24
+  i32.const 24
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 35
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 216
+  i32.const 216
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 37
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 128
+  i32.const 128
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 39
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 240
+  global.set $~lib/rt/stub/startOffset
+  i32.const 240
+  global.set $~lib/rt/stub/offset
+  call $~lib/rt/stub/__alloc
+  global.set $typeof/c
+  i32.const 56
+  i32.const 56
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 41
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 128
+  i32.const 128
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 42
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $start (; 8 ;) (type $FUNCSIG$v)
+  global.get $~lib/started
+  if
+   return
+  else
+   i32.const 1
+   global.set $~lib/started
+  end
+  call $start:typeof
+ )
+)

--- a/tests/compiler/typeof.optimized.wat
+++ b/tests/compiler/typeof.optimized.wat
@@ -421,7 +421,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 43
+   i32.const 46
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -433,7 +433,19 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 44
+   i32.const 47
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 248
+  i32.const 248
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 48
    i32.const 0
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/typeof.ts
+++ b/tests/compiler/typeof.ts
@@ -40,5 +40,9 @@ assert(typeof fn == "function");
 var c = new SomeClass();
 assert(typeof c == "object");
 assert(typeof c.someInstanceMethod == "function");
+
+// would normally error but doesn't with typeof:
+
+assert(typeof d == "undefined");
 assert(typeof c.ba == "undefined");
 assert(typeof c[0] == "undefined");

--- a/tests/compiler/typeof.ts
+++ b/tests/compiler/typeof.ts
@@ -1,0 +1,42 @@
+assert(typeof 1 === "number"); // static string === static string precomputes
+
+// non-precomputed
+
+class SomeClass {
+  static someStaticMethod(): void {}
+  someInstanceMethod(): void {}
+}
+enum SomeEnum {}
+namespace SomeNamespace { const a: i32 = 1; }
+function SomeFunction(): void {}
+
+assert(typeof SomeClass == "object"); // ClassPrototype
+assert(typeof SomeEnum == "object"); // Enum
+assert(typeof SomeNamespace == "object"); // Namespace (TS complains if empty)
+assert(typeof SomeFunction == "function"); // FunctionPrototype
+assert(typeof SomeClass.someStaticMethod == "function");
+
+assert(typeof true == "boolean");
+assert(typeof null == "object");
+assert(typeof 1 == "number");
+assert(typeof 1.0 == "number");
+assert(typeof <i64>1 == "number");
+assert(typeof "1" == "string");
+
+var b = true;
+assert(typeof b == "boolean");
+var i = 1;
+assert(typeof i == "number");
+var f = <f32>1.0;
+assert(typeof f == "number");
+var I = <i64>1;
+assert(typeof I == "number");
+var F = 1.0;
+assert(typeof F == "number");
+var s = "1";
+assert(typeof s == "string");
+var fn = (): void => {};
+assert(typeof fn == "function");
+var c = new SomeClass();
+assert(typeof c == "object");
+assert(typeof c.someInstanceMethod == "function");

--- a/tests/compiler/typeof.ts
+++ b/tests/compiler/typeof.ts
@@ -40,3 +40,5 @@ assert(typeof fn == "function");
 var c = new SomeClass();
 assert(typeof c == "object");
 assert(typeof c.someInstanceMethod == "function");
+assert(typeof c.ba == "undefined");
+assert(typeof c[0] == "undefined");

--- a/tests/compiler/typeof.untouched.wat
+++ b/tests/compiler/typeof.untouched.wat
@@ -1,0 +1,575 @@
+(module
+ (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$iiiiii (func (param i32 i32 i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$v (func))
+ (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
+ (memory $0 1)
+ (data (i32.const 8) "\0c\00\00\00\01\00\00\00\01\00\00\00\0c\00\00\00n\00u\00m\00b\00e\00r\00")
+ (data (i32.const 40) "\0c\00\00\00\01\00\00\00\01\00\00\00\0c\00\00\00o\00b\00j\00e\00c\00t\00")
+ (data (i32.const 72) "\12\00\00\00\01\00\00\00\01\00\00\00\12\00\00\00t\00y\00p\00e\00o\00f\00.\00t\00s\00")
+ (data (i32.const 112) "\10\00\00\00\01\00\00\00\01\00\00\00\10\00\00\00f\00u\00n\00c\00t\00i\00o\00n\00")
+ (data (i32.const 144) "\0e\00\00\00\01\00\00\00\01\00\00\00\0e\00\00\00b\00o\00o\00l\00e\00a\00n\00")
+ (data (i32.const 176) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\001\00")
+ (data (i32.const 200) "\0c\00\00\00\01\00\00\00\01\00\00\00\0c\00\00\00s\00t\00r\00i\00n\00g\00")
+ (table $0 2 funcref)
+ (elem (i32.const 0) $null $start:typeof~anonymous|0)
+ (global $typeof/SomeNamespace.a i32 (i32.const 1))
+ (global $typeof/b (mut i32) (i32.const 1))
+ (global $typeof/i (mut i32) (i32.const 1))
+ (global $typeof/f (mut f32) (f32.const 1))
+ (global $typeof/I (mut i64) (i64.const 1))
+ (global $typeof/F (mut f64) (f64.const 1))
+ (global $typeof/s (mut i32) (i32.const 192))
+ (global $typeof/fn (mut i32) (i32.const 1))
+ (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
+ (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
+ (global $typeof/c (mut i32) (i32.const 0))
+ (global $~lib/started (mut i32) (i32.const 0))
+ (global $~lib/heap/__heap_base i32 (i32.const 228))
+ (export "__start" (func $start))
+ (export "memory" (memory $0))
+ (func $~lib/rt/stub/__retain (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+ )
+ (func $~lib/rt/stub/__release (; 2 ;) (type $FUNCSIG$vi) (param $0 i32)
+  nop
+ )
+ (func $~lib/string/String#get:length (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.const 16
+  i32.sub
+  i32.load offset=12
+  i32.const 1
+  i32.shr_u
+ )
+ (func $~lib/util/string/compareImpl (; 4 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $0
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $2
+  call $~lib/rt/stub/__retain
+  drop
+  i32.const 0
+  local.set $5
+  local.get $0
+  local.get $1
+  i32.const 1
+  i32.shl
+  i32.add
+  local.set $6
+  local.get $2
+  local.get $3
+  i32.const 1
+  i32.shl
+  i32.add
+  local.set $7
+  block $break|0
+   loop $continue|0
+    local.get $4
+    if (result i32)
+     local.get $6
+     i32.load16_u
+     local.get $7
+     i32.load16_u
+     i32.sub
+     local.tee $5
+     i32.eqz
+    else
+     i32.const 0
+    end
+    i32.eqz
+    br_if $break|0
+    local.get $4
+    i32.const 1
+    i32.sub
+    local.set $4
+    local.get $6
+    i32.const 2
+    i32.add
+    local.set $6
+    local.get $7
+    i32.const 2
+    i32.add
+    local.set $7
+    br $continue|0
+   end
+   unreachable
+  end
+  local.get $5
+  local.set $8
+  local.get $0
+  call $~lib/rt/stub/__release
+  local.get $2
+  call $~lib/rt/stub/__release
+  local.get $8
+ )
+ (func $~lib/string/String.__eq (; 5 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $1
+  call $~lib/rt/stub/__retain
+  drop
+  local.get $0
+  local.get $1
+  i32.eq
+  if
+   i32.const 1
+   local.set $2
+   local.get $0
+   call $~lib/rt/stub/__release
+   local.get $1
+   call $~lib/rt/stub/__release
+   local.get $2
+   return
+  end
+  local.get $0
+  i32.const 0
+  i32.eq
+  if (result i32)
+   i32.const 1
+  else
+   local.get $1
+   i32.const 0
+   i32.eq
+  end
+  if
+   i32.const 0
+   local.set $2
+   local.get $0
+   call $~lib/rt/stub/__release
+   local.get $1
+   call $~lib/rt/stub/__release
+   local.get $2
+   return
+  end
+  local.get $0
+  call $~lib/string/String#get:length
+  local.set $3
+  local.get $3
+  local.get $1
+  call $~lib/string/String#get:length
+  i32.ne
+  if
+   i32.const 0
+   local.set $2
+   local.get $0
+   call $~lib/rt/stub/__release
+   local.get $1
+   call $~lib/rt/stub/__release
+   local.get $2
+   return
+  end
+  local.get $0
+  i32.const 0
+  local.get $1
+  i32.const 0
+  local.get $3
+  call $~lib/util/string/compareImpl
+  i32.eqz
+  local.set $2
+  local.get $0
+  call $~lib/rt/stub/__release
+  local.get $1
+  call $~lib/rt/stub/__release
+  local.get $2
+ )
+ (func $start:typeof~anonymous|0 (; 6 ;) (type $FUNCSIG$v)
+  nop
+ )
+ (func $~lib/rt/stub/maybeGrowMemory (; 7 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  memory.size
+  local.set $1
+  local.get $1
+  i32.const 16
+  i32.shl
+  local.set $2
+  local.get $0
+  local.get $2
+  i32.gt_u
+  if
+   local.get $0
+   local.get $2
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const 65535
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.set $3
+   local.get $1
+   local.tee $4
+   local.get $3
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_s
+   select
+   local.set $4
+   local.get $4
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $3
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 8 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.const 1073741808
+  i32.gt_u
+  if
+   unreachable
+  end
+  global.get $~lib/rt/stub/offset
+  i32.const 16
+  i32.add
+  local.set $2
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  local.tee $3
+  i32.const 16
+  local.tee $4
+  local.get $3
+  local.get $4
+  i32.gt_u
+  select
+  local.set $5
+  local.get $2
+  local.get $5
+  i32.add
+  call $~lib/rt/stub/maybeGrowMemory
+  local.get $2
+  i32.const 16
+  i32.sub
+  local.set $6
+  local.get $6
+  local.get $5
+  i32.store
+  local.get $6
+  i32.const -1
+  i32.store offset=4
+  local.get $6
+  local.get $1
+  i32.store offset=8
+  local.get $6
+  local.get $0
+  i32.store offset=12
+  local.get $2
+ )
+ (func $typeof/SomeClass#constructor (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 3
+   call $~lib/rt/stub/__alloc
+   call $~lib/rt/stub/__retain
+   local.set $0
+  end
+  local.get $0
+ )
+ (func $start:typeof (; 10 ;) (type $FUNCSIG$v)
+  i32.const 56
+  i32.const 56
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 13
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 56
+  i32.const 56
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 14
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 56
+  i32.const 56
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 15
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 128
+  i32.const 128
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 16
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 128
+  i32.const 128
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 17
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 160
+  i32.const 160
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 19
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 56
+  i32.const 56
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 20
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 24
+  i32.const 24
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 21
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 24
+  i32.const 24
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 22
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 24
+  i32.const 24
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 23
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 216
+  i32.const 216
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 24
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 160
+  i32.const 160
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 27
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 24
+  i32.const 24
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 29
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 24
+  i32.const 24
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 31
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 24
+  i32.const 24
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 33
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 24
+  i32.const 24
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 35
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 216
+  i32.const 216
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 37
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 128
+  i32.const 128
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 39
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/heap/__heap_base
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  global.set $~lib/rt/stub/startOffset
+  global.get $~lib/rt/stub/startOffset
+  global.set $~lib/rt/stub/offset
+  i32.const 0
+  call $typeof/SomeClass#constructor
+  global.set $typeof/c
+  i32.const 56
+  i32.const 56
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 41
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 128
+  i32.const 128
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 42
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $start (; 11 ;) (type $FUNCSIG$v)
+  global.get $~lib/started
+  if
+   return
+  else
+   i32.const 1
+   global.set $~lib/started
+  end
+  call $start:typeof
+ )
+ (func $null (; 12 ;) (type $FUNCSIG$v)
+ )
+)

--- a/tests/compiler/typeof.untouched.wat
+++ b/tests/compiler/typeof.untouched.wat
@@ -567,7 +567,7 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 43
+   i32.const 46
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -579,7 +579,19 @@
   if
    i32.const 0
    i32.const 88
-   i32.const 44
+   i32.const 47
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 248
+  i32.const 248
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 48
    i32.const 0
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/typeof.untouched.wat
+++ b/tests/compiler/typeof.untouched.wat
@@ -14,6 +14,7 @@
  (data (i32.const 144) "\0e\00\00\00\01\00\00\00\01\00\00\00\0e\00\00\00b\00o\00o\00l\00e\00a\00n\00")
  (data (i32.const 176) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\001\00")
  (data (i32.const 200) "\0c\00\00\00\01\00\00\00\01\00\00\00\0c\00\00\00s\00t\00r\00i\00n\00g\00")
+ (data (i32.const 232) "\12\00\00\00\01\00\00\00\01\00\00\00\12\00\00\00u\00n\00d\00e\00f\00i\00n\00e\00d\00")
  (table $0 2 funcref)
  (elem (i32.const 0) $null $start:typeof~anonymous|0)
  (global $typeof/SomeNamespace.a i32 (i32.const 1))
@@ -28,7 +29,7 @@
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (global $typeof/c (mut i32) (i32.const 0))
  (global $~lib/started (mut i32) (i32.const 0))
- (global $~lib/heap/__heap_base i32 (i32.const 228))
+ (global $~lib/heap/__heap_base i32 (i32.const 268))
  (export "__start" (func $start))
  (export "memory" (memory $0))
  (func $~lib/rt/stub/__retain (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
@@ -555,6 +556,30 @@
    i32.const 0
    i32.const 88
    i32.const 42
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 248
+  i32.const 248
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 43
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 248
+  i32.const 248
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 88
+   i32.const 44
    i32.const 0
    call $~lib/builtins/abort
    unreachable


### PR DESCRIPTION
This PR implements `typeof` by emulating what JS/TS would do ([see also](https://github.com/AssemblyScript/assemblyscript/pull/783)). As such, it's not particularly accurate, for example

* `typeof null == "object"` even though AS would compile a lone `null` without class context as `usize`
* `typeof SomeClassEnumOrNamespace == "object"` even though that's not actually a runtime object in AS
* `typeof doesntEvenExist == "undefined"` even though that's not a type in AS (ofc also true for `object`)
* there's just `"number"`

plus

* `typeof someAnyref == "anyref"` since [MDN says](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#Description) "Host object (provided by the JS environment) - Implementation-dependent." Not sure if that applies here, though.