### PR TITLE
Improve holey array handling and remove Array.create

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -5865,7 +5865,7 @@ export class Compiler extends DiagnosticEmitter {
           }
 
           // apply concrete types to the generic function signature
-          let resolvedTypeArguments = Array.create<Type>(numTypeParameters);
+          let resolvedTypeArguments = new Array<Type>(numTypeParameters);
           for (let i = 0; i < numTypeParameters; ++i) {
             let name = typeParameterNodes[i].name.text;
             if (contextualTypeArguments.has(name)) {

--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -31,14 +31,21 @@ export class Array<T> extends ArrayBufferView {
   // to work with typed and normal arrays interchangeably. Technically, normal arrays do not need
   // `dataStart` (equals `data`) and `dataLength` (equals computed `data.byteLength`).
 
-  // Also note that Array<T> with non-nullable T must guard against implicit null values whenever
-  // length is modified in a way that a null value would exist. Otherwise, the compiler wouldn't be
-  // able to guarantee type-safety anymore. For lack of a better word, such an array is "holey".
+  // Also note that Array<T> with non-nullable T must guard against uninitialized null values
+  // whenever an element is accessed. Otherwise, the compiler wouldn't be able to guarantee
+  // type-safety anymore. For lack of a better word, such an array is "holey".
 
   private length_: i32;
 
   static isArray<U>(value: U): bool {
     return builtin_isArray(value) && value !== null;
+  }
+
+  static create<T>(capacity: i32 = 0): Array<T> {
+    WARNING("'Array.create' is deprecated. Use 'new Array' instead, making sure initial elements are initialized.");
+    var array = new Array<T>(capacity);
+    array.length = 0;
+    return array;
   }
 
   constructor(length: i32 = 0) {

--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -56,16 +56,15 @@ export class Array<T> extends ArrayBufferView {
 
   set length(newLength: i32) {
     var oldLength = this.length_;
-    if (oldLength > newLength) {
-      let start = this.dataStart + (<usize>newLength << alignof<T>());
-      let size = <usize>(oldLength - newLength) << alignof<T>();
-      if (isManaged<T>()) { // release no longer used refs
-        let cur = start;
-        let end = start + size;
+    if (isManaged<T>()) {
+      if (oldLength > newLength) { // release no longer used refs
+        let cur = (<usize>newLength << alignof<T>());
+        let end = (<usize>oldLength << alignof<T>());
         do __release(load<usize>(cur));
         while ((cur += sizeof<T>()) < end);
+      } else {
+        ensureSize(changetype<usize>(this), newLength, alignof<T>());
       }
-      memory.fill(start, 0, size);
     } else {
       ensureSize(changetype<usize>(this), newLength, alignof<T>());
     }

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -1249,13 +1249,11 @@ declare class Array<T> {
 
   /** Tests if a value is an array. */
   static isArray<U>(value: any): value is Array<any>;
-  /** Creates a new array with at least the specified capacity and length zero. */
-  static create<T>(capacity?: i32): Array<T>;
 
   [key: number]: T;
   /** Current length of the array. */
   length: i32;
-  /** Constructs a new array. If length is greater than zero and T is a non-nullable reference, use `Array.create` instead.*/
+  /** Constructs a new array. */
   constructor(capacity?: i32);
 
   fill(value: T, start?: i32, end?: i32): this;

--- a/std/assembly/map.ts
+++ b/std/assembly/map.ts
@@ -197,13 +197,16 @@ export class Map<K,V> {
     // FIXME: this is preliminary, needs iterators/closures
     var start = changetype<usize>(this.entries);
     var size = this.entriesOffset;
-    var keys = Array.create<K>(size);
+    var keys = new Array<K>(size);
+    var length = 0;
     for (let i = 0; i < size; ++i) {
       let entry = changetype<MapEntry<K,V>>(start + <usize>i * ENTRY_SIZE<K,V>());
       if (!(entry.taggedNext & EMPTY)) {
         keys.push(entry.key);
+        ++length;
       }
     }
+    keys.length = length;
     return keys;
   }
 
@@ -211,13 +214,16 @@ export class Map<K,V> {
     // FIXME: this is preliminary, needs iterators/closures
     var start = changetype<usize>(this.entries);
     var size = this.entriesOffset;
-    var values = Array.create<V>(size);
+    var values = new Array<V>(size);
+    var length = 0;
     for (let i = 0; i < size; ++i) {
       let entry = changetype<MapEntry<K,V>>(start + <usize>i * ENTRY_SIZE<K,V>());
       if (!(entry.taggedNext & EMPTY)) {
         values.push(entry.value);
+        ++length;
       }
     }
+    values.length = length;
     return values;
   }
 

--- a/std/assembly/set.ts
+++ b/std/assembly/set.ts
@@ -174,13 +174,16 @@ export class Set<T> {
     // FIXME: this is preliminary, needs iterators/closures
     var start = changetype<usize>(this.entries);
     var size = this.entriesOffset;
-    var values = Array.create<T>(size);
+    var values = new Array<T>(size);
+    var length = 0;
     for (let i = 0; i < size; ++i) {
       let entry = changetype<SetEntry<T>>(start + <usize>i * ENTRY_SIZE<T>());
       if (!(entry.taggedNext & EMPTY)) {
         values.push(entry.key);
+        ++length;
       }
     }
+    values.length = length;
     return values;
   }
 

--- a/std/portable/index.d.ts
+++ b/std/portable/index.d.ts
@@ -379,7 +379,6 @@ declare class DataView {
 declare class Array<T> {
 
   static isArray<U>(value: any): value is Array<any>;
-  static create<T>(capacity?: i32): Array<T>;
 
   [key: number]: T;
   length: i32;

--- a/std/portable/index.js
+++ b/std/portable/index.js
@@ -237,12 +237,6 @@ globalScope["isArrayLike"] = function isArrayLike(expr) {
     && Math.trunc(expr.length) === expr.length;
 };
 
-Array.create = function(capacity) {
-  var arr = new Array(capacity);
-  arr.length = 0;
-  return arr;
-};
-
 globalScope["isDefined"] = function isDefined(expr) {
   return typeof expr !== "undefined";
 }

--- a/tests/compiler/assert-nonnull.optimized.wat
+++ b/tests/compiler/assert-nonnull.optimized.wat
@@ -5,9 +5,9 @@
  (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
- (data (i32.const 8) "^\00\00\00\01\00\00\00\01\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y")
- (data (i32.const 120) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s")
- (data (i32.const 168) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e")
+ (data (i32.const 8) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e")
+ (data (i32.const 64) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s")
+ (data (i32.const 112) "^\00\00\00\01\00\00\00\01\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y")
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (global $~lib/argc (mut i32) (i32.const 0))
@@ -63,28 +63,25 @@
   i32.ge_u
   if
    i32.const 24
-   i32.const 136
-   i32.const 106
-   i32.const 45
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 0
-  local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
-  i32.ge_u
-  if
-   i32.const 184
-   i32.const 136
-   i32.const 109
-   i32.const 61
+   i32.const 80
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   call $~lib/array/Array<assert-nonnull/Foo>#__unchecked_get
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 128
+   i32.const 80
+   i32.const 94
+   i32.const 39
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
  )
  (func $assert-nonnull/testArr (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
@@ -98,15 +95,13 @@
  (func $~lib/array/Array<assert-nonnull/Foo | null>#__get (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 0
   local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
-   i32.const 184
-   i32.const 136
-   i32.const 109
-   i32.const 61
+   i32.const 24
+   i32.const 80
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/assert-nonnull.optimized.wat
+++ b/tests/compiler/assert-nonnull.optimized.wat
@@ -64,7 +64,7 @@
   if
    i32.const 24
    i32.const 80
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -76,7 +76,7 @@
   if
    i32.const 128
    i32.const 80
-   i32.const 94
+   i32.const 93
    i32.const 39
    call $~lib/builtins/abort
    unreachable
@@ -100,7 +100,7 @@
   if
    i32.const 24
    i32.const 80
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/assert-nonnull.optimized.wat
+++ b/tests/compiler/assert-nonnull.optimized.wat
@@ -64,7 +64,7 @@
   if
    i32.const 24
    i32.const 80
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -76,7 +76,7 @@
   if
    i32.const 128
    i32.const 80
-   i32.const 93
+   i32.const 100
    i32.const 39
    call $~lib/builtins/abort
    unreachable
@@ -100,7 +100,7 @@
   if
    i32.const 24
    i32.const 80
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/assert-nonnull.untouched.wat
+++ b/tests/compiler/assert-nonnull.untouched.wat
@@ -107,7 +107,7 @@
   if
    i32.const 24
    i32.const 80
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -123,7 +123,7 @@
    call $~lib/rt/stub/__release
    i32.const 128
    i32.const 80
-   i32.const 93
+   i32.const 100
    i32.const 39
    call $~lib/builtins/abort
    unreachable
@@ -168,7 +168,7 @@
   if
    i32.const 24
    i32.const 80
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/assert-nonnull.untouched.wat
+++ b/tests/compiler/assert-nonnull.untouched.wat
@@ -7,9 +7,9 @@
  (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
- (data (i32.const 8) "^\00\00\00\01\00\00\00\01\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y\00")
- (data (i32.const 120) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s\00")
- (data (i32.const 168) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e\00")
+ (data (i32.const 8) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e\00")
+ (data (i32.const 64) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s\00")
+ (data (i32.const 112) "^\00\00\00\01\00\00\00\01\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y\00")
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (global $~lib/argc (mut i32) (i32.const 0))
@@ -99,35 +99,36 @@
   call $~lib/rt/stub/__retain
  )
  (func $~lib/array/Array<assert-nonnull/Foo>#__get (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
   i32.ge_u
   if
    i32.const 24
-   i32.const 136
-   i32.const 106
-   i32.const 45
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $1
-  local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
-  i32.ge_u
-  if
-   i32.const 184
-   i32.const 136
-   i32.const 109
-   i32.const 61
+   i32.const 80
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<assert-nonnull/Foo>#__unchecked_get
+  local.set $2
+  local.get $2
+  i32.eqz
+  if
+   local.get $2
+   call $~lib/rt/stub/__release
+   i32.const 128
+   i32.const 80
+   i32.const 94
+   i32.const 39
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
  )
  (func $assert-nonnull/testArr (; 8 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
@@ -159,23 +160,24 @@
   call $~lib/rt/stub/__retain
  )
  (func $~lib/array/Array<assert-nonnull/Foo | null>#__get (; 10 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
   local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
-   i32.const 184
-   i32.const 136
-   i32.const 109
-   i32.const 61
+   i32.const 24
+   i32.const 80
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<assert-nonnull/Foo | null>#__unchecked_get
+  local.set $2
+  local.get $2
  )
  (func $assert-nonnull/testElem (; 11 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)

--- a/tests/compiler/assert-nonnull.untouched.wat
+++ b/tests/compiler/assert-nonnull.untouched.wat
@@ -107,7 +107,7 @@
   if
    i32.const 24
    i32.const 80
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -123,7 +123,7 @@
    call $~lib/rt/stub/__release
    i32.const 128
    i32.const 80
-   i32.const 94
+   i32.const 93
    i32.const 39
    call $~lib/builtins/abort
    unreachable
@@ -168,7 +168,7 @@
   if
    i32.const 24
    i32.const 80
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.optimized.wat
+++ b/tests/compiler/resolve-access.optimized.wat
@@ -313,7 +313,7 @@
   if
    i32.const 48
    i32.const 104
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.optimized.wat
+++ b/tests/compiler/resolve-access.optimized.wat
@@ -308,15 +308,13 @@
  (func $~lib/array/Array<u64>#__get (; 5 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
   i32.const 0
   local.get $0
-  i32.load offset=8
-  i32.const 3
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
    i32.const 48
    i32.const 104
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/resolve-access.optimized.wat
+++ b/tests/compiler/resolve-access.optimized.wat
@@ -313,7 +313,7 @@
   if
    i32.const 48
    i32.const 104
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.untouched.wat
+++ b/tests/compiler/resolve-access.untouched.wat
@@ -1449,7 +1449,7 @@
   if
    i32.const 48
    i32.const 104
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-access.untouched.wat
+++ b/tests/compiler/resolve-access.untouched.wat
@@ -1441,23 +1441,24 @@
   i64.load
  )
  (func $~lib/array/Array<u64>#__get (; 8 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i64)
   local.get $1
   local.get $0
-  i32.load offset=8
-  i32.const 3
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
    i32.const 48
    i32.const 104
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<u64>#__unchecked_get
+  local.set $2
+  local.get $2
  )
  (func $~lib/util/number/decimalCount32 (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)

--- a/tests/compiler/resolve-access.untouched.wat
+++ b/tests/compiler/resolve-access.untouched.wat
@@ -1449,7 +1449,7 @@
   if
    i32.const 48
    i32.const 104
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/retain-release-sanity.optimized.wat
+++ b/tests/compiler/retain-release-sanity.optimized.wat
@@ -2298,7 +2298,7 @@
   if
    i32.const 424
    i32.const 376
-   i32.const 268
+   i32.const 267
    i32.const 20
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/retain-release-sanity.optimized.wat
+++ b/tests/compiler/retain-release-sanity.optimized.wat
@@ -2298,7 +2298,7 @@
   if
    i32.const 424
    i32.const 376
-   i32.const 267
+   i32.const 274
    i32.const 20
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/retain-release-sanity.optimized.wat
+++ b/tests/compiler/retain-release-sanity.optimized.wat
@@ -22,13 +22,12 @@
  (data (i32.const 320) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s")
  (data (i32.const 360) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s")
  (data (i32.const 408) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00A\00r\00r\00a\00y\00 \00i\00s\00 \00e\00m\00p\00t\00y")
- (data (i32.const 456) "^\00\00\00\01\00\00\00\01\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y")
- (data (i32.const 572) "\01\00\00\00\01")
- (data (i32.const 584) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\00a")
- (data (i32.const 608) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\00b")
- (data (i32.const 632) "\08\00\00\00\01\00\00\00\01\00\00\00\08\00\00\00n\00u\00l\00l")
- (data (i32.const 656) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\00d")
- (data (i32.const 680) "\08\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\93\04\00\00\02\00\00\00\93 \00\00\02\00\00\00\93 \00\00\02")
+ (data (i32.const 460) "\01\00\00\00\01")
+ (data (i32.const 472) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\00a")
+ (data (i32.const 496) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\00b")
+ (data (i32.const 520) "\08\00\00\00\01\00\00\00\01\00\00\00\08\00\00\00n\00u\00l\00l")
+ (data (i32.const 544) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\00d")
+ (data (i32.const 568) "\08\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\93\04\00\00\02\00\00\00\93 \00\00\02\00\00\00\93 \00\00\02")
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
  (global $~lib/rt/pure/ROOTS (mut i32) (i32.const 0))
@@ -621,10 +620,10 @@
   if
    unreachable
   end
-  i32.const 752
+  i32.const 640
   i32.const 0
   i32.store
-  i32.const 2320
+  i32.const 2208
   i32.const 0
   i32.store
   i32.const 0
@@ -638,7 +637,7 @@
     local.get $0
     i32.const 2
     i32.shl
-    i32.const 752
+    i32.const 640
     i32.add
     i32.const 0
     i32.store offset=4
@@ -657,7 +656,7 @@
       i32.add
       i32.const 2
       i32.shl
-      i32.const 752
+      i32.const 640
       i32.add
       i32.const 0
       i32.store offset=96
@@ -675,13 +674,13 @@
     br $loop|0
    end
   end
-  i32.const 752
-  i32.const 2336
+  i32.const 640
+  i32.const 2224
   memory.size
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
-  i32.const 752
+  i32.const 640
   global.set $~lib/rt/tlsf/ROOT
  )
  (func $~lib/rt/tlsf/prepareSize (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
@@ -1582,7 +1581,7 @@
  )
  (func $~lib/rt/pure/__retain (; 23 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
-  i32.const 748
+  i32.const 636
   i32.gt_u
   if
    local.get $0
@@ -1594,7 +1593,7 @@
  )
  (func $~lib/rt/__typeinfo (; 24 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
-  i32.const 680
+  i32.const 568
   i32.load
   i32.gt_u
   if
@@ -1608,7 +1607,7 @@
   local.get $0
   i32.const 3
   i32.shl
-  i32.const 684
+  i32.const 572
   i32.add
   i32.load
  )
@@ -1980,7 +1979,7 @@
  )
  (func $~lib/rt/pure/__release (; 30 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
-  i32.const 748
+  i32.const 636
   i32.gt_u
   if
    local.get $0
@@ -2299,7 +2298,7 @@
   if
    i32.const 424
    i32.const 376
-   i32.const 287
+   i32.const 268
    i32.const 20
    call $~lib/builtins/abort
    unreachable
@@ -2322,7 +2321,7 @@
  (func $~lib/array/Array<~lib/string/String>#push (; 37 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
-  i32.const 584
+  i32.const 472
   call $~lib/rt/pure/__retain
   drop
   local.get $0
@@ -2339,13 +2338,13 @@
   i32.const 2
   i32.shl
   i32.add
-  i32.const 584
+  i32.const 472
   call $~lib/rt/pure/__retain
   i32.store
   local.get $0
   local.get $2
   i32.store offset=12
-  i32.const 584
+  i32.const 472
   call $~lib/rt/pure/__release
  )
  (func $~lib/string/String#get:length (; 38 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
@@ -2367,16 +2366,16 @@
   i32.eqz
   if
    local.get $1
-   i32.const 648
+   i32.const 536
    i32.ne
    if
-    i32.const 648
+    i32.const 536
     call $~lib/rt/pure/__retain
     drop
     local.get $1
     call $~lib/rt/pure/__release
    end
-   i32.const 648
+   i32.const 536
    local.set $1
   end
   local.get $0
@@ -2393,7 +2392,7 @@
   local.tee $2
   i32.eqz
   if
-   i32.const 584
+   i32.const 472
    call $~lib/rt/pure/__retain
    local.get $1
    call $~lib/rt/pure/__release
@@ -2426,7 +2425,7 @@
   call $~lib/rt/pure/__retain
   drop
   local.get $0
-  i32.const 648
+  i32.const 536
   local.get $0
   select
   local.get $1
@@ -2518,15 +2517,15 @@
    end
   end
   call $~lib/rt/pure/__release
-  i32.const 600
+  i32.const 488
   call $~lib/rt/pure/__retain
   local.tee $0
-  i32.const 624
+  i32.const 512
   call $~lib/string/String.__concat
   local.tee $1
   call $~lib/rt/pure/__retain
   local.tee $2
-  i32.const 672
+  i32.const 560
   call $~lib/string/String.__concat
   local.get $0
   call $~lib/rt/pure/__release
@@ -2652,7 +2651,7 @@
  )
  (func $~lib/rt/pure/__visit (; 43 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
-  i32.const 748
+  i32.const 636
   i32.lt_u
   if
    return

--- a/tests/compiler/retain-release-sanity.untouched.wat
+++ b/tests/compiler/retain-release-sanity.untouched.wat
@@ -22,13 +22,12 @@
  (data (i32.const 320) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s\00")
  (data (i32.const 360) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s\00")
  (data (i32.const 408) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00A\00r\00r\00a\00y\00 \00i\00s\00 \00e\00m\00p\00t\00y\00")
- (data (i32.const 456) "^\00\00\00\01\00\00\00\01\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y\00")
- (data (i32.const 568) "\00\00\00\00\01\00\00\00\01\00\00\00\00\00\00\00")
- (data (i32.const 584) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\00a\00")
- (data (i32.const 608) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\00b\00")
- (data (i32.const 632) "\08\00\00\00\01\00\00\00\01\00\00\00\08\00\00\00n\00u\00l\00l\00")
- (data (i32.const 656) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\00d\00")
- (data (i32.const 680) "\08\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\93\04\00\00\02\00\00\00\93 \00\00\02\00\00\00\93 \00\00\02\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 456) "\00\00\00\00\01\00\00\00\01\00\00\00\00\00\00\00")
+ (data (i32.const 472) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\00a\00")
+ (data (i32.const 496) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\00b\00")
+ (data (i32.const 520) "\08\00\00\00\01\00\00\00\01\00\00\00\08\00\00\00n\00u\00l\00l\00")
+ (data (i32.const 544) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\00d\00")
+ (data (i32.const 568) "\08\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\93\04\00\00\02\00\00\00\93 \00\00\02\00\00\00\93 \00\00\02\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
@@ -38,8 +37,8 @@
  (global $~lib/rt/pure/CUR (mut i32) (i32.const 0))
  (global $~lib/ASC_SHRINK_LEVEL i32 (i32.const 0))
  (global $~lib/rt/pure/END (mut i32) (i32.const 0))
- (global $~lib/rt/__rtti_base i32 (i32.const 680))
- (global $~lib/heap/__heap_base i32 (i32.const 748))
+ (global $~lib/rt/__rtti_base i32 (i32.const 568))
+ (global $~lib/heap/__heap_base i32 (i32.const 636))
  (export "memory" (memory $0))
  (start $start)
  (func $~lib/rt/tlsf/removeBlock (; 5 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
@@ -3910,7 +3909,7 @@
   if
    i32.const 424
    i32.const 376
-   i32.const 287
+   i32.const 268
    i32.const 20
    call $~lib/builtins/abort
    unreachable
@@ -3948,15 +3947,6 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $1
-  if
-   i32.const 472
-   i32.const 376
-   i32.const 56
-   i32.const 20
-   call $~lib/builtins/abort
-   unreachable
-  end
   local.get $0
   local.get $1
   i32.store offset=12
@@ -3979,15 +3969,6 @@
   local.get $0
   i32.const 0
   i32.store offset=12
-  local.get $1
-  if
-   i32.const 472
-   i32.const 376
-   i32.const 56
-   i32.const 20
-   call $~lib/builtins/abort
-   unreachable
-  end
   local.get $0
   local.get $1
   i32.store offset=12
@@ -4051,7 +4032,7 @@
   i32.const 0
   i32.eq
   if
-   i32.const 648
+   i32.const 536
    local.tee $2
    local.get $1
    local.tee $3
@@ -4084,7 +4065,7 @@
   i32.const 0
   i32.eq
   if
-   i32.const 584
+   i32.const 472
    call $~lib/rt/pure/__retain
    local.set $2
    local.get $1
@@ -4122,7 +4103,7 @@
   call $~lib/rt/pure/__retain
   drop
   local.get $0
-  i32.const 648
+  i32.const 536
   local.get $0
   i32.const 0
   i32.ne
@@ -4215,7 +4196,7 @@
       i32.eqz
       br_if $break|1
       local.get $2
-      i32.const 584
+      i32.const 472
       call $~lib/array/Array<~lib/string/String>#push
       drop
       local.get $3
@@ -4238,17 +4219,17 @@
   end
   local.get $0
   call $~lib/rt/pure/__release
-  i32.const 600
+  i32.const 488
   call $~lib/rt/pure/__retain
   local.set $0
   local.get $0
-  i32.const 624
+  i32.const 512
   call $~lib/string/String.__concat
   local.tee $2
   call $~lib/rt/pure/__retain
   local.set $1
   local.get $1
-  i32.const 672
+  i32.const 560
   call $~lib/string/String.__concat
   local.tee $3
   drop

--- a/tests/compiler/retain-release-sanity.untouched.wat
+++ b/tests/compiler/retain-release-sanity.untouched.wat
@@ -3909,7 +3909,7 @@
   if
    i32.const 424
    i32.const 376
-   i32.const 268
+   i32.const 267
    i32.const 20
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/retain-release-sanity.untouched.wat
+++ b/tests/compiler/retain-release-sanity.untouched.wat
@@ -3909,7 +3909,7 @@
   if
    i32.const 424
    i32.const 376
-   i32.const 267
+   i32.const 274
    i32.const 20
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-access.optimized.wat
+++ b/tests/compiler/std/array-access.optimized.wat
@@ -25,7 +25,7 @@
   if
    i32.const 24
    i32.const 80
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -42,7 +42,7 @@
   if
    i32.const 128
    i32.const 80
-   i32.const 93
+   i32.const 100
    i32.const 39
    call $~lib/builtins/abort
    unreachable
@@ -57,7 +57,7 @@
   if
    i32.const 24
    i32.const 80
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-access.optimized.wat
+++ b/tests/compiler/std/array-access.optimized.wat
@@ -25,7 +25,7 @@
   if
    i32.const 24
    i32.const 80
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -42,7 +42,7 @@
   if
    i32.const 128
    i32.const 80
-   i32.const 94
+   i32.const 93
    i32.const 39
    call $~lib/builtins/abort
    unreachable
@@ -57,7 +57,7 @@
   if
    i32.const 24
    i32.const 80
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-access.optimized.wat
+++ b/tests/compiler/std/array-access.optimized.wat
@@ -6,9 +6,9 @@
  (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
- (data (i32.const 8) "^\00\00\00\01\00\00\00\01\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y")
- (data (i32.const 120) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s")
- (data (i32.const 168) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e")
+ (data (i32.const 8) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e")
+ (data (i32.const 64) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s")
+ (data (i32.const 112) "^\00\00\00\01\00\00\00\01\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y")
  (data (i32.const 228) "\01\00\00\00\01")
  (data (i32.const 240) "\08\00\00\00\01\00\00\00\01\00\00\00\08\00\00\00n\00u\00l\00l")
  (export "memory" (memory $0))
@@ -24,23 +24,9 @@
   i32.ge_u
   if
    i32.const 24
-   i32.const 136
-   i32.const 106
-   i32.const 45
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $1
-  local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
-  i32.ge_u
-  if
-   i32.const 184
-   i32.const 136
-   i32.const 109
-   i32.const 61
+   i32.const 80
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
@@ -51,19 +37,28 @@
   i32.shl
   i32.add
   i32.load
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 128
+   i32.const 80
+   i32.const 94
+   i32.const 39
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
  )
  (func $~lib/array/Array<i32>#__get (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
-   i32.const 184
-   i32.const 136
-   i32.const 109
-   i32.const 61
+   i32.const 24
+   i32.const 80
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/array-access.untouched.wat
+++ b/tests/compiler/std/array-access.untouched.wat
@@ -46,7 +46,7 @@
   if
    i32.const 24
    i32.const 80
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -62,7 +62,7 @@
    call $~lib/rt/stub/__release
    i32.const 128
    i32.const 80
-   i32.const 93
+   i32.const 100
    i32.const 39
    call $~lib/builtins/abort
    unreachable
@@ -87,7 +87,7 @@
   if
    i32.const 24
    i32.const 80
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -136,7 +136,7 @@
   if
    i32.const 24
    i32.const 80
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -152,7 +152,7 @@
    call $~lib/rt/stub/__release
    i32.const 128
    i32.const 80
-   i32.const 93
+   i32.const 100
    i32.const 39
    call $~lib/builtins/abort
    unreachable
@@ -364,7 +364,7 @@
   if
    i32.const 24
    i32.const 80
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -380,7 +380,7 @@
    call $~lib/rt/stub/__release
    i32.const 128
    i32.const 80
-   i32.const 93
+   i32.const 100
    i32.const 39
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-access.untouched.wat
+++ b/tests/compiler/std/array-access.untouched.wat
@@ -8,9 +8,9 @@
  (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
- (data (i32.const 8) "^\00\00\00\01\00\00\00\01\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y\00")
- (data (i32.const 120) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s\00")
- (data (i32.const 168) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e\00")
+ (data (i32.const 8) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e\00")
+ (data (i32.const 64) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s\00")
+ (data (i32.const 112) "^\00\00\00\01\00\00\00\01\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y\00")
  (data (i32.const 224) "\00\00\00\00\01\00\00\00\01\00\00\00\00\00\00\00")
  (data (i32.const 240) "\08\00\00\00\01\00\00\00\01\00\00\00\08\00\00\00n\00u\00l\00l\00")
  (table $0 1 funcref)
@@ -34,38 +34,42 @@
   i32.load
   call $~lib/rt/stub/__retain
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__get (; 3 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/stub/__release (; 3 ;) (type $FUNCSIG$vi) (param $0 i32)
+  nop
+ )
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__get (; 4 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
   i32.ge_u
   if
    i32.const 24
-   i32.const 136
-   i32.const 106
-   i32.const 45
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $1
-  local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
-  i32.ge_u
-  if
-   i32.const 184
-   i32.const 136
-   i32.const 109
-   i32.const 61
+   i32.const 80
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_get
+  local.set $2
+  local.get $2
+  i32.eqz
+  if
+   local.get $2
+   call $~lib/rt/stub/__release
+   i32.const 128
+   i32.const 80
+   i32.const 94
+   i32.const 39
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
  )
- (func $~lib/array/Array<i32>#__unchecked_get (; 4 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__unchecked_get (; 5 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -74,27 +78,25 @@
   i32.add
   i32.load
  )
- (func $~lib/array/Array<i32>#__get (; 5 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (; 6 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
   local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
-   i32.const 184
-   i32.const 136
-   i32.const 109
-   i32.const 61
+   i32.const 24
+   i32.const 80
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<i32>#__unchecked_get
- )
- (func $~lib/rt/stub/__release (; 6 ;) (type $FUNCSIG$vi) (param $0 i32)
-  nop
+  local.set $2
+  local.get $2
  )
  (func $std/array-access/i32ArrayArrayElementAccess (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
@@ -126,35 +128,36 @@
   call $~lib/rt/stub/__retain
  )
  (func $~lib/array/Array<~lib/string/String>#__get (; 9 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
   i32.ge_u
   if
    i32.const 24
-   i32.const 136
-   i32.const 106
-   i32.const 45
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $1
-  local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
-  i32.ge_u
-  if
-   i32.const 184
-   i32.const 136
-   i32.const 109
-   i32.const 61
+   i32.const 80
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<~lib/string/String>#__unchecked_get
+  local.set $2
+  local.get $2
+  i32.eqz
+  if
+   local.get $2
+   call $~lib/rt/stub/__release
+   i32.const 128
+   i32.const 80
+   i32.const 94
+   i32.const 39
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
  )
  (func $~lib/string/String#get:length (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
@@ -353,35 +356,36 @@
   call $~lib/rt/stub/__retain
  )
  (func $~lib/array/Array<~lib/array/Array<~lib/string/String>>#__get (; 16 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
   i32.ge_u
   if
    i32.const 24
-   i32.const 136
-   i32.const 106
-   i32.const 45
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $1
-  local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
-  i32.ge_u
-  if
-   i32.const 184
-   i32.const 136
-   i32.const 109
-   i32.const 61
+   i32.const 80
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<~lib/array/Array<~lib/string/String>>#__unchecked_get
+  local.set $2
+  local.get $2
+  i32.eqz
+  if
+   local.get $2
+   call $~lib/rt/stub/__release
+   i32.const 128
+   i32.const 80
+   i32.const 94
+   i32.const 39
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
  )
  (func $std/array-access/stringArrayArrayPropertyAccess (; 17 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)

--- a/tests/compiler/std/array-access.untouched.wat
+++ b/tests/compiler/std/array-access.untouched.wat
@@ -46,7 +46,7 @@
   if
    i32.const 24
    i32.const 80
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -62,7 +62,7 @@
    call $~lib/rt/stub/__release
    i32.const 128
    i32.const 80
-   i32.const 94
+   i32.const 93
    i32.const 39
    call $~lib/builtins/abort
    unreachable
@@ -87,7 +87,7 @@
   if
    i32.const 24
    i32.const 80
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -136,7 +136,7 @@
   if
    i32.const 24
    i32.const 80
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -152,7 +152,7 @@
    call $~lib/rt/stub/__release
    i32.const 128
    i32.const 80
-   i32.const 94
+   i32.const 93
    i32.const 39
    call $~lib/builtins/abort
    unreachable
@@ -364,7 +364,7 @@
   if
    i32.const 24
    i32.const 80
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -380,7 +380,7 @@
    call $~lib/rt/stub/__release
    i32.const 128
    i32.const 80
-   i32.const 94
+   i32.const 93
    i32.const 39
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -47,7 +47,7 @@
   if
    i32.const 136
    i32.const 192
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -66,7 +66,7 @@
   if
    i32.const 136
    i32.const 192
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -47,7 +47,7 @@
   if
    i32.const 136
    i32.const 192
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -66,7 +66,7 @@
   if
    i32.const 136
    i32.const 192
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -42,13 +42,13 @@
  (func $~lib/array/Array<i8>#__get (; 5 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
-  i32.load offset=8
+  i32.load offset=12
   i32.ge_u
   if
    i32.const 136
    i32.const 192
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
@@ -61,15 +61,13 @@
  (func $~lib/array/Array<i32>#__get (; 6 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
    i32.const 136
    i32.const 192
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -71,7 +71,7 @@
   if
    i32.const 136
    i32.const 192
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -104,7 +104,7 @@
   if
    i32.const 136
    i32.const 192
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -63,23 +63,24 @@
   i32.load8_s
  )
  (func $~lib/array/Array<i8>#__get (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
   local.get $0
-  i32.load offset=8
-  i32.const 0
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
    i32.const 136
    i32.const 192
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<i8>#__unchecked_get
+  local.set $2
+  local.get $2
  )
  (func $~lib/array/Array<i32>#get:length (; 8 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
@@ -95,23 +96,24 @@
   i32.load
  )
  (func $~lib/array/Array<i32>#__get (; 10 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
   local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
    i32.const 136
    i32.const 192
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<i32>#__unchecked_get
+  local.set $2
+  local.get $2
  )
  (func $~lib/rt/tlsf/removeBlock (; 11 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -71,7 +71,7 @@
   if
    i32.const 136
    i32.const 192
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -104,7 +104,7 @@
   if
    i32.const 136
    i32.const 192
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -2411,7 +2411,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -2563,7 +2563,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -2906,7 +2906,7 @@
   if
    i32.const 872
    i32.const 488
-   i32.const 267
+   i32.const 274
    i32.const 20
    call $~lib/builtins/abort
    unreachable
@@ -2951,7 +2951,7 @@
    call $~lib/rt/pure/__release
    i32.const 24
    i32.const 488
-   i32.const 197
+   i32.const 204
    i32.const 59
    call $~lib/builtins/abort
    unreachable
@@ -3131,7 +3131,7 @@
   if
    i32.const 872
    i32.const 488
-   i32.const 328
+   i32.const 335
    i32.const 20
    call $~lib/builtins/abort
    unreachable
@@ -3967,7 +3967,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -5392,7 +5392,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -6375,7 +6375,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -6390,7 +6390,7 @@
    call $~lib/rt/pure/__release
    i32.const 4040
    i32.const 488
-   i32.const 93
+   i32.const 100
    i32.const 39
    call $~lib/builtins/abort
    unreachable
@@ -6555,7 +6555,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -2268,22 +2268,22 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/array/Array<i32>#constructor (; 33 ;) (type $FUNCSIG$i) (result i32)
-  (local $0 i32)
+ (func $~lib/array/Array<i32>#constructor (; 33 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
   i32.const 16
   i32.const 3
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  i32.const 0
+  local.get $0
   i32.const 2
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $0
+  local.tee $1
   i32.const 0
   i32.store offset=12
+  local.get $1
   local.get $0
-  i32.const 0
   i32.store offset=12
-  local.get $0
+  local.get $1
  )
  (func $~lib/array/Array.isArray<~lib/array/Array<i32> | null> (; 34 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
@@ -2406,13 +2406,13 @@
  (func $~lib/array/Array<u8>#__get (; 38 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
-  i32.load offset=8
+  i32.load offset=12
   i32.ge_u
   if
    i32.const 280
    i32.const 488
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
@@ -2558,15 +2558,13 @@
  (func $~lib/array/Array<u32>#__get (; 41 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
    i32.const 280
    i32.const 488
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
@@ -2908,7 +2906,7 @@
   if
    i32.const 872
    i32.const 488
-   i32.const 287
+   i32.const 268
    i32.const 20
    call $~lib/builtins/abort
    unreachable
@@ -2953,7 +2951,7 @@
    call $~lib/rt/pure/__release
    i32.const 24
    i32.const 488
-   i32.const 217
+   i32.const 198
    i32.const 59
    call $~lib/builtins/abort
    unreachable
@@ -3133,7 +3131,7 @@
   if
    i32.const 872
    i32.const 488
-   i32.const 348
+   i32.const 329
    i32.const 20
    call $~lib/builtins/abort
    unreachable
@@ -3375,10 +3373,6 @@
   local.get $4
  )
  (func $~lib/array/Array<i32>#__set (; 57 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
-  local.get $0
-  i32.load offset=12
-  local.set $3
   local.get $0
   local.get $1
   i32.const 1
@@ -3393,7 +3387,8 @@
   local.get $2
   i32.store
   local.get $1
-  local.get $3
+  local.get $0
+  i32.load offset=12
   i32.ge_s
   if
    local.get $0
@@ -3967,15 +3962,13 @@
  (func $~lib/array/Array<f32>#__get (; 83 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
   local.get $1
   local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
    i32.const 280
    i32.const 488
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
@@ -5394,15 +5387,13 @@
  (func $~lib/array/Array<f64>#__get (; 113 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
   local.get $1
   local.get $0
-  i32.load offset=8
-  i32.const 3
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
    i32.const 280
    i32.const 488
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
@@ -5908,40 +5899,11 @@
   i32.lt_u
   i32.sub
  )
- (func $~lib/array/Array.create<i32> (; 121 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  local.get $0
-  i32.const 268435452
-  i32.gt_u
-  if
-   i32.const 24
-   i32.const 488
-   i32.const 45
-   i32.const 61
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  i32.const 2
-  i32.const 3
-  i32.const 0
-  call $~lib/rt/__allocArray
-  call $~lib/rt/pure/__retain
-  local.tee $0
-  i32.const 0
-  i32.store offset=12
-  local.get $0
-  i32.load offset=4
-  i32.const 0
-  local.get $0
-  i32.load offset=8
-  call $~lib/memory/memory.fill
-  local.get $0
- )
- (func $std/array/createReverseOrderedArray (; 122 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/array/createReverseOrderedArray (; 121 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
-  call $~lib/array/Array.create<i32>
+  call $~lib/array/Array<i32>#constructor
   local.set $2
   loop $loop|0
    block $break|0
@@ -5966,7 +5928,7 @@
   end
   local.get $2
  )
- (func $~lib/math/NativeMath.random (; 123 ;) (type $FUNCSIG$d) (result f64)
+ (func $~lib/math/NativeMath.random (; 122 ;) (type $FUNCSIG$d) (result f64)
   (local $0 i64)
   (local $1 i64)
   global.get $~lib/math/random_seeded
@@ -6010,11 +5972,11 @@
   f64.const 1
   f64.sub
  )
- (func $std/array/createRandomOrderedArray (; 124 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/array/createRandomOrderedArray (; 123 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
-  call $~lib/array/Array.create<i32>
+  call $~lib/array/Array<i32>#constructor
   local.set $2
   loop $loop|0
    block $break|0
@@ -6039,7 +6001,7 @@
   end
   local.get $2
  )
- (func $std/array/isSorted<i32> (; 125 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<i32> (; 124 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -6088,7 +6050,7 @@
   call $~lib/rt/pure/__release
   i32.const 1
  )
- (func $std/array/assertSorted<i32> (; 126 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<i32> (; 125 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -6113,7 +6075,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/array/assertSortedDefault<i32> (; 127 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $std/array/assertSortedDefault<i32> (; 126 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   drop
@@ -6123,31 +6085,12 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|44 (; 128 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|44 (; 127 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.sub
  )
- (func $~lib/array/Array.create<~lib/array/Array<i32>> (; 129 ;) (type $FUNCSIG$i) (result i32)
-  (local $0 i32)
-  i32.const 2
-  i32.const 2
-  i32.const 10
-  i32.const 0
-  call $~lib/rt/__allocArray
-  call $~lib/rt/pure/__retain
-  local.tee $0
-  i32.const 0
-  i32.store offset=12
-  local.get $0
-  i32.load offset=4
-  i32.const 0
-  local.get $0
-  i32.load offset=8
-  call $~lib/memory/memory.fill
-  local.get $0
- )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_set (; 130 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_set (; 128 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -6173,26 +6116,10 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__set (; 131 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__set (; 129 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
-  local.get $1
-  local.get $0
-  i32.load offset=12
-  local.tee $3
-  i32.gt_u
-  if
-   local.get $2
-   call $~lib/rt/pure/__release
-   i32.const 4040
-   i32.const 488
-   i32.const 121
-   i32.const 38
-   call $~lib/builtins/abort
-   unreachable
-  end
   local.get $0
   local.get $1
   i32.const 1
@@ -6203,7 +6130,8 @@
   local.get $2
   call $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_set
   local.get $1
-  local.get $3
+  local.get $0
+  i32.load offset=12
   i32.ge_s
   if
    local.get $0
@@ -6215,19 +6143,30 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/array/createReverseOrderedNestedArray (; 132 ;) (type $FUNCSIG$i) (result i32)
+ (func $std/array/createReverseOrderedNestedArray (; 130 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  call $~lib/array/Array.create<~lib/array/Array<i32>>
-  local.set $1
+  i32.const 16
+  i32.const 10
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  i32.const 2
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  i32.const 2
+  i32.store offset=12
   loop $loop|0
    local.get $0
    i32.const 2
    i32.lt_s
    if
     i32.const 1
-    call $~lib/array/Array.create<i32>
+    call $~lib/array/Array<i32>#constructor
     local.tee $2
     i32.const 0
     i32.const 1
@@ -6249,7 +6188,7 @@
   end
   local.get $1
  )
- (func $start:std/array~anonymous|47 (; 133 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|47 (; 131 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -6269,7 +6208,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/sort/insertionSort<~lib/array/Array<i32>> (; 134 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<~lib/array/Array<i32>> (; 132 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6358,7 +6297,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#sort (; 135 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#sort (; 133 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6418,7 +6357,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_get (; 136 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_get (; 134 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -6428,38 +6367,37 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__get (; 137 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__get (; 135 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
   i32.ge_u
   if
-   i32.const 4040
-   i32.const 488
-   i32.const 106
-   i32.const 45
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $1
-  local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
-  i32.ge_u
-  if
    i32.const 280
    i32.const 488
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_get
+  local.tee $0
+  i32.eqz
+  if
+   local.get $0
+   call $~lib/rt/pure/__release
+   i32.const 4040
+   i32.const 488
+   i32.const 94
+   i32.const 39
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
  )
- (func $std/array/isSorted<~lib/array/Array<i32>> (; 138 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<~lib/array/Array<i32>> (; 136 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6520,7 +6458,7 @@
   call $~lib/rt/pure/__release
   i32.const 1
  )
- (func $std/array/assertSorted<~lib/array/Array<i32>> (; 139 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/array/Array<i32>> (; 137 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -6545,31 +6483,23 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array.create<std/array/Proxy<i32>> (; 140 ;) (type $FUNCSIG$i) (result i32)
-  (local $0 i32)
-  i32.const 512
-  i32.const 2
-  i32.const 12
-  i32.const 0
-  call $~lib/rt/__allocArray
-  call $~lib/rt/pure/__retain
-  local.tee $0
-  i32.const 0
-  i32.store offset=12
-  local.get $0
-  i32.load offset=4
-  i32.const 0
-  local.get $0
-  i32.load offset=8
-  call $~lib/memory/memory.fill
-  local.get $0
- )
- (func $std/array/createReverseOrderedElementsArray (; 141 ;) (type $FUNCSIG$i) (result i32)
+ (func $std/array/createReverseOrderedElementsArray (; 138 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  call $~lib/array/Array.create<std/array/Proxy<i32>>
-  local.set $1
+  i32.const 16
+  i32.const 12
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  i32.const 512
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  i32.const 512
+  i32.store offset=12
   loop $loop|0
    local.get $0
    i32.const 512
@@ -6599,7 +6529,7 @@
   end
   local.get $1
  )
- (func $start:std/array~anonymous|48 (; 142 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|48 (; 139 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -6617,18 +6547,16 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<~lib/string/String | null>#__get (; 143 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#__get (; 140 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
    i32.const 280
    i32.const 488
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
@@ -6636,7 +6564,7 @@
   local.get $1
   call $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_get
  )
- (func $std/array/isSorted<~lib/string/String | null> (; 144 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<~lib/string/String | null> (; 141 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6697,7 +6625,7 @@
   call $~lib/rt/pure/__release
   i32.const 1
  )
- (func $std/array/assertSorted<~lib/string/String | null> (; 145 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/string/String | null> (; 142 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -6722,7 +6650,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/string/String#get:length (; 146 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (; 143 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -6730,7 +6658,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 147 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/compareImpl (; 144 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6779,7 +6707,7 @@
   call $~lib/rt/pure/__release
   local.get $5
  )
- (func $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0 (; 148 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0 (; 145 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -6858,7 +6786,7 @@
   call $~lib/rt/pure/__release
   i32.const 0
  )
- (func $~lib/string/String.__eq (; 149 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 146 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -6912,7 +6840,7 @@
   call $~lib/rt/pure/__release
   i32.const 0
  )
- (func $~lib/string/String.__ne (; 150 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__ne (; 147 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -6929,7 +6857,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/array/isArraysEqual<~lib/string/String | null> (; 151 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isArraysEqual<~lib/string/String | null> (; 148 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7010,26 +6938,7 @@
   call $~lib/rt/pure/__release
   i32.const 1
  )
- (func $~lib/array/Array.create<~lib/string/String> (; 152 ;) (type $FUNCSIG$i) (result i32)
-  (local $0 i32)
-  i32.const 400
-  i32.const 2
-  i32.const 14
-  i32.const 0
-  call $~lib/rt/__allocArray
-  call $~lib/rt/pure/__retain
-  local.tee $0
-  i32.const 0
-  i32.store offset=12
-  local.get $0
-  i32.load offset=4
-  i32.const 0
-  local.get $0
-  i32.load offset=8
-  call $~lib/memory/memory.fill
-  local.get $0
- )
- (func $~lib/string/String#charAt (; 153 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/string/String#charAt (; 149 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 3200
@@ -7054,7 +6963,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#concat (; 154 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#concat (; 150 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7115,7 +7024,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__concat (; 155 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (; 151 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -7134,7 +7043,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/array/createRandomString (; 156 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/array/createRandomString (; 152 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7185,19 +7094,30 @@
   end
   local.get $1
  )
- (func $std/array/createRandomStringArray (; 157 ;) (type $FUNCSIG$i) (result i32)
+ (func $std/array/createRandomStringArray (; 153 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  call $~lib/array/Array.create<~lib/string/String>
-  local.set $1
+  i32.const 16
+  i32.const 14
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  i32.const 400
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 400
+  i32.store offset=12
   loop $loop|0
-   local.get $0
+   local.get $1
    i32.const 400
    i32.lt_s
    if
-    local.get $1
     local.get $0
+    local.get $1
     call $~lib/math/NativeMath.random
     f64.const 32
     f64.mul
@@ -7205,18 +7125,18 @@
     call $std/array/createRandomString
     local.tee $2
     call $~lib/array/Array<~lib/array/Array<i32>>#__set
-    local.get $0
+    local.get $1
     i32.const 1
     i32.add
-    local.set $0
+    local.set $1
     local.get $2
     call $~lib/rt/pure/__release
     br $loop|0
    end
   end
-  local.get $1
+  local.get $0
  )
- (func $~lib/string/String#substring (; 158 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#substring (; 154 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 0
@@ -7293,7 +7213,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/string/joinBooleanArray (; 159 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinBooleanArray (; 155 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7445,7 +7365,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/util/number/decimalCount32 (; 160 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (; 156 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   i32.const 2
   local.get $0
@@ -7493,7 +7413,7 @@
   i32.lt_u
   select
  )
- (func $~lib/util/number/utoa_simple<u32> (; 161 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u32> (; 157 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   loop $continue|0
    local.get $1
@@ -7520,7 +7440,7 @@
    br_if $continue|0
   end
  )
- (func $~lib/util/number/itoa32 (; 162 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (; 158 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7563,7 +7483,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<i32> (; 163 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i32> (; 159 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   i32.const 1
   i32.shl
@@ -7605,7 +7525,7 @@
   end
   local.get $2
  )
- (func $~lib/util/string/joinIntegerArray<i32> (; 164 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i32> (; 160 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7728,7 +7648,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<i32>#join (; 165 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#join (; 161 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   call $~lib/rt/pure/__retain
   drop
@@ -7741,7 +7661,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/utoa32 (; 166 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/utoa32 (; 162 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -7765,7 +7685,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<u32> (; 167 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u32> (; 163 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   i32.const 1
   i32.shl
@@ -7789,7 +7709,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $0
  )
- (func $~lib/util/string/joinIntegerArray<u32> (; 168 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u32> (; 164 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7912,7 +7832,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<u32>#join (; 169 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#join (; 165 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   call $~lib/rt/pure/__retain
   drop
@@ -7925,14 +7845,14 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/number/isFinite<f64> (; 170 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/number/isFinite<f64> (; 166 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   local.get $0
   f64.sub
   f64.const 0
   f64.eq
  )
- (func $~lib/util/number/genDigits (; 171 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (; 167 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i32)
   (local $9 i64)
@@ -8331,7 +8251,7 @@
    local.get $6
   end
  )
- (func $~lib/util/number/prettify (; 172 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (; 168 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
@@ -8578,7 +8498,7 @@
    end
   end
  )
- (func $~lib/util/number/dtoa_core (; 173 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (; 169 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i64)
@@ -8866,7 +8786,7 @@
   local.get $10
   i32.add
  )
- (func $~lib/util/number/dtoa (; 174 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/util/number/dtoa (; 170 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -8917,7 +8837,7 @@
   local.get $1
   call $~lib/rt/tlsf/__free
  )
- (func $~lib/util/number/dtoa_stream (; 175 ;) (type $FUNCSIG$iiid) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
+ (func $~lib/util/number/dtoa_stream (; 171 ;) (type $FUNCSIG$iiid) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 1
@@ -8985,7 +8905,7 @@
   local.get $2
   call $~lib/util/number/dtoa_core
  )
- (func $~lib/util/string/joinFloatArray<f64> (; 176 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinFloatArray<f64> (; 172 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9108,7 +9028,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/string/joinStringArray (; 177 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinStringArray (; 173 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9305,7 +9225,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<~lib/string/String | null>#join (; 178 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#join (; 174 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   call $~lib/rt/pure/__retain
   drop
@@ -9318,13 +9238,13 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/array/Ref#constructor (; 179 ;) (type $FUNCSIG$i) (result i32)
+ (func $std/array/Ref#constructor (; 175 ;) (type $FUNCSIG$i) (result i32)
   i32.const 0
   i32.const 18
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/string/joinObjectArray<std/array/Ref | null> (; 180 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinObjectArray<std/array/Ref | null> (; 176 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9478,12 +9398,12 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<i32>#toString (; 181 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#toString (; 177 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4464
   call $~lib/array/Array<i32>#join
  )
- (func $~lib/util/number/itoa_stream<i8> (; 182 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i8> (; 178 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 1
@@ -9538,7 +9458,7 @@
   end
   local.get $2
  )
- (func $~lib/util/string/joinIntegerArray<i8> (; 183 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i8> (; 179 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9657,7 +9577,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/number/itoa_stream<u16> (; 184 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u16> (; 180 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   i32.const 1
   i32.shl
@@ -9687,7 +9607,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u16> (; 185 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u16> (; 181 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9810,7 +9730,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/number/decimalCount64 (; 186 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64 (; 182 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   i32.const 10
   i32.const 11
   i32.const 12
@@ -9863,7 +9783,7 @@
   i64.lt_u
   select
  )
- (func $~lib/util/number/utoa_simple<u64> (; 187 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u64> (; 183 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   loop $continue|0
    local.get $1
@@ -9893,7 +9813,7 @@
    br_if $continue|0
   end
  )
- (func $~lib/util/number/utoa64 (; 188 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/utoa64 (; 184 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9937,7 +9857,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<u64> (; 189 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<u64> (; 185 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 1
@@ -9977,7 +9897,7 @@
   end
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u64> (; 190 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u64> (; 186 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10100,7 +10020,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/number/itoa64 (; 191 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa64 (; 187 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -10165,7 +10085,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<i64> (; 192 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<i64> (; 188 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -10226,7 +10146,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<i64> (; 193 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i64> (; 189 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10349,12 +10269,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/array/Array<~lib/string/String | null>#toString (; 194 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#toString (; 190 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4464
   call $~lib/array/Array<~lib/string/String | null>#join
  )
- (func $~lib/util/string/joinArrays<~lib/array/Array<i32>> (; 195 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinArrays<~lib/array/Array<i32>> (; 191 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10536,7 +10456,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/util/number/itoa_stream<u8> (; 196 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u8> (; 192 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   i32.const 1
   i32.shl
@@ -10566,7 +10486,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u8> (; 197 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u8> (; 193 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10685,7 +10605,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/array/Array<u8>#join (; 198 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u8>#join (; 194 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 4464
   call $~lib/rt/pure/__retain
   drop
@@ -10697,7 +10617,7 @@
   i32.const 4464
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/string/joinArrays<~lib/array/Array<u8>> (; 199 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinArrays<~lib/array/Array<u8>> (; 195 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10876,7 +10796,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/util/string/joinArrays<~lib/array/Array<u32>> (; 200 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinArrays<~lib/array/Array<u32>> (; 196 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11058,7 +10978,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/array/Array<~lib/array/Array<u32>>#join (; 201 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u32>>#join (; 197 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 4464
   call $~lib/rt/pure/__retain
   drop
@@ -11070,7 +10990,7 @@
   i32.const 4464
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/string/joinArrays<~lib/array/Array<~lib/array/Array<u32>>> (; 202 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinArrays<~lib/array/Array<~lib/array/Array<u32>>> (; 198 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11249,7 +11169,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $start:std/array (; 203 ;) (type $FUNCSIG$v)
+ (func $start:std/array (; 199 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11303,6 +11223,7 @@
   (local $50 i32)
   (local $51 i32)
   (local $52 i32)
+  i32.const 0
   call $~lib/array/Array<i32>#constructor
   global.set $std/array/arr
   i32.const 0
@@ -11916,6 +11837,7 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 0
   call $~lib/array/Array<i32>#constructor
   local.set $4
   global.get $std/array/arr
@@ -16621,7 +16543,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $start (; 204 ;) (type $FUNCSIG$v)
+ (func $start (; 200 ;) (type $FUNCSIG$v)
   global.get $~lib/started
   if
    return
@@ -16631,7 +16553,7 @@
   end
   call $start:std/array
  )
- (func $~lib/rt/pure/__visit (; 205 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 201 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   i32.const 7412
   i32.lt_u
@@ -16741,7 +16663,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__visit_impl (; 206 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__visit_impl (; 202 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -16774,7 +16696,7 @@
    end
   end
  )
- (func $~lib/rt/__visit_members (; 207 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (; 203 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   block $block$4$break
    block $switch$1$default
     block $switch$1$case$27
@@ -16845,7 +16767,7 @@
    call $~lib/rt/pure/__visit
   end
  )
- (func $null (; 208 ;) (type $FUNCSIG$v)
+ (func $null (; 204 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -2411,7 +2411,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -2563,7 +2563,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -2906,7 +2906,7 @@
   if
    i32.const 872
    i32.const 488
-   i32.const 268
+   i32.const 267
    i32.const 20
    call $~lib/builtins/abort
    unreachable
@@ -2951,7 +2951,7 @@
    call $~lib/rt/pure/__release
    i32.const 24
    i32.const 488
-   i32.const 198
+   i32.const 197
    i32.const 59
    call $~lib/builtins/abort
    unreachable
@@ -3131,7 +3131,7 @@
   if
    i32.const 872
    i32.const 488
-   i32.const 329
+   i32.const 328
    i32.const 20
    call $~lib/builtins/abort
    unreachable
@@ -3967,7 +3967,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -5392,7 +5392,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -6375,7 +6375,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -6390,7 +6390,7 @@
    call $~lib/rt/pure/__release
    i32.const 4040
    i32.const 488
-   i32.const 94
+   i32.const 93
    i32.const 39
    call $~lib/builtins/abort
    unreachable
@@ -6555,7 +6555,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.ts
+++ b/tests/compiler/std/array.ts
@@ -769,7 +769,7 @@ function isSorted<T>(data: Array<T>, comparator: (a: T, b: T) => i32 = COMPARATO
 }
 
 function createReverseOrderedArray(size: i32): Array<i32> {
-  var arr = Array.create<i32>(size);
+  var arr = new Array<i32>(size);
   for (let i = 0; i < size; i++) {
     arr[i] = size - 1 - i;
   }
@@ -779,7 +779,7 @@ function createReverseOrderedArray(size: i32): Array<i32> {
 NativeMath.seedRandom(reinterpret<u64>(JSMath.random()));
 
 function createRandomOrderedArray(size: i32): Array<i32> {
-  var arr = Array.create<i32>(size);
+  var arr = new Array<i32>(size);
   for (let i = 0; i < size; i++) {
     arr[i] = <i32>(NativeMath.random() * size);
   }
@@ -787,9 +787,9 @@ function createRandomOrderedArray(size: i32): Array<i32> {
 }
 
 function createReverseOrderedNestedArray(size: i32): Array<Array<i32>> {
-  var arr = Array.create<Array<i32>>(size);
+  var arr = new Array<Array<i32>>(size);
   for (let i: i32 = 0; i < size; i++) {
-    let inner = Array.create<i32>(1);
+    let inner = new Array<i32>(1);
     inner[0] = size - 1 - i;
     arr[i] = inner;
   }
@@ -801,7 +801,7 @@ class Proxy<T> {
 }
 
 function createReverseOrderedElementsArray(size: i32): Proxy<i32>[] {
-  var arr = Array.create<Proxy<i32>>(size);
+  var arr = new Array<Proxy<i32>>(size);
   for (let i: i32 = 0; i < size; i++) {
     arr[i] = new Proxy<i32>(size - 1 - i);
   }
@@ -820,7 +820,7 @@ function createRandomString(len: i32): string {
 }
 
 function createRandomStringArray(size: i32): string[] {
-  var arr = Array.create<string>(size);
+  var arr = new Array<string>(size);
   for (let i: i32 = 0; i < size; i++) {
     arr[i] = createRandomString(<i32>(NativeMath.random() * 32));
   }

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -4085,23 +4085,24 @@
   i32.load8_u
  )
  (func $~lib/array/Array<u8>#__get (; 47 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
   local.get $0
-  i32.load offset=8
-  i32.const 0
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
    i32.const 280
    i32.const 488
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<u8>#__unchecked_get
+  local.set $2
+  local.get $2
  )
  (func $std/array/isArraysEqual<u8> (; 48 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -4288,23 +4289,24 @@
   i32.load
  )
  (func $~lib/array/Array<u32>#__get (; 52 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
   local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
    i32.const 280
    i32.const 488
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<u32>#__unchecked_get
+  local.set $2
+  local.get $2
  )
  (func $std/array/isArraysEqual<u32> (; 53 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -4700,23 +4702,24 @@
   i32.load
  )
  (func $~lib/array/Array<i32>#__get (; 62 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
   local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
    i32.const 280
    i32.const 488
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<i32>#__unchecked_get
+  local.set $2
+  local.get $2
  )
  (func $~lib/array/Array<i32>#pop (; 63 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
@@ -4730,7 +4733,7 @@
   if
    i32.const 872
    i32.const 488
-   i32.const 287
+   i32.const 268
    i32.const 20
    call $~lib/builtins/abort
    unreachable
@@ -4785,7 +4788,7 @@
    call $~lib/rt/pure/__release
    i32.const 24
    i32.const 488
-   i32.const 217
+   i32.const 198
    i32.const 59
    call $~lib/builtins/abort
    unreachable
@@ -5085,7 +5088,7 @@
   if
    i32.const 872
    i32.const 488
-   i32.const 348
+   i32.const 329
    i32.const 20
    call $~lib/builtins/abort
    unreachable
@@ -5372,10 +5375,6 @@
   i32.store
  )
  (func $~lib/array/Array<i32>#__set (; 74 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
-  local.get $0
-  i32.load offset=12
-  local.set $3
   local.get $0
   local.get $1
   i32.const 1
@@ -5387,7 +5386,8 @@
   local.get $2
   call $~lib/array/Array<i32>#__unchecked_set
   local.get $1
-  local.get $3
+  local.get $0
+  i32.load offset=12
   i32.ge_s
   if
    local.get $0
@@ -6094,23 +6094,24 @@
   f32.load
  )
  (func $~lib/array/Array<f32>#__get (; 104 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
+  (local $2 f32)
   local.get $1
   local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
    i32.const 280
    i32.const 488
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<f32>#__unchecked_get
+  local.set $2
+  local.get $2
  )
  (func $start:std/array~anonymous|22 (; 105 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -8021,23 +8022,24 @@
   f64.load
  )
  (func $~lib/array/Array<f64>#__get (; 149 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 f64)
   local.get $1
   local.get $0
-  i32.load offset=8
-  i32.const 3
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
    i32.const 280
    i32.const 488
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<f64>#__unchecked_get
+  local.set $2
+  local.get $2
  )
  (func $~lib/number/isNaN<f64> (; 150 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
@@ -9101,42 +9103,12 @@
   local.get $1
   call $~lib/array/Array<u32>#sort
  )
- (func $~lib/array/Array.create<i32> (; 162 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  local.get $0
-  i32.const 268435452
-  i32.gt_u
-  if
-   i32.const 24
-   i32.const 488
-   i32.const 45
-   i32.const 61
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  i32.const 2
-  i32.const 3
-  i32.const 0
-  call $~lib/rt/__allocArray
-  call $~lib/rt/pure/__retain
-  local.set $1
-  local.get $1
-  i32.const 0
-  i32.store offset=12
-  local.get $1
-  i32.load offset=4
-  i32.const 0
-  local.get $1
-  i32.load offset=8
-  call $~lib/memory/memory.fill
-  local.get $1
- )
- (func $std/array/createReverseOrderedArray (; 163 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/array/createReverseOrderedArray (; 162 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
+  i32.const 0
   local.get $0
-  call $~lib/array/Array.create<i32>
+  call $~lib/array/Array<i32>#constructor
   local.set $1
   block $break|0
    i32.const 0
@@ -9165,7 +9137,7 @@
   end
   local.get $1
  )
- (func $~lib/math/NativeMath.random (; 164 ;) (type $FUNCSIG$d) (result f64)
+ (func $~lib/math/NativeMath.random (; 163 ;) (type $FUNCSIG$d) (result f64)
   (local $0 i64)
   (local $1 i64)
   (local $2 i64)
@@ -9220,11 +9192,12 @@
   f64.const 1
   f64.sub
  )
- (func $std/array/createRandomOrderedArray (; 165 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/array/createRandomOrderedArray (; 164 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
+  i32.const 0
   local.get $0
-  call $~lib/array/Array.create<i32>
+  call $~lib/array/Array<i32>#constructor
   local.set $1
   block $break|0
    i32.const 0
@@ -9253,12 +9226,12 @@
   end
   local.get $1
  )
- (func $~lib/util/sort/COMPARATOR<i32>~anonymous|1 (; 166 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<i32>~anonymous|1 (; 165 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $std/array/isSorted<i32> (; 167 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<i32> (; 166 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9313,7 +9286,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/array/assertSorted<i32> (; 168 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<i32> (; 167 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -9338,7 +9311,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/array/assertSortedDefault<i32> (; 169 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $std/array/assertSortedDefault<i32> (; 168 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   drop
@@ -9351,58 +9324,49 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|43 (; 170 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|43 (; 169 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $start:std/array~anonymous|44 (; 171 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|44 (; 170 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.sub
  )
- (func $start:std/array~anonymous|45 (; 172 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|45 (; 171 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $start:std/array~anonymous|46 (; 173 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|46 (; 172 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.sub
  )
- (func $~lib/array/Array.create<~lib/array/Array<i32>> (; 174 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  (local $1 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#constructor (; 173 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
-  i32.const 268435452
-  i32.gt_u
-  if
-   i32.const 24
-   i32.const 488
-   i32.const 45
-   i32.const 61
-   call $~lib/builtins/abort
-   unreachable
+  if (result i32)
+   local.get $0
+  else
+   i32.const 16
+   i32.const 10
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
   end
-  local.get $0
-  i32.const 2
-  i32.const 10
-  i32.const 0
-  call $~lib/rt/__allocArray
-  call $~lib/rt/pure/__retain
-  local.set $1
   local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.set $0
+  local.get $0
   i32.const 0
   i32.store offset=12
+  local.get $0
   local.get $1
-  i32.load offset=4
-  i32.const 0
-  local.get $1
-  i32.load offset=8
-  call $~lib/memory/memory.fill
-  local.get $1
+  i32.store offset=12
+  local.get $0
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_set (; 175 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_set (; 174 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -9432,27 +9396,10 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__set (; 176 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__set (; 175 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
-  local.get $0
-  i32.load offset=12
-  local.set $3
-  local.get $1
-  local.get $3
-  i32.gt_u
-  if
-   local.get $2
-   call $~lib/rt/pure/__release
-   i32.const 4040
-   i32.const 488
-   i32.const 121
-   i32.const 38
-   call $~lib/builtins/abort
-   unreachable
-  end
   local.get $0
   local.get $1
   i32.const 1
@@ -9464,7 +9411,8 @@
   local.get $2
   call $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_set
   local.get $1
-  local.get $3
+  local.get $0
+  i32.load offset=12
   i32.ge_s
   if
    local.get $0
@@ -9476,12 +9424,13 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/array/createReverseOrderedNestedArray (; 177 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/array/createReverseOrderedNestedArray (; 176 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  i32.const 0
   local.get $0
-  call $~lib/array/Array.create<~lib/array/Array<i32>>
+  call $~lib/array/Array<~lib/array/Array<i32>>#constructor
   local.set $1
   block $break|0
    i32.const 0
@@ -9492,8 +9441,9 @@
     i32.lt_s
     i32.eqz
     br_if $break|0
+    i32.const 0
     i32.const 1
-    call $~lib/array/Array.create<i32>
+    call $~lib/array/Array<i32>#constructor
     local.set $3
     local.get $3
     i32.const 0
@@ -9519,7 +9469,7 @@
   end
   local.get $1
  )
- (func $start:std/array~anonymous|47 (; 178 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|47 (; 177 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -9541,7 +9491,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/sort/insertionSort<~lib/array/Array<i32>> (; 179 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<~lib/array/Array<i32>> (; 178 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9637,7 +9587,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#sort (; 180 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#sort (; 179 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9708,11 +9658,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#get:length (; 181 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#get:length (; 180 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_get (; 182 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_get (; 181 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -9722,38 +9672,39 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__get (; 183 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__get (; 182 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
   i32.ge_u
   if
-   i32.const 4040
-   i32.const 488
-   i32.const 106
-   i32.const 45
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $1
-  local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
-  i32.ge_u
-  if
    i32.const 280
    i32.const 488
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_get
+  local.set $2
+  local.get $2
+  i32.eqz
+  if
+   local.get $2
+   call $~lib/rt/pure/__release
+   i32.const 4040
+   i32.const 488
+   i32.const 94
+   i32.const 39
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
  )
- (func $std/array/isSorted<~lib/array/Array<i32>> (; 184 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<~lib/array/Array<i32>> (; 183 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9820,7 +9771,7 @@
   call $~lib/rt/pure/__release
   local.get $5
  )
- (func $std/array/assertSorted<~lib/array/Array<i32>> (; 185 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/array/Array<i32>> (; 184 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -9845,38 +9796,29 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array.create<std/array/Proxy<i32>> (; 186 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  (local $1 i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#constructor (; 185 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
-  i32.const 268435452
-  i32.gt_u
-  if
-   i32.const 24
-   i32.const 488
-   i32.const 45
-   i32.const 61
-   call $~lib/builtins/abort
-   unreachable
+  if (result i32)
+   local.get $0
+  else
+   i32.const 16
+   i32.const 12
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
   end
-  local.get $0
-  i32.const 2
-  i32.const 12
-  i32.const 0
-  call $~lib/rt/__allocArray
-  call $~lib/rt/pure/__retain
-  local.set $1
   local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.set $0
+  local.get $0
   i32.const 0
   i32.store offset=12
+  local.get $0
   local.get $1
-  i32.load offset=4
-  i32.const 0
-  local.get $1
-  i32.load offset=8
-  call $~lib/memory/memory.fill
-  local.get $1
+  i32.store offset=12
+  local.get $0
  )
- (func $std/array/Proxy<i32>#constructor (; 187 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/Proxy<i32>#constructor (; 186 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -9891,7 +9833,7 @@
   i32.store
   local.get $0
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#__unchecked_set (; 188 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#__unchecked_set (; 187 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -9921,27 +9863,10 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#__set (; 189 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#__set (; 188 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
-  local.get $0
-  i32.load offset=12
-  local.set $3
-  local.get $1
-  local.get $3
-  i32.gt_u
-  if
-   local.get $2
-   call $~lib/rt/pure/__release
-   i32.const 4040
-   i32.const 488
-   i32.const 121
-   i32.const 38
-   call $~lib/builtins/abort
-   unreachable
-  end
   local.get $0
   local.get $1
   i32.const 1
@@ -9953,7 +9878,8 @@
   local.get $2
   call $~lib/array/Array<std/array/Proxy<i32>>#__unchecked_set
   local.get $1
-  local.get $3
+  local.get $0
+  i32.load offset=12
   i32.ge_s
   if
    local.get $0
@@ -9965,12 +9891,13 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/array/createReverseOrderedElementsArray (; 190 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/array/createReverseOrderedElementsArray (; 189 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  i32.const 0
   local.get $0
-  call $~lib/array/Array.create<std/array/Proxy<i32>>
+  call $~lib/array/Array<std/array/Proxy<i32>>#constructor
   local.set $1
   block $break|0
    i32.const 0
@@ -10004,7 +9931,7 @@
   end
   local.get $1
  )
- (func $start:std/array~anonymous|48 (; 191 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|48 (; 190 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -10024,7 +9951,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/sort/insertionSort<std/array/Proxy<i32>> (; 192 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<std/array/Proxy<i32>> (; 191 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -10120,7 +10047,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#sort (; 193 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#sort (; 192 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10191,11 +10118,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#get:length (; 194 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#get:length (; 193 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#__unchecked_get (; 195 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#__unchecked_get (; 194 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -10205,38 +10132,39 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#__get (; 196 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#__get (; 195 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
   i32.ge_u
   if
-   i32.const 4040
-   i32.const 488
-   i32.const 106
-   i32.const 45
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $1
-  local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
-  i32.ge_u
-  if
    i32.const 280
    i32.const 488
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<std/array/Proxy<i32>>#__unchecked_get
+  local.set $2
+  local.get $2
+  i32.eqz
+  if
+   local.get $2
+   call $~lib/rt/pure/__release
+   i32.const 4040
+   i32.const 488
+   i32.const 94
+   i32.const 39
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
  )
- (func $std/array/isSorted<std/array/Proxy<i32>> (; 197 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<std/array/Proxy<i32>> (; 196 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10303,7 +10231,7 @@
   call $~lib/rt/pure/__release
   local.get $5
  )
- (func $std/array/assertSorted<std/array/Proxy<i32>> (; 198 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<std/array/Proxy<i32>> (; 197 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -10328,7 +10256,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/sort/insertionSort<~lib/string/String | null> (; 199 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<~lib/string/String | null> (; 198 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -10424,7 +10352,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/string/String | null>#sort (; 200 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#sort (; 199 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10495,11 +10423,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/string/String | null>#get:length (; 201 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#get:length (; 200 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<~lib/string/String | null>#__unchecked_get (; 202 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#__unchecked_get (; 201 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -10509,26 +10437,27 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/string/String | null>#__get (; 203 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#__get (; 202 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
   local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
    i32.const 280
    i32.const 488
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<~lib/string/String | null>#__unchecked_get
+  local.set $2
+  local.get $2
  )
- (func $std/array/isSorted<~lib/string/String | null> (; 204 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<~lib/string/String | null> (; 203 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10595,7 +10524,7 @@
   call $~lib/rt/pure/__release
   local.get $5
  )
- (func $std/array/assertSorted<~lib/string/String | null> (; 205 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/string/String | null> (; 204 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -10620,7 +10549,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/string/String#get:length (; 206 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (; 205 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -10628,7 +10557,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 207 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (; 206 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -10693,7 +10622,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0 (; 208 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0 (; 207 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10799,7 +10728,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $std/array/assertSorted<~lib/string/String | null>|trampoline (; 209 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/string/String | null>|trampoline (; 208 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -10820,7 +10749,7 @@
   local.get $1
   call $std/array/assertSorted<~lib/string/String | null>
  )
- (func $~lib/string/String.__eq (; 210 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 209 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -10893,7 +10822,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__ne (; 211 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__ne (; 210 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -10912,7 +10841,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $std/array/isArraysEqual<~lib/string/String | null> (; 212 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<~lib/string/String | null> (; 211 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -11009,38 +10938,29 @@
   call $~lib/rt/pure/__release
   local.get $5
  )
- (func $~lib/array/Array.create<~lib/string/String> (; 213 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  (local $1 i32)
+ (func $~lib/array/Array<~lib/string/String>#constructor (; 212 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
-  i32.const 268435452
-  i32.gt_u
-  if
-   i32.const 24
-   i32.const 488
-   i32.const 45
-   i32.const 61
-   call $~lib/builtins/abort
-   unreachable
+  if (result i32)
+   local.get $0
+  else
+   i32.const 16
+   i32.const 14
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
   end
-  local.get $0
-  i32.const 2
-  i32.const 14
-  i32.const 0
-  call $~lib/rt/__allocArray
-  call $~lib/rt/pure/__retain
-  local.set $1
   local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.set $0
+  local.get $0
   i32.const 0
   i32.store offset=12
+  local.get $0
   local.get $1
-  i32.load offset=4
-  i32.const 0
-  local.get $1
-  i32.load offset=8
-  call $~lib/memory/memory.fill
-  local.get $1
+  i32.store offset=12
+  local.get $0
  )
- (func $~lib/string/String#charAt (; 214 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#charAt (; 213 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -11066,7 +10986,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#concat (; 215 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#concat (; 214 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11142,7 +11062,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__concat (; 216 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (; 215 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -11165,7 +11085,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $std/array/createRandomString (; 217 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/array/createRandomString (; 216 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -11227,7 +11147,7 @@
   end
   local.get $1
  )
- (func $~lib/array/Array<~lib/string/String>#__unchecked_set (; 218 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<~lib/string/String>#__unchecked_set (; 217 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -11257,27 +11177,10 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<~lib/string/String>#__set (; 219 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
+ (func $~lib/array/Array<~lib/string/String>#__set (; 218 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
-  local.get $0
-  i32.load offset=12
-  local.set $3
-  local.get $1
-  local.get $3
-  i32.gt_u
-  if
-   local.get $2
-   call $~lib/rt/pure/__release
-   i32.const 4040
-   i32.const 488
-   i32.const 121
-   i32.const 38
-   call $~lib/builtins/abort
-   unreachable
-  end
   local.get $0
   local.get $1
   i32.const 1
@@ -11289,7 +11192,8 @@
   local.get $2
   call $~lib/array/Array<~lib/string/String>#__unchecked_set
   local.get $1
-  local.get $3
+  local.get $0
+  i32.load offset=12
   i32.ge_s
   if
    local.get $0
@@ -11301,12 +11205,13 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/array/createRandomStringArray (; 220 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/array/createRandomStringArray (; 219 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  i32.const 0
   local.get $0
-  call $~lib/array/Array.create<~lib/string/String>
+  call $~lib/array/Array<~lib/string/String>#constructor
   local.set $1
   block $break|0
    i32.const 0
@@ -11338,7 +11243,7 @@
   end
   local.get $1
  )
- (func $~lib/util/sort/insertionSort<~lib/string/String> (; 221 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<~lib/string/String> (; 220 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -11434,7 +11339,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/string/String>#sort (; 222 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#sort (; 221 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11505,11 +11410,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/string/String>#get:length (; 223 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#get:length (; 222 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<~lib/string/String>#__unchecked_get (; 224 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#__unchecked_get (; 223 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -11519,38 +11424,39 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/string/String>#__get (; 225 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#__get (; 224 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
   i32.ge_u
   if
-   i32.const 4040
-   i32.const 488
-   i32.const 106
-   i32.const 45
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $1
-  local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
-  i32.ge_u
-  if
    i32.const 280
    i32.const 488
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<~lib/string/String>#__unchecked_get
+  local.set $2
+  local.get $2
+  i32.eqz
+  if
+   local.get $2
+   call $~lib/rt/pure/__release
+   i32.const 4040
+   i32.const 488
+   i32.const 94
+   i32.const 39
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
  )
- (func $std/array/isSorted<~lib/string/String> (; 226 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<~lib/string/String> (; 225 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11617,7 +11523,7 @@
   call $~lib/rt/pure/__release
   local.get $5
  )
- (func $std/array/assertSorted<~lib/string/String> (; 227 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/string/String> (; 226 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -11642,7 +11548,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/sort/COMPARATOR<~lib/string/String>~anonymous|0 (; 228 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<~lib/string/String>~anonymous|0 (; 227 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11748,7 +11654,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $std/array/assertSorted<~lib/string/String>|trampoline (; 229 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/string/String>|trampoline (; 228 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -11769,7 +11675,7 @@
   local.get $1
   call $std/array/assertSorted<~lib/string/String>
  )
- (func $~lib/string/String#substring (; 230 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substring (; 229 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -11876,7 +11782,7 @@
   local.get $10
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/string/joinBooleanArray (; 231 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinBooleanArray (; 230 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12055,7 +11961,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<bool>#join (; 232 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<bool>#join (; 231 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12078,7 +11984,7 @@
   local.get $4
   return
  )
- (func $~lib/util/number/decimalCount32 (; 233 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (; 232 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 100000
@@ -12144,7 +12050,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/utoa32_lut (; 234 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa32_lut (; 233 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12286,7 +12192,7 @@
    i32.store16
   end
  )
- (func $~lib/util/number/itoa32 (; 235 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (; 234 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -12341,12 +12247,12 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<i32> (; 236 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<i32> (; 235 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/itoa32
   return
  )
- (func $~lib/util/number/itoa_stream<i32> (; 237 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i32> (; 236 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12403,7 +12309,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<i32> (; 238 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i32> (; 237 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12551,7 +12457,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i32>#join (; 239 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#join (; 238 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12574,7 +12480,7 @@
   local.get $4
   return
  )
- (func $~lib/util/number/utoa32 (; 240 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/utoa32 (; 239 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -12609,12 +12515,12 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<u32> (; 241 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<u32> (; 240 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/util/number/itoa_stream<u32> (; 242 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u32> (; 241 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12651,7 +12557,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<u32> (; 243 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u32> (; 242 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12799,7 +12705,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<u32>#join (; 244 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#join (; 243 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12822,14 +12728,14 @@
   local.get $4
   return
  )
- (func $~lib/number/isFinite<f64> (; 245 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/number/isFinite<f64> (; 244 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   local.get $0
   f64.sub
   f64.const 0
   f64.eq
  )
- (func $~lib/array/Array<u64>#__unchecked_get (; 246 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__unchecked_get (; 245 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -12838,7 +12744,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<i16>#__unchecked_get (; 247 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__unchecked_get (; 246 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -12847,7 +12753,7 @@
   i32.add
   i32.load16_s
  )
- (func $~lib/util/number/genDigits (; 248 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (; 247 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -13349,7 +13255,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/prettify (; 249 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (; 248 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -13668,7 +13574,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/dtoa_core (; 250 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (; 249 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14090,7 +13996,7 @@
   local.get $2
   i32.add
  )
- (func $~lib/util/number/dtoa (; 251 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/util/number/dtoa (; 250 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -14149,7 +14055,7 @@
   call $~lib/rt/tlsf/__free
   local.get $3
  )
- (func $~lib/util/number/dtoa_stream (; 252 ;) (type $FUNCSIG$iiid) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
+ (func $~lib/util/number/dtoa_stream (; 251 ;) (type $FUNCSIG$iiid) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -14219,7 +14125,7 @@
   local.get $2
   call $~lib/util/number/dtoa_core
  )
- (func $~lib/util/string/joinFloatArray<f64> (; 253 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinFloatArray<f64> (; 252 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -14367,7 +14273,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<f64>#join (; 254 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f64>#join (; 253 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14390,7 +14296,7 @@
   local.get $4
   return
  )
- (func $~lib/util/string/joinStringArray (; 255 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinStringArray (; 254 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -14620,7 +14526,7 @@
   call $~lib/rt/pure/__release
   local.get $9
  )
- (func $~lib/array/Array<~lib/string/String | null>#join (; 256 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#join (; 255 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14643,7 +14549,7 @@
   local.get $4
   return
  )
- (func $std/array/Ref#constructor (; 257 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/array/Ref#constructor (; 256 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -14655,7 +14561,7 @@
   end
   local.get $0
  )
- (func $~lib/util/string/joinObjectArray<std/array/Ref | null> (; 258 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinObjectArray<std/array/Ref | null> (; 257 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -14835,7 +14741,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<std/array/Ref | null>#join (; 259 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#join (; 258 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14858,12 +14764,12 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<i32>#toString (; 260 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#toString (; 259 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4464
   call $~lib/array/Array<i32>#join
  )
- (func $~lib/util/number/itoa<i8> (; 261 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<i8> (; 260 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -14872,7 +14778,7 @@
   call $~lib/util/number/itoa32
   return
  )
- (func $~lib/util/number/itoa_stream<i8> (; 262 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i8> (; 261 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -14945,7 +14851,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<i8> (; 263 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i8> (; 262 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15093,7 +14999,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i8>#join (; 264 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#join (; 263 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15116,19 +15022,19 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<i8>#toString (; 265 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i8>#toString (; 264 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4464
   call $~lib/array/Array<i8>#join
  )
- (func $~lib/util/number/itoa<u16> (; 266 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<u16> (; 265 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/util/number/itoa_stream<u16> (; 267 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u16> (; 266 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15171,7 +15077,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<u16> (; 268 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u16> (; 267 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15319,7 +15225,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<u16>#join (; 269 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#join (; 268 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15342,12 +15248,12 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<u16>#toString (; 270 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u16>#toString (; 269 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4464
   call $~lib/array/Array<u16>#join
  )
- (func $~lib/util/number/decimalCount64 (; 271 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64 (; 270 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   local.get $0
   i64.const 1000000000000000
@@ -15420,7 +15326,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/utoa64_lut (; 272 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/util/number/utoa64_lut (; 271 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -15547,7 +15453,7 @@
   local.get $2
   call $~lib/util/number/utoa32_lut
  )
- (func $~lib/util/number/utoa64 (; 273 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/utoa64 (; 272 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -15612,12 +15518,12 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<u64> (; 274 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa<u64> (; 273 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   local.get $0
   call $~lib/util/number/utoa64
   return
  )
- (func $~lib/util/number/itoa_stream<u64> (; 275 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<u64> (; 274 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15678,7 +15584,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<u64> (; 276 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u64> (; 275 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15826,7 +15732,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<u64>#join (; 277 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u64>#join (; 276 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15849,12 +15755,12 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<u64>#toString (; 278 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u64>#toString (; 277 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4464
   call $~lib/array/Array<u64>#join
  )
- (func $~lib/util/number/itoa64 (; 279 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa64 (; 278 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -15941,12 +15847,12 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<i64> (; 280 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa<i64> (; 279 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   local.get $0
   call $~lib/util/number/itoa64
   return
  )
- (func $~lib/util/number/itoa_stream<i64> (; 281 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<i64> (; 280 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16029,7 +15935,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<i64> (; 282 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i64> (; 281 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16177,7 +16083,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i64>#join (; 283 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i64>#join (; 282 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16200,17 +16106,17 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<i64>#toString (; 284 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i64>#toString (; 283 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4464
   call $~lib/array/Array<i64>#join
  )
- (func $~lib/array/Array<~lib/string/String | null>#toString (; 285 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#toString (; 284 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4464
   call $~lib/array/Array<~lib/string/String | null>#join
  )
- (func $~lib/util/string/joinArrays<~lib/array/Array<i32>> (; 286 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinArrays<~lib/array/Array<i32>> (; 285 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16423,7 +16329,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#join (; 287 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#join (; 286 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16446,19 +16352,19 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#toString (; 288 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#toString (; 287 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4464
   call $~lib/array/Array<~lib/array/Array<i32>>#join
  )
- (func $~lib/util/number/itoa<u8> (; 289 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<u8> (; 288 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/util/number/itoa_stream<u8> (; 290 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u8> (; 289 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16501,7 +16407,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<u8> (; 291 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u8> (; 290 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16649,7 +16555,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<u8>#join (; 292 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#join (; 291 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16672,7 +16578,7 @@
   local.get $4
   return
  )
- (func $~lib/util/string/joinArrays<~lib/array/Array<u8>> (; 293 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinArrays<~lib/array/Array<u8>> (; 292 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16885,7 +16791,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<~lib/array/Array<u8>>#join (; 294 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u8>>#join (; 293 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16908,12 +16814,12 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<~lib/array/Array<u8>>#toString (; 295 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u8>>#toString (; 294 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4464
   call $~lib/array/Array<~lib/array/Array<u8>>#join
  )
- (func $~lib/util/string/joinArrays<~lib/array/Array<u32>> (; 296 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinArrays<~lib/array/Array<u32>> (; 295 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -17126,7 +17032,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<~lib/array/Array<u32>>#join (; 297 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u32>>#join (; 296 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17149,7 +17055,7 @@
   local.get $4
   return
  )
- (func $~lib/util/string/joinArrays<~lib/array/Array<~lib/array/Array<u32>>> (; 298 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinArrays<~lib/array/Array<~lib/array/Array<u32>>> (; 297 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -17362,7 +17268,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#join (; 299 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#join (; 298 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17385,12 +17291,12 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#toString (; 300 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#toString (; 299 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4464
   call $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#join
  )
- (func $start:std/array (; 301 ;) (type $FUNCSIG$v)
+ (func $start:std/array (; 300 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -23067,7 +22973,7 @@
   local.get $56
   call $~lib/rt/pure/__release
  )
- (func $start (; 302 ;) (type $FUNCSIG$v)
+ (func $start (; 301 ;) (type $FUNCSIG$v)
   global.get $~lib/started
   if
    return
@@ -23077,22 +22983,22 @@
   end
   call $start:std/array
  )
- (func $~lib/array/Array<i32>#__visit_impl (; 303 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#__visit_impl (; 302 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u8>#__visit_impl (; 304 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u8>#__visit_impl (; 303 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u32>#__visit_impl (; 305 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u32>#__visit_impl (; 304 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<f32>#__visit_impl (; 306 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f32>#__visit_impl (; 305 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<f64>#__visit_impl (; 307 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f64>#__visit_impl (; 306 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/rt/pure/__visit (; 308 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 307 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -23222,7 +23128,7 @@
    end
   end
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__visit_impl (; 309 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__visit_impl (; 308 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23261,7 +23167,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#__visit_impl (; 310 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#__visit_impl (; 309 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23300,7 +23206,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/string/String | null>#__visit_impl (; 311 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/string/String | null>#__visit_impl (; 310 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23339,7 +23245,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/string/String>#__visit_impl (; 312 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/string/String>#__visit_impl (; 311 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23378,16 +23284,16 @@
    unreachable
   end
  )
- (func $~lib/array/Array<bool>#__visit_impl (; 313 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<bool>#__visit_impl (; 312 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u64>#__visit_impl (; 314 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u64>#__visit_impl (; 313 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<i16>#__visit_impl (; 315 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i16>#__visit_impl (; 314 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<std/array/Ref | null>#__visit_impl (; 316 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<std/array/Ref | null>#__visit_impl (; 315 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23426,16 +23332,16 @@
    unreachable
   end
  )
- (func $~lib/array/Array<i8>#__visit_impl (; 317 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i8>#__visit_impl (; 316 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u16>#__visit_impl (; 318 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u16>#__visit_impl (; 317 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<i64>#__visit_impl (; 319 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i64>#__visit_impl (; 318 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<~lib/array/Array<u8>>#__visit_impl (; 320 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/array/Array<u8>>#__visit_impl (; 319 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23474,7 +23380,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/array/Array<u32>>#__visit_impl (; 321 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/array/Array<u32>>#__visit_impl (; 320 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23513,7 +23419,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#__visit_impl (; 322 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#__visit_impl (; 321 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23552,7 +23458,7 @@
    unreachable
   end
  )
- (func $~lib/rt/__visit_members (; 323 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (; 322 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $block$4$break
    block $switch$1$default
@@ -23694,6 +23600,6 @@
   end
   return
  )
- (func $null (; 324 ;) (type $FUNCSIG$v)
+ (func $null (; 323 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -4093,7 +4093,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -4297,7 +4297,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -4710,7 +4710,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -4733,7 +4733,7 @@
   if
    i32.const 872
    i32.const 488
-   i32.const 267
+   i32.const 274
    i32.const 20
    call $~lib/builtins/abort
    unreachable
@@ -4788,7 +4788,7 @@
    call $~lib/rt/pure/__release
    i32.const 24
    i32.const 488
-   i32.const 197
+   i32.const 204
    i32.const 59
    call $~lib/builtins/abort
    unreachable
@@ -5088,7 +5088,7 @@
   if
    i32.const 872
    i32.const 488
-   i32.const 328
+   i32.const 335
    i32.const 20
    call $~lib/builtins/abort
    unreachable
@@ -6102,7 +6102,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -8030,7 +8030,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -9681,7 +9681,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -9697,7 +9697,7 @@
    call $~lib/rt/pure/__release
    i32.const 4040
    i32.const 488
-   i32.const 93
+   i32.const 100
    i32.const 39
    call $~lib/builtins/abort
    unreachable
@@ -10141,7 +10141,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -10157,7 +10157,7 @@
    call $~lib/rt/pure/__release
    i32.const 4040
    i32.const 488
-   i32.const 93
+   i32.const 100
    i32.const 39
    call $~lib/builtins/abort
    unreachable
@@ -10446,7 +10446,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -11433,7 +11433,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -11449,7 +11449,7 @@
    call $~lib/rt/pure/__release
    i32.const 4040
    i32.const 488
-   i32.const 93
+   i32.const 100
    i32.const 39
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -4093,7 +4093,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -4297,7 +4297,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -4710,7 +4710,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -4733,7 +4733,7 @@
   if
    i32.const 872
    i32.const 488
-   i32.const 268
+   i32.const 267
    i32.const 20
    call $~lib/builtins/abort
    unreachable
@@ -4788,7 +4788,7 @@
    call $~lib/rt/pure/__release
    i32.const 24
    i32.const 488
-   i32.const 198
+   i32.const 197
    i32.const 59
    call $~lib/builtins/abort
    unreachable
@@ -5088,7 +5088,7 @@
   if
    i32.const 872
    i32.const 488
-   i32.const 329
+   i32.const 328
    i32.const 20
    call $~lib/builtins/abort
    unreachable
@@ -6102,7 +6102,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -8030,7 +8030,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -9681,7 +9681,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -9697,7 +9697,7 @@
    call $~lib/rt/pure/__release
    i32.const 4040
    i32.const 488
-   i32.const 94
+   i32.const 93
    i32.const 39
    call $~lib/builtins/abort
    unreachable
@@ -10141,7 +10141,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -10157,7 +10157,7 @@
    call $~lib/rt/pure/__release
    i32.const 4040
    i32.const 488
-   i32.const 94
+   i32.const 93
    i32.const 39
    call $~lib/builtins/abort
    unreachable
@@ -10446,7 +10446,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -11433,7 +11433,7 @@
   if
    i32.const 280
    i32.const 488
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -11449,7 +11449,7 @@
    call $~lib/rt/pure/__release
    i32.const 4040
    i32.const 488
-   i32.const 94
+   i32.const 93
    i32.const 39
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -37,7 +37,7 @@
   if
    i32.const 320
    i32.const 376
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -724,7 +724,7 @@
   if
    i32.const 320
    i32.const 376
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -763,7 +763,7 @@
   if
    i32.const 320
    i32.const 376
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -802,7 +802,7 @@
   if
    i32.const 320
    i32.const 376
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -31,16 +31,14 @@
  (start $start)
  (func $~lib/array/Array<i32>#__get (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
-  i32.const 56
+  i32.const 60
   i32.load
-  i32.const 2
-  i32.shr_u
   i32.ge_u
   if
    i32.const 320
    i32.const 376
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
@@ -701,10 +699,6 @@
   end
  )
  (func $~lib/array/Array<i32>#__set (; 8 ;) (type $FUNCSIG$v)
-  (local $0 i32)
-  i32.const 60
-  i32.load
-  local.set $0
   i32.const 48
   i32.const 2
   call $~lib/array/ensureSize
@@ -713,7 +707,8 @@
   i32.const 2
   i32.store
   i32.const 0
-  local.get $0
+  i32.const 60
+  i32.load
   i32.ge_s
   if
    i32.const 60
@@ -723,16 +718,14 @@
  )
  (func $~lib/array/Array<i64>#__get (; 9 ;) (type $FUNCSIG$ji) (param $0 i32) (result i64)
   local.get $0
-  i32.const 120
+  i32.const 124
   i32.load
-  i32.const 3
-  i32.shr_u
   i32.ge_u
   if
    i32.const 320
    i32.const 376
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
@@ -745,10 +738,6 @@
   i64.load
  )
  (func $~lib/array/Array<i64>#__set (; 10 ;) (type $FUNCSIG$v)
-  (local $0 i32)
-  i32.const 124
-  i32.load
-  local.set $0
   i32.const 112
   i32.const 3
   call $~lib/array/ensureSize
@@ -757,7 +746,8 @@
   i64.const 4
   i64.store
   i32.const 0
-  local.get $0
+  i32.const 124
+  i32.load
   i32.ge_s
   if
    i32.const 124
@@ -767,16 +757,14 @@
  )
  (func $~lib/array/Array<f32>#__get (; 11 ;) (type $FUNCSIG$fi) (param $0 i32) (result f32)
   local.get $0
-  i32.const 176
+  i32.const 180
   i32.load
-  i32.const 2
-  i32.shr_u
   i32.ge_u
   if
    i32.const 320
    i32.const 376
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
@@ -789,10 +777,6 @@
   f32.load
  )
  (func $~lib/array/Array<f32>#__set (; 12 ;) (type $FUNCSIG$v)
-  (local $0 i32)
-  i32.const 180
-  i32.load
-  local.set $0
   i32.const 168
   i32.const 2
   call $~lib/array/ensureSize
@@ -801,7 +785,8 @@
   f32.const 2.5
   f32.store
   i32.const 0
-  local.get $0
+  i32.const 180
+  i32.load
   i32.ge_s
   if
    i32.const 180
@@ -811,16 +796,14 @@
  )
  (func $~lib/array/Array<f64>#__get (; 13 ;) (type $FUNCSIG$di) (param $0 i32) (result f64)
   local.get $0
-  i32.const 240
+  i32.const 244
   i32.load
-  i32.const 3
-  i32.shr_u
   i32.ge_u
   if
    i32.const 320
    i32.const 376
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
@@ -833,10 +816,6 @@
   f64.load
  )
  (func $~lib/array/Array<f64>#__set (; 14 ;) (type $FUNCSIG$v)
-  (local $0 i32)
-  i32.const 244
-  i32.load
-  local.set $0
   i32.const 232
   i32.const 3
   call $~lib/array/ensureSize
@@ -845,7 +824,8 @@
   f64.const 2.25
   f64.store
   i32.const 0
-  local.get $0
+  i32.const 244
+  i32.load
   i32.ge_s
   if
    i32.const 244

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -37,7 +37,7 @@
   if
    i32.const 320
    i32.const 376
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -724,7 +724,7 @@
   if
    i32.const 320
    i32.const 376
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -763,7 +763,7 @@
   if
    i32.const 320
    i32.const 376
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -802,7 +802,7 @@
   if
    i32.const 320
    i32.const 376
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -52,23 +52,24 @@
   i32.load
  )
  (func $~lib/array/Array<i32>#__get (; 3 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
   local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
    i32.const 320
    i32.const 376
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<i32>#__unchecked_get
+  local.set $2
+  local.get $2
  )
  (func $~lib/rt/stub/maybeGrowMemory (; 4 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
@@ -1910,10 +1911,6 @@
   i32.store
  )
  (func $~lib/array/Array<i32>#__set (; 13 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
-  local.get $0
-  i32.load offset=12
-  local.set $3
   local.get $0
   local.get $1
   i32.const 1
@@ -1925,7 +1922,8 @@
   local.get $2
   call $~lib/array/Array<i32>#__unchecked_set
   local.get $1
-  local.get $3
+  local.get $0
+  i32.load offset=12
   i32.ge_s
   if
    local.get $0
@@ -1949,23 +1947,24 @@
   i64.load
  )
  (func $~lib/array/Array<i64>#__get (; 16 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i64)
   local.get $1
   local.get $0
-  i32.load offset=8
-  i32.const 3
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
    i32.const 320
    i32.const 376
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<i64>#__unchecked_get
+  local.set $2
+  local.get $2
  )
  (func $~lib/array/Array<i64>#__unchecked_set (; 17 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $0
@@ -1978,10 +1977,6 @@
   i64.store
  )
  (func $~lib/array/Array<i64>#__set (; 18 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
-  (local $3 i32)
-  local.get $0
-  i32.load offset=12
-  local.set $3
   local.get $0
   local.get $1
   i32.const 1
@@ -1993,7 +1988,8 @@
   local.get $2
   call $~lib/array/Array<i64>#__unchecked_set
   local.get $1
-  local.get $3
+  local.get $0
+  i32.load offset=12
   i32.ge_s
   if
    local.get $0
@@ -2017,23 +2013,24 @@
   f32.load
  )
  (func $~lib/array/Array<f32>#__get (; 21 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
+  (local $2 f32)
   local.get $1
   local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
    i32.const 320
    i32.const 376
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<f32>#__unchecked_get
+  local.set $2
+  local.get $2
  )
  (func $~lib/array/Array<f32>#__unchecked_set (; 22 ;) (type $FUNCSIG$viif) (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $0
@@ -2046,10 +2043,6 @@
   f32.store
  )
  (func $~lib/array/Array<f32>#__set (; 23 ;) (type $FUNCSIG$viif) (param $0 i32) (param $1 i32) (param $2 f32)
-  (local $3 i32)
-  local.get $0
-  i32.load offset=12
-  local.set $3
   local.get $0
   local.get $1
   i32.const 1
@@ -2061,7 +2054,8 @@
   local.get $2
   call $~lib/array/Array<f32>#__unchecked_set
   local.get $1
-  local.get $3
+  local.get $0
+  i32.load offset=12
   i32.ge_s
   if
    local.get $0
@@ -2085,23 +2079,24 @@
   f64.load
  )
  (func $~lib/array/Array<f64>#__get (; 26 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 f64)
   local.get $1
   local.get $0
-  i32.load offset=8
-  i32.const 3
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
    i32.const 320
    i32.const 376
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<f64>#__unchecked_get
+  local.set $2
+  local.get $2
  )
  (func $~lib/array/Array<f64>#__unchecked_set (; 27 ;) (type $FUNCSIG$viid) (param $0 i32) (param $1 i32) (param $2 f64)
   local.get $0
@@ -2114,10 +2109,6 @@
   f64.store
  )
  (func $~lib/array/Array<f64>#__set (; 28 ;) (type $FUNCSIG$viid) (param $0 i32) (param $1 i32) (param $2 f64)
-  (local $3 i32)
-  local.get $0
-  i32.load offset=12
-  local.set $3
   local.get $0
   local.get $1
   i32.const 1
@@ -2129,7 +2120,8 @@
   local.get $2
   call $~lib/array/Array<f64>#__unchecked_set
   local.get $1
-  local.get $3
+  local.get $0
+  i32.load offset=12
   i32.ge_s
   if
    local.get $0

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -60,7 +60,7 @@
   if
    i32.const 320
    i32.const 376
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -1955,7 +1955,7 @@
   if
    i32.const 320
    i32.const 376
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -2021,7 +2021,7 @@
   if
    i32.const 320
    i32.const 376
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -2087,7 +2087,7 @@
   if
    i32.const 320
    i32.const 376
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -60,7 +60,7 @@
   if
    i32.const 320
    i32.const 376
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -1955,7 +1955,7 @@
   if
    i32.const 320
    i32.const 376
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -2021,7 +2021,7 @@
   if
    i32.const 320
    i32.const 376
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -2087,7 +2087,7 @@
   if
    i32.const 320
    i32.const 376
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -6201,7 +6201,7 @@
   if
    i32.const 232
    i32.const 10824
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -6221,7 +6221,7 @@
    call $~lib/rt/pure/__release
    i32.const 10872
    i32.const 10824
-   i32.const 94
+   i32.const 93
    i32.const 39
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -6199,24 +6199,10 @@
   i32.load offset=12
   i32.ge_u
   if
-   i32.const 10872
-   i32.const 10824
-   i32.const 106
-   i32.const 45
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $1
-  local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
-  i32.ge_u
-  if
    i32.const 232
    i32.const 10824
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
@@ -6228,6 +6214,19 @@
   i32.add
   i32.load
   call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.eqz
+  if
+   local.get $0
+   call $~lib/rt/pure/__release
+   i32.const 10872
+   i32.const 10824
+   i32.const 94
+   i32.const 39
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
  )
  (func $~lib/util/number/decimalCount32 (; 77 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -6201,7 +6201,7 @@
   if
    i32.const 232
    i32.const 10824
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -6221,7 +6221,7 @@
    call $~lib/rt/pure/__release
    i32.const 10872
    i32.const 10824
-   i32.const 93
+   i32.const 100
    i32.const 39
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -8905,35 +8905,36 @@
   call $~lib/rt/pure/__retain
  )
  (func $~lib/array/Array<~lib/string/String>#__get (; 83 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
   i32.ge_u
   if
-   i32.const 10872
-   i32.const 10824
-   i32.const 106
-   i32.const 45
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $1
-  local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
-  i32.ge_u
-  if
    i32.const 232
    i32.const 10824
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<~lib/string/String>#__unchecked_get
+  local.set $2
+  local.get $2
+  i32.eqz
+  if
+   local.get $2
+   call $~lib/rt/pure/__release
+   i32.const 10872
+   i32.const 10824
+   i32.const 94
+   i32.const 39
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
  )
  (func $~lib/util/number/decimalCount32 (; 84 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -8913,7 +8913,7 @@
   if
    i32.const 232
    i32.const 10824
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -8929,7 +8929,7 @@
    call $~lib/rt/pure/__release
    i32.const 10872
    i32.const 10824
-   i32.const 94
+   i32.const 93
    i32.const 39
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -8913,7 +8913,7 @@
   if
    i32.const 232
    i32.const 10824
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -8929,7 +8929,7 @@
    call $~lib/rt/pure/__release
    i32.const 10872
    i32.const 10824
-   i32.const 93
+   i32.const 100
    i32.const 39
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -3668,7 +3668,7 @@
   if
    i32.const 280
    i32.const 512
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -3915,7 +3915,7 @@
   if
    i32.const 280
    i32.const 512
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -3668,7 +3668,7 @@
   if
    i32.const 280
    i32.const 512
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -3915,7 +3915,7 @@
   if
    i32.const 280
    i32.const 512
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -3663,13 +3663,13 @@
  (func $~lib/array/Array<i8>#__get (; 64 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
-  i32.load offset=8
+  i32.load offset=12
   i32.ge_u
   if
    i32.const 280
    i32.const 512
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
@@ -3910,15 +3910,13 @@
  (func $~lib/array/Array<i32>#__get (; 68 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
    i32.const 280
    i32.const 512
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -5591,7 +5591,7 @@
   if
    i32.const 280
    i32.const 512
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -5913,7 +5913,7 @@
   if
    i32.const 280
    i32.const 512
-   i32.const 90
+   i32.const 89
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -5591,7 +5591,7 @@
   if
    i32.const 280
    i32.const 512
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable
@@ -5913,7 +5913,7 @@
   if
    i32.const 280
    i32.const 512
-   i32.const 89
+   i32.const 96
    i32.const 41
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -5583,23 +5583,24 @@
   i32.load8_s
  )
  (func $~lib/array/Array<i8>#__get (; 77 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
   local.get $0
-  i32.load offset=8
-  i32.const 0
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
    i32.const 280
    i32.const 512
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<i8>#__unchecked_get
+  local.set $2
+  local.get $2
  )
  (func $std/typedarray/isInt8ArrayEqual (; 78 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -5904,23 +5905,24 @@
   i32.load
  )
  (func $~lib/array/Array<i32>#__get (; 83 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
   local.get $1
   local.get $0
-  i32.load offset=8
-  i32.const 2
-  i32.shr_u
+  i32.load offset=12
   i32.ge_u
   if
    i32.const 280
    i32.const 512
-   i32.const 109
-   i32.const 61
+   i32.const 90
+   i32.const 41
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
   local.get $1
   call $~lib/array/Array<i32>#__unchecked_get
+  local.set $2
+  local.get $2
  )
  (func $std/typedarray/isInt32ArrayEqual (; 84 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)


### PR DESCRIPTION
This is an implementation of the suggestion made in https://github.com/AssemblyScript/assemblyscript/issues/853 in that it removes the need to use non-standard `Array.create<T>(length > 0)` over `new Array<T>(length > 0)` while moving that check to actually accessing an array's elements, throwing if there's an unexpected `null` in it as a result of not properly initializing it.