### PR TITLE
Temporarily disable testing Math.hypot against node/V8

### DIFF
--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -52,7 +52,6 @@
  (import "Math" "exp" (func $~lib/bindings/Math/exp (param f64) (result f64)))
  (import "Math" "expm1" (func $~lib/bindings/Math/expm1 (param f64) (result f64)))
  (import "Math" "floor" (func $~lib/bindings/Math/floor (param f64) (result f64)))
- (import "Math" "hypot" (func $~lib/bindings/Math/hypot (param f64 f64) (result f64)))
  (import "Math" "log" (func $~lib/bindings/Math/log (param f64) (result f64)))
  (import "Math" "log10" (func $~lib/bindings/Math/log10 (param f64) (result f64)))
  (import "Math" "log1p" (func $~lib/bindings/Math/log1p (param f64) (result f64)))
@@ -77,7 +76,6 @@
  (data (i32.const 336) "\10\00\00\00\01\00\00\00\03\00\00\00\10\00\00\000\01\00\000\01\00\00 \00\00\00\04")
  (data (i32.const 368) "\18\00\00\00\01\00\00\00\01\00\00\00\18\00\00\00~\00l\00i\00b\00/\00m\00a\00t\00h\00.\00t\00s")
  (data (i32.const 408) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00P\00R\00N\00G\00 \00m\00u\00s\00t\00 \00b\00e\00 \00s\00e\00e\00d\00e\00d\00.")
- (global $std/math/js (mut i32) (i32.const 1))
  (global $~lib/math/rempio2_y0 (mut f64) (f64.const 0))
  (global $~lib/math/rempio2_y1 (mut f64) (f64.const 0))
  (global $~lib/math/res128_hi (mut i64) (i64.const 0))
@@ -91,19 +89,19 @@
  (global $~lib/math/NativeMath.sincos_cos (mut f64) (f64.const 0))
  (export "memory" (memory $0))
  (start $start)
- (func $~lib/number/isNaN<f64> (; 33 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/number/isNaN<f64> (; 32 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   local.get $0
   f64.ne
  )
- (func $~lib/number/isFinite<f64> (; 34 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/number/isFinite<f64> (; 33 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   local.get $0
   f64.sub
   f64.const 0
   f64.eq
  )
- (func $~lib/math/NativeMath.scalbn (; 35 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/NativeMath.scalbn (; 34 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
   local.get $1
   i32.const 1023
   i32.gt_s
@@ -180,7 +178,7 @@
   f64.reinterpret_i64
   f64.mul
  )
- (func $std/math/ulperr (; 36 ;) (type $FUNCSIG$dddd) (param $0 f64) (param $1 f64) (param $2 f64) (result f64)
+ (func $std/math/ulperr (; 35 ;) (type $FUNCSIG$dddd) (param $0 f64) (param $1 f64) (param $2 f64) (result f64)
   (local $3 i32)
   local.get $0
   call $~lib/number/isNaN<f64>
@@ -268,7 +266,7 @@
   local.get $2
   f64.add
  )
- (func $std/math/check<f64> (; 37 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/check<f64> (; 36 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   f64.eq
@@ -296,12 +294,12 @@
   end
   i32.const 1
  )
- (func $~lib/number/isNaN<f32> (; 38 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
+ (func $~lib/number/isNaN<f32> (; 37 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
   local.get $0
   local.get $0
   f32.ne
  )
- (func $~lib/math/NativeMathf.scalbn (; 39 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
+ (func $~lib/math/NativeMathf.scalbn (; 38 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
   local.get $1
   i32.const 127
   i32.gt_s
@@ -377,7 +375,7 @@
   f32.reinterpret_i32
   f32.mul
  )
- (func $std/math/ulperrf (; 40 ;) (type $FUNCSIG$ffff) (param $0 f32) (param $1 f32) (param $2 f32) (result f32)
+ (func $std/math/ulperrf (; 39 ;) (type $FUNCSIG$ffff) (param $0 f32) (param $1 f32) (param $2 f32) (result f32)
   (local $3 i32)
   local.get $0
   call $~lib/number/isNaN<f32>
@@ -464,7 +462,7 @@
   local.get $2
   f32.add
  )
- (func $std/math/check<f32> (; 41 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/check<f32> (; 40 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   local.get $1
   f32.eq
@@ -492,7 +490,7 @@
   end
   i32.const 1
  )
- (func $std/math/test_scalbn (; 42 ;) (type $FUNCSIG$idid) (param $0 f64) (param $1 i32) (param $2 f64) (result i32)
+ (func $std/math/test_scalbn (; 41 ;) (type $FUNCSIG$idid) (param $0 f64) (param $1 i32) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.scalbn
@@ -500,7 +498,7 @@
   f64.const 0
   call $std/math/check<f64>
  )
- (func $std/math/test_scalbnf (; 43 ;) (type $FUNCSIG$ifif) (param $0 f32) (param $1 i32) (param $2 f32) (result i32)
+ (func $std/math/test_scalbnf (; 42 ;) (type $FUNCSIG$ifif) (param $0 f32) (param $1 i32) (param $2 f32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.scalbn
@@ -508,35 +506,30 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $std/math/test_abs (; 44 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
+ (func $std/math/test_abs (; 43 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
   local.get $0
   f64.abs
   local.get $1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    call $~lib/bindings/Math/abs
-    local.get $1
-    f64.const 0
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   call $~lib/bindings/Math/abs
+   local.get $1
+   f64.const 0
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $std/math/test_absf (; 45 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/math/test_absf (; 44 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
   local.get $0
   f32.abs
   local.get $1
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/R (; 46 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/R (; 45 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   f64.const 0.16666666666666666
   local.get $0
@@ -579,7 +572,7 @@
   f64.add
   f64.div
  )
- (func $~lib/math/NativeMath.acos (; 47 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.acos (; 46 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -703,28 +696,23 @@
   f64.add
   f64.mul
  )
- (func $std/math/test_acos (; 48 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_acos (; 47 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.acos
   local.get $1
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    call $~lib/bindings/Math/acos
-    local.get $1
-    local.get $2
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   call $~lib/bindings/Math/acos
+   local.get $1
+   local.get $2
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $~lib/math/Rf (; 49 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/Rf (; 48 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   f32.const 0.16666586697101593
   local.get $0
@@ -743,7 +731,7 @@
   f32.add
   f32.div
  )
- (func $~lib/math/NativeMathf.acos (; 50 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.acos (; 49 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -859,14 +847,14 @@
   f32.add
   f32.mul
  )
- (func $std/math/test_acosf (; 51 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_acosf (; 50 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.acos
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log1p (; 52 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log1p (; 51 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -1065,7 +1053,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.log (; 53 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log (; 52 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i64)
   (local $3 f64)
@@ -1235,7 +1223,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.acosh (; 54 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.acosh (; 53 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   local.get $0
   i64.reinterpret_f64
@@ -1289,28 +1277,23 @@
   f64.const 0.6931471805599453
   f64.add
  )
- (func $std/math/test_acosh (; 55 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_acosh (; 54 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.acosh
   local.get $1
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    call $~lib/bindings/Math/acosh
-    local.get $1
-    local.get $2
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   call $~lib/bindings/Math/acosh
+   local.get $1
+   local.get $2
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.log1p (; 56 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log1p (; 55 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -1480,7 +1463,7 @@
   f32.mul
   f32.add
  )
- (func $~lib/math/NativeMathf.log (; 57 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log (; 56 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -1614,7 +1597,7 @@
   f32.mul
   f32.add
  )
- (func $~lib/math/NativeMathf.acosh (; 58 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.acosh (; 57 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   local.get $0
   i32.reinterpret_f32
@@ -1664,14 +1647,14 @@
   f32.const 0.6931471824645996
   f32.add
  )
- (func $std/math/test_acoshf (; 59 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_acoshf (; 58 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.acosh
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.asin (; 60 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.asin (; 59 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -1809,28 +1792,23 @@
   end
   local.get $0
  )
- (func $std/math/test_asin (; 61 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_asin (; 60 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.asin
   local.get $1
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    call $~lib/bindings/Math/asin
-    local.get $1
-    local.get $2
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   call $~lib/bindings/Math/asin
+   local.get $1
+   local.get $2
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.asin (; 62 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.asin (; 61 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f64)
@@ -1910,14 +1888,14 @@
   local.get $0
   f32.copysign
  )
- (func $std/math/test_asinf (; 63 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_asinf (; 62 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.asin
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.asinh (; 64 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.asinh (; 63 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i64)
   local.get $0
@@ -1987,28 +1965,23 @@
   local.get $0
   f64.copysign
  )
- (func $std/math/test_asinh (; 65 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_asinh (; 64 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.asinh
   local.get $1
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    call $~lib/bindings/Math/asinh
-    local.get $1
-    local.get $2
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   call $~lib/bindings/Math/asinh
+   local.get $1
+   local.get $2
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.asinh (; 66 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.asinh (; 65 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   local.get $0
@@ -2073,14 +2046,14 @@
   local.get $0
   f32.copysign
  )
- (func $std/math/test_asinhf (; 67 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_asinhf (; 66 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.asinh
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atan (; 68 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atan (; 67 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -2305,28 +2278,23 @@
   local.get $3
   f64.copysign
  )
- (func $std/math/test_atan (; 69 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_atan (; 68 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.atan
   local.get $1
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    call $~lib/bindings/Math/atan
-    local.get $1
-    local.get $2
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   call $~lib/bindings/Math/atan
+   local.get $1
+   local.get $2
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.atan (; 70 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.atan (; 69 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -2524,14 +2492,14 @@
   local.get $4
   f32.copysign
  )
- (func $std/math/test_atanf (; 71 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_atanf (; 70 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.atan
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atanh (; 72 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atanh (; 71 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i64)
   (local $3 f64)
@@ -2585,28 +2553,23 @@
   local.get $0
   f64.copysign
  )
- (func $std/math/test_atanh (; 73 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_atanh (; 72 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.atanh
   local.get $1
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    call $~lib/bindings/Math/atanh
-    local.get $1
-    local.get $2
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   call $~lib/bindings/Math/atanh
+   local.get $1
+   local.get $2
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.atanh (; 74 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.atanh (; 73 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   local.get $0
@@ -2654,14 +2617,14 @@
   local.get $0
   f32.copysign
  )
- (func $std/math/test_atanhf (; 75 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_atanhf (; 74 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.atanh
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atan2 (; 76 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.atan2 (; 75 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2881,7 +2844,7 @@
   i32.and
   select
  )
- (func $std/math/test_atan2 (; 77 ;) (type $FUNCSIG$idddd) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (result i32)
+ (func $std/math/test_atan2 (; 76 ;) (type $FUNCSIG$idddd) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.atan2
@@ -2889,22 +2852,17 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    local.get $1
-    call $~lib/bindings/Math/atan2
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   local.get $1
+   call $~lib/bindings/Math/atan2
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.atan2 (; 78 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.atan2 (; 77 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3100,7 +3058,7 @@
   i32.and
   select
  )
- (func $std/math/test_atan2f (; 79 ;) (type $FUNCSIG$iffff) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (result i32)
+ (func $std/math/test_atan2f (; 78 ;) (type $FUNCSIG$iffff) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.atan2
@@ -3108,7 +3066,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.cbrt (; 80 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cbrt (; 79 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -3230,28 +3188,23 @@
   f64.mul
   f64.add
  )
- (func $std/math/test_cbrt (; 81 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_cbrt (; 80 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.cbrt
   local.get $1
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    call $~lib/bindings/Math/cbrt
-    local.get $1
-    local.get $2
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   call $~lib/bindings/Math/cbrt
+   local.get $1
+   local.get $2
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.cbrt (; 82 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cbrt (; 81 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f64)
   (local $2 f64)
   (local $3 i32)
@@ -3350,42 +3303,37 @@
   f64.div
   f32.demote_f64
  )
- (func $std/math/test_cbrtf (; 83 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_cbrtf (; 82 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.cbrt
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_ceil (; 84 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
+ (func $std/math/test_ceil (; 83 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
   local.get $0
   f64.ceil
   local.get $1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    call $~lib/bindings/Math/ceil
-    local.get $1
-    f64.const 0
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   call $~lib/bindings/Math/ceil
+   local.get $1
+   f64.const 0
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $std/math/test_ceilf (; 85 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/math/test_ceilf (; 84 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
   local.get $0
   f32.ceil
   local.get $1
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/pio2_large_quot (; 86 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/math/pio2_large_quot (; 85 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -3677,7 +3625,7 @@
   i64.sub
   i32.wrap_i64
  )
- (func $~lib/math/NativeMath.cos (; 87 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cos (; 86 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   (local $3 f64)
@@ -4017,28 +3965,23 @@
   end
   local.get $0
  )
- (func $std/math/test_cos (; 88 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_cos (; 87 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.cos
   local.get $1
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    call $~lib/bindings/Math/cos
-    local.get $1
-    local.get $2
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   call $~lib/bindings/Math/cos
+   local.get $1
+   local.get $2
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.cos (; 89 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cos (; 88 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -4308,14 +4251,14 @@
   end
   local.get $0
  )
- (func $std/math/test_cosf (; 90 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_cosf (; 89 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.cos
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.expm1 (; 91 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.expm1 (; 90 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -4587,7 +4530,7 @@
   local.get $4
   f64.mul
  )
- (func $~lib/math/NativeMath.exp (; 92 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.exp (; 91 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 f64)
   (local $3 i32)
@@ -4739,7 +4682,7 @@
   local.get $1
   call $~lib/math/NativeMath.scalbn
  )
- (func $~lib/math/NativeMath.cosh (; 93 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cosh (; 92 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i64)
   local.get $0
@@ -4803,28 +4746,23 @@
   f64.const 2247116418577894884661631e283
   f64.mul
  )
- (func $std/math/test_cosh (; 94 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_cosh (; 93 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.cosh
   local.get $1
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    call $~lib/bindings/Math/cosh
-    local.get $1
-    local.get $2
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   call $~lib/bindings/Math/cosh
+   local.get $1
+   local.get $2
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.expm1 (; 95 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.expm1 (; 94 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -5076,7 +5014,7 @@
   local.get $4
   f32.mul
  )
- (func $~lib/math/NativeMathf.exp (; 96 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.exp (; 95 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -5204,7 +5142,7 @@
   local.get $1
   call $~lib/math/NativeMathf.scalbn
  )
- (func $~lib/math/NativeMathf.cosh (; 97 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cosh (; 96 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   local.get $0
   i32.reinterpret_f32
@@ -5263,98 +5201,83 @@
   f32.const 1661534994731144841129758e11
   f32.mul
  )
- (func $std/math/test_coshf (; 98 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_coshf (; 97 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.cosh
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_exp (; 99 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_exp (; 98 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.exp
   local.get $1
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    call $~lib/bindings/Math/exp
-    local.get $1
-    local.get $2
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   call $~lib/bindings/Math/exp
+   local.get $1
+   local.get $2
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $std/math/test_expf (; 100 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_expf (; 99 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.exp
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_expm1 (; 101 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_expm1 (; 100 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.expm1
   local.get $1
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    call $~lib/bindings/Math/expm1
-    local.get $1
-    local.get $2
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   call $~lib/bindings/Math/expm1
+   local.get $1
+   local.get $2
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $std/math/test_expm1f (; 102 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_expm1f (; 101 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.expm1
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_floor (; 103 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
+ (func $std/math/test_floor (; 102 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
   local.get $0
   f64.floor
   local.get $1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    call $~lib/bindings/Math/floor
-    local.get $1
-    f64.const 0
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   call $~lib/bindings/Math/floor
+   local.get $1
+   f64.const 0
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $std/math/test_floorf (; 104 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/math/test_floorf (; 103 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
   local.get $0
   f32.floor
   local.get $1
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.hypot (; 105 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.hypot (; 104 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 f64)
   (local $4 i64)
@@ -5525,30 +5448,15 @@
   f64.sqrt
   f64.mul
  )
- (func $std/math/test_hypot (; 106 ;) (type $FUNCSIG$idddd) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (result i32)
+ (func $std/math/test_hypot (; 105 ;) (type $FUNCSIG$idddd) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.hypot
   local.get $2
   local.get $3
   call $std/math/check<f64>
-  if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    local.get $1
-    call $~lib/bindings/Math/hypot
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
-  else
-   i32.const 0
-  end
  )
- (func $~lib/math/NativeMathf.hypot (; 107 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.hypot (; 106 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 f32)
@@ -5653,7 +5561,7 @@
   f32.sqrt
   f32.mul
  )
- (func $std/math/test_hypotf (; 108 ;) (type $FUNCSIG$iffff) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (result i32)
+ (func $std/math/test_hypotf (; 107 ;) (type $FUNCSIG$iffff) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.hypot
@@ -5661,35 +5569,30 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_log (; 109 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_log (; 108 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.log
   local.get $1
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    call $~lib/bindings/Math/log
-    local.get $1
-    local.get $2
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   call $~lib/bindings/Math/log
+   local.get $1
+   local.get $2
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $std/math/test_logf (; 110 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/math/test_logf (; 109 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log
   local.get $1
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log10 (; 111 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log10 (; 110 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i64)
@@ -5893,28 +5796,23 @@
   local.get $1
   f64.add
  )
- (func $std/math/test_log10 (; 112 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_log10 (; 111 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.log10
   local.get $1
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    call $~lib/bindings/Math/log10
-    local.get $1
-    local.get $2
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   call $~lib/bindings/Math/log10
+   local.get $1
+   local.get $2
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.log10 (; 113 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log10 (; 112 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 i32)
@@ -6072,42 +5970,37 @@
   f32.mul
   f32.add
  )
- (func $std/math/test_log10f (; 114 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_log10f (; 113 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log10
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_log1p (; 115 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_log1p (; 114 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.log1p
   local.get $1
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    call $~lib/bindings/Math/log1p
-    local.get $1
-    local.get $2
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   call $~lib/bindings/Math/log1p
+   local.get $1
+   local.get $2
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $std/math/test_log1pf (; 116 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_log1pf (; 115 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log1p
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log2 (; 117 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log2 (; 116 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i64)
@@ -6304,28 +6197,23 @@
   local.get $1
   f64.add
  )
- (func $std/math/test_log2 (; 118 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_log2 (; 117 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.log2
   local.get $1
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    call $~lib/bindings/Math/log2
-    local.get $1
-    local.get $2
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   call $~lib/bindings/Math/log2
+   local.get $1
+   local.get $2
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.log2 (; 119 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log2 (; 118 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 i32)
@@ -6475,14 +6363,14 @@
   f32.convert_i32_s
   f32.add
  )
- (func $std/math/test_log2f (; 120 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_log2f (; 119 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log2
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_max (; 121 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_max (; 120 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   f64.max
@@ -6490,22 +6378,17 @@
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    local.get $1
-    call $~lib/bindings/Math/max
-    local.get $2
-    f64.const 0
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   local.get $1
+   call $~lib/bindings/Math/max
+   local.get $2
+   f64.const 0
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $std/math/test_maxf (; 122 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_maxf (; 121 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   local.get $1
   f32.max
@@ -6513,7 +6396,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $std/math/test_min (; 123 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_min (; 122 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   f64.min
@@ -6521,22 +6404,17 @@
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    local.get $1
-    call $~lib/bindings/Math/min
-    local.get $2
-    f64.const 0
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   local.get $1
+   call $~lib/bindings/Math/min
+   local.get $2
+   f64.const 0
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $std/math/test_minf (; 124 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_minf (; 123 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   local.get $1
   f32.min
@@ -6544,7 +6422,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.mod (; 125 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (; 124 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -6747,7 +6625,7 @@
   local.get $0
   f64.mul
  )
- (func $std/math/test_mod (; 126 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_mod (; 125 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.mod
@@ -6755,22 +6633,17 @@
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    local.get $1
-    call $std/math/mod
-    local.get $2
-    f64.const 0
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   local.get $1
+   call $std/math/mod
+   local.get $2
+   f64.const 0
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.mod (; 127 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (; 126 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6961,7 +6834,7 @@
   local.get $0
   f32.mul
  )
- (func $std/math/test_modf (; 128 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_modf (; 127 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.mod
@@ -6969,7 +6842,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.pow (; 129 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.pow (; 128 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 f64)
   (local $4 i32)
@@ -7877,7 +7750,7 @@
   f64.const 1e-300
   f64.mul
  )
- (func $std/math/test_pow (; 130 ;) (type $FUNCSIG$idddd) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (result i32)
+ (func $std/math/test_pow (; 129 ;) (type $FUNCSIG$idddd) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.pow
@@ -7885,22 +7758,17 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    local.get $1
-    call $~lib/bindings/Math/pow
-    local.get $2
-    local.get $3
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   local.get $1
+   call $~lib/bindings/Math/pow
+   local.get $2
+   local.get $3
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.pow (; 131 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.pow (; 130 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 f32)
   (local $3 f32)
   (local $4 i32)
@@ -8686,7 +8554,7 @@
   f32.const 1.0000000031710769e-30
   f32.mul
  )
- (func $std/math/test_powf (; 132 ;) (type $FUNCSIG$iffff) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (result i32)
+ (func $std/math/test_powf (; 131 ;) (type $FUNCSIG$iffff) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.pow
@@ -8694,7 +8562,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/murmurHash3 (; 133 ;) (type $FUNCSIG$jj) (param $0 i64) (result i64)
+ (func $~lib/math/murmurHash3 (; 132 ;) (type $FUNCSIG$jj) (param $0 i64) (result i64)
   local.get $0
   i64.const 33
   i64.shr_u
@@ -8715,7 +8583,7 @@
   i64.shr_u
   i64.xor
  )
- (func $~lib/math/splitMix32 (; 134 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/math/splitMix32 (; 133 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 1831565813
   i32.add
@@ -8747,7 +8615,7 @@
   i32.shr_u
   i32.xor
  )
- (func $~lib/math/NativeMath.seedRandom (; 135 ;) (type $FUNCSIG$vj) (param $0 i64)
+ (func $~lib/math/NativeMath.seedRandom (; 134 ;) (type $FUNCSIG$vj) (param $0 i64)
   i32.const 1
   global.set $~lib/math/random_seeded
   local.get $0
@@ -8791,7 +8659,7 @@
    unreachable
   end
  )
- (func $~lib/math/NativeMath.random (; 136 ;) (type $FUNCSIG$d) (result f64)
+ (func $~lib/math/NativeMath.random (; 135 ;) (type $FUNCSIG$d) (result f64)
   (local $0 i64)
   (local $1 i64)
   global.get $~lib/math/random_seeded
@@ -8835,7 +8703,7 @@
   f64.const 1
   f64.sub
  )
- (func $~lib/math/NativeMathf.random (; 137 ;) (type $FUNCSIG$f) (result f32)
+ (func $~lib/math/NativeMathf.random (; 136 ;) (type $FUNCSIG$f) (result f32)
   (local $0 i32)
   (local $1 i32)
   global.get $~lib/math/random_seeded
@@ -8881,7 +8749,7 @@
   f32.const 1
   f32.sub
  )
- (func $std/math/test_round (; 138 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
+ (func $std/math/test_round (; 137 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
   local.get $0
   f64.const 0.5
   f64.add
@@ -8892,7 +8760,7 @@
   f64.const 0
   call $std/math/check<f64>
  )
- (func $std/math/test_roundf (; 139 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/math/test_roundf (; 138 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
   local.get $0
   f32.const 0.5
   f32.add
@@ -8903,7 +8771,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $std/math/test_sign (; 140 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
+ (func $std/math/test_sign (; 139 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
   (local $2 f64)
   local.get $0
   local.set $2
@@ -8920,21 +8788,16 @@
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    call $~lib/bindings/Math/sign
-    local.get $1
-    f64.const 0
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   call $~lib/bindings/Math/sign
+   local.get $1
+   f64.const 0
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $std/math/test_signf (; 141 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/math/test_signf (; 140 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
   f32.const 1
   local.get $0
   f32.copysign
@@ -8948,7 +8811,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.rem (; 142 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.rem (; 141 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -9204,7 +9067,7 @@
   end
   local.get $0
  )
- (func $std/math/test_rem (; 143 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_rem (; 142 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.rem
@@ -9212,7 +9075,7 @@
   f64.const 0
   call $std/math/check<f64>
  )
- (func $~lib/math/NativeMathf.rem (; 144 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.rem (; 143 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9457,7 +9320,7 @@
   end
   local.get $0
  )
- (func $std/math/test_remf (; 145 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_remf (; 144 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.rem
@@ -9465,7 +9328,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.sin (; 146 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.sin (; 145 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   (local $3 f64)
@@ -9787,28 +9650,23 @@
   end
   local.get $0
  )
- (func $std/math/test_sin (; 147 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_sin (; 146 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.sin
   local.get $1
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    call $~lib/bindings/Math/sin
-    local.get $1
-    local.get $2
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   call $~lib/bindings/Math/sin
+   local.get $1
+   local.get $2
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.sin (; 148 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.sin (; 147 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -10079,14 +9937,14 @@
   end
   local.get $0
  )
- (func $std/math/test_sinf (; 149 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_sinf (; 148 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.sin
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.sinh (; 150 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.sinh (; 149 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   (local $3 i32)
@@ -10163,28 +10021,23 @@
   f64.mul
   f64.mul
  )
- (func $std/math/test_sinh (; 151 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_sinh (; 150 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.sinh
   local.get $1
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    call $~lib/bindings/Math/sinh
-    local.get $1
-    local.get $2
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   call $~lib/bindings/Math/sinh
+   local.get $1
+   local.get $2
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.sinh (; 152 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.sinh (; 151 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 f32)
@@ -10256,42 +10109,37 @@
   f32.mul
   f32.mul
  )
- (func $std/math/test_sinhf (; 153 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_sinhf (; 152 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.sinh
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_sqrt (; 154 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_sqrt (; 153 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   f64.sqrt
   local.get $1
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    call $~lib/bindings/Math/sqrt
-    local.get $1
-    local.get $2
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   call $~lib/bindings/Math/sqrt
+   local.get $1
+   local.get $2
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $std/math/test_sqrtf (; 155 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_sqrtf (; 154 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   f32.sqrt
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/tan_kern (; 156 ;) (type $FUNCSIG$dddi) (param $0 f64) (param $1 f64) (param $2 i32) (result f64)
+ (func $~lib/math/tan_kern (; 155 ;) (type $FUNCSIG$dddi) (param $0 f64) (param $1 f64) (param $2 i32) (result f64)
   (local $3 f64)
   (local $4 f64)
   (local $5 f64)
@@ -10473,7 +10321,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.tan (; 157 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.tan (; 156 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -10652,28 +10500,23 @@
   i32.sub
   call $~lib/math/tan_kern
  )
- (func $std/math/test_tan (; 158 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_tan (; 157 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.tan
   local.get $1
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    call $~lib/bindings/Math/tan
-    local.get $1
-    local.get $2
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   call $~lib/bindings/Math/tan
+   local.get $1
+   local.get $2
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.tan (; 159 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.tan (; 158 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -10928,14 +10771,14 @@
   local.get $1
   f32.demote_f64
  )
- (func $std/math/test_tanf (; 160 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_tanf (; 159 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.tan
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.tanh (; 161 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.tanh (; 160 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i64)
@@ -11014,28 +10857,23 @@
   local.get $0
   f64.copysign
  )
- (func $std/math/test_tanh (; 162 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_tanh (; 161 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.tanh
   local.get $1
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    call $~lib/bindings/Math/tanh
-    local.get $1
-    local.get $2
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   call $~lib/bindings/Math/tanh
+   local.get $1
+   local.get $2
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.tanh (; 163 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.tanh (; 162 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   local.get $0
@@ -11109,42 +10947,37 @@
   local.get $0
   f32.copysign
  )
- (func $std/math/test_tanhf (; 164 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_tanhf (; 163 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.tanh
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_trunc (; 165 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
+ (func $std/math/test_trunc (; 164 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
   local.get $0
   f64.trunc
   local.get $1
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   global.get $std/math/js
-   if (result i32)
-    local.get $0
-    call $~lib/bindings/Math/trunc
-    local.get $1
-    f64.const 0
-    call $std/math/check<f64>
-   else
-    i32.const 1
-   end
+   local.get $0
+   call $~lib/bindings/Math/trunc
+   local.get $1
+   f64.const 0
+   call $std/math/check<f64>
   else
    i32.const 0
   end
  )
- (func $std/math/test_truncf (; 166 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/math/test_truncf (; 165 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
   local.get $0
   f32.trunc
   local.get $1
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.sincos (; 167 ;) (type $FUNCSIG$vd) (param $0 f64)
+ (func $~lib/math/NativeMath.sincos (; 166 ;) (type $FUNCSIG$vd) (param $0 f64)
   (local $1 f64)
   (local $2 f64)
   (local $3 f64)
@@ -11542,7 +11375,7 @@
   local.get $1
   global.set $~lib/math/NativeMath.sincos_cos
  )
- (func $std/math/test_sincos (; 168 ;) (type $FUNCSIG$vjjjjj) (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64)
+ (func $std/math/test_sincos (; 167 ;) (type $FUNCSIG$vjjjjj) (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64)
   (local $5 f64)
   (local $6 f64)
   local.get $3
@@ -11568,7 +11401,7 @@
    drop
   end
  )
- (func $~lib/math/dtoi32 (; 169 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/math/dtoi32 (; 168 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   f64.const 4294967296
   local.get $0
@@ -11580,7 +11413,7 @@
   i64.trunc_f64_s
   i32.wrap_i64
  )
- (func $~lib/math/NativeMath.imul (; 170 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.imul (; 169 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   f64.add
@@ -11597,7 +11430,7 @@
   i32.mul
   f64.convert_i32_s
  )
- (func $~lib/math/NativeMath.clz32 (; 171 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.clz32 (; 170 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/number/isFinite<f64>
   i32.eqz
@@ -11610,7 +11443,7 @@
   i32.clz
   f64.convert_i32_s
  )
- (func $~lib/math/ipow64 (; 172 ;) (type $FUNCSIG$jji) (param $0 i64) (param $1 i32) (result i64)
+ (func $~lib/math/ipow64 (; 171 ;) (type $FUNCSIG$jji) (param $0 i64) (param $1 i32) (result i64)
   (local $2 i64)
   i64.const 1
   local.set $2
@@ -11642,7 +11475,7 @@
   end
   local.get $2
  )
- (func $~lib/math/ipow32f (; 173 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
+ (func $~lib/math/ipow32f (; 172 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
   (local $2 f32)
   (local $3 i32)
   local.get $1
@@ -11688,7 +11521,7 @@
   end
   local.get $2
  )
- (func $~lib/math/ipow64f (; 174 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/ipow64f (; 173 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
   (local $2 f64)
   (local $3 i32)
   local.get $1
@@ -11734,7 +11567,7 @@
   end
   local.get $2
  )
- (func $start:std/math (; 175 ;) (type $FUNCSIG$v)
+ (func $start:std/math (; 174 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f64)
   (local $2 f32)
@@ -24139,7 +23972,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1621
+   i32.const 1623
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24153,7 +23986,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1622
+   i32.const 1624
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24167,7 +24000,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1623
+   i32.const 1625
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24181,7 +24014,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1624
+   i32.const 1626
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24195,7 +24028,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1625
+   i32.const 1627
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24209,7 +24042,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1626
+   i32.const 1628
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24223,7 +24056,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1627
+   i32.const 1629
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24237,7 +24070,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1628
+   i32.const 1630
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24251,7 +24084,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1629
+   i32.const 1631
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24265,41 +24098,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1630
+   i32.const 1632
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 3
   f64.const 4
-  f64.const 5
-  f64.const 0
-  call $std/math/test_hypot
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1633
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -3
-  f64.const 4
-  f64.const 5
-  f64.const 0
-  call $std/math/test_hypot
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1634
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4
-  f64.const 3
   f64.const 5
   f64.const 0
   call $std/math/test_hypot
@@ -24312,6 +24117,34 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -3
+  f64.const 4
+  f64.const 5
+  f64.const 0
+  call $std/math/test_hypot
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1636
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4
+  f64.const 3
+  f64.const 5
+  f64.const 0
+  call $std/math/test_hypot
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1637
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 4
   f64.const -3
   f64.const 5
@@ -24321,7 +24154,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1636
+   i32.const 1638
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24335,42 +24168,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1637
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1797693134862315708145274e284
-  f64.const 0
-  f64.const 1797693134862315708145274e284
-  f64.const 0
-  call $std/math/test_hypot
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1638
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1797693134862315708145274e284
-  f64.const -0
-  f64.const 1797693134862315708145274e284
-  f64.const 0
-  call $std/math/test_hypot
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 1639
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5e-324
+  f64.const 1797693134862315708145274e284
   f64.const 0
-  f64.const 5e-324
+  f64.const 1797693134862315708145274e284
   f64.const 0
   call $std/math/test_hypot
   i32.eqz
@@ -24382,9 +24187,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5e-324
+  f64.const 1797693134862315708145274e284
   f64.const -0
-  f64.const 5e-324
+  f64.const 1797693134862315708145274e284
   f64.const 0
   call $std/math/test_hypot
   i32.eqz
@@ -24396,9 +24201,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 1
-  f64.const inf
+  f64.const 5e-324
+  f64.const 0
+  f64.const 5e-324
   f64.const 0
   call $std/math/test_hypot
   i32.eqz
@@ -24410,9 +24215,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const inf
-  f64.const inf
+  f64.const 5e-324
+  f64.const -0
+  f64.const 5e-324
   f64.const 0
   call $std/math/test_hypot
   i32.eqz
@@ -24424,10 +24229,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 0
-  global.set $std/math/js
   f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const inf
   f64.const 0
   call $std/math/test_hypot
@@ -24436,13 +24239,11 @@
    i32.const 0
    i32.const 24
    i32.const 1644
-   i32.const 12
+   i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  global.set $std/math/js
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const inf
   f64.const inf
   f64.const 0
@@ -24456,8 +24257,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const 1
+  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const inf
   f64.const 0
   call $std/math/test_hypot
@@ -24470,8 +24271,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const inf
   f64.const inf
   f64.const 0
   call $std/math/test_hypot
@@ -24484,10 +24285,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 0
-  global.set $std/math/js
   f64.const -inf
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const inf
   f64.const 0
   call $std/math/test_hypot
@@ -24496,13 +24295,11 @@
    i32.const 0
    i32.const 24
    i32.const 1648
-   i32.const 12
+   i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  global.set $std/math/js
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const -inf
   f64.const inf
   f64.const 0
@@ -24516,9 +24313,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -inf
   f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const inf
   f64.const 0
   call $std/math/test_hypot
   i32.eqz
@@ -24530,9 +24327,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const inf
   f64.const 0
   call $std/math/test_hypot
   i32.eqz
@@ -24544,10 +24341,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 0
-  global.set $std/math/js
   f64.const nan:0x8000000000000
-  f64.const 0
+  f64.const 1
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_hypot
@@ -24556,13 +24351,11 @@
    i32.const 0
    i32.const 24
    i32.const 1652
-   i32.const 12
+   i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  global.set $std/math/js
-  f64.const 0
+  f64.const 1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -24576,6 +24369,34 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_hypot
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1654
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_hypot
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1655
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -8.066848754882812
   f32.const 4.535662651062012
   f32.const 9.254528045654297
@@ -24585,7 +24406,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1665
+   i32.const 1664
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24599,7 +24420,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1666
+   i32.const 1665
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24613,7 +24434,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1667
+   i32.const 1666
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24627,7 +24448,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1668
+   i32.const 1667
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24641,7 +24462,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1669
+   i32.const 1668
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24655,7 +24476,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1670
+   i32.const 1669
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24669,7 +24490,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1671
+   i32.const 1670
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24683,7 +24504,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1672
+   i32.const 1671
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24697,7 +24518,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1673
+   i32.const 1672
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24711,12 +24532,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1674
+   i32.const 1673
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 3
+  f32.const 4
+  f32.const 5
+  f32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1676
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -3
   f32.const 4
   f32.const 5
   f32.const 0
@@ -24730,8 +24565,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -3
   f32.const 4
+  f32.const 3
   f32.const 5
   f32.const 0
   call $std/math/test_hypotf
@@ -24745,20 +24580,6 @@
    unreachable
   end
   f32.const 4
-  f32.const 3
-  f32.const 5
-  f32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1679
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 4
   f32.const -3
   f32.const 5
   f32.const 0
@@ -24767,7 +24588,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1680
+   i32.const 1679
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24781,13 +24602,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1681
+   i32.const 1680
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 3402823466385288598117041e14
   f32.const 0
+  f32.const 3402823466385288598117041e14
+  f32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1681
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 3402823466385288598117041e14
+  f32.const -0
   f32.const 3402823466385288598117041e14
   f32.const 0
   call $std/math/test_hypotf
@@ -24800,9 +24635,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 3402823466385288598117041e14
-  f32.const -0
-  f32.const 3402823466385288598117041e14
+  f32.const 1.401298464324817e-45
+  f32.const 0
+  f32.const 1.401298464324817e-45
   f32.const 0
   call $std/math/test_hypotf
   i32.eqz
@@ -24815,7 +24650,7 @@
    unreachable
   end
   f32.const 1.401298464324817e-45
-  f32.const 0
+  f32.const -0
   f32.const 1.401298464324817e-45
   f32.const 0
   call $std/math/test_hypotf
@@ -24828,9 +24663,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.401298464324817e-45
-  f32.const -0
-  f32.const 1.401298464324817e-45
+  f32.const inf
+  f32.const 1
+  f32.const inf
   f32.const 0
   call $std/math/test_hypotf
   i32.eqz
@@ -24842,8 +24677,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
   f32.const 1
+  f32.const inf
   f32.const inf
   f32.const 0
   call $std/math/test_hypotf
@@ -24856,8 +24691,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const inf
+  f32.const nan:0x400000
   f32.const inf
   f32.const 0
   call $std/math/test_hypotf
@@ -24870,8 +24705,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
   f32.const nan:0x400000
+  f32.const inf
   f32.const inf
   f32.const 0
   call $std/math/test_hypotf
@@ -24884,8 +24719,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const inf
+  f32.const -inf
+  f32.const 1
   f32.const inf
   f32.const 0
   call $std/math/test_hypotf
@@ -24898,8 +24733,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
   f32.const 1
+  f32.const -inf
   f32.const inf
   f32.const 0
   call $std/math/test_hypotf
@@ -24912,8 +24747,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const -inf
+  f32.const nan:0x400000
   f32.const inf
   f32.const 0
   call $std/math/test_hypotf
@@ -24926,8 +24761,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
   f32.const nan:0x400000
+  f32.const -inf
   f32.const inf
   f32.const 0
   call $std/math/test_hypotf
@@ -24941,8 +24776,8 @@
    unreachable
   end
   f32.const nan:0x400000
-  f32.const -inf
-  f32.const inf
+  f32.const 1
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_hypotf
   i32.eqz
@@ -24954,8 +24789,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
   f32.const 1
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_hypotf
@@ -24968,20 +24803,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1695
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -8.06684839057968
   f64.const nan:0x8000000000000
   f64.const 0
@@ -24990,7 +24811,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1707
+   i32.const 1706
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25003,12 +24824,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1708
+   i32.const 1707
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.38143342755525
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_log
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1708
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -6.531673581913484
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_log
@@ -25021,19 +24855,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -6.531673581913484
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_log
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1710
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const 9.267056966972586
   f64.const 2.2264658498795615
   f64.const 0.3638114035129547
@@ -25042,7 +24863,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1711
+   i32.const 1710
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25055,7 +24876,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1712
+   i32.const 1711
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25068,7 +24889,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1713
+   i32.const 1712
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25081,7 +24902,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1714
+   i32.const 1713
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25094,7 +24915,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1715
+   i32.const 1714
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25107,12 +24928,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1716
+   i32.const 1715
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
+  f64.const -inf
+  f64.const 0
+  call $std/math/test_log
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1718
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
   f64.const -inf
   f64.const 0
   call $std/math/test_log
@@ -25125,19 +24959,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -inf
-  f64.const 0
-  call $std/math/test_log
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1720
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -7.888609052210118e-31
   f64.const nan:0x8000000000000
   f64.const 0
@@ -25146,7 +24967,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1721
+   i32.const 1720
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25159,7 +24980,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1722
+   i32.const 1721
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25172,7 +24993,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1723
+   i32.const 1722
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25185,12 +25006,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1724
+   i32.const 1723
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_log
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1724
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_log
@@ -25203,20 +25037,19 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_log
+  f32.const 0
+  f32.const -inf
+  call $std/math/test_logf
   i32.eqz
   if
    i32.const 0
    i32.const 24
-   i32.const 1726
+   i32.const 1734
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
+  f32.const -0
   f32.const -inf
   call $std/math/test_logf
   i32.eqz
@@ -25228,18 +25061,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -inf
-  call $std/math/test_logf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1736
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -7.888609052210118e-31
   f32.const nan:0x400000
   call $std/math/test_logf
@@ -25247,7 +25068,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1737
+   i32.const 1736
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25259,7 +25080,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1738
+   i32.const 1737
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25271,7 +25092,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1739
+   i32.const 1738
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25283,12 +25104,24 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1740
+   i32.const 1739
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -inf
+  f32.const nan:0x400000
+  call $std/math/test_logf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1740
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_logf
   i32.eqz
@@ -25300,18 +25133,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  call $std/math/test_logf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1742
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const 0
   f32.const -inf
   call $std/math/test_logf
@@ -25319,7 +25140,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1745
+   i32.const 1744
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25331,7 +25152,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1746
+   i32.const 1745
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25343,7 +25164,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1747
+   i32.const 1746
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25355,7 +25176,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1748
+   i32.const 1747
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25367,7 +25188,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1749
+   i32.const 1748
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25379,7 +25200,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1750
+   i32.const 1749
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25391,7 +25212,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1751
+   i32.const 1750
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25403,7 +25224,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1752
+   i32.const 1751
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25416,7 +25237,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1764
+   i32.const 1763
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25429,12 +25250,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1765
+   i32.const 1764
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.38143342755525
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_log10
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1765
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -6.531673581913484
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_log10
@@ -25447,19 +25281,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -6.531673581913484
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_log10
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1767
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const 9.267056966972586
   f64.const 0.9669418327487274
   f64.const -0.06120431795716286
@@ -25468,7 +25289,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1768
+   i32.const 1767
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25481,7 +25302,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1769
+   i32.const 1768
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25494,7 +25315,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1770
+   i32.const 1769
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25507,7 +25328,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1771
+   i32.const 1770
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25520,7 +25341,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1772
+   i32.const 1771
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25533,12 +25354,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1773
+   i32.const 1772
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
+  f64.const -inf
+  f64.const 0
+  call $std/math/test_log10
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1775
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
   f64.const -inf
   f64.const 0
   call $std/math/test_log10
@@ -25551,19 +25385,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -inf
-  f64.const 0
-  call $std/math/test_log10
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1777
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -7.888609052210118e-31
   f64.const nan:0x8000000000000
   f64.const 0
@@ -25572,7 +25393,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1778
+   i32.const 1777
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25585,7 +25406,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1779
+   i32.const 1778
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25598,7 +25419,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1780
+   i32.const 1779
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25611,12 +25432,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1781
+   i32.const 1780
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_log10
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1781
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_log10
@@ -25629,19 +25463,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_log10
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1783
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -8.066848754882812
   f32.const nan:0x400000
   f32.const 0
@@ -25650,7 +25471,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1792
+   i32.const 1791
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25663,12 +25484,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1793
+   i32.const 1792
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8.381433486938477
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_log10f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1793
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -6.531673431396484
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_log10f
@@ -25681,19 +25515,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.531673431396484
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_log10f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1795
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const 9.267057418823242
   f32.const 0.9669418334960938
   f32.const -0.34273025393486023
@@ -25702,7 +25523,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1796
+   i32.const 1795
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25715,7 +25536,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1797
+   i32.const 1796
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25728,7 +25549,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1798
+   i32.const 1797
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25741,7 +25562,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1799
+   i32.const 1798
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25754,7 +25575,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1800
+   i32.const 1799
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25767,12 +25588,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1801
+   i32.const 1800
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
+  f32.const -inf
+  f32.const 0
+  call $std/math/test_log10f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1803
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
   f32.const -inf
   f32.const 0
   call $std/math/test_log10f
@@ -25785,19 +25619,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -inf
-  f32.const 0
-  call $std/math/test_log10f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1805
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -7.888609052210118e-31
   f32.const nan:0x400000
   f32.const 0
@@ -25806,7 +25627,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1806
+   i32.const 1805
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25819,7 +25640,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1807
+   i32.const 1806
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25832,7 +25653,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1808
+   i32.const 1807
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25845,12 +25666,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1809
+   i32.const 1808
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -inf
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_log10f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1809
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_log10f
@@ -25863,19 +25697,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_log10f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1811
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -8.06684839057968
   f64.const nan:0x8000000000000
   f64.const 0
@@ -25884,7 +25705,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1823
+   i32.const 1822
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25897,12 +25718,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1824
+   i32.const 1823
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.38143342755525
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_log1p
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1824
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -6.531673581913484
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_log1p
@@ -25915,19 +25749,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -6.531673581913484
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_log1p
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1826
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const 9.267056966972586
   f64.const 2.3289404168523826
   f64.const -0.411114901304245
@@ -25936,7 +25757,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1827
+   i32.const 1826
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25949,7 +25770,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1828
+   i32.const 1827
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25962,7 +25783,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1829
+   i32.const 1828
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25975,7 +25796,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1830
+   i32.const 1829
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25988,7 +25809,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1831
+   i32.const 1830
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26001,13 +25822,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1832
+   i32.const 1831
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const 0
+  f64.const 0
+  call $std/math/test_log1p
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1834
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
   f64.const 0
   call $std/math/test_log1p
   i32.eqz
@@ -26015,19 +25849,6 @@
    i32.const 0
    i32.const 24
    i32.const 1835
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  call $std/math/test_log1p
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1836
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26040,7 +25861,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1837
+   i32.const 1836
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26053,7 +25874,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1838
+   i32.const 1837
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26066,7 +25887,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1839
+   i32.const 1838
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26079,12 +25900,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1840
+   i32.const 1839
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_log1p
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1840
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_log1p
@@ -26097,19 +25931,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_log1p
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1842
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -8.066848754882812
   f32.const nan:0x400000
   f32.const 0
@@ -26118,7 +25939,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1851
+   i32.const 1850
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26131,12 +25952,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1852
+   i32.const 1851
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8.381433486938477
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_log1pf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1852
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -6.531673431396484
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_log1pf
@@ -26149,19 +25983,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.531673431396484
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_log1pf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1854
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const 9.267057418823242
   f32.const 2.3289403915405273
   f32.const -0.29075589776039124
@@ -26170,7 +25991,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1855
+   i32.const 1854
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26183,7 +26004,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1856
+   i32.const 1855
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26196,7 +26017,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1857
+   i32.const 1856
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26209,7 +26030,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1858
+   i32.const 1857
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26222,7 +26043,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1859
+   i32.const 1858
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26235,13 +26056,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1860
+   i32.const 1859
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const 0
+  f32.const 0
+  call $std/math/test_log1pf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1862
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/test_log1pf
   i32.eqz
@@ -26249,19 +26083,6 @@
    i32.const 0
    i32.const 24
    i32.const 1863
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  call $std/math/test_log1pf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1864
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26274,7 +26095,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1865
+   i32.const 1864
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26287,7 +26108,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1866
+   i32.const 1865
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26300,7 +26121,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1867
+   i32.const 1866
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26313,12 +26134,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1868
+   i32.const 1867
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -inf
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_log1pf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1868
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_log1pf
@@ -26331,19 +26165,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_log1pf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1870
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -1.1754942106924411e-38
   f32.const -1.1754942106924411e-38
   f32.const 4.930380657631324e-32
@@ -26352,7 +26173,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1871
+   i32.const 1870
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26365,7 +26186,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1883
+   i32.const 1882
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26378,12 +26199,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1884
+   i32.const 1883
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.38143342755525
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_log2
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1884
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -6.531673581913484
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_log2
@@ -26396,19 +26230,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -6.531673581913484
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_log2
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1886
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const 9.267056966972586
   f64.const 3.2121112403298744
   f64.const -0.15739446878433228
@@ -26417,7 +26238,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1887
+   i32.const 1886
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26430,7 +26251,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1888
+   i32.const 1887
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26443,7 +26264,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1889
+   i32.const 1888
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26456,7 +26277,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1890
+   i32.const 1889
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26469,7 +26290,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1891
+   i32.const 1890
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26482,12 +26303,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1892
+   i32.const 1891
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
+  f64.const -inf
+  f64.const 0
+  call $std/math/test_log2
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1894
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
   f64.const -inf
   f64.const 0
   call $std/math/test_log2
@@ -26500,19 +26334,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -inf
-  f64.const 0
-  call $std/math/test_log2
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1896
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -7.888609052210118e-31
   f64.const nan:0x8000000000000
   f64.const 0
@@ -26521,7 +26342,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1897
+   i32.const 1896
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26534,7 +26355,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1898
+   i32.const 1897
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26547,7 +26368,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1899
+   i32.const 1898
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26560,12 +26381,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1900
+   i32.const 1899
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_log2
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1900
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_log2
@@ -26578,19 +26412,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_log2
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1902
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -8.066848754882812
   f32.const nan:0x400000
   f32.const 0
@@ -26599,7 +26420,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1911
+   i32.const 1910
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26612,12 +26433,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1912
+   i32.const 1911
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8.381433486938477
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_log2f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1912
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -6.531673431396484
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_log2f
@@ -26630,19 +26464,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.531673431396484
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_log2f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1914
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const 9.267057418823242
   f32.const 3.212111234664917
   f32.const -0.3188050389289856
@@ -26651,7 +26472,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1915
+   i32.const 1914
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26664,7 +26485,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1916
+   i32.const 1915
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26677,7 +26498,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1917
+   i32.const 1916
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26690,7 +26511,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1918
+   i32.const 1917
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26703,7 +26524,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1919
+   i32.const 1918
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26716,12 +26537,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1920
+   i32.const 1919
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
+  f32.const -inf
+  f32.const 0
+  call $std/math/test_log2f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1922
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
   f32.const -inf
   f32.const 0
   call $std/math/test_log2f
@@ -26734,19 +26568,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -inf
-  f32.const 0
-  call $std/math/test_log2f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1924
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -7.888609052210118e-31
   f32.const nan:0x400000
   f32.const 0
@@ -26755,7 +26576,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1925
+   i32.const 1924
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26768,7 +26589,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1926
+   i32.const 1925
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26781,7 +26602,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1927
+   i32.const 1926
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26794,12 +26615,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1928
+   i32.const 1927
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -inf
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_log2f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1928
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_log2f
@@ -26812,19 +26646,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_log2f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1930
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -8.06684839057968
   f64.const 4.535662560676869
   f64.const 4.535662560676869
@@ -26833,7 +26654,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1942
+   i32.const 1941
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26846,7 +26667,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1943
+   i32.const 1942
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26859,7 +26680,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1944
+   i32.const 1943
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26872,7 +26693,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1945
+   i32.const 1944
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26885,7 +26706,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1946
+   i32.const 1945
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26898,7 +26719,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1947
+   i32.const 1946
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26911,7 +26732,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1948
+   i32.const 1947
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26924,7 +26745,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1949
+   i32.const 1948
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26937,7 +26758,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1950
+   i32.const 1949
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26950,12 +26771,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1951
+   i32.const 1950
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
+  f64.const 1
+  f64.const 1
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1953
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
   f64.const 1
   f64.const 1
   call $std/math/test_max
@@ -26968,7 +26802,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0.5
   f64.const 1
   f64.const 1
   call $std/math/test_max
@@ -26981,7 +26815,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0.5
   f64.const 1
   f64.const 1
   call $std/math/test_max
@@ -26994,7 +26828,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const 1
   f64.const 1
   f64.const 1
   call $std/math/test_max
@@ -27007,7 +26841,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const 1
   f64.const 1
   call $std/math/test_max
@@ -27020,9 +26854,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const 1
-  f64.const 1
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -27033,9 +26867,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const 1
-  f64.const inf
+  f64.const 1
   call $std/math/test_max
   i32.eqz
   if
@@ -27046,9 +26880,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const 1
-  f64.const 1
+  f64.const nan:0x8000000000000
   call $std/math/test_max
   i32.eqz
   if
@@ -27059,9 +26893,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const -1
+  f64.const 0
   call $std/math/test_max
   i32.eqz
   if
@@ -27072,9 +26906,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
+  f64.const -0
   f64.const -1
-  f64.const 0
+  f64.const -0
   call $std/math/test_max
   i32.eqz
   if
@@ -27085,9 +26919,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0.5
   f64.const -1
-  f64.const -0
+  f64.const 0.5
   call $std/math/test_max
   i32.eqz
   if
@@ -27098,9 +26932,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0.5
   f64.const -1
-  f64.const 0.5
+  f64.const -0.5
   call $std/math/test_max
   i32.eqz
   if
@@ -27111,9 +26945,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const 1
   f64.const -1
-  f64.const -0.5
+  f64.const 1
   call $std/math/test_max
   i32.eqz
   if
@@ -27124,9 +26958,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const -1
-  f64.const 1
+  f64.const -1
+  f64.const -1
   call $std/math/test_max
   i32.eqz
   if
@@ -27137,28 +26971,15 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
   f64.const -1
-  f64.const -1
-  f64.const -1
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 1968
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -1
-  f64.const inf
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1969
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27171,7 +26992,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1970
+   i32.const 1969
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27179,6 +27000,19 @@
   f64.const nan:0x8000000000000
   f64.const -1
   f64.const nan:0x8000000000000
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1970
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const 0
   call $std/math/test_max
   i32.eqz
   if
@@ -27190,7 +27024,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 0
+  f64.const -0
   f64.const 0
   call $std/math/test_max
   i32.eqz
@@ -27203,8 +27037,8 @@
    unreachable
   end
   f64.const 0
-  f64.const -0
-  f64.const 0
+  f64.const inf
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -27216,8 +27050,8 @@
    unreachable
   end
   f64.const 0
-  f64.const inf
-  f64.const inf
+  f64.const -inf
+  f64.const 0
   call $std/math/test_max
   i32.eqz
   if
@@ -27229,8 +27063,8 @@
    unreachable
   end
   f64.const 0
-  f64.const -inf
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_max
   i32.eqz
   if
@@ -27241,9 +27075,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 0
   call $std/math/test_max
   i32.eqz
   if
@@ -27255,8 +27089,8 @@
    unreachable
   end
   f64.const -0
-  f64.const 0
-  f64.const 0
+  f64.const -0
+  f64.const -0
   call $std/math/test_max
   i32.eqz
   if
@@ -27268,8 +27102,8 @@
    unreachable
   end
   f64.const -0
-  f64.const -0
-  f64.const -0
+  f64.const inf
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -27281,8 +27115,8 @@
    unreachable
   end
   f64.const -0
-  f64.const inf
-  f64.const inf
+  f64.const -inf
+  f64.const -0
   call $std/math/test_max
   i32.eqz
   if
@@ -27294,8 +27128,8 @@
    unreachable
   end
   f64.const -0
-  f64.const -inf
-  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_max
   i32.eqz
   if
@@ -27306,9 +27140,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const 0
+  f64.const 1
   call $std/math/test_max
   i32.eqz
   if
@@ -27319,9 +27153,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const 0
-  f64.const 1
+  f64.const 0
   call $std/math/test_max
   i32.eqz
   if
@@ -27332,9 +27166,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const 0
-  f64.const 0
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -27345,9 +27179,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const 0
-  f64.const inf
+  f64.const 0
   call $std/math/test_max
   i32.eqz
   if
@@ -27358,28 +27192,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const 0
-  f64.const 0
+  f64.const nan:0x8000000000000
   call $std/math/test_max
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 1985
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 0
-  f64.const nan:0x8000000000000
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1986
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27392,7 +27213,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1987
+   i32.const 1986
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27405,7 +27226,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1988
+   i32.const 1987
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27418,7 +27239,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1989
+   i32.const 1988
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27426,6 +27247,19 @@
   f64.const nan:0x8000000000000
   f64.const -0
   f64.const nan:0x8000000000000
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1989
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const 2
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -27437,7 +27271,7 @@
    unreachable
   end
   f64.const inf
-  f64.const 2
+  f64.const -0.5
   f64.const inf
   call $std/math/test_max
   i32.eqz
@@ -27450,8 +27284,8 @@
    unreachable
   end
   f64.const inf
-  f64.const -0.5
-  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_max
   i32.eqz
   if
@@ -27462,9 +27296,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const 2
+  f64.const 2
   call $std/math/test_max
   i32.eqz
   if
@@ -27476,8 +27310,8 @@
    unreachable
   end
   f64.const -inf
-  f64.const 2
-  f64.const 2
+  f64.const -0.5
+  f64.const -0.5
   call $std/math/test_max
   i32.eqz
   if
@@ -27489,8 +27323,8 @@
    unreachable
   end
   f64.const -inf
-  f64.const -0.5
-  f64.const -0.5
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_max
   i32.eqz
   if
@@ -27501,7 +27335,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_max
@@ -27514,7 +27348,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_max
@@ -27527,7 +27361,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_max
@@ -27540,9 +27374,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const inf
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -27553,7 +27387,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const inf
   f64.const inf
   call $std/math/test_max
@@ -27566,7 +27400,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const inf
   f64.const inf
   call $std/math/test_max
@@ -27579,7 +27413,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const inf
   f64.const inf
   call $std/math/test_max
@@ -27592,9 +27426,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
   f64.const -inf
-  f64.const inf
-  f64.const inf
+  f64.const 1
   call $std/math/test_max
   i32.eqz
   if
@@ -27605,9 +27439,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const -inf
-  f64.const 1
+  f64.const -1
   call $std/math/test_max
   i32.eqz
   if
@@ -27618,9 +27452,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const -inf
-  f64.const -1
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -27631,9 +27465,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
   f64.const -inf
-  f64.const inf
+  f64.const -inf
+  f64.const -inf
   call $std/math/test_max
   i32.eqz
   if
@@ -27644,9 +27478,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
-  f64.const -inf
+  f64.const 1.75
+  f64.const 0.5
+  f64.const 1.75
   call $std/math/test_max
   i32.eqz
   if
@@ -27657,9 +27491,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
+  f64.const -1.75
   f64.const 0.5
-  f64.const 1.75
+  f64.const 0.5
   call $std/math/test_max
   i32.eqz
   if
@@ -27670,9 +27504,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.75
-  f64.const 0.5
-  f64.const 0.5
+  f64.const 1.75
+  f64.const -0.5
+  f64.const 1.75
   call $std/math/test_max
   i32.eqz
   if
@@ -27683,19 +27517,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const -0.5
-  f64.const 1.75
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2010
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -1.75
   f64.const -0.5
   f64.const -0.5
@@ -27704,7 +27525,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2011
+   i32.const 2010
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27717,7 +27538,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2020
+   i32.const 2019
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27730,7 +27551,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2021
+   i32.const 2020
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27743,7 +27564,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2022
+   i32.const 2021
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27756,7 +27577,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2023
+   i32.const 2022
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27769,7 +27590,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2024
+   i32.const 2023
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27782,7 +27603,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2025
+   i32.const 2024
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27795,7 +27616,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2026
+   i32.const 2025
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27808,7 +27629,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2027
+   i32.const 2026
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27821,7 +27642,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2028
+   i32.const 2027
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27834,12 +27655,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2029
+   i32.const 2028
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
+  f32.const 1
+  f32.const 1
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2031
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
   f32.const 1
   f32.const 1
   call $std/math/test_maxf
@@ -27852,7 +27686,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0.5
   f32.const 1
   f32.const 1
   call $std/math/test_maxf
@@ -27865,7 +27699,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -0.5
   f32.const 1
   f32.const 1
   call $std/math/test_maxf
@@ -27878,7 +27712,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const 1
   f32.const 1
   f32.const 1
   call $std/math/test_maxf
@@ -27891,7 +27725,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const 1
   f32.const 1
   call $std/math/test_maxf
@@ -27904,9 +27738,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const inf
   f32.const 1
-  f32.const 1
+  f32.const inf
   call $std/math/test_maxf
   i32.eqz
   if
@@ -27917,9 +27751,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const 1
-  f32.const inf
+  f32.const 1
   call $std/math/test_maxf
   i32.eqz
   if
@@ -27930,9 +27764,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const 1
-  f32.const 1
+  f32.const nan:0x400000
   call $std/math/test_maxf
   i32.eqz
   if
@@ -27943,9 +27777,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const 1
-  f32.const nan:0x400000
+  f32.const 0
+  f32.const -1
+  f32.const 0
   call $std/math/test_maxf
   i32.eqz
   if
@@ -27956,9 +27790,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
+  f32.const -0
   f32.const -1
-  f32.const 0
+  f32.const -0
   call $std/math/test_maxf
   i32.eqz
   if
@@ -27969,9 +27803,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0.5
   f32.const -1
-  f32.const -0
+  f32.const 0.5
   call $std/math/test_maxf
   i32.eqz
   if
@@ -27982,9 +27816,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -0.5
   f32.const -1
-  f32.const 0.5
+  f32.const -0.5
   call $std/math/test_maxf
   i32.eqz
   if
@@ -27995,9 +27829,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const 1
   f32.const -1
-  f32.const -0.5
+  f32.const 1
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28008,9 +27842,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const -1
-  f32.const 1
+  f32.const -1
+  f32.const -1
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28021,28 +27855,15 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
   f32.const -1
-  f32.const -1
-  f32.const -1
+  f32.const inf
   call $std/math/test_maxf
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2046
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -1
-  f32.const inf
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2047
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28055,7 +27876,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2048
+   i32.const 2047
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28063,6 +27884,19 @@
   f32.const nan:0x400000
   f32.const -1
   f32.const nan:0x400000
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2048
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  f32.const 0
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28074,7 +27908,7 @@
    unreachable
   end
   f32.const 0
-  f32.const 0
+  f32.const -0
   f32.const 0
   call $std/math/test_maxf
   i32.eqz
@@ -28087,8 +27921,8 @@
    unreachable
   end
   f32.const 0
-  f32.const -0
-  f32.const 0
+  f32.const inf
+  f32.const inf
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28100,8 +27934,8 @@
    unreachable
   end
   f32.const 0
-  f32.const inf
-  f32.const inf
+  f32.const -inf
+  f32.const 0
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28113,8 +27947,8 @@
    unreachable
   end
   f32.const 0
-  f32.const -inf
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28125,9 +27959,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const 0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 0
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28139,8 +27973,8 @@
    unreachable
   end
   f32.const -0
-  f32.const 0
-  f32.const 0
+  f32.const -0
+  f32.const -0
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28152,8 +27986,8 @@
    unreachable
   end
   f32.const -0
-  f32.const -0
-  f32.const -0
+  f32.const inf
+  f32.const inf
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28165,8 +27999,8 @@
    unreachable
   end
   f32.const -0
-  f32.const inf
-  f32.const inf
+  f32.const -inf
+  f32.const -0
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28178,8 +28012,8 @@
    unreachable
   end
   f32.const -0
-  f32.const -inf
-  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28190,9 +28024,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 1
+  f32.const 0
+  f32.const 1
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28203,9 +28037,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const 0
-  f32.const 1
+  f32.const 0
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28216,9 +28050,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const inf
   f32.const 0
-  f32.const 0
+  f32.const inf
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28229,9 +28063,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const 0
-  f32.const inf
+  f32.const 0
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28242,28 +28076,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const 0
-  f32.const 0
+  f32.const nan:0x400000
   call $std/math/test_maxf
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2063
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 0
-  f32.const nan:0x400000
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2064
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28276,7 +28097,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2065
+   i32.const 2064
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28289,7 +28110,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2066
+   i32.const 2065
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28302,7 +28123,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2067
+   i32.const 2066
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28310,6 +28131,19 @@
   f32.const nan:0x400000
   f32.const -0
   f32.const nan:0x400000
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2067
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const 2
+  f32.const inf
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28321,7 +28155,7 @@
    unreachable
   end
   f32.const inf
-  f32.const 2
+  f32.const -0.5
   f32.const inf
   call $std/math/test_maxf
   i32.eqz
@@ -28334,8 +28168,8 @@
    unreachable
   end
   f32.const inf
-  f32.const -0.5
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28346,9 +28180,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const 2
+  f32.const 2
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28360,8 +28194,8 @@
    unreachable
   end
   f32.const -inf
-  f32.const 2
-  f32.const 2
+  f32.const -0.5
+  f32.const -0.5
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28373,8 +28207,8 @@
    unreachable
   end
   f32.const -inf
-  f32.const -0.5
-  f32.const -0.5
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28385,7 +28219,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_maxf
@@ -28398,7 +28232,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const 1
   f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_maxf
@@ -28411,7 +28245,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_maxf
@@ -28424,9 +28258,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 1
+  f32.const inf
+  f32.const inf
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28437,7 +28271,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const inf
   f32.const inf
   call $std/math/test_maxf
@@ -28450,7 +28284,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const inf
   f32.const inf
   f32.const inf
   call $std/math/test_maxf
@@ -28463,7 +28297,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const inf
   f32.const inf
   call $std/math/test_maxf
@@ -28476,9 +28310,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1
   f32.const -inf
-  f32.const inf
-  f32.const inf
+  f32.const 1
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28489,9 +28323,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const -inf
-  f32.const 1
+  f32.const -1
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28502,9 +28336,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const inf
   f32.const -inf
-  f32.const -1
+  f32.const inf
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28515,9 +28349,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
   f32.const -inf
-  f32.const inf
+  f32.const -inf
+  f32.const -inf
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28528,9 +28362,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
-  f32.const -inf
+  f32.const 1.75
+  f32.const 0.5
+  f32.const 1.75
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28541,9 +28375,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
+  f32.const -1.75
   f32.const 0.5
-  f32.const 1.75
+  f32.const 0.5
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28554,9 +28388,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.75
-  f32.const 0.5
-  f32.const 0.5
+  f32.const 1.75
+  f32.const -0.5
+  f32.const 1.75
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28567,19 +28401,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
-  f32.const -0.5
-  f32.const 1.75
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2088
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -1.75
   f32.const -0.5
   f32.const -0.5
@@ -28588,7 +28409,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2089
+   i32.const 2088
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28601,7 +28422,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2101
+   i32.const 2100
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28614,7 +28435,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2102
+   i32.const 2101
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28627,7 +28448,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2103
+   i32.const 2102
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28640,7 +28461,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2104
+   i32.const 2103
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28653,7 +28474,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2105
+   i32.const 2104
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28666,7 +28487,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2106
+   i32.const 2105
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28679,7 +28500,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2107
+   i32.const 2106
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28692,7 +28513,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2108
+   i32.const 2107
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28705,7 +28526,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2109
+   i32.const 2108
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28718,7 +28539,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2110
+   i32.const 2109
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28726,6 +28547,19 @@
   f64.const 0
   f64.const 1
   f64.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2112
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const 1
+  f64.const -0
   call $std/math/test_min
   i32.eqz
   if
@@ -28736,9 +28570,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0.5
   f64.const 1
-  f64.const -0
+  f64.const 0.5
   call $std/math/test_min
   i32.eqz
   if
@@ -28749,9 +28583,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0.5
   f64.const 1
-  f64.const 0.5
+  f64.const -0.5
   call $std/math/test_min
   i32.eqz
   if
@@ -28762,9 +28596,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
   f64.const 1
-  f64.const -0.5
+  f64.const 1
+  f64.const 1
   call $std/math/test_min
   i32.eqz
   if
@@ -28775,28 +28609,15 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
   f64.const 1
-  f64.const 1
-  f64.const 1
+  f64.const -1
   call $std/math/test_min
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2117
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const 1
-  f64.const -1
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2118
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28809,7 +28630,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2119
+   i32.const 2118
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28817,6 +28638,19 @@
   f64.const -inf
   f64.const 1
   f64.const -inf
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2119
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const nan:0x8000000000000
   call $std/math/test_min
   i32.eqz
   if
@@ -28827,9 +28661,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const -1
+  f64.const -1
   call $std/math/test_min
   i32.eqz
   if
@@ -28840,7 +28674,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
+  f64.const -0
   f64.const -1
   f64.const -1
   call $std/math/test_min
@@ -28853,7 +28687,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0.5
   f64.const -1
   f64.const -1
   call $std/math/test_min
@@ -28866,7 +28700,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0.5
   f64.const -1
   f64.const -1
   call $std/math/test_min
@@ -28879,7 +28713,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const 1
   f64.const -1
   f64.const -1
   call $std/math/test_min
@@ -28892,7 +28726,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const -1
   f64.const -1
   call $std/math/test_min
@@ -28905,7 +28739,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const -1
   f64.const -1
   call $std/math/test_min
@@ -28918,9 +28752,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const -1
-  f64.const -1
+  f64.const -inf
   call $std/math/test_min
   i32.eqz
   if
@@ -28931,9 +28765,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const -1
-  f64.const -inf
+  f64.const nan:0x8000000000000
   call $std/math/test_min
   i32.eqz
   if
@@ -28944,9 +28778,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -1
-  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const 0
+  f64.const 0
   call $std/math/test_min
   i32.eqz
   if
@@ -28958,27 +28792,14 @@
    unreachable
   end
   f64.const 0
-  f64.const 0
-  f64.const 0
+  f64.const -0
+  f64.const -0
   call $std/math/test_min
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2131
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -0
-  f64.const -0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2132
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28991,7 +28812,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2133
+   i32.const 2132
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29004,7 +28825,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2134
+   i32.const 2133
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29012,6 +28833,19 @@
   f64.const 0
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2134
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const 0
+  f64.const -0
   call $std/math/test_min
   i32.eqz
   if
@@ -29023,7 +28857,7 @@
    unreachable
   end
   f64.const -0
-  f64.const 0
+  f64.const -0
   f64.const -0
   call $std/math/test_min
   i32.eqz
@@ -29036,7 +28870,7 @@
    unreachable
   end
   f64.const -0
-  f64.const -0
+  f64.const inf
   f64.const -0
   call $std/math/test_min
   i32.eqz
@@ -29049,8 +28883,8 @@
    unreachable
   end
   f64.const -0
-  f64.const inf
-  f64.const -0
+  f64.const -inf
+  f64.const -inf
   call $std/math/test_min
   i32.eqz
   if
@@ -29062,27 +28896,14 @@
    unreachable
   end
   f64.const -0
-  f64.const -inf
-  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_min
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2139
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2140
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29095,7 +28916,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2141
+   i32.const 2140
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29103,6 +28924,19 @@
   f64.const -1
   f64.const 0
   f64.const -1
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2141
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const 0
+  f64.const 0
   call $std/math/test_min
   i32.eqz
   if
@@ -29113,9 +28947,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const 0
-  f64.const 0
+  f64.const -inf
   call $std/math/test_min
   i32.eqz
   if
@@ -29126,28 +28960,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const 0
-  f64.const -inf
+  f64.const nan:0x8000000000000
   call $std/math/test_min
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2144
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 0
-  f64.const nan:0x8000000000000
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2145
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29160,7 +28981,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2146
+   i32.const 2145
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29173,7 +28994,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2147
+   i32.const 2146
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29186,7 +29007,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2148
+   i32.const 2147
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29194,6 +29015,19 @@
   f64.const nan:0x8000000000000
   f64.const -0
   f64.const nan:0x8000000000000
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2148
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const 2
+  f64.const 2
   call $std/math/test_min
   i32.eqz
   if
@@ -29205,8 +29039,8 @@
    unreachable
   end
   f64.const inf
-  f64.const 2
-  f64.const 2
+  f64.const -0.5
+  f64.const -0.5
   call $std/math/test_min
   i32.eqz
   if
@@ -29218,8 +29052,8 @@
    unreachable
   end
   f64.const inf
-  f64.const -0.5
-  f64.const -0.5
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_min
   i32.eqz
   if
@@ -29230,9 +29064,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const 2
+  f64.const -inf
   call $std/math/test_min
   i32.eqz
   if
@@ -29244,7 +29078,7 @@
    unreachable
   end
   f64.const -inf
-  f64.const 2
+  f64.const -0.5
   f64.const -inf
   call $std/math/test_min
   i32.eqz
@@ -29257,8 +29091,8 @@
    unreachable
   end
   f64.const -inf
-  f64.const -0.5
-  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_min
   i32.eqz
   if
@@ -29269,7 +29103,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_min
@@ -29282,7 +29116,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_min
@@ -29295,7 +29129,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_min
@@ -29308,9 +29142,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const inf
+  f64.const 1
   call $std/math/test_min
   i32.eqz
   if
@@ -29321,9 +29155,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const inf
-  f64.const 1
+  f64.const -1
   call $std/math/test_min
   i32.eqz
   if
@@ -29334,9 +29168,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
   f64.const inf
-  f64.const -1
+  f64.const inf
+  f64.const inf
   call $std/math/test_min
   i32.eqz
   if
@@ -29347,9 +29181,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -inf
   f64.const inf
-  f64.const inf
-  f64.const inf
+  f64.const -inf
   call $std/math/test_min
   i32.eqz
   if
@@ -29360,8 +29194,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
   f64.const -inf
-  f64.const inf
   f64.const -inf
   call $std/math/test_min
   i32.eqz
@@ -29373,7 +29207,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const -inf
   f64.const -inf
   call $std/math/test_min
@@ -29386,7 +29220,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const -inf
   f64.const -inf
   call $std/math/test_min
@@ -29399,7 +29233,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const -inf
   f64.const -inf
   call $std/math/test_min
@@ -29412,9 +29246,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
-  f64.const -inf
+  f64.const 1.75
+  f64.const 0.5
+  f64.const 0.5
   call $std/math/test_min
   i32.eqz
   if
@@ -29425,9 +29259,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
+  f64.const -1.75
   f64.const 0.5
-  f64.const 0.5
+  f64.const -1.75
   call $std/math/test_min
   i32.eqz
   if
@@ -29438,9 +29272,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.75
-  f64.const 0.5
-  f64.const -1.75
+  f64.const 1.75
+  f64.const -0.5
+  f64.const -0.5
   call $std/math/test_min
   i32.eqz
   if
@@ -29451,28 +29285,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
+  f64.const -1.75
   f64.const -0.5
-  f64.const -0.5
+  f64.const -1.75
   call $std/math/test_min
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2169
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.75
-  f64.const -0.5
-  f64.const -1.75
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2170
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29485,7 +29306,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2179
+   i32.const 2178
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29498,7 +29319,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2180
+   i32.const 2179
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29511,7 +29332,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2181
+   i32.const 2180
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29524,7 +29345,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2182
+   i32.const 2181
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29537,7 +29358,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2183
+   i32.const 2182
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29550,7 +29371,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2184
+   i32.const 2183
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29563,7 +29384,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2185
+   i32.const 2184
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29576,7 +29397,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2186
+   i32.const 2185
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29589,7 +29410,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2187
+   i32.const 2186
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29602,7 +29423,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2188
+   i32.const 2187
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29610,6 +29431,19 @@
   f32.const 0
   f32.const 1
   f32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2190
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 1
+  f32.const -0
   call $std/math/test_minf
   i32.eqz
   if
@@ -29620,9 +29454,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0.5
   f32.const 1
-  f32.const -0
+  f32.const 0.5
   call $std/math/test_minf
   i32.eqz
   if
@@ -29633,9 +29467,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -0.5
   f32.const 1
-  f32.const 0.5
+  f32.const -0.5
   call $std/math/test_minf
   i32.eqz
   if
@@ -29646,9 +29480,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
   f32.const 1
-  f32.const -0.5
+  f32.const 1
+  f32.const 1
   call $std/math/test_minf
   i32.eqz
   if
@@ -29659,28 +29493,15 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
   f32.const 1
-  f32.const 1
-  f32.const 1
+  f32.const -1
   call $std/math/test_minf
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2195
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const 1
-  f32.const -1
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2196
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29693,7 +29514,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2197
+   i32.const 2196
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29701,6 +29522,19 @@
   f32.const -inf
   f32.const 1
   f32.const -inf
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2197
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const 1
+  f32.const nan:0x400000
   call $std/math/test_minf
   i32.eqz
   if
@@ -29711,9 +29545,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const 1
-  f32.const nan:0x400000
+  f32.const 0
+  f32.const -1
+  f32.const -1
   call $std/math/test_minf
   i32.eqz
   if
@@ -29724,7 +29558,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
+  f32.const -0
   f32.const -1
   f32.const -1
   call $std/math/test_minf
@@ -29737,7 +29571,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0.5
   f32.const -1
   f32.const -1
   call $std/math/test_minf
@@ -29750,7 +29584,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -0.5
   f32.const -1
   f32.const -1
   call $std/math/test_minf
@@ -29763,7 +29597,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const 1
   f32.const -1
   f32.const -1
   call $std/math/test_minf
@@ -29776,7 +29610,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const -1
   f32.const -1
   call $std/math/test_minf
@@ -29789,7 +29623,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const inf
   f32.const -1
   f32.const -1
   call $std/math/test_minf
@@ -29802,9 +29636,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const -1
-  f32.const -1
+  f32.const -inf
   call $std/math/test_minf
   i32.eqz
   if
@@ -29815,9 +29649,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const -1
-  f32.const -inf
+  f32.const nan:0x400000
   call $std/math/test_minf
   i32.eqz
   if
@@ -29828,9 +29662,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -1
-  f32.const nan:0x400000
+  f32.const 0
+  f32.const 0
+  f32.const 0
   call $std/math/test_minf
   i32.eqz
   if
@@ -29842,27 +29676,14 @@
    unreachable
   end
   f32.const 0
-  f32.const 0
-  f32.const 0
+  f32.const -0
+  f32.const -0
   call $std/math/test_minf
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2209
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -0
-  f32.const -0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2210
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29875,7 +29696,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2211
+   i32.const 2210
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29888,7 +29709,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2212
+   i32.const 2211
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29896,6 +29717,19 @@
   f32.const 0
   f32.const nan:0x400000
   f32.const nan:0x400000
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2212
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 0
+  f32.const -0
   call $std/math/test_minf
   i32.eqz
   if
@@ -29907,7 +29741,7 @@
    unreachable
   end
   f32.const -0
-  f32.const 0
+  f32.const -0
   f32.const -0
   call $std/math/test_minf
   i32.eqz
@@ -29920,7 +29754,7 @@
    unreachable
   end
   f32.const -0
-  f32.const -0
+  f32.const inf
   f32.const -0
   call $std/math/test_minf
   i32.eqz
@@ -29933,8 +29767,8 @@
    unreachable
   end
   f32.const -0
-  f32.const inf
-  f32.const -0
+  f32.const -inf
+  f32.const -inf
   call $std/math/test_minf
   i32.eqz
   if
@@ -29946,27 +29780,14 @@
    unreachable
   end
   f32.const -0
-  f32.const -inf
-  f32.const -inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   call $std/math/test_minf
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2217
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2218
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29979,7 +29800,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2219
+   i32.const 2218
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29987,6 +29808,19 @@
   f32.const -1
   f32.const 0
   f32.const -1
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2219
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const 0
+  f32.const 0
   call $std/math/test_minf
   i32.eqz
   if
@@ -29997,9 +29831,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const 0
-  f32.const 0
+  f32.const -inf
   call $std/math/test_minf
   i32.eqz
   if
@@ -30010,28 +29844,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const 0
-  f32.const -inf
+  f32.const nan:0x400000
   call $std/math/test_minf
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2222
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 0
-  f32.const nan:0x400000
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2223
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30044,7 +29865,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2224
+   i32.const 2223
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30057,7 +29878,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2225
+   i32.const 2224
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30070,7 +29891,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2226
+   i32.const 2225
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30078,6 +29899,19 @@
   f32.const nan:0x400000
   f32.const -0
   f32.const nan:0x400000
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2226
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const 2
+  f32.const 2
   call $std/math/test_minf
   i32.eqz
   if
@@ -30089,8 +29923,8 @@
    unreachable
   end
   f32.const inf
-  f32.const 2
-  f32.const 2
+  f32.const -0.5
+  f32.const -0.5
   call $std/math/test_minf
   i32.eqz
   if
@@ -30102,8 +29936,8 @@
    unreachable
   end
   f32.const inf
-  f32.const -0.5
-  f32.const -0.5
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   call $std/math/test_minf
   i32.eqz
   if
@@ -30114,9 +29948,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const 2
+  f32.const -inf
   call $std/math/test_minf
   i32.eqz
   if
@@ -30128,7 +29962,7 @@
    unreachable
   end
   f32.const -inf
-  f32.const 2
+  f32.const -0.5
   f32.const -inf
   call $std/math/test_minf
   i32.eqz
@@ -30141,8 +29975,8 @@
    unreachable
   end
   f32.const -inf
-  f32.const -0.5
-  f32.const -inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   call $std/math/test_minf
   i32.eqz
   if
@@ -30153,7 +29987,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_minf
@@ -30166,7 +30000,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const 1
   f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_minf
@@ -30179,7 +30013,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_minf
@@ -30192,9 +30026,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 1
+  f32.const inf
+  f32.const 1
   call $std/math/test_minf
   i32.eqz
   if
@@ -30205,9 +30039,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const inf
-  f32.const 1
+  f32.const -1
   call $std/math/test_minf
   i32.eqz
   if
@@ -30218,9 +30052,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
   f32.const inf
-  f32.const -1
+  f32.const inf
+  f32.const inf
   call $std/math/test_minf
   i32.eqz
   if
@@ -30231,9 +30065,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -inf
   f32.const inf
-  f32.const inf
-  f32.const inf
+  f32.const -inf
   call $std/math/test_minf
   i32.eqz
   if
@@ -30244,8 +30078,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1
   f32.const -inf
-  f32.const inf
   f32.const -inf
   call $std/math/test_minf
   i32.eqz
@@ -30257,7 +30091,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const -inf
   f32.const -inf
   call $std/math/test_minf
@@ -30270,7 +30104,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const inf
   f32.const -inf
   f32.const -inf
   call $std/math/test_minf
@@ -30283,7 +30117,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const -inf
   f32.const -inf
   call $std/math/test_minf
@@ -30296,9 +30130,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
-  f32.const -inf
+  f32.const 1.75
+  f32.const 0.5
+  f32.const 0.5
   call $std/math/test_minf
   i32.eqz
   if
@@ -30309,9 +30143,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
+  f32.const -1.75
   f32.const 0.5
-  f32.const 0.5
+  f32.const -1.75
   call $std/math/test_minf
   i32.eqz
   if
@@ -30322,9 +30156,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.75
-  f32.const 0.5
-  f32.const -1.75
+  f32.const 1.75
+  f32.const -0.5
+  f32.const -0.5
   call $std/math/test_minf
   i32.eqz
   if
@@ -30335,28 +30169,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
+  f32.const -1.75
   f32.const -0.5
-  f32.const -0.5
+  f32.const -1.75
   call $std/math/test_minf
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2247
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.75
-  f32.const -0.5
-  f32.const -1.75
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2248
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30369,7 +30190,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2262
+   i32.const 2261
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30382,7 +30203,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2263
+   i32.const 2262
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30395,7 +30216,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2264
+   i32.const 2263
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30408,7 +30229,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2265
+   i32.const 2264
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30421,7 +30242,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2266
+   i32.const 2265
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30434,7 +30255,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2267
+   i32.const 2266
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30447,7 +30268,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2268
+   i32.const 2267
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30460,7 +30281,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2269
+   i32.const 2268
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30473,7 +30294,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2270
+   i32.const 2269
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30486,7 +30307,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2271
+   i32.const 2270
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30494,6 +30315,19 @@
   f64.const 0
   f64.const 1
   f64.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2273
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const 1
+  f64.const -0
   call $std/math/test_mod
   i32.eqz
   if
@@ -30504,9 +30338,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0.5
   f64.const 1
-  f64.const -0
+  f64.const 0.5
   call $std/math/test_mod
   i32.eqz
   if
@@ -30517,28 +30351,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0.5
   f64.const 1
-  f64.const 0.5
+  f64.const -0.5
   call $std/math/test_mod
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2276
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const 1
-  f64.const -0.5
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2277
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30551,7 +30372,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2278
+   i32.const 2277
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30564,7 +30385,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2279
+   i32.const 2278
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30577,7 +30398,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2280
+   i32.const 2279
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30590,7 +30411,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2281
+   i32.const 2280
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30603,7 +30424,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2282
+   i32.const 2281
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30616,12 +30437,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2283
+   i32.const 2282
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
+  f64.const 1
+  f64.const nan:0x8000000000000
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2283
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
   f64.const 1
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -30634,7 +30468,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const 1
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -30647,9 +30481,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const -1
+  f64.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -30660,9 +30494,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
+  f64.const -0
   f64.const -1
-  f64.const 0
+  f64.const -0
   call $std/math/test_mod
   i32.eqz
   if
@@ -30673,9 +30507,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0.5
   f64.const -1
-  f64.const -0
+  f64.const 0.5
   call $std/math/test_mod
   i32.eqz
   if
@@ -30686,28 +30520,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0.5
   f64.const -1
-  f64.const 0.5
+  f64.const -0.5
   call $std/math/test_mod
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2289
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const -1
-  f64.const -0.5
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2290
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30720,7 +30541,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2291
+   i32.const 2290
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30733,7 +30554,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2292
+   i32.const 2291
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30746,7 +30567,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2293
+   i32.const 2292
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30759,7 +30580,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2294
+   i32.const 2293
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30772,7 +30593,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2295
+   i32.const 2294
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30785,12 +30606,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2296
+   i32.const 2295
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
+  f64.const -1
+  f64.const nan:0x8000000000000
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2296
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
   f64.const -1
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -30803,7 +30637,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const -1
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -30816,8 +30650,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -1
+  f64.const 0
+  f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -30830,7 +30664,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 0
+  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -30843,8 +30677,8 @@
    unreachable
   end
   f64.const 0
-  f64.const -0
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -30856,7 +30690,7 @@
    unreachable
   end
   f64.const 0
-  f64.const inf
+  f64.const -inf
   f64.const 0
   call $std/math/test_mod
   i32.eqz
@@ -30869,8 +30703,8 @@
    unreachable
   end
   f64.const 0
-  f64.const -inf
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
   if
@@ -30881,8 +30715,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const 0
-  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -30895,7 +30729,7 @@
    unreachable
   end
   f64.const -0
-  f64.const 0
+  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -30908,8 +30742,8 @@
    unreachable
   end
   f64.const -0
+  f64.const inf
   f64.const -0
-  f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
   if
@@ -30921,7 +30755,7 @@
    unreachable
   end
   f64.const -0
-  f64.const inf
+  f64.const -inf
   f64.const -0
   call $std/math/test_mod
   i32.eqz
@@ -30934,8 +30768,8 @@
    unreachable
   end
   f64.const -0
-  f64.const -inf
-  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
   if
@@ -30946,8 +30780,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -30959,7 +30793,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -30972,7 +30806,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -30985,7 +30819,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -30998,7 +30832,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -31011,8 +30845,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 0
+  f64.const -1
+  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -31024,7 +30858,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -31037,7 +30871,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -31050,7 +30884,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -31063,8 +30897,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -0
+  f64.const inf
+  f64.const 2
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -31077,7 +30911,7 @@
    unreachable
   end
   f64.const inf
-  f64.const 2
+  f64.const -0.5
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -31090,7 +30924,7 @@
    unreachable
   end
   f64.const inf
-  f64.const -0.5
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -31098,19 +30932,6 @@
    i32.const 0
    i32.const 24
    i32.const 2320
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2321
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31123,7 +30944,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2322
+   i32.const 2321
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31136,12 +30957,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2323
+   i32.const 2322
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2323
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -31154,7 +30988,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -31167,7 +31001,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -31180,9 +31014,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const inf
+  f64.const 1
   call $std/math/test_mod
   i32.eqz
   if
@@ -31193,9 +31027,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const inf
-  f64.const 1
+  f64.const -1
   call $std/math/test_mod
   i32.eqz
   if
@@ -31206,9 +31040,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
   f64.const inf
-  f64.const -1
+  f64.const inf
+  f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
   if
@@ -31219,7 +31053,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const inf
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -31232,9 +31066,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
   f64.const -inf
-  f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const 1
   call $std/math/test_mod
   i32.eqz
   if
@@ -31245,9 +31079,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const -inf
-  f64.const 1
+  f64.const -1
   call $std/math/test_mod
   i32.eqz
   if
@@ -31258,9 +31092,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const -inf
-  f64.const -1
+  f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
   if
@@ -31271,7 +31105,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const -inf
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -31284,9 +31118,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
-  f64.const nan:0x8000000000000
+  f64.const 1.75
+  f64.const 0.5
+  f64.const 0.25
   call $std/math/test_mod
   i32.eqz
   if
@@ -31297,9 +31131,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
+  f64.const -1.75
   f64.const 0.5
-  f64.const 0.25
+  f64.const -0.25
   call $std/math/test_mod
   i32.eqz
   if
@@ -31310,9 +31144,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.75
-  f64.const 0.5
-  f64.const -0.25
+  f64.const 1.75
+  f64.const -0.5
+  f64.const 0.25
   call $std/math/test_mod
   i32.eqz
   if
@@ -31323,9 +31157,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
+  f64.const -1.75
   f64.const -0.5
-  f64.const 0.25
+  f64.const -0.25
   call $std/math/test_mod
   i32.eqz
   if
@@ -31336,21 +31170,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.75
-  f64.const -0.5
-  f64.const -0.25
+  f64.const 2.2250738585072014e-308
+  f64.const 2.2250738585072014e-308
+  f64.const 0
   call $std/math/test_mod
   i32.eqz
   if
    i32.const 0
    i32.const 24
-   i32.const 2339
+   i32.const 2341
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.2250738585072014e-308
-  f64.const 2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
   f64.const 0
   call $std/math/test_mod
   i32.eqz
@@ -31362,9 +31196,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072014e-308
   f64.const -2.2250738585072014e-308
-  f64.const 0
+  f64.const 2.2250738585072014e-308
+  f64.const -0
   call $std/math/test_mod
   i32.eqz
   if
@@ -31376,7 +31210,7 @@
    unreachable
   end
   f64.const -2.2250738585072014e-308
-  f64.const 2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
   f64.const -0
   call $std/math/test_mod
   i32.eqz
@@ -31388,9 +31222,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
-  f64.const -0
+  f64.const 1797693134862315708145274e284
+  f64.const 1797693134862315708145274e284
+  f64.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -31402,7 +31236,7 @@
    unreachable
   end
   f64.const 1797693134862315708145274e284
-  f64.const 1797693134862315708145274e284
+  f64.const -1797693134862315708145274e284
   f64.const 0
   call $std/math/test_mod
   i32.eqz
@@ -31414,9 +31248,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1797693134862315708145274e284
   f64.const -1797693134862315708145274e284
-  f64.const 0
+  f64.const 1797693134862315708145274e284
+  f64.const -0
   call $std/math/test_mod
   i32.eqz
   if
@@ -31428,7 +31262,7 @@
    unreachable
   end
   f64.const -1797693134862315708145274e284
-  f64.const 1797693134862315708145274e284
+  f64.const -1797693134862315708145274e284
   f64.const -0
   call $std/math/test_mod
   i32.eqz
@@ -31440,21 +31274,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1797693134862315708145274e284
-  f64.const -1797693134862315708145274e284
-  f64.const -0
+  f64.const 0
+  f64.const 2.2250738585072014e-308
+  f64.const 0
   call $std/math/test_mod
   i32.eqz
   if
    i32.const 0
    i32.const 24
-   i32.const 2349
+   i32.const 2351
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  f64.const 2.2250738585072014e-308
+  f64.const 1797693134862315708145274e284
   f64.const 0
   call $std/math/test_mod
   i32.eqz
@@ -31467,7 +31301,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 1797693134862315708145274e284
+  f64.const -2.2250738585072014e-308
   f64.const 0
   call $std/math/test_mod
   i32.eqz
@@ -31480,7 +31314,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -2.2250738585072014e-308
+  f64.const -1797693134862315708145274e284
   f64.const 0
   call $std/math/test_mod
   i32.eqz
@@ -31492,9 +31326,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -1797693134862315708145274e284
-  f64.const 0
+  f64.const -0
+  f64.const 2.2250738585072014e-308
+  f64.const -0
   call $std/math/test_mod
   i32.eqz
   if
@@ -31506,7 +31340,7 @@
    unreachable
   end
   f64.const -0
-  f64.const 2.2250738585072014e-308
+  f64.const 1797693134862315708145274e284
   f64.const -0
   call $std/math/test_mod
   i32.eqz
@@ -31519,7 +31353,7 @@
    unreachable
   end
   f64.const -0
-  f64.const 1797693134862315708145274e284
+  f64.const -2.2250738585072014e-308
   f64.const -0
   call $std/math/test_mod
   i32.eqz
@@ -31532,19 +31366,6 @@
    unreachable
   end
   f64.const -0
-  f64.const -2.2250738585072014e-308
-  f64.const -0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2358
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
   f64.const -1797693134862315708145274e284
   f64.const -0
   call $std/math/test_mod
@@ -31552,7 +31373,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2359
+   i32.const 2358
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31565,7 +31386,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2362
+   i32.const 2361
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31578,7 +31399,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2363
+   i32.const 2362
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31591,7 +31412,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2365
+   i32.const 2364
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31604,7 +31425,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2366
+   i32.const 2365
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31617,7 +31438,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2368
+   i32.const 2367
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31630,7 +31451,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2369
+   i32.const 2368
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31643,7 +31464,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2371
+   i32.const 2370
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31656,7 +31477,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2372
+   i32.const 2371
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31664,6 +31485,19 @@
   f64.const 8988465674311579538646525e283
   f64.const 1797693134862315708145274e284
   f64.const 8988465674311579538646525e283
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2373
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -8988465674311579538646525e283
+  f64.const 1797693134862315708145274e284
+  f64.const -8988465674311579538646525e283
   call $std/math/test_mod
   i32.eqz
   if
@@ -31674,22 +31508,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8988465674311579538646525e283
-  f64.const 1797693134862315708145274e284
-  f64.const -8988465674311579538646525e283
+  f64.const 8988465674311578540726371e283
+  f64.const -1797693134862315708145274e284
+  f64.const 8988465674311578540726371e283
   call $std/math/test_mod
   i32.eqz
   if
    i32.const 0
    i32.const 24
-   i32.const 2375
+   i32.const 2376
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 8988465674311578540726371e283
+  f64.const -8988465674311578540726371e283
   f64.const -1797693134862315708145274e284
-  f64.const 8988465674311578540726371e283
+  f64.const -8988465674311578540726371e283
   call $std/math/test_mod
   i32.eqz
   if
@@ -31700,22 +31534,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8988465674311578540726371e283
-  f64.const -1797693134862315708145274e284
-  f64.const -8988465674311578540726371e283
+  f64.const 8988465674311577542806216e283
+  f64.const 1797693134862315708145274e284
+  f64.const 8988465674311577542806216e283
   call $std/math/test_mod
   i32.eqz
   if
    i32.const 0
    i32.const 24
-   i32.const 2378
+   i32.const 2379
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 8988465674311577542806216e283
+  f64.const -8988465674311577542806216e283
   f64.const 1797693134862315708145274e284
-  f64.const 8988465674311577542806216e283
+  f64.const -8988465674311577542806216e283
   call $std/math/test_mod
   i32.eqz
   if
@@ -31726,41 +31560,28 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8988465674311577542806216e283
-  f64.const 1797693134862315708145274e284
-  f64.const -8988465674311577542806216e283
+  f64.const 1797693134862315508561243e284
+  f64.const -1797693134862315708145274e284
+  f64.const 1797693134862315508561243e284
   call $std/math/test_mod
   i32.eqz
   if
    i32.const 0
    i32.const 24
-   i32.const 2381
+   i32.const 2382
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1797693134862315508561243e284
+  f64.const -1797693134862315508561243e284
   f64.const -1797693134862315708145274e284
-  f64.const 1797693134862315508561243e284
+  f64.const -1797693134862315508561243e284
   call $std/math/test_mod
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2383
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1797693134862315508561243e284
-  f64.const -1797693134862315708145274e284
-  f64.const -1797693134862315508561243e284
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2384
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31773,7 +31594,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2386
+   i32.const 2385
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31786,7 +31607,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2387
+   i32.const 2386
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31799,7 +31620,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2389
+   i32.const 2388
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31812,7 +31633,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2390
+   i32.const 2389
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31825,7 +31646,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2391
+   i32.const 2390
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31838,7 +31659,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2392
+   i32.const 2391
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31851,7 +31672,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2393
+   i32.const 2392
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31864,7 +31685,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2394
+   i32.const 2393
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31877,7 +31698,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2395
+   i32.const 2394
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31890,7 +31711,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2396
+   i32.const 2395
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31903,7 +31724,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2398
+   i32.const 2397
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31916,7 +31737,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2399
+   i32.const 2398
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31929,7 +31750,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2400
+   i32.const 2399
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31942,7 +31763,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2401
+   i32.const 2400
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31955,7 +31776,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2402
+   i32.const 2401
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31968,7 +31789,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2403
+   i32.const 2402
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31981,7 +31802,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2404
+   i32.const 2403
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31994,7 +31815,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2405
+   i32.const 2404
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32007,7 +31828,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2406
+   i32.const 2405
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32020,7 +31841,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2407
+   i32.const 2406
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32033,13 +31854,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2408
+   i32.const 2407
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.2250738585072024e-308
   f64.const 1.5e-323
+  f64.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2408
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.2250738585072024e-308
+  f64.const -1.5e-323
   f64.const 0
   call $std/math/test_mod
   i32.eqz
@@ -32051,9 +31885,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072024e-308
-  f64.const -1.5e-323
-  f64.const 0
+  f64.const 2.225073858507203e-308
+  f64.const 1.5e-323
+  f64.const 5e-324
   call $std/math/test_mod
   i32.eqz
   if
@@ -32065,19 +31899,6 @@
    unreachable
   end
   f64.const 2.225073858507203e-308
-  f64.const 1.5e-323
-  f64.const 5e-324
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2411
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507203e-308
   f64.const 2.225073858507204e-308
   f64.const 2.225073858507203e-308
   call $std/math/test_mod
@@ -32085,7 +31906,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2412
+   i32.const 2411
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32098,7 +31919,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2413
+   i32.const 2412
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32111,7 +31932,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2414
+   i32.const 2413
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32124,7 +31945,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2415
+   i32.const 2414
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32137,7 +31958,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2416
+   i32.const 2415
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32150,7 +31971,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2417
+   i32.const 2416
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32163,7 +31984,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2426
+   i32.const 2425
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32176,7 +31997,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2427
+   i32.const 2426
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32189,7 +32010,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2428
+   i32.const 2427
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32202,7 +32023,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2429
+   i32.const 2428
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32215,7 +32036,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2430
+   i32.const 2429
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32228,7 +32049,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2431
+   i32.const 2430
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32241,7 +32062,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2432
+   i32.const 2431
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32254,7 +32075,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2433
+   i32.const 2432
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32267,7 +32088,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2434
+   i32.const 2433
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32280,7 +32101,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2435
+   i32.const 2434
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32288,6 +32109,19 @@
   f32.const 0
   f32.const 1
   f32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2437
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 1
+  f32.const -0
   call $std/math/test_modf
   i32.eqz
   if
@@ -32298,9 +32132,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0.5
   f32.const 1
-  f32.const -0
+  f32.const 0.5
   call $std/math/test_modf
   i32.eqz
   if
@@ -32311,28 +32145,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -0.5
   f32.const 1
-  f32.const 0.5
+  f32.const -0.5
   call $std/math/test_modf
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2440
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const 1
-  f32.const -0.5
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2441
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32345,7 +32166,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2442
+   i32.const 2441
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32358,7 +32179,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2443
+   i32.const 2442
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32371,7 +32192,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2444
+   i32.const 2443
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32384,7 +32205,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2445
+   i32.const 2444
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32397,7 +32218,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2446
+   i32.const 2445
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32410,12 +32231,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2447
+   i32.const 2446
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const inf
+  f32.const 1
+  f32.const nan:0x400000
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2447
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
   f32.const 1
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -32428,7 +32262,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const 1
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -32441,9 +32275,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const 1
-  f32.const nan:0x400000
+  f32.const 0
+  f32.const -1
+  f32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -32454,9 +32288,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
+  f32.const -0
   f32.const -1
-  f32.const 0
+  f32.const -0
   call $std/math/test_modf
   i32.eqz
   if
@@ -32467,9 +32301,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0.5
   f32.const -1
-  f32.const -0
+  f32.const 0.5
   call $std/math/test_modf
   i32.eqz
   if
@@ -32480,28 +32314,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -0.5
   f32.const -1
-  f32.const 0.5
+  f32.const -0.5
   call $std/math/test_modf
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2453
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const -1
-  f32.const -0.5
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2454
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32514,7 +32335,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2455
+   i32.const 2454
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32527,7 +32348,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2456
+   i32.const 2455
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32540,7 +32361,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2457
+   i32.const 2456
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32553,7 +32374,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2458
+   i32.const 2457
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32566,7 +32387,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2459
+   i32.const 2458
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32579,12 +32400,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2460
+   i32.const 2459
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const inf
+  f32.const -1
+  f32.const nan:0x400000
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2460
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
   f32.const -1
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -32597,7 +32431,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const -1
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -32610,8 +32444,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -1
+  f32.const 0
+  f32.const 0
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32624,7 +32458,7 @@
    unreachable
   end
   f32.const 0
-  f32.const 0
+  f32.const -0
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32637,8 +32471,8 @@
    unreachable
   end
   f32.const 0
-  f32.const -0
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -32650,7 +32484,7 @@
    unreachable
   end
   f32.const 0
-  f32.const inf
+  f32.const -inf
   f32.const 0
   call $std/math/test_modf
   i32.eqz
@@ -32663,8 +32497,8 @@
    unreachable
   end
   f32.const 0
-  f32.const -inf
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
   if
@@ -32675,8 +32509,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const 0
-  f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32689,7 +32523,7 @@
    unreachable
   end
   f32.const -0
-  f32.const 0
+  f32.const -0
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32702,8 +32536,8 @@
    unreachable
   end
   f32.const -0
+  f32.const inf
   f32.const -0
-  f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
   if
@@ -32715,7 +32549,7 @@
    unreachable
   end
   f32.const -0
-  f32.const inf
+  f32.const -inf
   f32.const -0
   call $std/math/test_modf
   i32.eqz
@@ -32728,8 +32562,8 @@
    unreachable
   end
   f32.const -0
-  f32.const -inf
-  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
   if
@@ -32740,8 +32574,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const nan:0x400000
+  f32.const 1
+  f32.const 0
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32753,7 +32587,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const 0
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -32766,7 +32600,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const inf
   f32.const 0
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -32779,7 +32613,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const 0
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -32792,7 +32626,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const 0
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -32805,8 +32639,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const 0
+  f32.const -1
+  f32.const -0
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32818,7 +32652,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const inf
   f32.const -0
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -32831,7 +32665,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const -0
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -32844,7 +32678,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const -0
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -32857,8 +32691,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -0
+  f32.const inf
+  f32.const 2
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32871,7 +32705,7 @@
    unreachable
   end
   f32.const inf
-  f32.const 2
+  f32.const -0.5
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32884,7 +32718,7 @@
    unreachable
   end
   f32.const inf
-  f32.const -0.5
+  f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32892,19 +32726,6 @@
    i32.const 0
    i32.const 24
    i32.const 2484
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2485
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32917,7 +32738,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2486
+   i32.const 2485
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32930,12 +32751,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2487
+   i32.const 2486
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2487
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -32948,7 +32782,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const 1
   f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -32961,7 +32795,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -32974,9 +32808,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 1
+  f32.const inf
+  f32.const 1
   call $std/math/test_modf
   i32.eqz
   if
@@ -32987,9 +32821,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const inf
-  f32.const 1
+  f32.const -1
   call $std/math/test_modf
   i32.eqz
   if
@@ -33000,9 +32834,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
   f32.const inf
-  f32.const -1
+  f32.const inf
+  f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
   if
@@ -33013,7 +32847,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const inf
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -33026,9 +32860,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1
   f32.const -inf
-  f32.const inf
-  f32.const nan:0x400000
+  f32.const 1
   call $std/math/test_modf
   i32.eqz
   if
@@ -33039,9 +32873,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const -inf
-  f32.const 1
+  f32.const -1
   call $std/math/test_modf
   i32.eqz
   if
@@ -33052,9 +32886,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const inf
   f32.const -inf
-  f32.const -1
+  f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
   if
@@ -33065,7 +32899,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const -inf
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -33078,9 +32912,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
-  f32.const nan:0x400000
+  f32.const 1.75
+  f32.const 0.5
+  f32.const 0.25
   call $std/math/test_modf
   i32.eqz
   if
@@ -33091,9 +32925,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
+  f32.const -1.75
   f32.const 0.5
-  f32.const 0.25
+  f32.const -0.25
   call $std/math/test_modf
   i32.eqz
   if
@@ -33104,9 +32938,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.75
-  f32.const 0.5
-  f32.const -0.25
+  f32.const 1.75
+  f32.const -0.5
+  f32.const 0.25
   call $std/math/test_modf
   i32.eqz
   if
@@ -33117,19 +32951,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
-  f32.const -0.5
-  f32.const 0.25
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2502
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -1.75
   f32.const -0.5
   f32.const -0.25
@@ -33138,7 +32959,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2503
+   i32.const 2502
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33152,7 +32973,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2515
+   i32.const 2514
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33166,7 +32987,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2516
+   i32.const 2515
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33180,7 +33001,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2517
+   i32.const 2516
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33194,7 +33015,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2518
+   i32.const 2517
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33208,7 +33029,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2519
+   i32.const 2518
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33222,7 +33043,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2520
+   i32.const 2519
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33236,7 +33057,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2521
+   i32.const 2520
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33250,7 +33071,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2522
+   i32.const 2521
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33264,7 +33085,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2523
+   i32.const 2522
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33278,7 +33099,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2524
+   i32.const 2523
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33292,13 +33113,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2527
+   i32.const 2526
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const inf
+  f64.const 0
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2527
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 3
   f64.const 0
   f64.const 0
   call $std/math/test_pow
@@ -33312,7 +33147,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 3
+  f64.const 2
   f64.const 0
   f64.const 0
   call $std/math/test_pow
@@ -33326,7 +33161,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 2
+  f64.const 1
   f64.const 0
   f64.const 0
   call $std/math/test_pow
@@ -33340,7 +33175,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 1
+  f64.const 0.5
   f64.const 0
   f64.const 0
   call $std/math/test_pow
@@ -33354,8 +33189,8 @@
    unreachable
   end
   f64.const 0
-  f64.const 0.5
   f64.const 0
+  f64.const 1
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -33368,7 +33203,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 0
+  f64.const -0
   f64.const 1
   f64.const 0
   call $std/math/test_pow
@@ -33382,8 +33217,8 @@
    unreachable
   end
   f64.const 0
-  f64.const -0
-  f64.const 1
+  f64.const -0.5
+  f64.const inf
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -33396,7 +33231,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -0.5
+  f64.const -1
   f64.const inf
   f64.const 0
   call $std/math/test_pow
@@ -33410,7 +33245,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -1
+  f64.const -2
   f64.const inf
   f64.const 0
   call $std/math/test_pow
@@ -33424,7 +33259,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -2
+  f64.const -3
   f64.const inf
   f64.const 0
   call $std/math/test_pow
@@ -33438,7 +33273,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -3
+  f64.const -4
   f64.const inf
   f64.const 0
   call $std/math/test_pow
@@ -33452,7 +33287,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -4
+  f64.const -inf
   f64.const inf
   f64.const 0
   call $std/math/test_pow
@@ -33465,9 +33300,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -inf
-  f64.const inf
+  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -33480,20 +33315,6 @@
    unreachable
   end
   f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2541
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
   f64.const inf
   f64.const 0
   f64.const 0
@@ -33502,7 +33323,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2542
+   i32.const 2541
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33516,7 +33337,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2543
+   i32.const 2542
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33530,7 +33351,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2544
+   i32.const 2543
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33544,7 +33365,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2545
+   i32.const 2544
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33558,13 +33379,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2546
+   i32.const 2545
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0
   f64.const 0
+  f64.const 1
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2546
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
   f64.const 1
   f64.const 0
   call $std/math/test_pow
@@ -33578,20 +33413,6 @@
    unreachable
   end
   f64.const -0
-  f64.const -0
-  f64.const 1
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2548
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
   f64.const -0.5
   f64.const inf
   f64.const 0
@@ -33600,7 +33421,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2549
+   i32.const 2548
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33614,7 +33435,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2550
+   i32.const 2549
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33628,7 +33449,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2551
+   i32.const 2550
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33642,7 +33463,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2552
+   i32.const 2551
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33656,7 +33477,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2553
+   i32.const 2552
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33670,12 +33491,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2554
+   i32.const 2553
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const 1
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2554
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
   f64.const 0
   f64.const 1
   f64.const 0
@@ -33689,7 +33524,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const 0
   f64.const 1
   f64.const 0
@@ -33703,7 +33538,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const 1
   f64.const 0
   f64.const 1
   f64.const 0
@@ -33717,7 +33552,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const 0
   f64.const 1
   f64.const 0
@@ -33731,7 +33566,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const -0.5
   f64.const 0
   f64.const 1
   f64.const 0
@@ -33745,8 +33580,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const -0
   f64.const 1
   f64.const 0
   call $std/math/test_pow
@@ -33759,7 +33594,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const inf
   f64.const -0
   f64.const 1
   f64.const 0
@@ -33773,7 +33608,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const -0
   f64.const 1
   f64.const 0
@@ -33787,7 +33622,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const 1
   f64.const -0
   f64.const 1
   f64.const 0
@@ -33801,7 +33636,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const -0
   f64.const 1
   f64.const 0
@@ -33815,7 +33650,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const -0.5
   f64.const -0
   f64.const 1
   f64.const 0
@@ -33829,9 +33664,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
-  f64.const -0
-  f64.const 1
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -33844,7 +33679,7 @@
    unreachable
   end
   f64.const -1
-  f64.const nan:0x8000000000000
+  f64.const inf
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
@@ -33858,7 +33693,7 @@
    unreachable
   end
   f64.const -1
-  f64.const inf
+  f64.const -inf
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
@@ -33872,8 +33707,8 @@
    unreachable
   end
   f64.const -1
-  f64.const -inf
-  f64.const nan:0x8000000000000
+  f64.const 2
+  f64.const 1
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -33886,8 +33721,8 @@
    unreachable
   end
   f64.const -1
-  f64.const 2
-  f64.const 1
+  f64.const -1
+  f64.const -1
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -33895,20 +33730,6 @@
    i32.const 0
    i32.const 24
    i32.const 2570
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -1
-  f64.const -1
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2571
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33922,7 +33743,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2572
+   i32.const 2571
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33936,13 +33757,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2573
+   i32.const 2572
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1
   f64.const 0.5
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2573
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
@@ -33956,7 +33791,7 @@
    unreachable
   end
   f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const inf
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
@@ -33970,7 +33805,7 @@
    unreachable
   end
   f64.const 1
-  f64.const inf
+  f64.const -inf
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
@@ -33984,8 +33819,8 @@
    unreachable
   end
   f64.const 1
-  f64.const -inf
-  f64.const nan:0x8000000000000
+  f64.const 3
+  f64.const 1
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -33998,7 +33833,7 @@
    unreachable
   end
   f64.const 1
-  f64.const 3
+  f64.const 0.5
   f64.const 1
   f64.const 0
   call $std/math/test_pow
@@ -34012,7 +33847,7 @@
    unreachable
   end
   f64.const 1
-  f64.const 0.5
+  f64.const -0.5
   f64.const 1
   f64.const 0
   call $std/math/test_pow
@@ -34026,7 +33861,7 @@
    unreachable
   end
   f64.const 1
-  f64.const -0.5
+  f64.const -3
   f64.const 1
   f64.const 0
   call $std/math/test_pow
@@ -34039,9 +33874,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const -3
-  f64.const 1
+  f64.const -0.5
+  f64.const 0.5
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -34054,7 +33889,7 @@
    unreachable
   end
   f64.const -0.5
-  f64.const 0.5
+  f64.const 1.5
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
@@ -34068,20 +33903,6 @@
    unreachable
   end
   f64.const -0.5
-  f64.const 1.5
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2583
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
   f64.const 2
   f64.const 0.25
   f64.const 0
@@ -34090,7 +33911,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2584
+   i32.const 2583
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34104,7 +33925,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2585
+   i32.const 2584
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34112,6 +33933,20 @@
   f64.const -0.5
   f64.const inf
   f64.const 0
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2585
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.5
+  f64.const -inf
+  f64.const inf
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -34124,8 +33959,8 @@
    unreachable
   end
   f64.const -0.5
-  f64.const -inf
-  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -34137,9 +33972,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 0.5
+  f64.const inf
+  f64.const 0
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -34152,8 +33987,8 @@
    unreachable
   end
   f64.const 0.5
+  f64.const -inf
   f64.const inf
-  f64.const 0
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -34166,8 +34001,8 @@
    unreachable
   end
   f64.const 0.5
-  f64.const -inf
-  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -34179,9 +34014,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 1.5
+  f64.const inf
+  f64.const inf
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -34194,8 +34029,8 @@
    unreachable
   end
   f64.const 1.5
-  f64.const inf
-  f64.const inf
+  f64.const -inf
+  f64.const 0
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -34208,8 +34043,8 @@
    unreachable
   end
   f64.const 1.5
-  f64.const -inf
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -34221,7 +34056,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5
+  f64.const inf
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -34236,8 +34071,8 @@
    unreachable
   end
   f64.const inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const inf
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -34245,20 +34080,6 @@
    i32.const 0
    i32.const 24
    i32.const 2595
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  f64.const inf
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2596
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34272,13 +34093,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2597
+   i32.const 2596
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
   f64.const 3
+  f64.const inf
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2597
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const 2
   f64.const inf
   f64.const 0
   call $std/math/test_pow
@@ -34292,7 +34127,7 @@
    unreachable
   end
   f64.const inf
-  f64.const 2
+  f64.const 1
   f64.const inf
   f64.const 0
   call $std/math/test_pow
@@ -34306,7 +34141,7 @@
    unreachable
   end
   f64.const inf
-  f64.const 1
+  f64.const 0.5
   f64.const inf
   f64.const 0
   call $std/math/test_pow
@@ -34320,8 +34155,8 @@
    unreachable
   end
   f64.const inf
-  f64.const 0.5
-  f64.const inf
+  f64.const -0.5
+  f64.const 0
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -34334,7 +34169,7 @@
    unreachable
   end
   f64.const inf
-  f64.const -0.5
+  f64.const -1
   f64.const 0
   f64.const 0
   call $std/math/test_pow
@@ -34348,7 +34183,7 @@
    unreachable
   end
   f64.const inf
-  f64.const -1
+  f64.const -2
   f64.const 0
   f64.const 0
   call $std/math/test_pow
@@ -34361,9 +34196,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const -2
-  f64.const 0
+  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -34376,8 +34211,8 @@
    unreachable
   end
   f64.const -inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const inf
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -34390,8 +34225,8 @@
    unreachable
   end
   f64.const -inf
-  f64.const inf
-  f64.const inf
+  f64.const -inf
+  f64.const 0
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -34399,20 +34234,6 @@
    i32.const 0
    i32.const 24
    i32.const 2606
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -inf
-  f64.const 0
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2607
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34426,7 +34247,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2608
+   i32.const 2607
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34440,7 +34261,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2609
+   i32.const 2608
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34454,7 +34275,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2610
+   i32.const 2609
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34468,7 +34289,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2611
+   i32.const 2610
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34482,7 +34303,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2612
+   i32.const 2611
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34496,7 +34317,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2613
+   i32.const 2612
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34510,7 +34331,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2614
+   i32.const 2613
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34524,7 +34345,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2615
+   i32.const 2614
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34538,7 +34359,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2616
+   i32.const 2615
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34552,7 +34373,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2617
+   i32.const 2616
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34566,7 +34387,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2618
+   i32.const 2617
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34580,7 +34401,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2627
+   i32.const 2626
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34594,7 +34415,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2628
+   i32.const 2627
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34608,7 +34429,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2629
+   i32.const 2628
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34622,7 +34443,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2630
+   i32.const 2629
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34636,7 +34457,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2631
+   i32.const 2630
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34650,7 +34471,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2632
+   i32.const 2631
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34664,7 +34485,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2633
+   i32.const 2632
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34678,7 +34499,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2634
+   i32.const 2633
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34692,7 +34513,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2635
+   i32.const 2634
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34706,7 +34527,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2636
+   i32.const 2635
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34720,13 +34541,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2639
+   i32.const 2638
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const inf
+  f32.const 0
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2639
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 3
   f32.const 0
   f32.const 0
   call $std/math/test_powf
@@ -34740,7 +34575,7 @@
    unreachable
   end
   f32.const 0
-  f32.const 3
+  f32.const 2
   f32.const 0
   f32.const 0
   call $std/math/test_powf
@@ -34754,7 +34589,7 @@
    unreachable
   end
   f32.const 0
-  f32.const 2
+  f32.const 1
   f32.const 0
   f32.const 0
   call $std/math/test_powf
@@ -34768,7 +34603,7 @@
    unreachable
   end
   f32.const 0
-  f32.const 1
+  f32.const 0.5
   f32.const 0
   f32.const 0
   call $std/math/test_powf
@@ -34782,8 +34617,8 @@
    unreachable
   end
   f32.const 0
-  f32.const 0.5
   f32.const 0
+  f32.const 1
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -34796,7 +34631,7 @@
    unreachable
   end
   f32.const 0
-  f32.const 0
+  f32.const -0
   f32.const 1
   f32.const 0
   call $std/math/test_powf
@@ -34810,8 +34645,8 @@
    unreachable
   end
   f32.const 0
-  f32.const -0
-  f32.const 1
+  f32.const -0.5
+  f32.const inf
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -34824,7 +34659,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -0.5
+  f32.const -1
   f32.const inf
   f32.const 0
   call $std/math/test_powf
@@ -34838,7 +34673,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -1
+  f32.const -2
   f32.const inf
   f32.const 0
   call $std/math/test_powf
@@ -34852,7 +34687,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -2
+  f32.const -3
   f32.const inf
   f32.const 0
   call $std/math/test_powf
@@ -34866,7 +34701,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -3
+  f32.const -4
   f32.const inf
   f32.const 0
   call $std/math/test_powf
@@ -34880,7 +34715,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -4
+  f32.const -inf
   f32.const inf
   f32.const 0
   call $std/math/test_powf
@@ -34893,9 +34728,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const -inf
-  f32.const inf
+  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -34908,20 +34743,6 @@
    unreachable
   end
   f32.const -0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2653
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
   f32.const inf
   f32.const 0
   f32.const 0
@@ -34930,7 +34751,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2654
+   i32.const 2653
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34944,7 +34765,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2655
+   i32.const 2654
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34958,7 +34779,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2656
+   i32.const 2655
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34972,7 +34793,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2657
+   i32.const 2656
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34986,13 +34807,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2658
+   i32.const 2657
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -0
   f32.const 0
+  f32.const 1
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2658
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
   f32.const 1
   f32.const 0
   call $std/math/test_powf
@@ -35006,20 +34841,6 @@
    unreachable
   end
   f32.const -0
-  f32.const -0
-  f32.const 1
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2660
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
   f32.const -0.5
   f32.const inf
   f32.const 0
@@ -35028,7 +34849,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2661
+   i32.const 2660
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35042,7 +34863,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2662
+   i32.const 2661
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35056,7 +34877,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2663
+   i32.const 2662
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35070,7 +34891,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2664
+   i32.const 2663
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35084,7 +34905,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2665
+   i32.const 2664
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35098,12 +34919,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2666
+   i32.const 2665
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
+  f32.const 0
+  f32.const 1
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2666
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
   f32.const 0
   f32.const 1
   f32.const 0
@@ -35117,7 +34952,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const 0
   f32.const 1
   f32.const 0
@@ -35131,7 +34966,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const 1
   f32.const 0
   f32.const 1
   f32.const 0
@@ -35145,7 +34980,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const 0
   f32.const 1
   f32.const 0
@@ -35159,7 +34994,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const -0.5
   f32.const 0
   f32.const 1
   f32.const 0
@@ -35173,8 +35008,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const -0
   f32.const 1
   f32.const 0
   call $std/math/test_powf
@@ -35187,7 +35022,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const inf
   f32.const -0
   f32.const 1
   f32.const 0
@@ -35201,7 +35036,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const -0
   f32.const 1
   f32.const 0
@@ -35215,7 +35050,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const 1
   f32.const -0
   f32.const 1
   f32.const 0
@@ -35229,7 +35064,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const -0
   f32.const 1
   f32.const 0
@@ -35243,7 +35078,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const -0.5
   f32.const -0
   f32.const 1
   f32.const 0
@@ -35257,9 +35092,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const -0
-  f32.const 1
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35272,7 +35107,7 @@
    unreachable
   end
   f32.const -1
-  f32.const nan:0x400000
+  f32.const inf
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_powf
@@ -35286,7 +35121,7 @@
    unreachable
   end
   f32.const -1
-  f32.const inf
+  f32.const -inf
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_powf
@@ -35300,8 +35135,8 @@
    unreachable
   end
   f32.const -1
-  f32.const -inf
-  f32.const nan:0x400000
+  f32.const 2
+  f32.const 1
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35314,8 +35149,8 @@
    unreachable
   end
   f32.const -1
-  f32.const 2
-  f32.const 1
+  f32.const -1
+  f32.const -1
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35323,20 +35158,6 @@
    i32.const 0
    i32.const 24
    i32.const 2682
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -1
-  f32.const -1
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2683
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35350,7 +35171,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2684
+   i32.const 2683
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35364,13 +35185,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2685
+   i32.const 2684
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1
   f32.const 0.5
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2685
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_powf
@@ -35384,7 +35219,7 @@
    unreachable
   end
   f32.const 1
-  f32.const nan:0x400000
+  f32.const inf
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_powf
@@ -35398,7 +35233,7 @@
    unreachable
   end
   f32.const 1
-  f32.const inf
+  f32.const -inf
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_powf
@@ -35412,8 +35247,8 @@
    unreachable
   end
   f32.const 1
-  f32.const -inf
-  f32.const nan:0x400000
+  f32.const 3
+  f32.const 1
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35426,7 +35261,7 @@
    unreachable
   end
   f32.const 1
-  f32.const 3
+  f32.const 0.5
   f32.const 1
   f32.const 0
   call $std/math/test_powf
@@ -35440,7 +35275,7 @@
    unreachable
   end
   f32.const 1
-  f32.const 0.5
+  f32.const -0.5
   f32.const 1
   f32.const 0
   call $std/math/test_powf
@@ -35454,7 +35289,7 @@
    unreachable
   end
   f32.const 1
-  f32.const -0.5
+  f32.const -3
   f32.const 1
   f32.const 0
   call $std/math/test_powf
@@ -35467,9 +35302,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const -3
-  f32.const 1
+  f32.const -0.5
+  f32.const 0.5
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35482,7 +35317,7 @@
    unreachable
   end
   f32.const -0.5
-  f32.const 0.5
+  f32.const 1.5
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_powf
@@ -35496,20 +35331,6 @@
    unreachable
   end
   f32.const -0.5
-  f32.const 1.5
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2695
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
   f32.const 2
   f32.const 0.25
   f32.const 0
@@ -35518,7 +35339,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2696
+   i32.const 2695
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35532,7 +35353,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2697
+   i32.const 2696
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35540,6 +35361,20 @@
   f32.const -0.5
   f32.const inf
   f32.const 0
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2697
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.5
+  f32.const -inf
+  f32.const inf
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35552,8 +35387,8 @@
    unreachable
   end
   f32.const -0.5
-  f32.const -inf
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35565,9 +35400,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 0.5
+  f32.const inf
+  f32.const 0
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35580,8 +35415,8 @@
    unreachable
   end
   f32.const 0.5
+  f32.const -inf
   f32.const inf
-  f32.const 0
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35594,8 +35429,8 @@
    unreachable
   end
   f32.const 0.5
-  f32.const -inf
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35607,9 +35442,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 1.5
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35622,8 +35457,8 @@
    unreachable
   end
   f32.const 1.5
-  f32.const inf
-  f32.const inf
+  f32.const -inf
+  f32.const 0
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35636,8 +35471,8 @@
    unreachable
   end
   f32.const 1.5
-  f32.const -inf
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35649,7 +35484,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.5
+  f32.const inf
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -35664,8 +35499,8 @@
    unreachable
   end
   f32.const inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35673,20 +35508,6 @@
    i32.const 0
    i32.const 24
    i32.const 2707
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2708
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35700,13 +35521,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2709
+   i32.const 2708
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const inf
   f32.const 3
+  f32.const inf
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2709
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const 2
   f32.const inf
   f32.const 0
   call $std/math/test_powf
@@ -35720,7 +35555,7 @@
    unreachable
   end
   f32.const inf
-  f32.const 2
+  f32.const 1
   f32.const inf
   f32.const 0
   call $std/math/test_powf
@@ -35734,7 +35569,7 @@
    unreachable
   end
   f32.const inf
-  f32.const 1
+  f32.const 0.5
   f32.const inf
   f32.const 0
   call $std/math/test_powf
@@ -35748,8 +35583,8 @@
    unreachable
   end
   f32.const inf
-  f32.const 0.5
-  f32.const inf
+  f32.const -0.5
+  f32.const 0
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35762,7 +35597,7 @@
    unreachable
   end
   f32.const inf
-  f32.const -0.5
+  f32.const -1
   f32.const 0
   f32.const 0
   call $std/math/test_powf
@@ -35776,7 +35611,7 @@
    unreachable
   end
   f32.const inf
-  f32.const -1
+  f32.const -2
   f32.const 0
   f32.const 0
   call $std/math/test_powf
@@ -35789,9 +35624,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const -2
-  f32.const 0
+  f32.const -inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35804,8 +35639,8 @@
    unreachable
   end
   f32.const -inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35818,8 +35653,8 @@
    unreachable
   end
   f32.const -inf
-  f32.const inf
-  f32.const inf
+  f32.const -inf
+  f32.const 0
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35827,20 +35662,6 @@
    i32.const 0
    i32.const 24
    i32.const 2718
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -inf
-  f32.const 0
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2719
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35854,7 +35675,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2720
+   i32.const 2719
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35868,7 +35689,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2721
+   i32.const 2720
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35882,7 +35703,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2722
+   i32.const 2721
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35896,7 +35717,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2723
+   i32.const 2722
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35910,7 +35731,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2724
+   i32.const 2723
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35924,7 +35745,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2725
+   i32.const 2724
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35938,7 +35759,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2726
+   i32.const 2725
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35952,7 +35773,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2727
+   i32.const 2726
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35966,7 +35787,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2728
+   i32.const 2727
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35980,7 +35801,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2729
+   i32.const 2728
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35994,7 +35815,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2730
+   i32.const 2729
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36030,7 +35851,7 @@
     else
      i32.const 0
      i32.const 24
-     i32.const 2739
+     i32.const 2738
      i32.const 2
      call $~lib/builtins/abort
      unreachable
@@ -36071,7 +35892,7 @@
     else
      i32.const 0
      i32.const 24
-     i32.const 2747
+     i32.const 2746
      i32.const 2
      call $~lib/builtins/abort
      unreachable
@@ -36086,7 +35907,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2761
+   i32.const 2760
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36098,7 +35919,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2762
+   i32.const 2761
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36110,7 +35931,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2763
+   i32.const 2762
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36122,7 +35943,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2764
+   i32.const 2763
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36134,7 +35955,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2765
+   i32.const 2764
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36146,7 +35967,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2766
+   i32.const 2765
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36158,7 +35979,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2767
+   i32.const 2766
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36170,7 +35991,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2768
+   i32.const 2767
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36182,7 +36003,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2769
+   i32.const 2768
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36194,13 +36015,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2770
+   i32.const 2769
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2772
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
   call $std/math/test_round
   i32.eqz
   if
@@ -36211,8 +36044,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const -inf
+  f64.const -inf
   call $std/math/test_round
   i32.eqz
   if
@@ -36223,8 +36056,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
+  f64.const 0
+  f64.const 0
   call $std/math/test_round
   i32.eqz
   if
@@ -36235,8 +36068,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -0
+  f64.const -0
   call $std/math/test_round
   i32.eqz
   if
@@ -36247,8 +36080,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 1
+  f64.const 1
   call $std/math/test_round
   i32.eqz
   if
@@ -36259,26 +36092,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 1
+  f64.const -1
+  f64.const -1
   call $std/math/test_round
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2778
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -1
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2779
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36290,7 +36111,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2780
+   i32.const 2779
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36302,7 +36123,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2781
+   i32.const 2780
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36314,7 +36135,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2782
+   i32.const 2781
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36326,7 +36147,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2783
+   i32.const 2782
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36338,7 +36159,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2784
+   i32.const 2783
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36350,7 +36171,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2785
+   i32.const 2784
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36362,7 +36183,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2786
+   i32.const 2785
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36374,7 +36195,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2787
+   i32.const 2786
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36386,7 +36207,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2788
+   i32.const 2787
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36398,7 +36219,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2789
+   i32.const 2788
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36410,7 +36231,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2798
+   i32.const 2797
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36422,7 +36243,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2799
+   i32.const 2798
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36434,7 +36255,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2800
+   i32.const 2799
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36446,7 +36267,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2801
+   i32.const 2800
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36458,7 +36279,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2802
+   i32.const 2801
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36470,7 +36291,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2803
+   i32.const 2802
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36482,7 +36303,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2804
+   i32.const 2803
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36494,7 +36315,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2805
+   i32.const 2804
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36506,7 +36327,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2806
+   i32.const 2805
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36518,13 +36339,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2807
+   i32.const 2806
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const nan:0x400000
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2809
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
   call $std/math/test_roundf
   i32.eqz
   if
@@ -36535,8 +36368,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -inf
+  f32.const -inf
   call $std/math/test_roundf
   i32.eqz
   if
@@ -36547,8 +36380,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const 0
+  f32.const 0
   call $std/math/test_roundf
   i32.eqz
   if
@@ -36559,8 +36392,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -0
+  f32.const -0
   call $std/math/test_roundf
   i32.eqz
   if
@@ -36571,8 +36404,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   call $std/math/test_roundf
   i32.eqz
   if
@@ -36583,26 +36416,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -1
+  f32.const -1
   call $std/math/test_roundf
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2815
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -1
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2816
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36614,7 +36435,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2817
+   i32.const 2816
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36626,7 +36447,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2818
+   i32.const 2817
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36638,7 +36459,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2819
+   i32.const 2818
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36650,7 +36471,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2820
+   i32.const 2819
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36662,7 +36483,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2821
+   i32.const 2820
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36674,7 +36495,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2822
+   i32.const 2821
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36686,7 +36507,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2823
+   i32.const 2822
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36698,7 +36519,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2824
+   i32.const 2823
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36710,7 +36531,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2825
+   i32.const 2824
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36722,13 +36543,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2826
+   i32.const 2825
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const 0
+  call $std/math/test_sign
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2836
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
   call $std/math/test_sign
   i32.eqz
   if
@@ -36739,26 +36572,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 1
+  f64.const 1
   call $std/math/test_sign
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2838
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  call $std/math/test_sign
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2839
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36770,7 +36591,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2840
+   i32.const 2839
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36782,7 +36603,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2841
+   i32.const 2840
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36794,7 +36615,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2842
+   i32.const 2841
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36806,7 +36627,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2843
+   i32.const 2842
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36818,7 +36639,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2844
+   i32.const 2843
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36830,13 +36651,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2845
+   i32.const 2844
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const 0
+  call $std/math/test_signf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2852
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
   call $std/math/test_signf
   i32.eqz
   if
@@ -36847,26 +36680,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   call $std/math/test_signf
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2854
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  call $std/math/test_signf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2855
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36878,7 +36699,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2856
+   i32.const 2855
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36890,7 +36711,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2857
+   i32.const 2856
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36902,7 +36723,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2858
+   i32.const 2857
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36914,7 +36735,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2859
+   i32.const 2858
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36926,7 +36747,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2860
+   i32.const 2859
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36938,7 +36759,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2861
+   i32.const 2860
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36951,7 +36772,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2898
+   i32.const 2897
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36964,7 +36785,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2899
+   i32.const 2898
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36977,7 +36798,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2900
+   i32.const 2899
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36990,7 +36811,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2901
+   i32.const 2900
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37003,7 +36824,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2902
+   i32.const 2901
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37016,7 +36837,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2903
+   i32.const 2902
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37029,7 +36850,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2904
+   i32.const 2903
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37042,7 +36863,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2905
+   i32.const 2904
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37055,7 +36876,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2906
+   i32.const 2905
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37068,7 +36889,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2907
+   i32.const 2906
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37076,6 +36897,19 @@
   f64.const 0
   f64.const 1
   f64.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2909
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const 1
+  f64.const -0
   call $std/math/test_rem
   i32.eqz
   if
@@ -37086,9 +36920,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0.5
   f64.const 1
-  f64.const -0
+  f64.const 0.5
   call $std/math/test_rem
   i32.eqz
   if
@@ -37099,28 +36933,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0.5
   f64.const 1
-  f64.const 0.5
+  f64.const -0.5
   call $std/math/test_rem
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2912
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const 1
-  f64.const -0.5
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2913
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37133,7 +36954,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2914
+   i32.const 2913
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37146,7 +36967,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2915
+   i32.const 2914
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37159,7 +36980,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2916
+   i32.const 2915
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37172,7 +36993,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2917
+   i32.const 2916
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37185,7 +37006,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2918
+   i32.const 2917
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37198,12 +37019,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2919
+   i32.const 2918
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
+  f64.const 1
+  f64.const nan:0x8000000000000
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2919
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
   f64.const 1
   f64.const nan:0x8000000000000
   call $std/math/test_rem
@@ -37216,7 +37050,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const 1
   f64.const nan:0x8000000000000
   call $std/math/test_rem
@@ -37229,9 +37063,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const -1
+  f64.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -37242,9 +37076,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
+  f64.const -0
   f64.const -1
-  f64.const 0
+  f64.const -0
   call $std/math/test_rem
   i32.eqz
   if
@@ -37255,9 +37089,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0.5
   f64.const -1
-  f64.const -0
+  f64.const 0.5
   call $std/math/test_rem
   i32.eqz
   if
@@ -37268,28 +37102,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0.5
   f64.const -1
-  f64.const 0.5
+  f64.const -0.5
   call $std/math/test_rem
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2925
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const -1
-  f64.const -0.5
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2926
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37302,7 +37123,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2927
+   i32.const 2926
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37315,7 +37136,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2928
+   i32.const 2927
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37328,7 +37149,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2929
+   i32.const 2928
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37341,7 +37162,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2930
+   i32.const 2929
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37354,7 +37175,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2931
+   i32.const 2930
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37367,12 +37188,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2932
+   i32.const 2931
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
+  f64.const -1
+  f64.const nan:0x8000000000000
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2932
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
   f64.const -1
   f64.const nan:0x8000000000000
   call $std/math/test_rem
@@ -37385,7 +37219,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const -1
   f64.const nan:0x8000000000000
   call $std/math/test_rem
@@ -37398,8 +37232,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -1
+  f64.const 0
+  f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37412,7 +37246,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 0
+  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37425,8 +37259,8 @@
    unreachable
   end
   f64.const 0
-  f64.const -0
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -37438,7 +37272,7 @@
    unreachable
   end
   f64.const 0
-  f64.const inf
+  f64.const -inf
   f64.const 0
   call $std/math/test_rem
   i32.eqz
@@ -37451,8 +37285,8 @@
    unreachable
   end
   f64.const 0
-  f64.const -inf
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
   if
@@ -37463,8 +37297,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const 0
-  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37477,7 +37311,7 @@
    unreachable
   end
   f64.const -0
-  f64.const 0
+  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37490,8 +37324,8 @@
    unreachable
   end
   f64.const -0
+  f64.const inf
   f64.const -0
-  f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
   if
@@ -37503,7 +37337,7 @@
    unreachable
   end
   f64.const -0
-  f64.const inf
+  f64.const -inf
   f64.const -0
   call $std/math/test_rem
   i32.eqz
@@ -37516,8 +37350,8 @@
    unreachable
   end
   f64.const -0
-  f64.const -inf
-  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
   if
@@ -37528,8 +37362,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37541,7 +37375,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
@@ -37554,7 +37388,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
@@ -37567,7 +37401,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
@@ -37580,7 +37414,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
@@ -37593,8 +37427,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 0
+  f64.const -1
+  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37606,7 +37440,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
@@ -37619,7 +37453,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
@@ -37632,7 +37466,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
@@ -37645,8 +37479,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -0
+  f64.const inf
+  f64.const 2
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37659,7 +37493,7 @@
    unreachable
   end
   f64.const inf
-  f64.const 2
+  f64.const -0.5
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37672,7 +37506,7 @@
    unreachable
   end
   f64.const inf
-  f64.const -0.5
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37680,19 +37514,6 @@
    i32.const 0
    i32.const 24
    i32.const 2956
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2957
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37705,7 +37526,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2958
+   i32.const 2957
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37718,12 +37539,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2959
+   i32.const 2958
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2959
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_rem
@@ -37736,7 +37570,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_rem
@@ -37749,7 +37583,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_rem
@@ -37762,9 +37596,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const inf
+  f64.const 1
   call $std/math/test_rem
   i32.eqz
   if
@@ -37775,9 +37609,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const inf
-  f64.const 1
+  f64.const -1
   call $std/math/test_rem
   i32.eqz
   if
@@ -37788,9 +37622,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
   f64.const inf
-  f64.const -1
+  f64.const inf
+  f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
   if
@@ -37801,7 +37635,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const inf
   f64.const nan:0x8000000000000
   call $std/math/test_rem
@@ -37814,9 +37648,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
   f64.const -inf
-  f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const 1
   call $std/math/test_rem
   i32.eqz
   if
@@ -37827,9 +37661,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const -inf
-  f64.const 1
+  f64.const -1
   call $std/math/test_rem
   i32.eqz
   if
@@ -37840,9 +37674,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const -inf
-  f64.const -1
+  f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
   if
@@ -37853,7 +37687,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const -inf
   f64.const nan:0x8000000000000
   call $std/math/test_rem
@@ -37866,9 +37700,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
-  f64.const nan:0x8000000000000
+  f64.const 1.75
+  f64.const 0.5
+  f64.const -0.25
   call $std/math/test_rem
   i32.eqz
   if
@@ -37879,9 +37713,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
+  f64.const -1.75
   f64.const 0.5
-  f64.const -0.25
+  f64.const 0.25
   call $std/math/test_rem
   i32.eqz
   if
@@ -37892,9 +37726,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.75
-  f64.const 0.5
-  f64.const 0.25
+  f64.const 1.75
+  f64.const -0.5
+  f64.const -0.25
   call $std/math/test_rem
   i32.eqz
   if
@@ -37905,19 +37739,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const -0.5
-  f64.const -0.25
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2974
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -1.75
   f64.const -0.5
   f64.const 0.25
@@ -37926,7 +37747,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2975
+   i32.const 2974
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37939,7 +37760,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2976
+   i32.const 2975
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37952,7 +37773,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2985
+   i32.const 2984
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37965,7 +37786,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2986
+   i32.const 2985
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37978,7 +37799,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2987
+   i32.const 2986
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37991,7 +37812,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2988
+   i32.const 2987
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38004,7 +37825,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2989
+   i32.const 2988
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38017,7 +37838,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2990
+   i32.const 2989
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38030,7 +37851,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2991
+   i32.const 2990
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38043,7 +37864,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2992
+   i32.const 2991
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38056,7 +37877,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2993
+   i32.const 2992
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38069,7 +37890,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2994
+   i32.const 2993
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38077,6 +37898,19 @@
   f32.const 0
   f32.const 1
   f32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2996
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 1
+  f32.const -0
   call $std/math/test_remf
   i32.eqz
   if
@@ -38087,9 +37921,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0.5
   f32.const 1
-  f32.const -0
+  f32.const 0.5
   call $std/math/test_remf
   i32.eqz
   if
@@ -38100,28 +37934,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -0.5
   f32.const 1
-  f32.const 0.5
+  f32.const -0.5
   call $std/math/test_remf
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2999
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const 1
-  f32.const -0.5
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3000
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38134,7 +37955,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3001
+   i32.const 3000
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38147,7 +37968,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3002
+   i32.const 3001
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38160,7 +37981,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3003
+   i32.const 3002
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38173,7 +37994,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3004
+   i32.const 3003
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38186,7 +38007,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3005
+   i32.const 3004
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38199,12 +38020,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3006
+   i32.const 3005
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const inf
+  f32.const 1
+  f32.const nan:0x400000
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3006
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
   f32.const 1
   f32.const nan:0x400000
   call $std/math/test_remf
@@ -38217,7 +38051,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const 1
   f32.const nan:0x400000
   call $std/math/test_remf
@@ -38230,9 +38064,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const 1
-  f32.const nan:0x400000
+  f32.const 0
+  f32.const -1
+  f32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -38243,9 +38077,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
+  f32.const -0
   f32.const -1
-  f32.const 0
+  f32.const -0
   call $std/math/test_remf
   i32.eqz
   if
@@ -38256,9 +38090,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0.5
   f32.const -1
-  f32.const -0
+  f32.const 0.5
   call $std/math/test_remf
   i32.eqz
   if
@@ -38269,28 +38103,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -0.5
   f32.const -1
-  f32.const 0.5
+  f32.const -0.5
   call $std/math/test_remf
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 3012
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const -1
-  f32.const -0.5
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3013
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38303,7 +38124,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3014
+   i32.const 3013
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38316,7 +38137,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3015
+   i32.const 3014
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38329,7 +38150,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3016
+   i32.const 3015
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38342,7 +38163,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3017
+   i32.const 3016
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38355,7 +38176,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3018
+   i32.const 3017
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38368,12 +38189,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3019
+   i32.const 3018
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const inf
+  f32.const -1
+  f32.const nan:0x400000
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3019
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
   f32.const -1
   f32.const nan:0x400000
   call $std/math/test_remf
@@ -38386,7 +38220,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const -1
   f32.const nan:0x400000
   call $std/math/test_remf
@@ -38399,8 +38233,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -1
+  f32.const 0
+  f32.const 0
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38413,7 +38247,7 @@
    unreachable
   end
   f32.const 0
-  f32.const 0
+  f32.const -0
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38426,8 +38260,8 @@
    unreachable
   end
   f32.const 0
-  f32.const -0
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -38439,7 +38273,7 @@
    unreachable
   end
   f32.const 0
-  f32.const inf
+  f32.const -inf
   f32.const 0
   call $std/math/test_remf
   i32.eqz
@@ -38452,8 +38286,8 @@
    unreachable
   end
   f32.const 0
-  f32.const -inf
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
   if
@@ -38464,8 +38298,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const 0
-  f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38478,7 +38312,7 @@
    unreachable
   end
   f32.const -0
-  f32.const 0
+  f32.const -0
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38491,8 +38325,8 @@
    unreachable
   end
   f32.const -0
+  f32.const inf
   f32.const -0
-  f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
   if
@@ -38504,7 +38338,7 @@
    unreachable
   end
   f32.const -0
-  f32.const inf
+  f32.const -inf
   f32.const -0
   call $std/math/test_remf
   i32.eqz
@@ -38517,8 +38351,8 @@
    unreachable
   end
   f32.const -0
-  f32.const -inf
-  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
   if
@@ -38529,8 +38363,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const nan:0x400000
+  f32.const 1
+  f32.const 0
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38542,7 +38376,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const 0
   f32.const nan:0x400000
   call $std/math/test_remf
@@ -38555,7 +38389,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const inf
   f32.const 0
   f32.const nan:0x400000
   call $std/math/test_remf
@@ -38568,7 +38402,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const 0
   f32.const nan:0x400000
   call $std/math/test_remf
@@ -38581,7 +38415,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const 0
   f32.const nan:0x400000
   call $std/math/test_remf
@@ -38594,8 +38428,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const 0
+  f32.const -1
+  f32.const -0
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38607,7 +38441,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const inf
   f32.const -0
   f32.const nan:0x400000
   call $std/math/test_remf
@@ -38620,7 +38454,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const -0
   f32.const nan:0x400000
   call $std/math/test_remf
@@ -38633,7 +38467,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const -0
   f32.const nan:0x400000
   call $std/math/test_remf
@@ -38646,8 +38480,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -0
+  f32.const inf
+  f32.const 2
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38660,7 +38494,7 @@
    unreachable
   end
   f32.const inf
-  f32.const 2
+  f32.const -0.5
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38673,7 +38507,7 @@
    unreachable
   end
   f32.const inf
-  f32.const -0.5
+  f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38681,19 +38515,6 @@
    i32.const 0
    i32.const 24
    i32.const 3043
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3044
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38706,7 +38527,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3045
+   i32.const 3044
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38719,12 +38540,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3046
+   i32.const 3045
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3046
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_remf
@@ -38737,7 +38571,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const 1
   f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_remf
@@ -38750,7 +38584,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_remf
@@ -38763,9 +38597,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 1
+  f32.const inf
+  f32.const 1
   call $std/math/test_remf
   i32.eqz
   if
@@ -38776,9 +38610,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const inf
-  f32.const 1
+  f32.const -1
   call $std/math/test_remf
   i32.eqz
   if
@@ -38789,9 +38623,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
   f32.const inf
-  f32.const -1
+  f32.const inf
+  f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
   if
@@ -38802,7 +38636,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const inf
   f32.const nan:0x400000
   call $std/math/test_remf
@@ -38815,9 +38649,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1
   f32.const -inf
-  f32.const inf
-  f32.const nan:0x400000
+  f32.const 1
   call $std/math/test_remf
   i32.eqz
   if
@@ -38828,9 +38662,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const -inf
-  f32.const 1
+  f32.const -1
   call $std/math/test_remf
   i32.eqz
   if
@@ -38841,9 +38675,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const inf
   f32.const -inf
-  f32.const -1
+  f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
   if
@@ -38854,7 +38688,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const -inf
   f32.const nan:0x400000
   call $std/math/test_remf
@@ -38867,9 +38701,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
-  f32.const nan:0x400000
+  f32.const 1.75
+  f32.const 0.5
+  f32.const -0.25
   call $std/math/test_remf
   i32.eqz
   if
@@ -38880,9 +38714,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
+  f32.const -1.75
   f32.const 0.5
-  f32.const -0.25
+  f32.const 0.25
   call $std/math/test_remf
   i32.eqz
   if
@@ -38893,9 +38727,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.75
-  f32.const 0.5
-  f32.const 0.25
+  f32.const 1.75
+  f32.const -0.5
+  f32.const -0.25
   call $std/math/test_remf
   i32.eqz
   if
@@ -38906,19 +38740,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
-  f32.const -0.5
-  f32.const -0.25
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3061
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -1.75
   f32.const -0.5
   f32.const 0.25
@@ -38927,7 +38748,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3062
+   i32.const 3061
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38940,7 +38761,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3063
+   i32.const 3062
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38953,7 +38774,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3075
+   i32.const 3074
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38966,7 +38787,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3076
+   i32.const 3075
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38979,7 +38800,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3077
+   i32.const 3076
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38992,7 +38813,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3078
+   i32.const 3077
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39005,7 +38826,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3079
+   i32.const 3078
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39018,7 +38839,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3080
+   i32.const 3079
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39031,7 +38852,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3081
+   i32.const 3080
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39044,7 +38865,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3082
+   i32.const 3081
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39057,7 +38878,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3083
+   i32.const 3082
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39070,7 +38891,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3084
+   i32.const 3083
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39083,7 +38904,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3087
+   i32.const 3086
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39096,13 +38917,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3088
+   i32.const 3087
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.2250738585072014e-308
   f64.const 2.2250738585072014e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3088
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39114,8 +38948,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
+  f64.const 5e-324
+  f64.const 5e-324
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39127,8 +38961,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5e-324
-  f64.const 5e-324
+  f64.const -5e-324
+  f64.const -5e-324
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39140,8 +38974,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5e-324
-  f64.const -5e-324
+  f64.const 0
+  f64.const 0
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39153,8 +38987,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -0
+  f64.const -0
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39166,8 +39000,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 2.225073858507202e-308
+  f64.const 2.225073858507202e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39179,8 +39013,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507202e-308
-  f64.const 2.225073858507202e-308
+  f64.const 2.2250738585072024e-308
+  f64.const 2.2250738585072024e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39192,8 +39026,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072024e-308
-  f64.const 2.2250738585072024e-308
+  f64.const 4.4501477170144003e-308
+  f64.const 4.4501477170144003e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39205,8 +39039,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4501477170144003e-308
-  f64.const 4.4501477170144003e-308
+  f64.const 4.450147717014403e-308
+  f64.const 4.450147717014403e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39218,8 +39052,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.450147717014403e-308
-  f64.const 4.450147717014403e-308
+  f64.const 4.450147717014406e-308
+  f64.const 4.450147717014406e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39231,8 +39065,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.450147717014406e-308
-  f64.const 4.450147717014406e-308
+  f64.const 8.900295434028806e-308
+  f64.const 8.900295434028806e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39240,19 +39074,6 @@
    i32.const 0
    i32.const 24
    i32.const 3099
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 8.900295434028806e-308
-  f64.const 8.900295434028806e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3100
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39265,7 +39086,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3101
+   i32.const 3100
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39278,13 +39099,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3102
+   i32.const 3101
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2.225073858507202e-308
   f64.const -2.225073858507202e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3102
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072024e-308
+  f64.const -2.2250738585072024e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39296,8 +39130,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072024e-308
-  f64.const -2.2250738585072024e-308
+  f64.const -4.4501477170144003e-308
+  f64.const -4.4501477170144003e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39309,8 +39143,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4501477170144003e-308
-  f64.const -4.4501477170144003e-308
+  f64.const -4.450147717014403e-308
+  f64.const -4.450147717014403e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39322,8 +39156,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.450147717014403e-308
-  f64.const -4.450147717014403e-308
+  f64.const -4.450147717014406e-308
+  f64.const -4.450147717014406e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39335,8 +39169,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.450147717014406e-308
-  f64.const -4.450147717014406e-308
+  f64.const -8.900295434028806e-308
+  f64.const -8.900295434028806e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39348,9 +39182,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8.900295434028806e-308
-  f64.const -8.900295434028806e-308
-  f64.const 0
+  f64.const -1.1175870895385742e-08
+  f64.const -1.1175870895385742e-08
+  f64.const -0.140625
   call $std/math/test_sin
   i32.eqz
   if
@@ -39361,9 +39195,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.1175870895385742e-08
-  f64.const -1.1175870895385742e-08
-  f64.const -0.140625
+  f64.const -1.4901161193847656e-08
+  f64.const -1.4901161193847656e-08
+  f64.const -0.1666666716337204
   call $std/math/test_sin
   i32.eqz
   if
@@ -39387,9 +39221,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.4901161193847656e-08
-  f64.const -1.4901161193847656e-08
-  f64.const -0.1666666716337204
+  f64.const 1e-323
+  f64.const 1e-323
+  f64.const 0
   call $std/math/test_sin
   i32.eqz
   if
@@ -39400,8 +39234,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1e-323
-  f64.const 1e-323
+  f64.const 4.4e-323
+  f64.const 4.4e-323
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39413,8 +39247,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4e-323
-  f64.const 4.4e-323
+  f64.const 5.562684646268003e-309
+  f64.const 5.562684646268003e-309
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39426,8 +39260,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5.562684646268003e-309
-  f64.const 5.562684646268003e-309
+  f64.const 1.1125369292536007e-308
+  f64.const 1.1125369292536007e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39439,8 +39273,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.1125369292536007e-308
-  f64.const 1.1125369292536007e-308
+  f64.const 2.2250738585072004e-308
+  f64.const 2.2250738585072004e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39452,8 +39286,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072004e-308
-  f64.const 2.2250738585072004e-308
+  f64.const 2.225073858507201e-308
+  f64.const 2.225073858507201e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39465,8 +39299,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507201e-308
-  f64.const 2.225073858507201e-308
+  f64.const -1e-323
+  f64.const -1e-323
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39478,8 +39312,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1e-323
-  f64.const -1e-323
+  f64.const -4.4e-323
+  f64.const -4.4e-323
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39491,8 +39325,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4e-323
-  f64.const -4.4e-323
+  f64.const -5.562684646268003e-309
+  f64.const -5.562684646268003e-309
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39504,8 +39338,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5.562684646268003e-309
-  f64.const -5.562684646268003e-309
+  f64.const -1.1125369292536007e-308
+  f64.const -1.1125369292536007e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39517,8 +39351,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.1125369292536007e-308
-  f64.const -1.1125369292536007e-308
+  f64.const -2.2250738585072004e-308
+  f64.const -2.2250738585072004e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39530,8 +39364,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072004e-308
-  f64.const -2.2250738585072004e-308
+  f64.const -2.225073858507201e-308
+  f64.const -2.225073858507201e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39543,21 +39377,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.225073858507201e-308
-  f64.const -2.225073858507201e-308
+  f64.const 0
+  f64.const 0
   f64.const 0
   call $std/math/test_sin
   i32.eqz
   if
    i32.const 0
    i32.const 24
-   i32.const 3123
+   i32.const 3125
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -0
+  f64.const -0
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39569,8 +39403,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39582,7 +39416,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_sin
@@ -39595,7 +39429,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_sin
@@ -39608,22 +39442,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
+  f64.const 1.5707963267948966
+  call $~lib/math/NativeMath.sin
+  f64.const 1.5707963267948966
+  call $~lib/bindings/Math/sin
+  f64.ne
   if
    i32.const 0
    i32.const 24
-   i32.const 3130
+   i32.const 3132
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5707963267948966
+  f64.const 3.141592653589793
   call $~lib/math/NativeMath.sin
-  f64.const 1.5707963267948966
+  f64.const 3.141592653589793
   call $~lib/bindings/Math/sin
   f64.ne
   if
@@ -39634,39 +39468,26 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 3.141592653589793
+  f64.const 2.3283064365386963e-10
+  f64.const 2.3283064365386963e-10
   call $~lib/math/NativeMath.sin
-  f64.const 3.141592653589793
-  call $~lib/bindings/Math/sin
   f64.ne
   if
    i32.const 0
    i32.const 24
-   i32.const 3134
+   i32.const 3136
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.3283064365386963e-10
-  f64.const 2.3283064365386963e-10
+  f64.const -2.3283064365386963e-10
+  f64.const -2.3283064365386963e-10
   call $~lib/math/NativeMath.sin
   f64.ne
   if
    i32.const 0
    i32.const 24
    i32.const 3137
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.3283064365386963e-10
-  f64.const -2.3283064365386963e-10
-  call $~lib/math/NativeMath.sin
-  f64.ne
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3138
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39678,7 +39499,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3140
+   i32.const 3139
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39690,7 +39511,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3141
+   i32.const 3140
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39702,7 +39523,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3144
+   i32.const 3143
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39714,7 +39535,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3145
+   i32.const 3144
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39726,7 +39547,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3146
+   i32.const 3145
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39738,7 +39559,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3147
+   i32.const 3146
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39750,7 +39571,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3149
+   i32.const 3148
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39762,7 +39583,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3150
+   i32.const 3149
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39774,7 +39595,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3152
+   i32.const 3151
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39786,7 +39607,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3153
+   i32.const 3152
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39798,7 +39619,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3154
+   i32.const 3153
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39810,7 +39631,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3155
+   i32.const 3154
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39822,7 +39643,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3156
+   i32.const 3155
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39834,7 +39655,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3159
+   i32.const 3158
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39846,7 +39667,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3160
+   i32.const 3159
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39859,7 +39680,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3169
+   i32.const 3168
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39872,7 +39693,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3170
+   i32.const 3169
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39885,7 +39706,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3171
+   i32.const 3170
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39898,7 +39719,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3172
+   i32.const 3171
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39911,7 +39732,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3173
+   i32.const 3172
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39924,7 +39745,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3174
+   i32.const 3173
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39937,7 +39758,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3175
+   i32.const 3174
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39950,7 +39771,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3176
+   i32.const 3175
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39963,7 +39784,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3177
+   i32.const 3176
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39976,13 +39797,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3178
+   i32.const 3177
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const 0
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3180
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -39994,8 +39828,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40007,7 +39841,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_sinf
@@ -40020,7 +39854,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_sinf
@@ -40033,19 +39867,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3185
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const 1.862645149230957e-09
   f32.const 1.862645149230957e-09
   f32.const 4.850638554015907e-12
@@ -40054,7 +39875,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3188
+   i32.const 3187
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40067,13 +39888,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3189
+   i32.const 3188
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.1754943508222875e-38
   f32.const 1.1754943508222875e-38
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3189
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754943508222875e-38
+  f32.const -1.1754943508222875e-38
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40085,8 +39919,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754943508222875e-38
-  f32.const -1.1754943508222875e-38
+  f32.const 1.401298464324817e-45
+  f32.const 1.401298464324817e-45
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40098,8 +39932,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.401298464324817e-45
-  f32.const 1.401298464324817e-45
+  f32.const -1.401298464324817e-45
+  f32.const -1.401298464324817e-45
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40111,8 +39945,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.401298464324817e-45
-  f32.const -1.401298464324817e-45
+  f32.const 1.175494490952134e-38
+  f32.const 1.175494490952134e-38
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40124,8 +39958,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.175494490952134e-38
-  f32.const 1.175494490952134e-38
+  f32.const 1.1754946310819804e-38
+  f32.const 1.1754946310819804e-38
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40137,8 +39971,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754946310819804e-38
-  f32.const 1.1754946310819804e-38
+  f32.const 2.3509880009953429e-38
+  f32.const 2.3509880009953429e-38
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40150,8 +39984,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509880009953429e-38
-  f32.const 2.3509880009953429e-38
+  f32.const 2.350988701644575e-38
+  f32.const 2.350988701644575e-38
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40163,8 +39997,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.350988701644575e-38
-  f32.const 2.350988701644575e-38
+  f32.const 2.3509895424236536e-38
+  f32.const 2.3509895424236536e-38
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40176,8 +40010,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509895424236536e-38
-  f32.const 2.3509895424236536e-38
+  f32.const 4.70197740328915e-38
+  f32.const 4.70197740328915e-38
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40185,19 +40019,6 @@
    i32.const 0
    i32.const 24
    i32.const 3198
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 4.70197740328915e-38
-  f32.const 4.70197740328915e-38
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3199
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40210,7 +40031,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3200
+   i32.const 3199
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40223,7 +40044,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3201
+   i32.const 3200
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40236,7 +40057,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3202
+   i32.const 3201
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40249,13 +40070,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3203
+   i32.const 3202
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1.175494490952134e-38
   f32.const -1.175494490952134e-38
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3203
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754946310819804e-38
+  f32.const -1.1754946310819804e-38
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40267,8 +40101,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754946310819804e-38
-  f32.const -1.1754946310819804e-38
+  f32.const -2.3509880009953429e-38
+  f32.const -2.3509880009953429e-38
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40280,8 +40114,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.3509880009953429e-38
-  f32.const -2.3509880009953429e-38
+  f32.const -2.350988701644575e-38
+  f32.const -2.350988701644575e-38
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40293,8 +40127,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.350988701644575e-38
-  f32.const -2.350988701644575e-38
+  f32.const -2.3509895424236536e-38
+  f32.const -2.3509895424236536e-38
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40306,8 +40140,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.3509895424236536e-38
-  f32.const -2.3509895424236536e-38
+  f32.const -4.70197740328915e-38
+  f32.const -4.70197740328915e-38
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40315,19 +40149,6 @@
    i32.const 0
    i32.const 24
    i32.const 3208
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -4.70197740328915e-38
-  f32.const -4.70197740328915e-38
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3209
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40340,7 +40161,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3210
+   i32.const 3209
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40353,7 +40174,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3211
+   i32.const 3210
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40366,7 +40187,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3212
+   i32.const 3211
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40379,13 +40200,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3213
+   i32.const 3212
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 2.802596928649634e-45
   f32.const 2.802596928649634e-45
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3213
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.2611686178923354e-44
+  f32.const 1.2611686178923354e-44
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40397,8 +40231,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.2611686178923354e-44
-  f32.const 1.2611686178923354e-44
+  f32.const 2.938735877055719e-39
+  f32.const 2.938735877055719e-39
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40410,8 +40244,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.938735877055719e-39
-  f32.const 2.938735877055719e-39
+  f32.const 5.877471754111438e-39
+  f32.const 5.877471754111438e-39
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40423,8 +40257,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 5.877471754111438e-39
-  f32.const 5.877471754111438e-39
+  f32.const 1.1754940705625946e-38
+  f32.const 1.1754940705625946e-38
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40436,8 +40270,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754940705625946e-38
-  f32.const 1.1754940705625946e-38
+  f32.const 1.1754942106924411e-38
+  f32.const 1.1754942106924411e-38
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40449,8 +40283,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754942106924411e-38
-  f32.const 1.1754942106924411e-38
+  f32.const -2.802596928649634e-45
+  f32.const -2.802596928649634e-45
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40462,8 +40296,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.802596928649634e-45
-  f32.const -2.802596928649634e-45
+  f32.const -1.2611686178923354e-44
+  f32.const -1.2611686178923354e-44
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40475,8 +40309,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.2611686178923354e-44
-  f32.const -1.2611686178923354e-44
+  f32.const -2.938735877055719e-39
+  f32.const -2.938735877055719e-39
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40488,8 +40322,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.938735877055719e-39
-  f32.const -2.938735877055719e-39
+  f32.const -5.877471754111438e-39
+  f32.const -5.877471754111438e-39
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40501,8 +40335,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -5.877471754111438e-39
-  f32.const -5.877471754111438e-39
+  f32.const -1.1754940705625946e-38
+  f32.const -1.1754940705625946e-38
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40514,8 +40348,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754940705625946e-38
-  f32.const -1.1754940705625946e-38
+  f32.const -1.1754942106924411e-38
+  f32.const -1.1754942106924411e-38
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40523,19 +40357,6 @@
    i32.const 0
    i32.const 24
    i32.const 3224
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754942106924411e-38
-  f32.const -1.1754942106924411e-38
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3225
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40548,7 +40369,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3228
+   i32.const 3227
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40561,7 +40382,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3229
+   i32.const 3228
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40574,7 +40395,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3230
+   i32.const 3229
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40587,7 +40408,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3231
+   i32.const 3230
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40600,7 +40421,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3232
+   i32.const 3231
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40613,7 +40434,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3233
+   i32.const 3232
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40626,7 +40447,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3234
+   i32.const 3233
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40639,7 +40460,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3235
+   i32.const 3234
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40652,7 +40473,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3236
+   i32.const 3235
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40665,7 +40486,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3237
+   i32.const 3236
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40678,7 +40499,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3238
+   i32.const 3237
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40691,7 +40512,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3239
+   i32.const 3238
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40704,7 +40525,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3240
+   i32.const 3239
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40717,7 +40538,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3241
+   i32.const 3240
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40730,7 +40551,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3253
+   i32.const 3252
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40743,7 +40564,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3254
+   i32.const 3253
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40756,7 +40577,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3255
+   i32.const 3254
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40769,7 +40590,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3256
+   i32.const 3255
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40782,7 +40603,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3257
+   i32.const 3256
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40795,7 +40616,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3258
+   i32.const 3257
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40808,7 +40629,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3259
+   i32.const 3258
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40821,7 +40642,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3260
+   i32.const 3259
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40834,7 +40655,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3261
+   i32.const 3260
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40847,13 +40668,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3262
+   i32.const 3261
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const 0
+  f64.const 0
+  call $std/math/test_sinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3264
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
   f64.const 0
   call $std/math/test_sinh
   i32.eqz
@@ -40865,8 +40699,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const inf
+  f64.const inf
   f64.const 0
   call $std/math/test_sinh
   i32.eqz
@@ -40878,8 +40712,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const -inf
+  f64.const -inf
   f64.const 0
   call $std/math/test_sinh
   i32.eqz
@@ -40891,8 +40725,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_sinh
   i32.eqz
@@ -40900,19 +40734,6 @@
    i32.const 0
    i32.const 24
    i32.const 3268
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_sinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3269
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40925,7 +40746,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3278
+   i32.const 3277
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40938,7 +40759,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3279
+   i32.const 3278
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40951,7 +40772,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3280
+   i32.const 3279
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40964,7 +40785,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3281
+   i32.const 3280
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40977,7 +40798,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3282
+   i32.const 3281
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40990,7 +40811,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3283
+   i32.const 3282
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41003,7 +40824,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3284
+   i32.const 3283
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41016,7 +40837,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3285
+   i32.const 3284
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41029,7 +40850,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3286
+   i32.const 3285
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41042,13 +40863,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3287
+   i32.const 3286
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const 0
+  f32.const 0
+  call $std/math/test_sinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3289
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/test_sinhf
   i32.eqz
@@ -41060,8 +40894,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/test_sinhf
   i32.eqz
@@ -41073,8 +40907,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   call $std/math/test_sinhf
   i32.eqz
@@ -41086,8 +40920,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_sinhf
   i32.eqz
@@ -41095,19 +40929,6 @@
    i32.const 0
    i32.const 24
    i32.const 3293
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_sinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3294
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41120,7 +40941,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3306
+   i32.const 3305
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41133,12 +40954,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3307
+   i32.const 3306
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.38143342755525
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_sqrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3307
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -6.531673581913484
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_sqrt
@@ -41151,19 +40985,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -6.531673581913484
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_sqrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3309
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const 9.267056966972586
   f64.const 3.0441841217266385
   f64.const -0.01546262577176094
@@ -41172,7 +40993,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3310
+   i32.const 3309
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41185,7 +41006,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3311
+   i32.const 3310
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41198,7 +41019,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3312
+   i32.const 3311
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41211,7 +41032,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3313
+   i32.const 3312
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41224,7 +41045,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3314
+   i32.const 3313
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41237,13 +41058,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3315
+   i32.const 3314
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_sqrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3317
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
   f64.const 0
   call $std/math/test_sqrt
   i32.eqz
@@ -41251,19 +41085,6 @@
    i32.const 0
    i32.const 24
    i32.const 3318
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  f64.const 0
-  call $std/math/test_sqrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3319
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41276,13 +41097,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3320
+   i32.const 3319
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const 0
+  f64.const 0
+  call $std/math/test_sqrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3320
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
   f64.const 0
   call $std/math/test_sqrt
   i32.eqz
@@ -41294,8 +41128,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 1
+  f64.const 1
   f64.const 0
   call $std/math/test_sqrt
   i32.eqz
@@ -41303,19 +41137,6 @@
    i32.const 0
    i32.const 24
    i32.const 3322
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  f64.const 0
-  call $std/math/test_sqrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3323
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41328,7 +41149,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3324
+   i32.const 3323
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41341,7 +41162,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3325
+   i32.const 3324
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41354,7 +41175,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3326
+   i32.const 3325
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41367,7 +41188,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3327
+   i32.const 3326
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41380,7 +41201,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3328
+   i32.const 3327
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41393,7 +41214,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3329
+   i32.const 3328
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41406,7 +41227,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3330
+   i32.const 3329
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41419,7 +41240,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3331
+   i32.const 3330
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41432,7 +41253,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3332
+   i32.const 3331
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41445,7 +41266,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3333
+   i32.const 3332
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41458,7 +41279,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3334
+   i32.const 3333
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41471,7 +41292,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3335
+   i32.const 3334
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41484,7 +41305,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3336
+   i32.const 3335
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41497,7 +41318,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3337
+   i32.const 3336
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41510,7 +41331,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3338
+   i32.const 3337
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41523,7 +41344,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3339
+   i32.const 3338
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41536,7 +41357,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3340
+   i32.const 3339
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41549,7 +41370,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3341
+   i32.const 3340
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41562,7 +41383,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3342
+   i32.const 3341
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41575,7 +41396,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3343
+   i32.const 3342
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41588,7 +41409,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3344
+   i32.const 3343
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41601,7 +41422,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3345
+   i32.const 3344
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41614,7 +41435,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3346
+   i32.const 3345
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41627,7 +41448,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3347
+   i32.const 3346
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41640,7 +41461,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3348
+   i32.const 3347
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41653,7 +41474,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3349
+   i32.const 3348
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41666,7 +41487,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3350
+   i32.const 3349
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41679,7 +41500,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3351
+   i32.const 3350
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41692,7 +41513,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3352
+   i32.const 3351
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41705,7 +41526,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3353
+   i32.const 3352
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41718,7 +41539,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3354
+   i32.const 3353
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41731,7 +41552,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3355
+   i32.const 3354
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41744,7 +41565,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3356
+   i32.const 3355
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41757,7 +41578,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3357
+   i32.const 3356
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41770,7 +41591,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3358
+   i32.const 3357
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41783,7 +41604,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3359
+   i32.const 3358
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41796,7 +41617,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3360
+   i32.const 3359
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41809,7 +41630,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3361
+   i32.const 3360
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41822,7 +41643,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3362
+   i32.const 3361
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41835,7 +41656,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3363
+   i32.const 3362
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41848,7 +41669,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3364
+   i32.const 3363
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41861,7 +41682,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3365
+   i32.const 3364
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41874,7 +41695,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3366
+   i32.const 3365
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41887,7 +41708,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3367
+   i32.const 3366
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41900,7 +41721,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3368
+   i32.const 3367
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41913,7 +41734,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3369
+   i32.const 3368
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41926,7 +41747,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3370
+   i32.const 3369
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41939,7 +41760,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3371
+   i32.const 3370
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41952,7 +41773,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3372
+   i32.const 3371
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41965,7 +41786,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3373
+   i32.const 3372
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41978,7 +41799,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3374
+   i32.const 3373
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41991,7 +41812,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3375
+   i32.const 3374
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42004,7 +41825,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3376
+   i32.const 3375
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42017,7 +41838,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3377
+   i32.const 3376
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42030,7 +41851,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3378
+   i32.const 3377
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42043,7 +41864,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3379
+   i32.const 3378
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42056,7 +41877,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3380
+   i32.const 3379
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42069,7 +41890,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3381
+   i32.const 3380
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42082,7 +41903,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3382
+   i32.const 3381
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42095,7 +41916,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3383
+   i32.const 3382
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42108,7 +41929,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3384
+   i32.const 3383
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42121,7 +41942,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3385
+   i32.const 3384
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42134,7 +41955,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3386
+   i32.const 3385
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42147,7 +41968,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3387
+   i32.const 3386
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42160,7 +41981,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3388
+   i32.const 3387
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42173,7 +41994,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3389
+   i32.const 3388
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42186,7 +42007,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3390
+   i32.const 3389
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42199,7 +42020,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3391
+   i32.const 3390
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42212,7 +42033,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3400
+   i32.const 3399
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42225,12 +42046,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3401
+   i32.const 3400
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8.381433486938477
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_sqrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3401
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -6.531673431396484
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_sqrtf
@@ -42243,19 +42077,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.531673431396484
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_sqrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3403
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const 9.267057418823242
   f32.const 3.0441842079162598
   f32.const 0.05022354796528816
@@ -42264,7 +42085,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3404
+   i32.const 3403
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42277,7 +42098,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3405
+   i32.const 3404
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42290,7 +42111,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3406
+   i32.const 3405
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42303,7 +42124,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3407
+   i32.const 3406
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42316,7 +42137,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3408
+   i32.const 3407
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42329,13 +42150,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3409
+   i32.const 3408
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_sqrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3411
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/test_sqrtf
   i32.eqz
@@ -42343,19 +42177,6 @@
    i32.const 0
    i32.const 24
    i32.const 3412
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  call $std/math/test_sqrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3413
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42368,13 +42189,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3414
+   i32.const 3413
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const 0
+  f32.const 0
+  call $std/math/test_sqrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3414
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/test_sqrtf
   i32.eqz
@@ -42386,8 +42220,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   f32.const 0
   call $std/math/test_sqrtf
   i32.eqz
@@ -42395,19 +42229,6 @@
    i32.const 0
    i32.const 24
    i32.const 3416
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  call $std/math/test_sqrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3417
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42420,7 +42241,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3418
+   i32.const 3417
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42433,7 +42254,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3419
+   i32.const 3418
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42446,7 +42267,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3420
+   i32.const 3419
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42459,7 +42280,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3421
+   i32.const 3420
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42472,7 +42293,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3422
+   i32.const 3421
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42485,7 +42306,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3423
+   i32.const 3422
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42498,7 +42319,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3424
+   i32.const 3423
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42511,7 +42332,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3425
+   i32.const 3424
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42524,7 +42345,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3426
+   i32.const 3425
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42537,7 +42358,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3427
+   i32.const 3426
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42550,7 +42371,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3428
+   i32.const 3427
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42563,7 +42384,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3429
+   i32.const 3428
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42576,7 +42397,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3430
+   i32.const 3429
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42589,7 +42410,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3431
+   i32.const 3430
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42602,7 +42423,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3432
+   i32.const 3431
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42615,7 +42436,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3433
+   i32.const 3432
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42628,7 +42449,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3445
+   i32.const 3444
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42641,7 +42462,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3446
+   i32.const 3445
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42654,7 +42475,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3447
+   i32.const 3446
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42667,7 +42488,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3448
+   i32.const 3447
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42680,7 +42501,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3449
+   i32.const 3448
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42693,7 +42514,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3450
+   i32.const 3449
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42706,7 +42527,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3451
+   i32.const 3450
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42719,7 +42540,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3452
+   i32.const 3451
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42732,7 +42553,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3453
+   i32.const 3452
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42745,7 +42566,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3454
+   i32.const 3453
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42758,7 +42579,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3457
+   i32.const 3456
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42771,13 +42592,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3458
+   i32.const 3457
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.2250738585072014e-308
   f64.const 2.2250738585072014e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3458
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -42789,8 +42623,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
+  f64.const 5e-324
+  f64.const 5e-324
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -42802,8 +42636,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5e-324
-  f64.const 5e-324
+  f64.const -5e-324
+  f64.const -5e-324
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -42815,8 +42649,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5e-324
-  f64.const -5e-324
+  f64.const 0
+  f64.const 0
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -42828,8 +42662,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -0
+  f64.const -0
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -42837,19 +42671,6 @@
    i32.const 0
    i32.const 24
    i32.const 3463
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3464
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42862,7 +42683,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3465
+   i32.const 3464
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42875,13 +42696,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3466
+   i32.const 3465
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.225073858507202e-308
   f64.const 2.225073858507202e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3466
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.2250738585072024e-308
+  f64.const 2.2250738585072024e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -42893,8 +42727,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072024e-308
-  f64.const 2.2250738585072024e-308
+  f64.const 4.4501477170144003e-308
+  f64.const 4.4501477170144003e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -42906,8 +42740,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4501477170144003e-308
-  f64.const 4.4501477170144003e-308
+  f64.const 4.450147717014403e-308
+  f64.const 4.450147717014403e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -42919,8 +42753,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.450147717014403e-308
-  f64.const 4.450147717014403e-308
+  f64.const 4.450147717014406e-308
+  f64.const 4.450147717014406e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -42932,8 +42766,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.450147717014406e-308
-  f64.const 4.450147717014406e-308
+  f64.const 8.900295434028806e-308
+  f64.const 8.900295434028806e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -42941,19 +42775,6 @@
    i32.const 0
    i32.const 24
    i32.const 3471
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 8.900295434028806e-308
-  f64.const 8.900295434028806e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3472
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42966,7 +42787,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3473
+   i32.const 3472
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42979,13 +42800,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3474
+   i32.const 3473
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2.225073858507202e-308
   f64.const -2.225073858507202e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3474
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072024e-308
+  f64.const -2.2250738585072024e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -42997,8 +42831,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072024e-308
-  f64.const -2.2250738585072024e-308
+  f64.const -4.4501477170144003e-308
+  f64.const -4.4501477170144003e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -43010,8 +42844,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4501477170144003e-308
-  f64.const -4.4501477170144003e-308
+  f64.const -4.450147717014403e-308
+  f64.const -4.450147717014403e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -43023,8 +42857,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.450147717014403e-308
-  f64.const -4.450147717014403e-308
+  f64.const -4.450147717014406e-308
+  f64.const -4.450147717014406e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -43036,8 +42870,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.450147717014406e-308
-  f64.const -4.450147717014406e-308
+  f64.const -8.900295434028806e-308
+  f64.const -8.900295434028806e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -43045,19 +42879,6 @@
    i32.const 0
    i32.const 24
    i32.const 3479
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -8.900295434028806e-308
-  f64.const -8.900295434028806e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3480
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43070,7 +42891,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3481
+   i32.const 3480
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43083,13 +42904,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3482
+   i32.const 3481
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1e-323
   f64.const 1e-323
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3482
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.4e-323
+  f64.const 4.4e-323
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -43101,8 +42935,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4e-323
-  f64.const 4.4e-323
+  f64.const 5.562684646268003e-309
+  f64.const 5.562684646268003e-309
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -43114,8 +42948,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5.562684646268003e-309
-  f64.const 5.562684646268003e-309
+  f64.const 1.1125369292536007e-308
+  f64.const 1.1125369292536007e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -43127,8 +42961,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.1125369292536007e-308
-  f64.const 1.1125369292536007e-308
+  f64.const 2.2250738585072004e-308
+  f64.const 2.2250738585072004e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -43140,8 +42974,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072004e-308
-  f64.const 2.2250738585072004e-308
+  f64.const 2.225073858507201e-308
+  f64.const 2.225073858507201e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -43153,8 +42987,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507201e-308
-  f64.const 2.225073858507201e-308
+  f64.const -1e-323
+  f64.const -1e-323
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -43166,8 +43000,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1e-323
-  f64.const -1e-323
+  f64.const -4.4e-323
+  f64.const -4.4e-323
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -43179,8 +43013,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4e-323
-  f64.const -4.4e-323
+  f64.const -5.562684646268003e-309
+  f64.const -5.562684646268003e-309
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -43192,8 +43026,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5.562684646268003e-309
-  f64.const -5.562684646268003e-309
+  f64.const -1.1125369292536007e-308
+  f64.const -1.1125369292536007e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -43205,8 +43039,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.1125369292536007e-308
-  f64.const -1.1125369292536007e-308
+  f64.const -2.2250738585072004e-308
+  f64.const -2.2250738585072004e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -43218,8 +43052,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072004e-308
-  f64.const -2.2250738585072004e-308
+  f64.const -2.225073858507201e-308
+  f64.const -2.225073858507201e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -43231,22 +43065,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.225073858507201e-308
-  f64.const -2.225073858507201e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
+  f64.const 2.3283064365386963e-10
+  call $~lib/math/NativeMath.tan
+  f64.const 2.3283064365386963e-10
+  call $~lib/bindings/Math/tan
+  f64.ne
   if
    i32.const 0
    i32.const 24
-   i32.const 3494
+   i32.const 3496
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.3283064365386963e-10
+  f64.const -2.3283064365386963e-10
   call $~lib/math/NativeMath.tan
-  f64.const 2.3283064365386963e-10
+  f64.const -2.3283064365386963e-10
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -43257,9 +43091,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.3283064365386963e-10
+  f64.const 0.6875
   call $~lib/math/NativeMath.tan
-  f64.const -2.3283064365386963e-10
+  f64.const 0.6875
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -43270,9 +43104,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.6875
+  f64.const -0.6875
   call $~lib/math/NativeMath.tan
-  f64.const 0.6875
+  f64.const -0.6875
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -43283,9 +43117,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.6875
+  f64.const 0.39269908169872414
   call $~lib/math/NativeMath.tan
-  f64.const -0.6875
+  f64.const 0.39269908169872414
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -43296,9 +43130,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.39269908169872414
+  f64.const 0.6743358
   call $~lib/math/NativeMath.tan
-  f64.const 0.39269908169872414
+  f64.const 0.6743358
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -43309,9 +43143,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.6743358
+  f64.const 3.725290298461914e-09
   call $~lib/math/NativeMath.tan
-  f64.const 0.6743358
+  f64.const 3.725290298461914e-09
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -43322,9 +43156,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 3.725290298461914e-09
+  f64.const 1.5707963267948966
   call $~lib/math/NativeMath.tan
-  f64.const 3.725290298461914e-09
+  f64.const 1.5707963267948966
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -43335,22 +43169,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5707963267948966
+  f64.const 0.5
   call $~lib/math/NativeMath.tan
-  f64.const 1.5707963267948966
+  f64.const 0.5
   call $~lib/bindings/Math/tan
   f64.ne
   if
    i32.const 0
    i32.const 24
-   i32.const 3504
+   i32.const 3505
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const 1.107148717794091
   call $~lib/math/NativeMath.tan
-  f64.const 0.5
+  f64.const 1.107148717794091
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -43361,9 +43195,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.107148717794091
+  f64.const 5.497787143782138
   call $~lib/math/NativeMath.tan
-  f64.const 1.107148717794091
+  f64.const 5.497787143782138
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -43374,9 +43208,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5.497787143782138
+  f64.const 7.0685834705770345
   call $~lib/math/NativeMath.tan
-  f64.const 5.497787143782138
+  f64.const 7.0685834705770345
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -43387,9 +43221,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 7.0685834705770345
+  f64.const 1647099.3291652855
   call $~lib/math/NativeMath.tan
-  f64.const 7.0685834705770345
+  f64.const 1647099.3291652855
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -43400,9 +43234,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1647099.3291652855
+  f64.const 1647097.7583689587
   call $~lib/math/NativeMath.tan
-  f64.const 1647099.3291652855
+  f64.const 1647097.7583689587
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -43413,9 +43247,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1647097.7583689587
+  f64.const 1329227995784915872903807e12
   call $~lib/math/NativeMath.tan
-  f64.const 1647097.7583689587
+  f64.const 1329227995784915872903807e12
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -43426,9 +43260,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1329227995784915872903807e12
+  f64.const -1329227995784915872903807e12
   call $~lib/math/NativeMath.tan
-  f64.const 1329227995784915872903807e12
+  f64.const -1329227995784915872903807e12
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -43439,21 +43273,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1329227995784915872903807e12
-  call $~lib/math/NativeMath.tan
-  f64.const -1329227995784915872903807e12
-  call $~lib/bindings/Math/tan
-  f64.ne
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
   if
    i32.const 0
    i32.const 24
-   i32.const 3513
+   i32.const 3515
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -0
+  f64.const -0
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -43465,8 +43299,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -43478,7 +43312,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_tan
@@ -43491,7 +43325,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_tan
@@ -43504,19 +43338,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3520
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -8.066848754882812
   f32.const 4.626595497131348
   f32.const 0.2455666959285736
@@ -43525,7 +43346,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3529
+   i32.const 3528
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43538,7 +43359,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3530
+   i32.const 3529
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43551,7 +43372,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3531
+   i32.const 3530
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43564,7 +43385,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3532
+   i32.const 3531
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43577,7 +43398,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3533
+   i32.const 3532
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43590,7 +43411,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3534
+   i32.const 3533
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43603,7 +43424,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3535
+   i32.const 3534
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43616,7 +43437,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3536
+   i32.const 3535
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43629,7 +43450,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3537
+   i32.const 3536
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43642,13 +43463,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3538
+   i32.const 3537
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const 0
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3540
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -43660,8 +43494,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -43673,7 +43507,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_tanf
@@ -43686,7 +43520,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_tanf
@@ -43699,19 +43533,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3545
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const 1.862645149230957e-09
   f32.const 1.862645149230957e-09
   f32.const -9.701277108031814e-12
@@ -43720,7 +43541,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3548
+   i32.const 3547
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43733,13 +43554,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3549
+   i32.const 3548
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.1754943508222875e-38
   f32.const 1.1754943508222875e-38
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3549
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754943508222875e-38
+  f32.const -1.1754943508222875e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -43751,8 +43585,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754943508222875e-38
-  f32.const -1.1754943508222875e-38
+  f32.const 1.401298464324817e-45
+  f32.const 1.401298464324817e-45
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -43764,8 +43598,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.401298464324817e-45
-  f32.const 1.401298464324817e-45
+  f32.const -1.401298464324817e-45
+  f32.const -1.401298464324817e-45
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -43777,8 +43611,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.401298464324817e-45
-  f32.const -1.401298464324817e-45
+  f32.const 1.175494490952134e-38
+  f32.const 1.175494490952134e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -43790,8 +43624,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.175494490952134e-38
-  f32.const 1.175494490952134e-38
+  f32.const 1.1754946310819804e-38
+  f32.const 1.1754946310819804e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -43803,8 +43637,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754946310819804e-38
-  f32.const 1.1754946310819804e-38
+  f32.const 2.3509880009953429e-38
+  f32.const 2.3509880009953429e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -43816,8 +43650,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509880009953429e-38
-  f32.const 2.3509880009953429e-38
+  f32.const 2.350988701644575e-38
+  f32.const 2.350988701644575e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -43829,8 +43663,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.350988701644575e-38
-  f32.const 2.350988701644575e-38
+  f32.const 2.3509895424236536e-38
+  f32.const 2.3509895424236536e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -43842,8 +43676,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509895424236536e-38
-  f32.const 2.3509895424236536e-38
+  f32.const 4.70197740328915e-38
+  f32.const 4.70197740328915e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -43851,19 +43685,6 @@
    i32.const 0
    i32.const 24
    i32.const 3558
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 4.70197740328915e-38
-  f32.const 4.70197740328915e-38
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3559
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43876,7 +43697,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3560
+   i32.const 3559
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43889,7 +43710,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3561
+   i32.const 3560
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43902,13 +43723,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3562
+   i32.const 3561
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1.175494490952134e-38
   f32.const -1.175494490952134e-38
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3562
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754946310819804e-38
+  f32.const -1.1754946310819804e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -43920,8 +43754,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754946310819804e-38
-  f32.const -1.1754946310819804e-38
+  f32.const -2.3509880009953429e-38
+  f32.const -2.3509880009953429e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -43933,8 +43767,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.3509880009953429e-38
-  f32.const -2.3509880009953429e-38
+  f32.const 2.350988701644575e-38
+  f32.const 2.350988701644575e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -43946,8 +43780,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.350988701644575e-38
-  f32.const 2.350988701644575e-38
+  f32.const -2.3509895424236536e-38
+  f32.const -2.3509895424236536e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -43959,8 +43793,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.3509895424236536e-38
-  f32.const -2.3509895424236536e-38
+  f32.const -4.70197740328915e-38
+  f32.const -4.70197740328915e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -43968,19 +43802,6 @@
    i32.const 0
    i32.const 24
    i32.const 3567
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -4.70197740328915e-38
-  f32.const -4.70197740328915e-38
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3568
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43993,7 +43814,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3569
+   i32.const 3568
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44006,7 +43827,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3570
+   i32.const 3569
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44019,13 +43840,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3571
+   i32.const 3570
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 2.802596928649634e-45
   f32.const 2.802596928649634e-45
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3571
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.2611686178923354e-44
+  f32.const 1.2611686178923354e-44
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -44037,8 +43871,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.2611686178923354e-44
-  f32.const 1.2611686178923354e-44
+  f32.const 2.938735877055719e-39
+  f32.const 2.938735877055719e-39
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -44050,8 +43884,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.938735877055719e-39
-  f32.const 2.938735877055719e-39
+  f32.const 5.877471754111438e-39
+  f32.const 5.877471754111438e-39
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -44063,8 +43897,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 5.877471754111438e-39
-  f32.const 5.877471754111438e-39
+  f32.const 1.1754940705625946e-38
+  f32.const 1.1754940705625946e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -44076,8 +43910,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754940705625946e-38
-  f32.const 1.1754940705625946e-38
+  f32.const 1.1754942106924411e-38
+  f32.const 1.1754942106924411e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -44089,8 +43923,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754942106924411e-38
-  f32.const 1.1754942106924411e-38
+  f32.const -2.802596928649634e-45
+  f32.const -2.802596928649634e-45
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -44102,8 +43936,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.802596928649634e-45
-  f32.const -2.802596928649634e-45
+  f32.const -1.2611686178923354e-44
+  f32.const -1.2611686178923354e-44
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -44115,8 +43949,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.2611686178923354e-44
-  f32.const -1.2611686178923354e-44
+  f32.const -2.938735877055719e-39
+  f32.const -2.938735877055719e-39
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -44128,8 +43962,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.938735877055719e-39
-  f32.const -2.938735877055719e-39
+  f32.const -5.877471754111438e-39
+  f32.const -5.877471754111438e-39
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -44141,8 +43975,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -5.877471754111438e-39
-  f32.const -5.877471754111438e-39
+  f32.const -1.1754940705625946e-38
+  f32.const -1.1754940705625946e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -44154,8 +43988,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754940705625946e-38
-  f32.const -1.1754940705625946e-38
+  f32.const -1.1754942106924411e-38
+  f32.const -1.1754942106924411e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -44163,19 +43997,6 @@
    i32.const 0
    i32.const 24
    i32.const 3582
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754942106924411e-38
-  f32.const -1.1754942106924411e-38
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3583
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44188,7 +44009,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3595
+   i32.const 3594
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44201,7 +44022,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3596
+   i32.const 3595
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44214,7 +44035,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3597
+   i32.const 3596
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44227,7 +44048,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3598
+   i32.const 3597
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44240,7 +44061,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3599
+   i32.const 3598
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44253,7 +44074,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3600
+   i32.const 3599
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44266,7 +44087,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3601
+   i32.const 3600
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44279,7 +44100,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3602
+   i32.const 3601
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44292,7 +44113,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3603
+   i32.const 3602
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44305,13 +44126,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3604
+   i32.const 3603
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const 0
+  f64.const 0
+  call $std/math/test_tanh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3606
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
   f64.const 0
   call $std/math/test_tanh
   i32.eqz
@@ -44319,19 +44153,6 @@
    i32.const 0
    i32.const 24
    i32.const 3607
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  call $std/math/test_tanh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3608
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44344,7 +44165,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3609
+   i32.const 3608
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44357,7 +44178,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3610
+   i32.const 3609
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44370,7 +44191,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3611
+   i32.const 3610
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44383,7 +44204,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3620
+   i32.const 3619
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44396,7 +44217,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3621
+   i32.const 3620
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44409,7 +44230,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3622
+   i32.const 3621
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44422,7 +44243,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3623
+   i32.const 3622
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44435,7 +44256,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3624
+   i32.const 3623
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44448,7 +44269,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3625
+   i32.const 3624
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44461,7 +44282,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3626
+   i32.const 3625
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44474,7 +44295,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3627
+   i32.const 3626
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44487,7 +44308,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3628
+   i32.const 3627
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44500,13 +44321,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3629
+   i32.const 3628
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const 0
+  f32.const 0
+  call $std/math/test_tanhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3631
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
   f32.const 0
   call $std/math/test_tanhf
   i32.eqz
@@ -44518,8 +44352,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const inf
+  f32.const 1
   f32.const 0
   call $std/math/test_tanhf
   i32.eqz
@@ -44531,8 +44365,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const 1
+  f32.const -inf
+  f32.const -1
   f32.const 0
   call $std/math/test_tanhf
   i32.eqz
@@ -44544,8 +44378,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_tanhf
   i32.eqz
@@ -44557,19 +44391,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_tanhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3636
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -8.06684839057968
   f64.const -8
   call $std/math/test_trunc
@@ -44577,7 +44398,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3648
+   i32.const 3647
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44589,7 +44410,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3649
+   i32.const 3648
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44601,7 +44422,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3650
+   i32.const 3649
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44613,7 +44434,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3651
+   i32.const 3650
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44625,7 +44446,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3652
+   i32.const 3651
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44637,7 +44458,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3653
+   i32.const 3652
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44649,7 +44470,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3654
+   i32.const 3653
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44661,7 +44482,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3655
+   i32.const 3654
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44673,7 +44494,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3656
+   i32.const 3655
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44685,13 +44506,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3657
+   i32.const 3656
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3659
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
   call $std/math/test_trunc
   i32.eqz
   if
@@ -44702,8 +44535,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const -inf
+  f64.const -inf
   call $std/math/test_trunc
   i32.eqz
   if
@@ -44714,8 +44547,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
+  f64.const 0
+  f64.const 0
   call $std/math/test_trunc
   i32.eqz
   if
@@ -44726,8 +44559,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -0
+  f64.const -0
   call $std/math/test_trunc
   i32.eqz
   if
@@ -44738,8 +44571,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 1
+  f64.const 1
   call $std/math/test_trunc
   i32.eqz
   if
@@ -44750,26 +44583,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 1
+  f64.const -1
+  f64.const -1
   call $std/math/test_trunc
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 3665
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -1
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3666
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44781,7 +44602,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3667
+   i32.const 3666
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44793,7 +44614,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3668
+   i32.const 3667
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44805,7 +44626,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3669
+   i32.const 3668
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44817,7 +44638,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3670
+   i32.const 3669
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44829,7 +44650,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3671
+   i32.const 3670
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44841,7 +44662,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3672
+   i32.const 3671
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44853,7 +44674,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3673
+   i32.const 3672
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44865,7 +44686,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3674
+   i32.const 3673
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44877,7 +44698,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3683
+   i32.const 3682
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44889,7 +44710,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3684
+   i32.const 3683
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44901,7 +44722,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3685
+   i32.const 3684
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44913,7 +44734,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3686
+   i32.const 3685
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44925,7 +44746,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3687
+   i32.const 3686
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44937,7 +44758,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3688
+   i32.const 3687
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44949,7 +44770,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3689
+   i32.const 3688
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44961,7 +44782,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3690
+   i32.const 3689
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44973,7 +44794,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3691
+   i32.const 3690
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44985,13 +44806,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3692
+   i32.const 3691
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const nan:0x400000
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3694
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
   call $std/math/test_truncf
   i32.eqz
   if
@@ -45002,8 +44835,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -inf
+  f32.const -inf
   call $std/math/test_truncf
   i32.eqz
   if
@@ -45014,8 +44847,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const 0
+  f32.const 0
   call $std/math/test_truncf
   i32.eqz
   if
@@ -45026,8 +44859,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -0
+  f32.const -0
   call $std/math/test_truncf
   i32.eqz
   if
@@ -45038,8 +44871,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   call $std/math/test_truncf
   i32.eqz
   if
@@ -45050,26 +44883,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -1
+  f32.const -1
   call $std/math/test_truncf
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 3700
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -1
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3701
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45081,7 +44902,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3702
+   i32.const 3701
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45093,7 +44914,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3703
+   i32.const 3702
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45105,7 +44926,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3704
+   i32.const 3703
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45117,7 +44938,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3705
+   i32.const 3704
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45129,7 +44950,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3706
+   i32.const 3705
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45141,7 +44962,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3707
+   i32.const 3706
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45153,7 +44974,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3708
+   i32.const 3707
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45165,7 +44986,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3709
+   i32.const 3708
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45238,7 +45059,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3750
+   i32.const 3749
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45251,7 +45072,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3751
+   i32.const 3750
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45264,7 +45085,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3752
+   i32.const 3751
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45277,7 +45098,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3753
+   i32.const 3752
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45290,7 +45111,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3754
+   i32.const 3753
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45303,12 +45124,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3755
+   i32.const 3754
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.e+60
+  f64.const -1.e+60
+  call $~lib/math/NativeMath.imul
+  f64.const 0
+  f64.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3755
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.e+60
   f64.const -1.e+60
   call $~lib/math/NativeMath.imul
   f64.const 0
@@ -45321,10 +45155,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.e+60
-  f64.const -1.e+60
+  f64.const 1.e+24
+  f64.const 100
   call $~lib/math/NativeMath.imul
-  f64.const 0
+  f64.const -2147483648
   f64.ne
   if
    i32.const 0
@@ -45334,10 +45168,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.e+24
-  f64.const 100
+  f64.const nan:0x8000000000000
+  f64.const 1
   call $~lib/math/NativeMath.imul
-  f64.const -2147483648
+  f64.const 0
   f64.ne
   if
    i32.const 0
@@ -45347,8 +45181,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
   f64.const 1
+  f64.const inf
   call $~lib/math/NativeMath.imul
   f64.const 0
   f64.ne
@@ -45360,8 +45194,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const inf
+  f64.const 1797693134862315708145274e284
+  f64.const 1797693134862315708145274e284
   call $~lib/math/NativeMath.imul
   f64.const 0
   f64.ne
@@ -45373,19 +45207,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1797693134862315708145274e284
-  f64.const 1797693134862315708145274e284
-  call $~lib/math/NativeMath.imul
-  f64.const 0
-  f64.ne
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3761
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const 0
   call $~lib/math/NativeMath.clz32
   f64.const 32
@@ -45393,7 +45214,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3765
+   i32.const 3764
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45405,7 +45226,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3766
+   i32.const 3765
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45417,7 +45238,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3767
+   i32.const 3766
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45429,7 +45250,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3768
+   i32.const 3767
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45441,7 +45262,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3769
+   i32.const 3768
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45453,7 +45274,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3770
+   i32.const 3769
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45465,7 +45286,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3771
+   i32.const 3770
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45477,7 +45298,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3772
+   i32.const 3771
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45489,7 +45310,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3773
+   i32.const 3772
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45501,7 +45322,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3774
+   i32.const 3773
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45513,7 +45334,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3775
+   i32.const 3774
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45525,7 +45346,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3776
+   i32.const 3775
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45537,7 +45358,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3777
+   i32.const 3776
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45549,7 +45370,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3778
+   i32.const 3777
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45561,7 +45382,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3779
+   i32.const 3778
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45573,7 +45394,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3780
+   i32.const 3779
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45586,13 +45407,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3784
+   i32.const 3783
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 0
   i32.const 1
+  call $~lib/math/ipow64
+  i64.const 0
+  i64.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3784
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 0
+  i32.const 2
   call $~lib/math/ipow64
   i64.const 0
   i64.ne
@@ -45605,7 +45439,7 @@
    unreachable
   end
   i64.const 0
-  i32.const 2
+  i32.const 3
   call $~lib/math/ipow64
   i64.const 0
   i64.ne
@@ -45617,21 +45451,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 0
-  i32.const 3
+  i64.const 1
+  i32.const 0
   call $~lib/math/ipow64
-  i64.const 0
+  i64.const 1
   i64.ne
   if
    i32.const 0
    i32.const 24
-   i32.const 3787
+   i32.const 3788
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 1
-  i32.const 0
+  i32.const 1
   call $~lib/math/ipow64
   i64.const 1
   i64.ne
@@ -45644,7 +45478,7 @@
    unreachable
   end
   i64.const 1
-  i32.const 1
+  i32.const 2
   call $~lib/math/ipow64
   i64.const 1
   i64.ne
@@ -45657,19 +45491,6 @@
    unreachable
   end
   i64.const 1
-  i32.const 2
-  call $~lib/math/ipow64
-  i64.const 1
-  i64.ne
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3791
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 1
   i32.const 3
   call $~lib/math/ipow64
   i64.const 1
@@ -45677,7 +45498,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3792
+   i32.const 3791
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45690,7 +45511,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3794
+   i32.const 3793
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45703,7 +45524,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3795
+   i32.const 3794
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45716,7 +45537,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3796
+   i32.const 3795
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45729,7 +45550,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3797
+   i32.const 3796
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45742,7 +45563,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3799
+   i32.const 3798
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45755,7 +45576,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3800
+   i32.const 3799
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45768,7 +45589,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3801
+   i32.const 3800
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45781,7 +45602,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3802
+   i32.const 3801
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45794,7 +45615,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3804
+   i32.const 3803
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45807,7 +45628,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3805
+   i32.const 3804
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45820,7 +45641,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3806
+   i32.const 3805
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45833,7 +45654,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3807
+   i32.const 3806
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45846,7 +45667,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3809
+   i32.const 3808
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45859,7 +45680,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3810
+   i32.const 3809
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45872,7 +45693,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3811
+   i32.const 3810
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45885,7 +45706,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3812
+   i32.const 3811
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45898,7 +45719,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3813
+   i32.const 3812
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45911,7 +45732,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3814
+   i32.const 3813
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45924,7 +45745,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3815
+   i32.const 3814
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45941,12 +45762,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3817
+   i32.const 3816
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
+  i32.const 0
+  call $~lib/math/ipow32f
+  f32.const 1
+  f32.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3820
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
   i32.const 0
   call $~lib/math/ipow32f
   f32.const 1
@@ -45960,10 +45794,10 @@
    unreachable
   end
   f32.const nan:0x400000
-  i32.const 0
+  i32.const 1
   call $~lib/math/ipow32f
-  f32.const 1
-  f32.ne
+  call $~lib/number/isNaN<f32>
+  i32.eqz
   if
    i32.const 0
    i32.const 24
@@ -45973,7 +45807,7 @@
    unreachable
   end
   f32.const nan:0x400000
-  i32.const 1
+  i32.const -1
   call $~lib/math/ipow32f
   call $~lib/number/isNaN<f32>
   i32.eqz
@@ -45986,7 +45820,7 @@
    unreachable
   end
   f32.const nan:0x400000
-  i32.const -1
+  i32.const 2
   call $~lib/math/ipow32f
   call $~lib/number/isNaN<f32>
   i32.eqz
@@ -45998,11 +45832,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  i32.const 2
+  f32.const inf
+  i32.const 0
   call $~lib/math/ipow32f
-  call $~lib/number/isNaN<f32>
-  i32.eqz
+  f32.const 1
+  f32.ne
   if
    i32.const 0
    i32.const 24
@@ -46012,9 +45846,9 @@
    unreachable
   end
   f32.const inf
-  i32.const 0
+  i32.const 1
   call $~lib/math/ipow32f
-  f32.const 1
+  f32.const inf
   f32.ne
   if
    i32.const 0
@@ -46024,10 +45858,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  i32.const 1
+  f32.const -inf
+  i32.const 0
   call $~lib/math/ipow32f
-  f32.const inf
+  f32.const 1
   f32.ne
   if
    i32.const 0
@@ -46038,19 +45872,6 @@
    unreachable
   end
   f32.const -inf
-  i32.const 0
-  call $~lib/math/ipow32f
-  f32.const 1
-  f32.ne
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3828
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
   i32.const 1
   call $~lib/math/ipow32f
   f32.const -inf
@@ -46058,7 +45879,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3829
+   i32.const 3828
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46071,7 +45892,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3830
+   i32.const 3829
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46084,7 +45905,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3831
+   i32.const 3830
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46097,7 +45918,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3832
+   i32.const 3831
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46110,7 +45931,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3833
+   i32.const 3832
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46123,7 +45944,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3834
+   i32.const 3833
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46136,7 +45957,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3835
+   i32.const 3834
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46149,12 +45970,25 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3836
+   i32.const 3835
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
+  i32.const 0
+  call $~lib/math/ipow64f
+  f64.const 1
+  f64.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3839
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
   i32.const 0
   call $~lib/math/ipow64f
   f64.const 1
@@ -46168,10 +46002,10 @@
    unreachable
   end
   f64.const nan:0x8000000000000
-  i32.const 0
+  i32.const 1
   call $~lib/math/ipow64f
-  f64.const 1
-  f64.ne
+  call $~lib/number/isNaN<f64>
+  i32.eqz
   if
    i32.const 0
    i32.const 24
@@ -46181,7 +46015,7 @@
    unreachable
   end
   f64.const nan:0x8000000000000
-  i32.const 1
+  i32.const -1
   call $~lib/math/ipow64f
   call $~lib/number/isNaN<f64>
   i32.eqz
@@ -46194,7 +46028,7 @@
    unreachable
   end
   f64.const nan:0x8000000000000
-  i32.const -1
+  i32.const 2
   call $~lib/math/ipow64f
   call $~lib/number/isNaN<f64>
   i32.eqz
@@ -46206,11 +46040,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  i32.const 2
+  f64.const inf
+  i32.const 0
   call $~lib/math/ipow64f
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  f64.const 1
+  f64.ne
   if
    i32.const 0
    i32.const 24
@@ -46220,9 +46054,9 @@
    unreachable
   end
   f64.const inf
-  i32.const 0
+  i32.const 1
   call $~lib/math/ipow64f
-  f64.const 1
+  f64.const inf
   f64.ne
   if
    i32.const 0
@@ -46232,10 +46066,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  i32.const 1
+  f64.const -inf
+  i32.const 0
   call $~lib/math/ipow64f
-  f64.const inf
+  f64.const 1
   f64.ne
   if
    i32.const 0
@@ -46246,19 +46080,6 @@
    unreachable
   end
   f64.const -inf
-  i32.const 0
-  call $~lib/math/ipow64f
-  f64.const 1
-  f64.ne
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3847
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
   i32.const 1
   call $~lib/math/ipow64f
   f64.const -inf
@@ -46266,7 +46087,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3848
+   i32.const 3847
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46279,7 +46100,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3849
+   i32.const 3848
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46292,7 +46113,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3850
+   i32.const 3849
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46305,7 +46126,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3851
+   i32.const 3850
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46318,7 +46139,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3852
+   i32.const 3851
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46331,7 +46152,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3853
+   i32.const 3852
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46344,7 +46165,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3854
+   i32.const 3853
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46357,16 +46178,16 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3855
+   i32.const 3854
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
  )
- (func $start (; 176 ;) (type $FUNCSIG$v)
+ (func $start (; 175 ;) (type $FUNCSIG$v)
   call $start:std/math
  )
- (func $null (; 177 ;) (type $FUNCSIG$v)
+ (func $null (; 176 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -77,6 +77,7 @@
  (data (i32.const 336) "\10\00\00\00\01\00\00\00\03\00\00\00\10\00\00\000\01\00\000\01\00\00 \00\00\00\04")
  (data (i32.const 368) "\18\00\00\00\01\00\00\00\01\00\00\00\18\00\00\00~\00l\00i\00b\00/\00m\00a\00t\00h\00.\00t\00s")
  (data (i32.const 408) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00P\00R\00N\00G\00 \00m\00u\00s\00t\00 \00b\00e\00 \00s\00e\00e\00d\00e\00d\00.")
+ (global $std/math/js (mut i32) (i32.const 1))
  (global $~lib/math/rempio2_y0 (mut f64) (f64.const 0))
  (global $~lib/math/rempio2_y1 (mut f64) (f64.const 0))
  (global $~lib/math/res128_hi (mut i64) (i64.const 0))
@@ -514,11 +515,16 @@
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   call $~lib/bindings/Math/abs
-   local.get $1
-   f64.const 0
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    call $~lib/bindings/Math/abs
+    local.get $1
+    f64.const 0
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -704,11 +710,16 @@
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   call $~lib/bindings/Math/acos
-   local.get $1
-   local.get $2
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    call $~lib/bindings/Math/acos
+    local.get $1
+    local.get $2
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -1285,11 +1296,16 @@
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   call $~lib/bindings/Math/acosh
-   local.get $1
-   local.get $2
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    call $~lib/bindings/Math/acosh
+    local.get $1
+    local.get $2
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -1800,11 +1816,16 @@
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   call $~lib/bindings/Math/asin
-   local.get $1
-   local.get $2
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    call $~lib/bindings/Math/asin
+    local.get $1
+    local.get $2
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -1973,11 +1994,16 @@
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   call $~lib/bindings/Math/asinh
-   local.get $1
-   local.get $2
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    call $~lib/bindings/Math/asinh
+    local.get $1
+    local.get $2
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -2286,11 +2312,16 @@
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   call $~lib/bindings/Math/atan
-   local.get $1
-   local.get $2
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    call $~lib/bindings/Math/atan
+    local.get $1
+    local.get $2
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -2561,11 +2592,16 @@
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   call $~lib/bindings/Math/atanh
-   local.get $1
-   local.get $2
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    call $~lib/bindings/Math/atanh
+    local.get $1
+    local.get $2
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -2853,12 +2889,17 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   local.get $1
-   call $~lib/bindings/Math/atan2
-   local.get $2
-   local.get $3
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    local.get $1
+    call $~lib/bindings/Math/atan2
+    local.get $2
+    local.get $3
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -3196,11 +3237,16 @@
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   call $~lib/bindings/Math/cbrt
-   local.get $1
-   local.get $2
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    call $~lib/bindings/Math/cbrt
+    local.get $1
+    local.get $2
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -3318,11 +3364,16 @@
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   call $~lib/bindings/Math/ceil
-   local.get $1
-   f64.const 0
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    call $~lib/bindings/Math/ceil
+    local.get $1
+    f64.const 0
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -3973,11 +4024,16 @@
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   call $~lib/bindings/Math/cos
-   local.get $1
-   local.get $2
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    call $~lib/bindings/Math/cos
+    local.get $1
+    local.get $2
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -4754,11 +4810,16 @@
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   call $~lib/bindings/Math/cosh
-   local.get $1
-   local.get $2
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    call $~lib/bindings/Math/cosh
+    local.get $1
+    local.get $2
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -5216,11 +5277,16 @@
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   call $~lib/bindings/Math/exp
-   local.get $1
-   local.get $2
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    call $~lib/bindings/Math/exp
+    local.get $1
+    local.get $2
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -5239,11 +5305,16 @@
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   call $~lib/bindings/Math/expm1
-   local.get $1
-   local.get $2
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    call $~lib/bindings/Math/expm1
+    local.get $1
+    local.get $2
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -5262,11 +5333,16 @@
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   call $~lib/bindings/Math/floor
-   local.get $1
-   f64.const 0
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    call $~lib/bindings/Math/floor
+    local.get $1
+    f64.const 0
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -5457,12 +5533,17 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   local.get $1
-   call $~lib/bindings/Math/hypot
-   local.get $2
-   local.get $3
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    local.get $1
+    call $~lib/bindings/Math/hypot
+    local.get $2
+    local.get $3
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -5587,11 +5668,16 @@
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   call $~lib/bindings/Math/log
-   local.get $1
-   local.get $2
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    call $~lib/bindings/Math/log
+    local.get $1
+    local.get $2
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -5814,11 +5900,16 @@
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   call $~lib/bindings/Math/log10
-   local.get $1
-   local.get $2
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    call $~lib/bindings/Math/log10
+    local.get $1
+    local.get $2
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -5995,11 +6086,16 @@
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   call $~lib/bindings/Math/log1p
-   local.get $1
-   local.get $2
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    call $~lib/bindings/Math/log1p
+    local.get $1
+    local.get $2
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -6215,11 +6311,16 @@
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   call $~lib/bindings/Math/log2
-   local.get $1
-   local.get $2
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    call $~lib/bindings/Math/log2
+    local.get $1
+    local.get $2
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -6389,12 +6490,17 @@
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   local.get $1
-   call $~lib/bindings/Math/max
-   local.get $2
-   f64.const 0
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    local.get $1
+    call $~lib/bindings/Math/max
+    local.get $2
+    f64.const 0
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -6415,12 +6521,17 @@
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   local.get $1
-   call $~lib/bindings/Math/min
-   local.get $2
-   f64.const 0
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    local.get $1
+    call $~lib/bindings/Math/min
+    local.get $2
+    f64.const 0
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -6644,12 +6755,17 @@
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   local.get $1
-   call $std/math/mod
-   local.get $2
-   f64.const 0
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    local.get $1
+    call $std/math/mod
+    local.get $2
+    f64.const 0
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -7769,12 +7885,17 @@
   local.get $3
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   local.get $1
-   call $~lib/bindings/Math/pow
-   local.get $2
-   local.get $3
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    local.get $1
+    call $~lib/bindings/Math/pow
+    local.get $2
+    local.get $3
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -8799,11 +8920,16 @@
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   call $~lib/bindings/Math/sign
-   local.get $1
-   f64.const 0
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    call $~lib/bindings/Math/sign
+    local.get $1
+    f64.const 0
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -9668,11 +9794,16 @@
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   call $~lib/bindings/Math/sin
-   local.get $1
-   local.get $2
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    call $~lib/bindings/Math/sin
+    local.get $1
+    local.get $2
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -10039,11 +10170,16 @@
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   call $~lib/bindings/Math/sinh
-   local.get $1
-   local.get $2
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    call $~lib/bindings/Math/sinh
+    local.get $1
+    local.get $2
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -10134,11 +10270,16 @@
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   call $~lib/bindings/Math/sqrt
-   local.get $1
-   local.get $2
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    call $~lib/bindings/Math/sqrt
+    local.get $1
+    local.get $2
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -10518,11 +10659,16 @@
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   call $~lib/bindings/Math/tan
-   local.get $1
-   local.get $2
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    call $~lib/bindings/Math/tan
+    local.get $1
+    local.get $2
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -10875,11 +11021,16 @@
   local.get $2
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   call $~lib/bindings/Math/tanh
-   local.get $1
-   local.get $2
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    call $~lib/bindings/Math/tanh
+    local.get $1
+    local.get $2
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -10972,11 +11123,16 @@
   f64.const 0
   call $std/math/check<f64>
   if (result i32)
-   local.get $0
-   call $~lib/bindings/Math/trunc
-   local.get $1
-   f64.const 0
-   call $std/math/check<f64>
+   global.get $std/math/js
+   if (result i32)
+    local.get $0
+    call $~lib/bindings/Math/trunc
+    local.get $1
+    f64.const 0
+    call $std/math/check<f64>
+   else
+    i32.const 1
+   end
   else
    i32.const 0
   end
@@ -24268,6 +24424,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 0
+  global.set $std/math/js
   f64.const inf
   f64.const nan:0x8000000000000
   f64.const inf
@@ -24278,10 +24436,12 @@
    i32.const 0
    i32.const 24
    i32.const 1644
-   i32.const 0
+   i32.const 12
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 1
+  global.set $std/math/js
   f64.const nan:0x8000000000000
   f64.const inf
   f64.const inf
@@ -24324,6 +24484,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 0
+  global.set $std/math/js
   f64.const -inf
   f64.const nan:0x8000000000000
   f64.const inf
@@ -24334,10 +24496,12 @@
    i32.const 0
    i32.const 24
    i32.const 1648
-   i32.const 0
+   i32.const 12
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 1
+  global.set $std/math/js
   f64.const nan:0x8000000000000
   f64.const -inf
   f64.const inf
@@ -24380,6 +24544,38 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 0
+  global.set $std/math/js
+  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_hypot
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1652
+   i32.const 12
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1
+  global.set $std/math/js
+  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_hypot
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1653
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -8.066848754882812
   f32.const 4.535662651062012
   f32.const 9.254528045654297
@@ -24389,7 +24585,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1660
+   i32.const 1665
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24403,7 +24599,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1661
+   i32.const 1666
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24417,7 +24613,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1662
+   i32.const 1667
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24431,7 +24627,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1663
+   i32.const 1668
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24445,7 +24641,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1664
+   i32.const 1669
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24459,7 +24655,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1665
+   i32.const 1670
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24473,7 +24669,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1666
+   i32.const 1671
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24487,7 +24683,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1667
+   i32.const 1672
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24501,7 +24697,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1668
+   i32.const 1673
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24515,53 +24711,53 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1669
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 3
-  f32.const 4
-  f32.const 5
-  f32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1672
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -3
-  f32.const 4
-  f32.const 5
-  f32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1673
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 4
-  f32.const 3
-  f32.const 5
-  f32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 1674
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 3
+  f32.const 4
+  f32.const 5
+  f32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1677
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -3
+  f32.const 4
+  f32.const 5
+  f32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1678
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4
+  f32.const 3
+  f32.const 5
+  f32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1679
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 4
   f32.const -3
   f32.const 5
@@ -24571,7 +24767,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1675
+   i32.const 1680
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24585,84 +24781,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1676
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 3402823466385288598117041e14
-  f32.const 0
-  f32.const 3402823466385288598117041e14
-  f32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1677
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 3402823466385288598117041e14
-  f32.const -0
-  f32.const 3402823466385288598117041e14
-  f32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1678
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.401298464324817e-45
-  f32.const 0
-  f32.const 1.401298464324817e-45
-  f32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1679
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.401298464324817e-45
-  f32.const -0
-  f32.const 1.401298464324817e-45
-  f32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1680
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 1
-  f32.const inf
-  f32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 1681
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const inf
-  f32.const inf
+  f32.const 3402823466385288598117041e14
+  f32.const 0
+  f32.const 3402823466385288598117041e14
   f32.const 0
   call $std/math/test_hypotf
   i32.eqz
@@ -24674,9 +24800,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const nan:0x400000
-  f32.const inf
+  f32.const 3402823466385288598117041e14
+  f32.const -0
+  f32.const 3402823466385288598117041e14
   f32.const 0
   call $std/math/test_hypotf
   i32.eqz
@@ -24688,9 +24814,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const inf
-  f32.const inf
+  f32.const 1.401298464324817e-45
+  f32.const 0
+  f32.const 1.401298464324817e-45
   f32.const 0
   call $std/math/test_hypotf
   i32.eqz
@@ -24702,9 +24828,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const 1
-  f32.const inf
+  f32.const 1.401298464324817e-45
+  f32.const -0
+  f32.const 1.401298464324817e-45
   f32.const 0
   call $std/math/test_hypotf
   i32.eqz
@@ -24716,8 +24842,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
   f32.const 1
-  f32.const -inf
   f32.const inf
   f32.const 0
   call $std/math/test_hypotf
@@ -24730,8 +24856,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const nan:0x400000
+  f32.const 1
+  f32.const inf
   f32.const inf
   f32.const 0
   call $std/math/test_hypotf
@@ -24744,8 +24870,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
   f32.const nan:0x400000
-  f32.const -inf
   f32.const inf
   f32.const 0
   call $std/math/test_hypotf
@@ -24759,6 +24885,76 @@
    unreachable
   end
   f32.const nan:0x400000
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1689
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const 1
+  f32.const inf
+  f32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1690
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const -inf
+  f32.const inf
+  f32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1691
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const nan:0x400000
+  f32.const inf
+  f32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1692
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const -inf
+  f32.const inf
+  f32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1693
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
   f32.const 1
   f32.const nan:0x400000
   f32.const 0
@@ -24767,7 +24963,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1689
+   i32.const 1694
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24781,7 +24977,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1690
+   i32.const 1695
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24794,7 +24990,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1702
+   i32.const 1707
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24807,7 +25003,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1703
+   i32.const 1708
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24820,7 +25016,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1704
+   i32.const 1709
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24833,7 +25029,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1705
+   i32.const 1710
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24846,7 +25042,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1706
+   i32.const 1711
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24859,7 +25055,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1707
+   i32.const 1712
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24872,7 +25068,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1708
+   i32.const 1713
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24885,7 +25081,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1709
+   i32.const 1714
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -24898,51 +25094,12 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1710
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.6787637026394024
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_log
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1711
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -inf
-  f64.const 0
-  call $std/math/test_log
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1714
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -inf
-  f64.const 0
-  call $std/math/test_log
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 1715
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -7.888609052210118e-31
+  f64.const -0.6787637026394024
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_log
@@ -24955,34 +25112,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const 0
-  f64.const 0
-  call $std/math/test_log
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1717
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_log
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1718
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
+  f64.const -inf
   f64.const 0
   call $std/math/test_log
   i32.eqz
@@ -24994,8 +25125,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const -inf
-  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_log
   i32.eqz
@@ -25007,7 +25138,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -7.888609052210118e-31
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_log
@@ -25020,6 +25151,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
+  f64.const 0
+  f64.const 0
+  call $std/math/test_log
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1722
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_log
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1723
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  call $std/math/test_log
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1724
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_log
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1725
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_log
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1726
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 0
   f32.const -inf
   call $std/math/test_logf
@@ -25027,7 +25223,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1730
+   i32.const 1735
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25039,72 +25235,12 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1731
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -7.888609052210118e-31
-  f32.const nan:0x400000
-  call $std/math/test_logf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1732
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 0
-  call $std/math/test_logf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1733
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const nan:0x400000
-  call $std/math/test_logf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1734
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  call $std/math/test_logf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1735
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const nan:0x400000
-  call $std/math/test_logf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 1736
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -7.888609052210118e-31
   f32.const nan:0x400000
   call $std/math/test_logf
   i32.eqz
@@ -25116,42 +25252,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const -inf
-  call $std/math/test_logf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1740
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -inf
-  call $std/math/test_logf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1741
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -7.888609052210118e-31
-  f32.const nan:0x400000
-  call $std/math/test_logf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1742
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const 1
   f32.const 0
   call $std/math/test_logf
@@ -25159,7 +25259,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1743
+   i32.const 1738
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25171,7 +25271,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1744
+   i32.const 1739
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25183,7 +25283,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1745
+   i32.const 1740
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25195,7 +25295,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1746
+   i32.const 1741
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25207,7 +25307,103 @@
   if
    i32.const 0
    i32.const 24
+   i32.const 1742
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const -inf
+  call $std/math/test_logf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1745
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -inf
+  call $std/math/test_logf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1746
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -7.888609052210118e-31
+  f32.const nan:0x400000
+  call $std/math/test_logf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
    i32.const 1747
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 0
+  call $std/math/test_logf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1748
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const nan:0x400000
+  call $std/math/test_logf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1749
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  call $std/math/test_logf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1750
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const nan:0x400000
+  call $std/math/test_logf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1751
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  call $std/math/test_logf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1752
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25220,7 +25416,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1759
+   i32.const 1764
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25233,7 +25429,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1760
+   i32.const 1765
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25246,7 +25442,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1761
+   i32.const 1766
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25259,7 +25455,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1762
+   i32.const 1767
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25272,7 +25468,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1763
+   i32.const 1768
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25285,7 +25481,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1764
+   i32.const 1769
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25298,7 +25494,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1765
+   i32.const 1770
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25311,7 +25507,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1766
+   i32.const 1771
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25324,51 +25520,12 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1767
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.6787637026394024
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_log10
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1768
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -inf
-  f64.const 0
-  call $std/math/test_log10
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1771
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -inf
-  f64.const 0
-  call $std/math/test_log10
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 1772
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -7.888609052210118e-31
+  f64.const -0.6787637026394024
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_log10
@@ -25381,34 +25538,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const 0
-  f64.const 0
-  call $std/math/test_log10
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1774
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_log10
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1775
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
+  f64.const -inf
   f64.const 0
   call $std/math/test_log10
   i32.eqz
@@ -25420,8 +25551,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const -inf
-  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_log10
   i32.eqz
@@ -25433,7 +25564,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -7.888609052210118e-31
   f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_log10
@@ -25446,6 +25577,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
+  f64.const 0
+  f64.const 0
+  call $std/math/test_log10
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1779
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_log10
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1780
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  call $std/math/test_log10
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1781
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_log10
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1782
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  call $std/math/test_log10
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1783
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -8.066848754882812
   f32.const nan:0x400000
   f32.const 0
@@ -25454,7 +25650,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1787
+   i32.const 1792
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25467,7 +25663,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1788
+   i32.const 1793
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25480,7 +25676,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1789
+   i32.const 1794
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25493,7 +25689,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1790
+   i32.const 1795
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25506,7 +25702,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1791
+   i32.const 1796
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25519,7 +25715,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1792
+   i32.const 1797
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25532,7 +25728,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1793
+   i32.const 1798
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25545,7 +25741,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1794
+   i32.const 1799
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25558,51 +25754,12 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1795
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.6787636876106262
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_log10f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1796
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -inf
-  f32.const 0
-  call $std/math/test_log10f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1799
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -inf
-  f32.const 0
-  call $std/math/test_log10f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 1800
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -7.888609052210118e-31
+  f32.const -0.6787636876106262
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_log10f
@@ -25615,34 +25772,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const 0
-  f32.const 0
-  call $std/math/test_log10f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1802
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_log10f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1803
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
+  f32.const -inf
   f32.const 0
   call $std/math/test_log10f
   i32.eqz
@@ -25654,8 +25785,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const -inf
-  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_log10f
   i32.eqz
@@ -25667,7 +25798,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -7.888609052210118e-31
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_log10f
@@ -25680,6 +25811,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1
+  f32.const 0
+  f32.const 0
+  call $std/math/test_log10f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1807
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_log10f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1808
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  call $std/math/test_log10f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1809
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_log10f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1810
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_log10f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1811
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -8.06684839057968
   f64.const nan:0x8000000000000
   f64.const 0
@@ -25688,7 +25884,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1818
+   i32.const 1823
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25701,7 +25897,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1819
+   i32.const 1824
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25714,7 +25910,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1820
+   i32.const 1825
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25727,7 +25923,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1821
+   i32.const 1826
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25740,7 +25936,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1822
+   i32.const 1827
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25753,7 +25949,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1823
+   i32.const 1828
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25766,7 +25962,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1824
+   i32.const 1829
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25779,7 +25975,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1825
+   i32.const 1830
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25792,7 +25988,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1826
+   i32.const 1831
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25805,7 +26001,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1827
+   i32.const 1832
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25818,7 +26014,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1830
+   i32.const 1835
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25831,7 +26027,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1831
+   i32.const 1836
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25844,7 +26040,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1832
+   i32.const 1837
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25857,7 +26053,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1833
+   i32.const 1838
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25870,7 +26066,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1834
+   i32.const 1839
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25883,7 +26079,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1835
+   i32.const 1840
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25896,7 +26092,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1836
+   i32.const 1841
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25909,7 +26105,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1837
+   i32.const 1842
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25922,7 +26118,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1846
+   i32.const 1851
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25935,7 +26131,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1847
+   i32.const 1852
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25948,7 +26144,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1848
+   i32.const 1853
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25961,7 +26157,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1849
+   i32.const 1854
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25974,7 +26170,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1850
+   i32.const 1855
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -25987,7 +26183,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1851
+   i32.const 1856
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26000,7 +26196,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1852
+   i32.const 1857
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26013,7 +26209,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1853
+   i32.const 1858
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26026,7 +26222,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1854
+   i32.const 1859
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26039,7 +26235,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1855
+   i32.const 1860
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26052,7 +26248,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1858
+   i32.const 1863
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26065,7 +26261,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1859
+   i32.const 1864
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26078,7 +26274,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1860
+   i32.const 1865
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26091,7 +26287,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1861
+   i32.const 1866
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26104,7 +26300,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1862
+   i32.const 1867
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26117,7 +26313,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1863
+   i32.const 1868
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26130,7 +26326,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1864
+   i32.const 1869
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26143,7 +26339,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1865
+   i32.const 1870
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26156,7 +26352,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1866
+   i32.const 1871
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26169,7 +26365,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1878
+   i32.const 1883
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26182,7 +26378,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1879
+   i32.const 1884
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26195,7 +26391,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1880
+   i32.const 1885
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26208,7 +26404,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1881
+   i32.const 1886
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26221,7 +26417,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1882
+   i32.const 1887
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26234,7 +26430,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1883
+   i32.const 1888
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26247,7 +26443,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1884
+   i32.const 1889
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26260,7 +26456,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1885
+   i32.const 1890
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26273,7 +26469,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1886
+   i32.const 1891
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26286,7 +26482,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1887
+   i32.const 1892
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26299,7 +26495,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1890
+   i32.const 1895
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26312,7 +26508,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1891
+   i32.const 1896
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26325,7 +26521,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1892
+   i32.const 1897
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26338,7 +26534,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1893
+   i32.const 1898
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26351,7 +26547,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1894
+   i32.const 1899
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26364,7 +26560,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1895
+   i32.const 1900
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26377,7 +26573,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1896
+   i32.const 1901
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26390,7 +26586,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1897
+   i32.const 1902
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26403,7 +26599,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1906
+   i32.const 1911
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26416,7 +26612,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1907
+   i32.const 1912
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26429,7 +26625,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1908
+   i32.const 1913
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26442,7 +26638,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1909
+   i32.const 1914
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26455,7 +26651,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1910
+   i32.const 1915
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26468,7 +26664,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1911
+   i32.const 1916
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26481,7 +26677,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1912
+   i32.const 1917
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26494,7 +26690,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1913
+   i32.const 1918
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26507,7 +26703,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1914
+   i32.const 1919
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26520,7 +26716,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1915
+   i32.const 1920
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26533,7 +26729,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1918
+   i32.const 1923
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26546,7 +26742,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1919
+   i32.const 1924
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26559,7 +26755,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1920
+   i32.const 1925
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26572,7 +26768,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1921
+   i32.const 1926
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26585,7 +26781,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1922
+   i32.const 1927
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26598,7 +26794,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1923
+   i32.const 1928
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26611,7 +26807,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1924
+   i32.const 1929
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26624,7 +26820,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1925
+   i32.const 1930
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26637,7 +26833,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1937
+   i32.const 1942
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26650,7 +26846,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1938
+   i32.const 1943
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26663,7 +26859,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1939
+   i32.const 1944
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26676,7 +26872,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1940
+   i32.const 1945
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26689,7 +26885,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1941
+   i32.const 1946
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26702,7 +26898,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1942
+   i32.const 1947
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26715,7 +26911,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1943
+   i32.const 1948
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26728,7 +26924,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1944
+   i32.const 1949
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26741,7 +26937,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1945
+   i32.const 1950
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -26754,77 +26950,12 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1946
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 1
-  f64.const 1
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1949
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const 1
-  f64.const 1
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1950
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const 1
-  f64.const 1
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 1951
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
-  f64.const 1
-  f64.const 1
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1952
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  f64.const 1
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1953
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
+  f64.const 0
   f64.const 1
   f64.const 1
   call $std/math/test_max
@@ -26837,9 +26968,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -0
   f64.const 1
-  f64.const inf
+  f64.const 1
   call $std/math/test_max
   i32.eqz
   if
@@ -26850,7 +26981,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const 0.5
   f64.const 1
   f64.const 1
   call $std/math/test_max
@@ -26863,9 +26994,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -0.5
   f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const 1
   call $std/math/test_max
   i32.eqz
   if
@@ -26876,9 +27007,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -1
-  f64.const 0
+  f64.const 1
+  f64.const 1
+  f64.const 1
   call $std/math/test_max
   i32.eqz
   if
@@ -26889,9 +27020,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
   f64.const -1
-  f64.const -0
+  f64.const 1
+  f64.const 1
   call $std/math/test_max
   i32.eqz
   if
@@ -26902,9 +27033,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
-  f64.const -1
-  f64.const 0.5
+  f64.const inf
+  f64.const 1
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -26915,9 +27046,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
-  f64.const -1
-  f64.const -0.5
+  f64.const -inf
+  f64.const 1
+  f64.const 1
   call $std/math/test_max
   i32.eqz
   if
@@ -26928,9 +27059,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const nan:0x8000000000000
   f64.const 1
-  f64.const -1
-  f64.const 1
+  f64.const nan:0x8000000000000
   call $std/math/test_max
   i32.eqz
   if
@@ -26941,9 +27072,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0
   f64.const -1
-  f64.const -1
-  f64.const -1
+  f64.const 0
   call $std/math/test_max
   i32.eqz
   if
@@ -26954,9 +27085,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -0
   f64.const -1
-  f64.const inf
+  f64.const -0
   call $std/math/test_max
   i32.eqz
   if
@@ -26967,9 +27098,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const 0.5
   f64.const -1
-  f64.const -1
+  f64.const 0.5
   call $std/math/test_max
   i32.eqz
   if
@@ -26980,9 +27111,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -0.5
   f64.const -1
-  f64.const nan:0x8000000000000
+  f64.const -0.5
   call $std/math/test_max
   i32.eqz
   if
@@ -26993,9 +27124,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
-  f64.const 0
+  f64.const 1
+  f64.const -1
+  f64.const 1
   call $std/math/test_max
   i32.eqz
   if
@@ -27006,9 +27137,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -0
-  f64.const 0
+  f64.const -1
+  f64.const -1
+  f64.const -1
   call $std/math/test_max
   i32.eqz
   if
@@ -27019,8 +27150,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const inf
+  f64.const -1
   f64.const inf
   call $std/math/test_max
   i32.eqz
@@ -27032,9 +27163,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const -inf
-  f64.const 0
+  f64.const -1
+  f64.const -1
   call $std/math/test_max
   i32.eqz
   if
@@ -27045,8 +27176,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const nan:0x8000000000000
+  f64.const -1
   f64.const nan:0x8000000000000
   call $std/math/test_max
   i32.eqz
@@ -27058,7 +27189,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const 0
   f64.const 0
   call $std/math/test_max
@@ -27071,9 +27202,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0
   f64.const -0
-  f64.const -0
-  f64.const -0
+  f64.const 0
   call $std/math/test_max
   i32.eqz
   if
@@ -27084,7 +27215,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const inf
   f64.const inf
   call $std/math/test_max
@@ -27097,9 +27228,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const -inf
-  f64.const -0
+  f64.const 0
   call $std/math/test_max
   i32.eqz
   if
@@ -27110,7 +27241,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_max
@@ -27123,9 +27254,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -0
   f64.const 0
-  f64.const 1
+  f64.const 0
   call $std/math/test_max
   i32.eqz
   if
@@ -27136,9 +27267,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const 0
-  f64.const 0
+  f64.const -0
+  f64.const -0
+  f64.const -0
   call $std/math/test_max
   i32.eqz
   if
@@ -27149,8 +27280,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const inf
-  f64.const 0
   f64.const inf
   call $std/math/test_max
   i32.eqz
@@ -27162,6 +27293,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const -inf
+  f64.const -0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1980
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1981
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 0
+  f64.const 1
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1982
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const 0
+  f64.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1983
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const 0
+  f64.const inf
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1984
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -inf
   f64.const 0
   f64.const 0
@@ -27170,7 +27366,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1980
+   i32.const 1985
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27183,7 +27379,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1981
+   i32.const 1986
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27196,79 +27392,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1982
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -0
-  f64.const inf
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1983
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -0
-  f64.const -0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1984
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const -0
-  f64.const nan:0x8000000000000
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1985
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 2
-  f64.const inf
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1986
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -0.5
-  f64.const inf
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 1987
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -0
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -27280,8 +27411,8 @@
    unreachable
   end
   f64.const -inf
-  f64.const 2
-  f64.const 2
+  f64.const -0
+  f64.const -0
   call $std/math/test_max
   i32.eqz
   if
@@ -27292,9 +27423,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -0.5
-  f64.const -0.5
+  f64.const nan:0x8000000000000
+  f64.const -0
+  f64.const nan:0x8000000000000
   call $std/math/test_max
   i32.eqz
   if
@@ -27305,9 +27436,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const 2
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -27318,9 +27449,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const -0.5
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -27331,7 +27462,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const inf
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_max
@@ -27344,9 +27475,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const 2
+  f64.const 2
   call $std/math/test_max
   i32.eqz
   if
@@ -27357,9 +27488,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const inf
-  f64.const inf
+  f64.const -inf
+  f64.const -0.5
+  f64.const -0.5
   call $std/math/test_max
   i32.eqz
   if
@@ -27370,9 +27501,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const inf
-  f64.const inf
+  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_max
   i32.eqz
   if
@@ -27383,9 +27514,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
-  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_max
   i32.eqz
   if
@@ -27396,9 +27527,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const inf
-  f64.const inf
+  f64.const 1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_max
   i32.eqz
   if
@@ -27409,9 +27540,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const -inf
-  f64.const 1
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_max
   i32.eqz
   if
@@ -27422,9 +27553,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -inf
-  f64.const -1
+  f64.const 1
+  f64.const inf
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -27435,8 +27566,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
   f64.const inf
-  f64.const -inf
   f64.const inf
   call $std/math/test_max
   i32.eqz
@@ -27448,9 +27579,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
-  f64.const -inf
+  f64.const inf
+  f64.const inf
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -27461,9 +27592,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const 0.5
-  f64.const 1.75
+  f64.const -inf
+  f64.const inf
+  f64.const inf
   call $std/math/test_max
   i32.eqz
   if
@@ -27474,9 +27605,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.75
-  f64.const 0.5
-  f64.const 0.5
+  f64.const 1
+  f64.const -inf
+  f64.const 1
   call $std/math/test_max
   i32.eqz
   if
@@ -27487,6 +27618,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
+  f64.const -inf
+  f64.const -1
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2005
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const -inf
+  f64.const inf
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2006
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -inf
+  f64.const -inf
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2007
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.75
+  f64.const 0.5
+  f64.const 1.75
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2008
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.75
+  f64.const 0.5
+  f64.const 0.5
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2009
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1.75
   f64.const -0.5
   f64.const 1.75
@@ -27495,7 +27691,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2005
+   i32.const 2010
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27508,7 +27704,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2006
+   i32.const 2011
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27521,7 +27717,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2015
+   i32.const 2020
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27534,7 +27730,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2016
+   i32.const 2021
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27547,7 +27743,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2017
+   i32.const 2022
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27560,7 +27756,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2018
+   i32.const 2023
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27573,7 +27769,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2019
+   i32.const 2024
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27586,7 +27782,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2020
+   i32.const 2025
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27599,7 +27795,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2021
+   i32.const 2026
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27612,7 +27808,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2022
+   i32.const 2027
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27625,7 +27821,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2023
+   i32.const 2028
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -27638,77 +27834,12 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2024
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 1
-  f32.const 1
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2027
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 1
-  f32.const 1
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2028
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const 1
-  f32.const 1
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2029
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const 1
-  f32.const 1
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2030
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  f32.const 1
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2031
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
+  f32.const 0
   f32.const 1
   f32.const 1
   call $std/math/test_maxf
@@ -27721,9 +27852,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -0
   f32.const 1
-  f32.const inf
+  f32.const 1
   call $std/math/test_maxf
   i32.eqz
   if
@@ -27734,7 +27865,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const 0.5
   f32.const 1
   f32.const 1
   call $std/math/test_maxf
@@ -27747,9 +27878,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -0.5
   f32.const 1
-  f32.const nan:0x400000
+  f32.const 1
   call $std/math/test_maxf
   i32.eqz
   if
@@ -27760,9 +27891,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const -1
-  f32.const 0
+  f32.const 1
+  f32.const 1
+  f32.const 1
   call $std/math/test_maxf
   i32.eqz
   if
@@ -27773,9 +27904,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
   f32.const -1
-  f32.const -0
+  f32.const 1
+  f32.const 1
   call $std/math/test_maxf
   i32.eqz
   if
@@ -27786,9 +27917,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
-  f32.const -1
-  f32.const 0.5
+  f32.const inf
+  f32.const 1
+  f32.const inf
   call $std/math/test_maxf
   i32.eqz
   if
@@ -27799,9 +27930,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const -1
-  f32.const -0.5
+  f32.const -inf
+  f32.const 1
+  f32.const 1
   call $std/math/test_maxf
   i32.eqz
   if
@@ -27812,9 +27943,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const nan:0x400000
   f32.const 1
-  f32.const -1
-  f32.const 1
+  f32.const nan:0x400000
   call $std/math/test_maxf
   i32.eqz
   if
@@ -27825,9 +27956,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 0
   f32.const -1
-  f32.const -1
-  f32.const -1
+  f32.const 0
   call $std/math/test_maxf
   i32.eqz
   if
@@ -27838,9 +27969,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -0
   f32.const -1
-  f32.const inf
+  f32.const -0
   call $std/math/test_maxf
   i32.eqz
   if
@@ -27851,9 +27982,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const 0.5
   f32.const -1
-  f32.const -1
+  f32.const 0.5
   call $std/math/test_maxf
   i32.eqz
   if
@@ -27864,9 +27995,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -0.5
   f32.const -1
-  f32.const nan:0x400000
+  f32.const -0.5
   call $std/math/test_maxf
   i32.eqz
   if
@@ -27877,9 +28008,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
-  f32.const 0
+  f32.const 1
+  f32.const -1
+  f32.const 1
   call $std/math/test_maxf
   i32.eqz
   if
@@ -27890,9 +28021,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const -0
-  f32.const 0
+  f32.const -1
+  f32.const -1
+  f32.const -1
   call $std/math/test_maxf
   i32.eqz
   if
@@ -27903,8 +28034,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
   f32.const inf
+  f32.const -1
   f32.const inf
   call $std/math/test_maxf
   i32.eqz
@@ -27916,9 +28047,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
   f32.const -inf
-  f32.const 0
+  f32.const -1
+  f32.const -1
   call $std/math/test_maxf
   i32.eqz
   if
@@ -27929,8 +28060,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
   f32.const nan:0x400000
+  f32.const -1
   f32.const nan:0x400000
   call $std/math/test_maxf
   i32.eqz
@@ -27942,7 +28073,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const 0
   f32.const 0
   call $std/math/test_maxf
@@ -27955,9 +28086,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 0
   f32.const -0
-  f32.const -0
-  f32.const -0
+  f32.const 0
   call $std/math/test_maxf
   i32.eqz
   if
@@ -27968,7 +28099,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const inf
   f32.const inf
   call $std/math/test_maxf
@@ -27981,9 +28112,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const -inf
-  f32.const -0
+  f32.const 0
   call $std/math/test_maxf
   i32.eqz
   if
@@ -27994,7 +28125,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_maxf
@@ -28007,9 +28138,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -0
   f32.const 0
-  f32.const 1
+  f32.const 0
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28020,9 +28151,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const 0
-  f32.const 0
+  f32.const -0
+  f32.const -0
+  f32.const -0
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28033,8 +28164,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const inf
-  f32.const 0
   f32.const inf
   call $std/math/test_maxf
   i32.eqz
@@ -28046,6 +28177,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const -inf
+  f32.const -0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2058
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2059
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 0
+  f32.const 1
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2060
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const 0
+  f32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2061
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const 0
+  f32.const inf
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2062
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -inf
   f32.const 0
   f32.const 0
@@ -28054,7 +28250,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2058
+   i32.const 2063
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28067,7 +28263,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2059
+   i32.const 2064
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28080,79 +28276,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2060
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -0
-  f32.const inf
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2061
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -0
-  f32.const -0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2062
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const -0
-  f32.const nan:0x400000
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2063
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 2
-  f32.const inf
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2064
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -0.5
-  f32.const inf
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2065
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -0
+  f32.const inf
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28164,8 +28295,8 @@
    unreachable
   end
   f32.const -inf
-  f32.const 2
-  f32.const 2
+  f32.const -0
+  f32.const -0
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28176,9 +28307,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -0.5
-  f32.const -0.5
+  f32.const nan:0x400000
+  f32.const -0
+  f32.const nan:0x400000
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28189,9 +28320,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const 2
+  f32.const inf
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28202,9 +28333,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const -0.5
+  f32.const inf
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28215,7 +28346,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const inf
   f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_maxf
@@ -28228,9 +28359,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const 2
+  f32.const 2
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28241,9 +28372,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const inf
-  f32.const inf
+  f32.const -inf
+  f32.const -0.5
+  f32.const -0.5
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28254,9 +28385,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const inf
-  f32.const inf
+  f32.const -inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28267,9 +28398,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28280,9 +28411,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const inf
-  f32.const inf
+  f32.const 1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28293,9 +28424,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const -inf
-  f32.const 1
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28306,9 +28437,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -inf
-  f32.const -1
+  f32.const 1
+  f32.const inf
+  f32.const inf
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28319,8 +28450,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
   f32.const inf
-  f32.const -inf
   f32.const inf
   call $std/math/test_maxf
   i32.eqz
@@ -28332,9 +28463,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
-  f32.const -inf
+  f32.const inf
+  f32.const inf
+  f32.const inf
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28345,9 +28476,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
-  f32.const 0.5
-  f32.const 1.75
+  f32.const -inf
+  f32.const inf
+  f32.const inf
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28358,9 +28489,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.75
-  f32.const 0.5
-  f32.const 0.5
+  f32.const 1
+  f32.const -inf
+  f32.const 1
   call $std/math/test_maxf
   i32.eqz
   if
@@ -28371,6 +28502,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
+  f32.const -inf
+  f32.const -1
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2083
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const -inf
+  f32.const inf
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2084
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -inf
+  f32.const -inf
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2085
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.75
+  f32.const 0.5
+  f32.const 1.75
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2086
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.75
+  f32.const 0.5
+  f32.const 0.5
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2087
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1.75
   f32.const -0.5
   f32.const 1.75
@@ -28379,7 +28575,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2083
+   i32.const 2088
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28392,7 +28588,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2084
+   i32.const 2089
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28405,7 +28601,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2096
+   i32.const 2101
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28418,7 +28614,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2097
+   i32.const 2102
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28431,7 +28627,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2098
+   i32.const 2103
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28444,7 +28640,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2099
+   i32.const 2104
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28457,7 +28653,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2100
+   i32.const 2105
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28470,7 +28666,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2101
+   i32.const 2106
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28483,7 +28679,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2102
+   i32.const 2107
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28496,7 +28692,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2103
+   i32.const 2108
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28509,7 +28705,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2104
+   i32.const 2109
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28522,85 +28718,85 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2105
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2108
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const 1
-  f64.const -0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2109
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const 1
-  f64.const 0.5
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2110
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const 0
   f64.const 1
-  f64.const -0.5
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2111
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  f64.const 1
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2112
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const 1
-  f64.const -1
+  f64.const 0
   call $std/math/test_min
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2113
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const 1
+  f64.const -0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2114
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
+  f64.const 1
+  f64.const 0.5
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2115
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.5
+  f64.const 1
+  f64.const -0.5
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2116
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 1
+  f64.const 1
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2117
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const 1
+  f64.const -1
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2118
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -28613,79 +28809,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2114
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const 1
-  f64.const -inf
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2115
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2116
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -1
-  f64.const -1
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2117
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -1
-  f64.const -1
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2118
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const -1
-  f64.const -1
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2119
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
-  f64.const -1
-  f64.const -1
+  f64.const -inf
+  f64.const 1
+  f64.const -inf
   call $std/math/test_min
   i32.eqz
   if
@@ -28696,9 +28827,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const nan:0x8000000000000
   f64.const 1
-  f64.const -1
-  f64.const -1
+  f64.const nan:0x8000000000000
   call $std/math/test_min
   i32.eqz
   if
@@ -28709,7 +28840,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 0
   f64.const -1
   f64.const -1
   call $std/math/test_min
@@ -28722,7 +28853,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -0
   f64.const -1
   f64.const -1
   call $std/math/test_min
@@ -28735,9 +28866,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const 0.5
   f64.const -1
-  f64.const -inf
+  f64.const -1
   call $std/math/test_min
   i32.eqz
   if
@@ -28748,9 +28879,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -0.5
   f64.const -1
-  f64.const nan:0x8000000000000
+  f64.const -1
   call $std/math/test_min
   i32.eqz
   if
@@ -28761,9 +28892,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
-  f64.const 0
+  f64.const 1
+  f64.const -1
+  f64.const -1
   call $std/math/test_min
   i32.eqz
   if
@@ -28774,9 +28905,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -0
-  f64.const -0
+  f64.const -1
+  f64.const -1
+  f64.const -1
   call $std/math/test_min
   i32.eqz
   if
@@ -28787,9 +28918,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const inf
-  f64.const 0
+  f64.const -1
+  f64.const -1
   call $std/math/test_min
   i32.eqz
   if
@@ -28800,8 +28931,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const -inf
+  f64.const -1
   f64.const -inf
   call $std/math/test_min
   i32.eqz
@@ -28813,8 +28944,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const nan:0x8000000000000
+  f64.const -1
   f64.const nan:0x8000000000000
   call $std/math/test_min
   i32.eqz
@@ -28826,9 +28957,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
   f64.const 0
-  f64.const -0
+  f64.const 0
+  f64.const 0
   call $std/math/test_min
   i32.eqz
   if
@@ -28839,7 +28970,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const -0
   f64.const -0
   call $std/math/test_min
@@ -28852,9 +28983,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const inf
-  f64.const -0
+  f64.const 0
   call $std/math/test_min
   i32.eqz
   if
@@ -28865,7 +28996,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const -inf
   f64.const -inf
   call $std/math/test_min
@@ -28878,7 +29009,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_min
@@ -28891,9 +29022,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -0
   f64.const 0
-  f64.const 0
+  f64.const -0
   call $std/math/test_min
   i32.eqz
   if
@@ -28904,9 +29035,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const 0
-  f64.const -1
+  f64.const -0
+  f64.const -0
+  f64.const -0
   call $std/math/test_min
   i32.eqz
   if
@@ -28917,9 +29048,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const inf
-  f64.const 0
-  f64.const 0
+  f64.const -0
   call $std/math/test_min
   i32.eqz
   if
@@ -28930,8 +29061,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const -inf
-  f64.const 0
   f64.const -inf
   call $std/math/test_min
   i32.eqz
@@ -28943,8 +29074,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const nan:0x8000000000000
-  f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_min
   i32.eqz
@@ -28956,9 +29087,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -0
-  f64.const -1
+  f64.const 1
+  f64.const 0
+  f64.const 0
   call $std/math/test_min
   i32.eqz
   if
@@ -28969,9 +29100,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const -0
-  f64.const -0
+  f64.const -1
+  f64.const 0
+  f64.const -1
   call $std/math/test_min
   i32.eqz
   if
@@ -28982,9 +29113,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -0
-  f64.const -inf
+  f64.const inf
+  f64.const 0
+  f64.const 0
   call $std/math/test_min
   i32.eqz
   if
@@ -28995,9 +29126,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -0
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const 0
+  f64.const -inf
   call $std/math/test_min
   i32.eqz
   if
@@ -29008,9 +29139,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 2
-  f64.const 2
+  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const nan:0x8000000000000
   call $std/math/test_min
   i32.eqz
   if
@@ -29021,9 +29152,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const -0.5
-  f64.const -0.5
+  f64.const -1
+  f64.const -0
+  f64.const -1
   call $std/math/test_min
   i32.eqz
   if
@@ -29035,8 +29166,8 @@
    unreachable
   end
   f64.const inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -0
+  f64.const -0
   call $std/math/test_min
   i32.eqz
   if
@@ -29048,7 +29179,7 @@
    unreachable
   end
   f64.const -inf
-  f64.const 2
+  f64.const -0
   f64.const -inf
   call $std/math/test_min
   i32.eqz
@@ -29060,9 +29191,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -0.5
-  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const -0
+  f64.const nan:0x8000000000000
   call $std/math/test_min
   i32.eqz
   if
@@ -29073,9 +29204,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const 2
+  f64.const 2
   call $std/math/test_min
   i32.eqz
   if
@@ -29086,9 +29217,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const -0.5
+  f64.const -0.5
   call $std/math/test_min
   i32.eqz
   if
@@ -29099,7 +29230,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const inf
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_min
@@ -29112,9 +29243,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const 2
+  f64.const -inf
   call $std/math/test_min
   i32.eqz
   if
@@ -29125,9 +29256,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const inf
-  f64.const 1
+  f64.const -inf
+  f64.const -0.5
+  f64.const -inf
   call $std/math/test_min
   i32.eqz
   if
@@ -29138,9 +29269,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const inf
-  f64.const -1
+  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_min
   i32.eqz
   if
@@ -29151,6 +29282,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2156
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2157
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2158
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const inf
+  f64.const 1
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2159
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const inf
+  f64.const -1
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2160
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const inf
   f64.const inf
   f64.const inf
@@ -29159,7 +29355,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2156
+   i32.const 2161
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29172,7 +29368,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2157
+   i32.const 2162
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29185,7 +29381,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2158
+   i32.const 2163
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29198,7 +29394,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2159
+   i32.const 2164
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29211,72 +29407,72 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2160
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -inf
-  f64.const -inf
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2161
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.75
-  f64.const 0.5
-  f64.const 0.5
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2162
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.75
-  f64.const 0.5
-  f64.const -1.75
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2163
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.75
-  f64.const -0.5
-  f64.const -0.5
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2164
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.75
-  f64.const -0.5
-  f64.const -1.75
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2165
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -inf
+  f64.const -inf
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2166
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.75
+  f64.const 0.5
+  f64.const 0.5
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2167
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.75
+  f64.const 0.5
+  f64.const -1.75
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2168
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.75
+  f64.const -0.5
+  f64.const -0.5
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2169
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.75
+  f64.const -0.5
+  f64.const -1.75
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2170
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29289,7 +29485,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2174
+   i32.const 2179
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29302,7 +29498,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2175
+   i32.const 2180
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29315,7 +29511,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2176
+   i32.const 2181
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29328,7 +29524,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2177
+   i32.const 2182
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29341,7 +29537,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2178
+   i32.const 2183
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29354,7 +29550,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2179
+   i32.const 2184
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29367,7 +29563,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2180
+   i32.const 2185
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29380,7 +29576,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2181
+   i32.const 2186
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29393,7 +29589,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2182
+   i32.const 2187
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29406,85 +29602,85 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2183
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2186
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 1
-  f32.const -0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2187
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const 1
-  f32.const 0.5
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2188
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const 0
   f32.const 1
-  f32.const -0.5
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2189
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  f32.const 1
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2190
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const 1
-  f32.const -1
+  f32.const 0
   call $std/math/test_minf
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2191
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 1
+  f32.const -0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2192
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
+  f32.const 1
+  f32.const 0.5
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2193
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.5
+  f32.const 1
+  f32.const -0.5
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2194
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 1
+  f32.const 1
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2195
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const 1
+  f32.const -1
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2196
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29497,79 +29693,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2192
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const 1
-  f32.const -inf
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2193
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 1
-  f32.const nan:0x400000
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2194
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -1
-  f32.const -1
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2195
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -1
-  f32.const -1
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2196
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const -1
-  f32.const -1
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2197
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const -1
-  f32.const -1
+  f32.const -inf
+  f32.const 1
+  f32.const -inf
   call $std/math/test_minf
   i32.eqz
   if
@@ -29580,9 +29711,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const nan:0x400000
   f32.const 1
-  f32.const -1
-  f32.const -1
+  f32.const nan:0x400000
   call $std/math/test_minf
   i32.eqz
   if
@@ -29593,7 +29724,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 0
   f32.const -1
   f32.const -1
   call $std/math/test_minf
@@ -29606,7 +29737,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -0
   f32.const -1
   f32.const -1
   call $std/math/test_minf
@@ -29619,9 +29750,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const 0.5
   f32.const -1
-  f32.const -inf
+  f32.const -1
   call $std/math/test_minf
   i32.eqz
   if
@@ -29632,9 +29763,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -0.5
   f32.const -1
-  f32.const nan:0x400000
+  f32.const -1
   call $std/math/test_minf
   i32.eqz
   if
@@ -29645,9 +29776,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
-  f32.const 0
+  f32.const 1
+  f32.const -1
+  f32.const -1
   call $std/math/test_minf
   i32.eqz
   if
@@ -29658,9 +29789,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const -0
-  f32.const -0
+  f32.const -1
+  f32.const -1
+  f32.const -1
   call $std/math/test_minf
   i32.eqz
   if
@@ -29671,9 +29802,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
   f32.const inf
-  f32.const 0
+  f32.const -1
+  f32.const -1
   call $std/math/test_minf
   i32.eqz
   if
@@ -29684,8 +29815,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
   f32.const -inf
+  f32.const -1
   f32.const -inf
   call $std/math/test_minf
   i32.eqz
@@ -29697,8 +29828,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
   f32.const nan:0x400000
+  f32.const -1
   f32.const nan:0x400000
   call $std/math/test_minf
   i32.eqz
@@ -29710,9 +29841,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
   f32.const 0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   call $std/math/test_minf
   i32.eqz
   if
@@ -29723,7 +29854,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const -0
   f32.const -0
   call $std/math/test_minf
@@ -29736,9 +29867,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const inf
-  f32.const -0
+  f32.const 0
   call $std/math/test_minf
   i32.eqz
   if
@@ -29749,7 +29880,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const -inf
   f32.const -inf
   call $std/math/test_minf
@@ -29762,7 +29893,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_minf
@@ -29775,9 +29906,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -0
   f32.const 0
-  f32.const 0
+  f32.const -0
   call $std/math/test_minf
   i32.eqz
   if
@@ -29788,9 +29919,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const 0
-  f32.const -1
+  f32.const -0
+  f32.const -0
+  f32.const -0
   call $std/math/test_minf
   i32.eqz
   if
@@ -29801,9 +29932,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const inf
-  f32.const 0
-  f32.const 0
+  f32.const -0
   call $std/math/test_minf
   i32.eqz
   if
@@ -29814,8 +29945,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const -inf
-  f32.const 0
   f32.const -inf
   call $std/math/test_minf
   i32.eqz
@@ -29827,8 +29958,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const nan:0x400000
-  f32.const 0
   f32.const nan:0x400000
   call $std/math/test_minf
   i32.eqz
@@ -29840,9 +29971,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -0
-  f32.const -1
+  f32.const 1
+  f32.const 0
+  f32.const 0
   call $std/math/test_minf
   i32.eqz
   if
@@ -29853,9 +29984,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const -0
-  f32.const -0
+  f32.const -1
+  f32.const 0
+  f32.const -1
   call $std/math/test_minf
   i32.eqz
   if
@@ -29866,9 +29997,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -0
-  f32.const -inf
+  f32.const inf
+  f32.const 0
+  f32.const 0
   call $std/math/test_minf
   i32.eqz
   if
@@ -29879,9 +30010,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -0
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const 0
+  f32.const -inf
   call $std/math/test_minf
   i32.eqz
   if
@@ -29892,9 +30023,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const 2
-  f32.const 2
+  f32.const nan:0x400000
+  f32.const 0
+  f32.const nan:0x400000
   call $std/math/test_minf
   i32.eqz
   if
@@ -29905,9 +30036,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const -0.5
-  f32.const -0.5
+  f32.const -1
+  f32.const -0
+  f32.const -1
   call $std/math/test_minf
   i32.eqz
   if
@@ -29919,8 +30050,8 @@
    unreachable
   end
   f32.const inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -0
+  f32.const -0
   call $std/math/test_minf
   i32.eqz
   if
@@ -29932,7 +30063,7 @@
    unreachable
   end
   f32.const -inf
-  f32.const 2
+  f32.const -0
   f32.const -inf
   call $std/math/test_minf
   i32.eqz
@@ -29944,9 +30075,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -0.5
-  f32.const -inf
+  f32.const nan:0x400000
+  f32.const -0
+  f32.const nan:0x400000
   call $std/math/test_minf
   i32.eqz
   if
@@ -29957,9 +30088,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const 2
+  f32.const 2
   call $std/math/test_minf
   i32.eqz
   if
@@ -29970,9 +30101,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const -0.5
+  f32.const -0.5
   call $std/math/test_minf
   i32.eqz
   if
@@ -29983,7 +30114,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const inf
   f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_minf
@@ -29996,9 +30127,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const 2
+  f32.const -inf
   call $std/math/test_minf
   i32.eqz
   if
@@ -30009,9 +30140,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const inf
-  f32.const 1
+  f32.const -inf
+  f32.const -0.5
+  f32.const -inf
   call $std/math/test_minf
   i32.eqz
   if
@@ -30022,9 +30153,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const inf
-  f32.const -1
+  f32.const -inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   call $std/math/test_minf
   i32.eqz
   if
@@ -30035,6 +30166,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2234
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2235
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2236
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const inf
+  f32.const 1
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2237
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const inf
+  f32.const -1
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2238
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const inf
   f32.const inf
   f32.const inf
@@ -30043,7 +30239,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2234
+   i32.const 2239
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30056,7 +30252,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2235
+   i32.const 2240
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30069,7 +30265,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2236
+   i32.const 2241
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30082,7 +30278,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2237
+   i32.const 2242
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30095,72 +30291,72 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2238
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -inf
-  f32.const -inf
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2239
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.75
-  f32.const 0.5
-  f32.const 0.5
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2240
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.75
-  f32.const 0.5
-  f32.const -1.75
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2241
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.75
-  f32.const -0.5
-  f32.const -0.5
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2242
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.75
-  f32.const -0.5
-  f32.const -1.75
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2243
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -inf
+  f32.const -inf
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2244
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.75
+  f32.const 0.5
+  f32.const 0.5
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2245
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.75
+  f32.const 0.5
+  f32.const -1.75
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2246
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.75
+  f32.const -0.5
+  f32.const -0.5
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2247
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.75
+  f32.const -0.5
+  f32.const -1.75
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2248
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30173,7 +30369,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2257
+   i32.const 2262
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30186,7 +30382,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2258
+   i32.const 2263
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30199,7 +30395,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2259
+   i32.const 2264
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30212,7 +30408,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2260
+   i32.const 2265
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30225,7 +30421,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2261
+   i32.const 2266
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30238,7 +30434,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2262
+   i32.const 2267
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30251,7 +30447,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2263
+   i32.const 2268
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30264,7 +30460,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2264
+   i32.const 2269
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30277,7 +30473,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2265
+   i32.const 2270
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30290,50 +30486,50 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2266
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2269
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const 1
-  f64.const -0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2270
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const 1
-  f64.const 0.5
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2271
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0
+  f64.const 1
+  f64.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2274
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const 1
+  f64.const -0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2275
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
+  f64.const 1
+  f64.const 0.5
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2276
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -0.5
   f64.const 1
   f64.const -0.5
@@ -30342,7 +30538,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2272
+   i32.const 2277
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30355,7 +30551,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2273
+   i32.const 2278
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30368,7 +30564,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2274
+   i32.const 2279
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30381,7 +30577,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2275
+   i32.const 2280
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30394,78 +30590,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2276
+   i32.const 2281
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2
   f64.const 1
-  f64.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2277
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2
-  f64.const 1
-  f64.const -0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2278
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 1
-  f64.const nan:0x8000000000000
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2279
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const 1
-  f64.const nan:0x8000000000000
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2280
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2281
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -1
   f64.const 0
   call $std/math/test_mod
   i32.eqz
@@ -30477,8 +30608,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -1
+  f64.const -2
+  f64.const 1
   f64.const -0
   call $std/math/test_mod
   i32.eqz
@@ -30490,6 +30621,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
+  f64.const 1
+  f64.const nan:0x8000000000000
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2284
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const 1
+  f64.const nan:0x8000000000000
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2285
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const nan:0x8000000000000
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2286
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -1
+  f64.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2287
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -1
+  f64.const -0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2288
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0.5
   f64.const -1
   f64.const 0.5
@@ -30498,7 +30694,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2284
+   i32.const 2289
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30511,7 +30707,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2285
+   i32.const 2290
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30524,7 +30720,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2286
+   i32.const 2291
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30537,7 +30733,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2287
+   i32.const 2292
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30550,7 +30746,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2288
+   i32.const 2293
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30563,7 +30759,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2289
+   i32.const 2294
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30576,7 +30772,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2290
+   i32.const 2295
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30589,79 +30785,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2291
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -1
-  f64.const nan:0x8000000000000
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2292
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -1
-  f64.const nan:0x8000000000000
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2293
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const -1
-  f64.const nan:0x8000000000000
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2294
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const nan:0x8000000000000
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2295
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -0
-  f64.const nan:0x8000000000000
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2296
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const inf
-  f64.const 0
+  f64.const -1
+  f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
   if
@@ -30672,9 +30803,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const -inf
-  f64.const 0
+  f64.const -1
+  f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
   if
@@ -30685,8 +30816,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const nan:0x8000000000000
+  f64.const -1
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -30698,7 +30829,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -30711,7 +30842,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -30724,9 +30855,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const inf
-  f64.const -0
+  f64.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -30737,9 +30868,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const -inf
-  f64.const -0
+  f64.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -30750,7 +30881,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -30763,7 +30894,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -0
   f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -30776,8 +30907,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const 0
+  f64.const -0
+  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -30789,9 +30920,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const inf
-  f64.const 0
-  f64.const nan:0x8000000000000
+  f64.const -0
   call $std/math/test_mod
   i32.eqz
   if
@@ -30802,9 +30933,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const -inf
-  f64.const 0
-  f64.const nan:0x8000000000000
+  f64.const -0
   call $std/math/test_mod
   i32.eqz
   if
@@ -30815,8 +30946,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const nan:0x8000000000000
-  f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -30828,8 +30959,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -0
+  f64.const 1
+  f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -30841,8 +30972,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const -0
+  f64.const -1
+  f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -30854,8 +30985,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -0
+  f64.const inf
+  f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -30867,8 +30998,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -0
+  f64.const -inf
+  f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -30880,8 +31011,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 2
+  f64.const nan:0x8000000000000
+  f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -30893,8 +31024,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const -0.5
+  f64.const -1
+  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -30907,7 +31038,7 @@
    unreachable
   end
   f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -30920,7 +31051,7 @@
    unreachable
   end
   f64.const -inf
-  f64.const 2
+  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -30932,8 +31063,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -0.5
+  f64.const nan:0x8000000000000
+  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -30945,8 +31076,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const 2
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -30958,8 +31089,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const -0.5
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -30971,7 +31102,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const inf
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_mod
@@ -30984,8 +31115,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const 2
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -30997,9 +31128,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const inf
-  f64.const 1
+  f64.const -inf
+  f64.const -0.5
+  f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
   if
@@ -31010,9 +31141,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const inf
-  f64.const -1
+  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
   if
@@ -31023,8 +31154,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -31036,8 +31167,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const inf
+  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_mod
   i32.eqz
@@ -31049,6 +31180,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2327
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const inf
+  f64.const 1
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2328
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const inf
+  f64.const -1
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2329
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  f64.const nan:0x8000000000000
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2330
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const inf
+  f64.const nan:0x8000000000000
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2331
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1
   f64.const -inf
   f64.const 1
@@ -31057,7 +31253,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2327
+   i32.const 2332
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31070,7 +31266,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2328
+   i32.const 2333
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31083,7 +31279,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2329
+   i32.const 2334
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31096,7 +31292,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2330
+   i32.const 2335
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31109,7 +31305,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2331
+   i32.const 2336
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31117,45 +31313,6 @@
   f64.const -1.75
   f64.const 0.5
   f64.const -0.25
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2332
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.75
-  f64.const -0.5
-  f64.const 0.25
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2333
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.75
-  f64.const -0.5
-  f64.const -0.25
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2334
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072014e-308
-  f64.const 2.2250738585072014e-308
-  f64.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -31166,9 +31323,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
-  f64.const 0
+  f64.const 1.75
+  f64.const -0.5
+  f64.const 0.25
   call $std/math/test_mod
   i32.eqz
   if
@@ -31179,9 +31336,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072014e-308
-  f64.const 2.2250738585072014e-308
-  f64.const -0
+  f64.const -1.75
+  f64.const -0.5
+  f64.const -0.25
   call $std/math/test_mod
   i32.eqz
   if
@@ -31192,34 +31349,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
-  f64.const -0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2340
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1797693134862315708145274e284
-  f64.const 1797693134862315708145274e284
-  f64.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2341
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1797693134862315708145274e284
-  f64.const -1797693134862315708145274e284
+  f64.const 2.2250738585072014e-308
+  f64.const 2.2250738585072014e-308
   f64.const 0
   call $std/math/test_mod
   i32.eqz
@@ -31231,9 +31362,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1797693134862315708145274e284
-  f64.const 1797693134862315708145274e284
-  f64.const -0
+  f64.const 2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
+  f64.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -31244,8 +31375,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1797693134862315708145274e284
-  f64.const -1797693134862315708145274e284
+  f64.const -2.2250738585072014e-308
+  f64.const 2.2250738585072014e-308
   f64.const -0
   call $std/math/test_mod
   i32.eqz
@@ -31257,8 +31388,34 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
+  f64.const -0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2345
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1797693134862315708145274e284
+  f64.const 1797693134862315708145274e284
   f64.const 0
-  f64.const 2.2250738585072014e-308
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2346
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1797693134862315708145274e284
+  f64.const -1797693134862315708145274e284
   f64.const 0
   call $std/math/test_mod
   i32.eqz
@@ -31270,6 +31427,45 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1797693134862315708145274e284
+  f64.const 1797693134862315708145274e284
+  f64.const -0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2348
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1797693134862315708145274e284
+  f64.const -1797693134862315708145274e284
+  f64.const -0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2349
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 2.2250738585072014e-308
+  f64.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2352
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0
   f64.const 1797693134862315708145274e284
   f64.const 0
@@ -31278,7 +31474,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2348
+   i32.const 2353
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31291,7 +31487,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2349
+   i32.const 2354
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31304,7 +31500,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2350
+   i32.const 2355
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31317,7 +31513,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2351
+   i32.const 2356
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31330,7 +31526,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2352
+   i32.const 2357
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31343,7 +31539,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2353
+   i32.const 2358
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31356,7 +31552,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2354
+   i32.const 2359
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31369,7 +31565,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2357
+   i32.const 2362
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31382,7 +31578,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2358
+   i32.const 2363
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31395,7 +31591,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2360
+   i32.const 2365
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31408,7 +31604,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2361
+   i32.const 2366
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31421,7 +31617,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2363
+   i32.const 2368
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31434,7 +31630,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2364
+   i32.const 2369
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31447,7 +31643,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2366
+   i32.const 2371
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31460,66 +31656,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2367
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 8988465674311579538646525e283
-  f64.const 1797693134862315708145274e284
-  f64.const 8988465674311579538646525e283
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2369
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -8988465674311579538646525e283
-  f64.const 1797693134862315708145274e284
-  f64.const -8988465674311579538646525e283
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2370
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 8988465674311578540726371e283
-  f64.const -1797693134862315708145274e284
-  f64.const 8988465674311578540726371e283
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2372
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8988465674311578540726371e283
-  f64.const -1797693134862315708145274e284
-  f64.const -8988465674311578540726371e283
+  f64.const 8988465674311579538646525e283
+  f64.const 1797693134862315708145274e284
+  f64.const 8988465674311579538646525e283
   call $std/math/test_mod
   i32.eqz
   if
    i32.const 0
    i32.const 24
-   i32.const 2373
+   i32.const 2374
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 8988465674311577542806216e283
+  f64.const -8988465674311579538646525e283
   f64.const 1797693134862315708145274e284
-  f64.const 8988465674311577542806216e283
+  f64.const -8988465674311579538646525e283
   call $std/math/test_mod
   i32.eqz
   if
@@ -31530,22 +31687,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8988465674311577542806216e283
-  f64.const 1797693134862315708145274e284
-  f64.const -8988465674311577542806216e283
+  f64.const 8988465674311578540726371e283
+  f64.const -1797693134862315708145274e284
+  f64.const 8988465674311578540726371e283
   call $std/math/test_mod
   i32.eqz
   if
    i32.const 0
    i32.const 24
-   i32.const 2376
+   i32.const 2377
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1797693134862315508561243e284
+  f64.const -8988465674311578540726371e283
   f64.const -1797693134862315708145274e284
-  f64.const 1797693134862315508561243e284
+  f64.const -8988465674311578540726371e283
   call $std/math/test_mod
   i32.eqz
   if
@@ -31556,6 +31713,45 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 8988465674311577542806216e283
+  f64.const 1797693134862315708145274e284
+  f64.const 8988465674311577542806216e283
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2380
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -8988465674311577542806216e283
+  f64.const 1797693134862315708145274e284
+  f64.const -8988465674311577542806216e283
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2381
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1797693134862315508561243e284
+  f64.const -1797693134862315708145274e284
+  f64.const 1797693134862315508561243e284
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2383
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -1797693134862315508561243e284
   f64.const -1797693134862315708145274e284
   f64.const -1797693134862315508561243e284
@@ -31564,7 +31760,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2379
+   i32.const 2384
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31577,7 +31773,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2381
+   i32.const 2386
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31590,7 +31786,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2382
+   i32.const 2387
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31603,7 +31799,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2384
+   i32.const 2389
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31616,7 +31812,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2385
+   i32.const 2390
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31629,7 +31825,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2386
+   i32.const 2391
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31642,7 +31838,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2387
+   i32.const 2392
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31655,7 +31851,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2388
+   i32.const 2393
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31668,7 +31864,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2389
+   i32.const 2394
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31681,7 +31877,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2390
+   i32.const 2395
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31694,7 +31890,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2391
+   i32.const 2396
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31707,7 +31903,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2393
+   i32.const 2398
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31720,7 +31916,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2394
+   i32.const 2399
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31733,7 +31929,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2395
+   i32.const 2400
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31746,7 +31942,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2396
+   i32.const 2401
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31759,7 +31955,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2397
+   i32.const 2402
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31772,7 +31968,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2398
+   i32.const 2403
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31785,7 +31981,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2399
+   i32.const 2404
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31798,7 +31994,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2400
+   i32.const 2405
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31811,7 +32007,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2401
+   i32.const 2406
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31824,7 +32020,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2402
+   i32.const 2407
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31837,85 +32033,85 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2403
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072024e-308
-  f64.const 1.5e-323
-  f64.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2404
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072024e-308
-  f64.const -1.5e-323
-  f64.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2405
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507203e-308
-  f64.const 1.5e-323
-  f64.const 5e-324
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2406
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507203e-308
-  f64.const 2.225073858507204e-308
-  f64.const 2.225073858507203e-308
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2407
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507203e-308
-  f64.const -1.5e-323
-  f64.const 5e-324
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2408
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072034e-308
-  f64.const 2.225073858507204e-308
-  f64.const 2.2250738585072034e-308
+  f64.const 2.2250738585072024e-308
+  f64.const 1.5e-323
+  f64.const 0
   call $std/math/test_mod
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 2409
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.2250738585072024e-308
+  f64.const -1.5e-323
+  f64.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2410
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.225073858507203e-308
+  f64.const 1.5e-323
+  f64.const 5e-324
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2411
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.225073858507203e-308
+  f64.const 2.225073858507204e-308
+  f64.const 2.225073858507203e-308
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2412
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.225073858507203e-308
+  f64.const -1.5e-323
+  f64.const 5e-324
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2413
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.2250738585072034e-308
+  f64.const 2.225073858507204e-308
+  f64.const 2.2250738585072034e-308
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2414
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31928,7 +32124,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2410
+   i32.const 2415
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31941,7 +32137,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2411
+   i32.const 2416
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31954,7 +32150,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2412
+   i32.const 2417
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31967,7 +32163,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2421
+   i32.const 2426
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31980,7 +32176,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2422
+   i32.const 2427
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31993,7 +32189,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2423
+   i32.const 2428
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32006,7 +32202,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2424
+   i32.const 2429
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32019,7 +32215,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2425
+   i32.const 2430
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32032,7 +32228,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2426
+   i32.const 2431
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32045,7 +32241,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2427
+   i32.const 2432
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32058,7 +32254,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2428
+   i32.const 2433
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32071,7 +32267,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2429
+   i32.const 2434
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32084,50 +32280,50 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2430
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2433
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 1
-  f32.const -0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2434
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const 1
-  f32.const 0.5
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2435
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 0
+  f32.const 1
+  f32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2438
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 1
+  f32.const -0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2439
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
+  f32.const 1
+  f32.const 0.5
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2440
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -0.5
   f32.const 1
   f32.const -0.5
@@ -32136,7 +32332,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2436
+   i32.const 2441
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32149,7 +32345,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2437
+   i32.const 2442
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32162,7 +32358,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2438
+   i32.const 2443
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32175,7 +32371,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2439
+   i32.const 2444
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32188,78 +32384,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2440
+   i32.const 2445
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 2
   f32.const 1
-  f32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2441
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2
-  f32.const 1
-  f32.const -0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2442
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 1
-  f32.const nan:0x400000
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2443
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const 1
-  f32.const nan:0x400000
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2444
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 1
-  f32.const nan:0x400000
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2445
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -1
   f32.const 0
   call $std/math/test_modf
   i32.eqz
@@ -32271,8 +32402,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -1
+  f32.const -2
+  f32.const 1
   f32.const -0
   call $std/math/test_modf
   i32.eqz
@@ -32284,6 +32415,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
+  f32.const 1
+  f32.const nan:0x400000
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2448
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const 1
+  f32.const nan:0x400000
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2449
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const 1
+  f32.const nan:0x400000
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2450
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const -1
+  f32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2451
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -1
+  f32.const -0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2452
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 0.5
   f32.const -1
   f32.const 0.5
@@ -32292,7 +32488,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2448
+   i32.const 2453
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32305,7 +32501,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2449
+   i32.const 2454
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32318,7 +32514,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2450
+   i32.const 2455
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32331,7 +32527,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2451
+   i32.const 2456
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32344,7 +32540,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2452
+   i32.const 2457
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32357,7 +32553,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2453
+   i32.const 2458
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32370,7 +32566,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2454
+   i32.const 2459
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32383,79 +32579,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2455
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -1
-  f32.const nan:0x400000
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2456
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -1
-  f32.const nan:0x400000
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2457
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const -1
-  f32.const nan:0x400000
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2458
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const nan:0x400000
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2459
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -0
-  f32.const nan:0x400000
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2460
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
   f32.const inf
-  f32.const 0
+  f32.const -1
+  f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
   if
@@ -32466,9 +32597,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
   f32.const -inf
-  f32.const 0
+  f32.const -1
+  f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
   if
@@ -32479,8 +32610,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
   f32.const nan:0x400000
+  f32.const -1
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32492,7 +32623,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const 0
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -32505,7 +32636,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const -0
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -32518,9 +32649,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const inf
-  f32.const -0
+  f32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -32531,9 +32662,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const -inf
-  f32.const -0
+  f32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -32544,7 +32675,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -32557,7 +32688,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -0
   f32.const 0
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -32570,8 +32701,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const 0
+  f32.const -0
+  f32.const -0
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32583,9 +32714,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const inf
-  f32.const 0
-  f32.const nan:0x400000
+  f32.const -0
   call $std/math/test_modf
   i32.eqz
   if
@@ -32596,9 +32727,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const -inf
-  f32.const 0
-  f32.const nan:0x400000
+  f32.const -0
   call $std/math/test_modf
   i32.eqz
   if
@@ -32609,8 +32740,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const nan:0x400000
-  f32.const 0
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32622,8 +32753,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -0
+  f32.const 1
+  f32.const 0
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32635,8 +32766,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const -0
+  f32.const -1
+  f32.const 0
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32648,8 +32779,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -0
+  f32.const inf
+  f32.const 0
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32661,8 +32792,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -0
+  f32.const -inf
+  f32.const 0
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32674,8 +32805,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const 2
+  f32.const nan:0x400000
+  f32.const 0
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32687,8 +32818,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const -0.5
+  f32.const -1
+  f32.const -0
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32701,7 +32832,7 @@
    unreachable
   end
   f32.const inf
-  f32.const nan:0x400000
+  f32.const -0
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32714,7 +32845,7 @@
    unreachable
   end
   f32.const -inf
-  f32.const 2
+  f32.const -0
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32726,8 +32857,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -0.5
+  f32.const nan:0x400000
+  f32.const -0
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32739,8 +32870,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const 2
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32752,8 +32883,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const -0.5
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32765,7 +32896,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const inf
   f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_modf
@@ -32778,8 +32909,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const 2
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32791,9 +32922,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const inf
-  f32.const 1
+  f32.const -inf
+  f32.const -0.5
+  f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
   if
@@ -32804,9 +32935,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const inf
-  f32.const -1
+  f32.const -inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
   if
@@ -32817,8 +32948,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32830,8 +32961,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const inf
+  f32.const 1
+  f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_modf
   i32.eqz
@@ -32843,6 +32974,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2491
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const inf
+  f32.const 1
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2492
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const inf
+  f32.const -1
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2493
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  f32.const nan:0x400000
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2494
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const inf
+  f32.const nan:0x400000
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2495
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1
   f32.const -inf
   f32.const 1
@@ -32851,7 +33047,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2491
+   i32.const 2496
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32864,7 +33060,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2492
+   i32.const 2497
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32877,7 +33073,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2493
+   i32.const 2498
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32890,7 +33086,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2494
+   i32.const 2499
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32903,7 +33099,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2495
+   i32.const 2500
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32916,7 +33112,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2496
+   i32.const 2501
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32929,7 +33125,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2497
+   i32.const 2502
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32942,7 +33138,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2498
+   i32.const 2503
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32956,7 +33152,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2510
+   i32.const 2515
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32970,7 +33166,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2511
+   i32.const 2516
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32984,7 +33180,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2512
+   i32.const 2517
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32998,7 +33194,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2513
+   i32.const 2518
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33012,7 +33208,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2514
+   i32.const 2519
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33026,7 +33222,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2515
+   i32.const 2520
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33040,7 +33236,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2516
+   i32.const 2521
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33054,7 +33250,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2517
+   i32.const 2522
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33068,7 +33264,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2518
+   i32.const 2523
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33082,84 +33278,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2519
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2522
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const inf
-  f64.const 0
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2523
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 3
-  f64.const 0
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2524
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  f64.const 2
-  f64.const 0
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2525
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2526
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0.5
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -33172,6 +33298,76 @@
    unreachable
   end
   f64.const 0
+  f64.const inf
+  f64.const 0
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2528
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 3
+  f64.const 0
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2529
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 2
+  f64.const 0
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2530
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 1
+  f64.const 0
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2531
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0.5
+  f64.const 0
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2532
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
   f64.const 0
   f64.const 1
   f64.const 0
@@ -33180,7 +33376,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2528
+   i32.const 2533
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33194,7 +33390,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2529
+   i32.const 2534
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33208,7 +33404,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2530
+   i32.const 2535
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33222,7 +33418,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2531
+   i32.const 2536
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33236,7 +33432,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2532
+   i32.const 2537
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33250,7 +33446,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2533
+   i32.const 2538
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33264,7 +33460,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2534
+   i32.const 2539
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33278,7 +33474,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2535
+   i32.const 2540
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33292,7 +33488,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2536
+   i32.const 2541
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33306,7 +33502,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2537
+   i32.const 2542
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33320,7 +33516,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2538
+   i32.const 2543
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33334,7 +33530,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2539
+   i32.const 2544
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33348,7 +33544,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2540
+   i32.const 2545
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33362,7 +33558,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2541
+   i32.const 2546
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33376,7 +33572,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2542
+   i32.const 2547
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33390,7 +33586,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2543
+   i32.const 2548
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33404,7 +33600,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2544
+   i32.const 2549
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33418,7 +33614,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2545
+   i32.const 2550
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33432,7 +33628,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2546
+   i32.const 2551
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33446,7 +33642,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2547
+   i32.const 2552
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33460,7 +33656,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2548
+   i32.const 2553
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33474,82 +33670,12 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2549
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2550
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2551
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2552
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2553
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2554
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const nan:0x8000000000000
   f64.const 0
   f64.const 1
   f64.const 0
@@ -33563,8 +33689,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -0
+  f64.const inf
+  f64.const 0
   f64.const 1
   f64.const 0
   call $std/math/test_pow
@@ -33577,8 +33703,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const -0
+  f64.const -inf
+  f64.const 0
   f64.const 1
   f64.const 0
   call $std/math/test_pow
@@ -33591,8 +33717,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -0
+  f64.const 1
+  f64.const 0
   f64.const 1
   f64.const 0
   call $std/math/test_pow
@@ -33605,8 +33731,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const -0
+  f64.const -1
+  f64.const 0
   f64.const 1
   f64.const 0
   call $std/math/test_pow
@@ -33619,8 +33745,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -0
+  f64.const -0.5
+  f64.const 0
   f64.const 1
   f64.const 0
   call $std/math/test_pow
@@ -33633,7 +33759,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const nan:0x8000000000000
   f64.const -0
   f64.const 1
   f64.const 0
@@ -33647,6 +33773,76 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
+  f64.const -0
+  f64.const 1
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2562
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -0
+  f64.const 1
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2563
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const -0
+  f64.const 1
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2564
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const -0
+  f64.const 1
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2565
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.5
+  f64.const -0
+  f64.const 1
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2566
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
@@ -33656,7 +33852,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2562
+   i32.const 2567
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33670,7 +33866,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2563
+   i32.const 2568
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33684,7 +33880,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2564
+   i32.const 2569
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33698,7 +33894,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2565
+   i32.const 2570
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33712,7 +33908,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2566
+   i32.const 2571
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33726,7 +33922,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2567
+   i32.const 2572
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33740,7 +33936,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2568
+   i32.const 2573
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33754,7 +33950,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2569
+   i32.const 2574
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33768,7 +33964,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2570
+   i32.const 2575
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33782,7 +33978,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2571
+   i32.const 2576
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33796,7 +33992,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2572
+   i32.const 2577
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33810,7 +34006,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2573
+   i32.const 2578
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33824,7 +34020,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2574
+   i32.const 2579
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33838,7 +34034,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2575
+   i32.const 2580
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33852,7 +34048,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2576
+   i32.const 2581
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33866,7 +34062,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2577
+   i32.const 2582
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33880,7 +34076,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2578
+   i32.const 2583
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33894,7 +34090,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2579
+   i32.const 2584
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33908,84 +34104,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2580
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const inf
-  f64.const 0
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2581
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const -inf
-  f64.const inf
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2582
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2583
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const inf
-  f64.const 0
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2584
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const -inf
-  f64.const inf
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2585
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -0.5
+  f64.const inf
+  f64.const 0
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -33997,8 +34123,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5
-  f64.const inf
+  f64.const -0.5
+  f64.const -inf
   f64.const inf
   f64.const 0
   call $std/math/test_pow
@@ -34011,9 +34137,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5
-  f64.const -inf
-  f64.const 0
+  f64.const -0.5
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -34025,9 +34151,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 0.5
+  f64.const inf
+  f64.const 0
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -34039,9 +34165,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0.5
+  f64.const -inf
   f64.const inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -34053,9 +34179,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
-  f64.const inf
+  f64.const 0.5
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -34067,9 +34193,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1.5
   f64.const inf
-  f64.const -inf
-  f64.const 0
+  f64.const inf
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -34081,9 +34207,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 3
-  f64.const inf
+  f64.const 1.5
+  f64.const -inf
+  f64.const 0
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -34095,9 +34221,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 2
-  f64.const inf
+  f64.const 1.5
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -34110,8 +34236,8 @@
    unreachable
   end
   f64.const inf
-  f64.const 1
-  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -34124,7 +34250,7 @@
    unreachable
   end
   f64.const inf
-  f64.const 0.5
+  f64.const inf
   f64.const inf
   f64.const 0
   call $std/math/test_pow
@@ -34138,7 +34264,7 @@
    unreachable
   end
   f64.const inf
-  f64.const -0.5
+  f64.const -inf
   f64.const 0
   f64.const 0
   call $std/math/test_pow
@@ -34152,6 +34278,76 @@
    unreachable
   end
   f64.const inf
+  f64.const 3
+  f64.const inf
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2598
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const 2
+  f64.const inf
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2599
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const 1
+  f64.const inf
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2600
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const 0.5
+  f64.const inf
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2601
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const -0.5
+  f64.const 0
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2602
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
   f64.const -1
   f64.const 0
   f64.const 0
@@ -34160,7 +34356,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2598
+   i32.const 2603
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34174,84 +34370,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2599
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2600
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const inf
-  f64.const inf
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2601
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -inf
-  f64.const 0
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2602
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const 3
-  f64.const -inf
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2603
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const 2
-  f64.const inf
-  f64.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2604
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -inf
-  f64.const 1
-  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   call $std/math/test_pow
   i32.eqz
@@ -34264,7 +34390,7 @@
    unreachable
   end
   f64.const -inf
-  f64.const 0.5
+  f64.const inf
   f64.const inf
   f64.const 0
   call $std/math/test_pow
@@ -34278,7 +34404,7 @@
    unreachable
   end
   f64.const -inf
-  f64.const -0.5
+  f64.const -inf
   f64.const 0
   f64.const 0
   call $std/math/test_pow
@@ -34292,6 +34418,76 @@
    unreachable
   end
   f64.const -inf
+  f64.const 3
+  f64.const -inf
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2608
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const 2
+  f64.const inf
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2609
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const 1
+  f64.const -inf
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2610
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const 0.5
+  f64.const inf
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2611
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -0.5
+  f64.const 0
+  f64.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2612
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
   f64.const -1
   f64.const -0
   f64.const 0
@@ -34300,7 +34496,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2608
+   i32.const 2613
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34314,7 +34510,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2609
+   i32.const 2614
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34328,7 +34524,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2610
+   i32.const 2615
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34342,7 +34538,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2611
+   i32.const 2616
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34356,7 +34552,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2612
+   i32.const 2617
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34370,7 +34566,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2613
+   i32.const 2618
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34384,7 +34580,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2622
+   i32.const 2627
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34398,7 +34594,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2623
+   i32.const 2628
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34412,7 +34608,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2624
+   i32.const 2629
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34426,7 +34622,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2625
+   i32.const 2630
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34440,7 +34636,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2626
+   i32.const 2631
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34454,7 +34650,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2627
+   i32.const 2632
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34468,7 +34664,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2628
+   i32.const 2633
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34482,7 +34678,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2629
+   i32.const 2634
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34496,7 +34692,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2630
+   i32.const 2635
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34510,84 +34706,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2631
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2634
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const inf
-  f32.const 0
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2635
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 3
-  f32.const 0
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2636
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
-  f32.const 2
-  f32.const 0
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2637
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2638
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0.5
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -34600,6 +34726,76 @@
    unreachable
   end
   f32.const 0
+  f32.const inf
+  f32.const 0
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2640
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 3
+  f32.const 0
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2641
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 2
+  f32.const 0
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2642
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 1
+  f32.const 0
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2643
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0.5
+  f32.const 0
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2644
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
   f32.const 0
   f32.const 1
   f32.const 0
@@ -34608,7 +34804,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2640
+   i32.const 2645
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34622,7 +34818,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2641
+   i32.const 2646
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34636,7 +34832,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2642
+   i32.const 2647
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34650,7 +34846,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2643
+   i32.const 2648
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34664,7 +34860,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2644
+   i32.const 2649
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34678,7 +34874,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2645
+   i32.const 2650
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34692,7 +34888,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2646
+   i32.const 2651
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34706,7 +34902,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2647
+   i32.const 2652
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34720,7 +34916,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2648
+   i32.const 2653
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34734,7 +34930,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2649
+   i32.const 2654
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34748,7 +34944,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2650
+   i32.const 2655
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34762,7 +34958,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2651
+   i32.const 2656
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34776,7 +34972,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2652
+   i32.const 2657
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34790,7 +34986,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2653
+   i32.const 2658
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34804,7 +35000,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2654
+   i32.const 2659
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34818,7 +35014,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2655
+   i32.const 2660
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34832,7 +35028,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2656
+   i32.const 2661
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34846,7 +35042,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2657
+   i32.const 2662
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34860,7 +35056,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2658
+   i32.const 2663
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34874,7 +35070,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2659
+   i32.const 2664
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34888,7 +35084,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2660
+   i32.const 2665
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34902,82 +35098,12 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2661
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2662
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2663
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2664
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2665
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2666
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const nan:0x400000
   f32.const 0
   f32.const 1
   f32.const 0
@@ -34991,8 +35117,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -0
+  f32.const inf
+  f32.const 0
   f32.const 1
   f32.const 0
   call $std/math/test_powf
@@ -35005,8 +35131,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const -0
+  f32.const -inf
+  f32.const 0
   f32.const 1
   f32.const 0
   call $std/math/test_powf
@@ -35019,8 +35145,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -0
+  f32.const 1
+  f32.const 0
   f32.const 1
   f32.const 0
   call $std/math/test_powf
@@ -35033,8 +35159,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const -0
+  f32.const -1
+  f32.const 0
   f32.const 1
   f32.const 0
   call $std/math/test_powf
@@ -35047,8 +35173,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -0
+  f32.const -0.5
+  f32.const 0
   f32.const 1
   f32.const 0
   call $std/math/test_powf
@@ -35061,7 +35187,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const nan:0x400000
   f32.const -0
   f32.const 1
   f32.const 0
@@ -35075,6 +35201,76 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
+  f32.const -0
+  f32.const 1
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2674
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -0
+  f32.const 1
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2675
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const -0
+  f32.const 1
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2676
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const -0
+  f32.const 1
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2677
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.5
+  f32.const -0
+  f32.const 1
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2678
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -1
   f32.const nan:0x400000
   f32.const nan:0x400000
@@ -35084,7 +35280,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2674
+   i32.const 2679
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35098,7 +35294,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2675
+   i32.const 2680
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35112,7 +35308,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2676
+   i32.const 2681
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35126,7 +35322,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2677
+   i32.const 2682
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35140,7 +35336,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2678
+   i32.const 2683
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35154,7 +35350,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2679
+   i32.const 2684
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35168,7 +35364,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2680
+   i32.const 2685
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35182,7 +35378,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2681
+   i32.const 2686
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35196,7 +35392,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2682
+   i32.const 2687
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35210,7 +35406,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2683
+   i32.const 2688
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35224,7 +35420,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2684
+   i32.const 2689
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35238,7 +35434,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2685
+   i32.const 2690
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35252,7 +35448,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2686
+   i32.const 2691
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35266,7 +35462,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2687
+   i32.const 2692
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35280,7 +35476,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2688
+   i32.const 2693
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35294,7 +35490,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2689
+   i32.const 2694
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35308,7 +35504,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2690
+   i32.const 2695
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35322,7 +35518,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2691
+   i32.const 2696
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35336,84 +35532,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2692
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const inf
-  f32.const 0
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2693
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const -inf
-  f32.const inf
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2694
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2695
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const inf
-  f32.const 0
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2696
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const -inf
-  f32.const inf
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2697
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -0.5
+  f32.const inf
+  f32.const 0
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35425,8 +35551,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.5
-  f32.const inf
+  f32.const -0.5
+  f32.const -inf
   f32.const inf
   f32.const 0
   call $std/math/test_powf
@@ -35439,9 +35565,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.5
-  f32.const -inf
-  f32.const 0
+  f32.const -0.5
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35453,9 +35579,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.5
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 0.5
+  f32.const inf
+  f32.const 0
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35467,9 +35593,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 0.5
+  f32.const -inf
   f32.const inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35481,9 +35607,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
-  f32.const inf
+  f32.const 0.5
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35495,9 +35621,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1.5
   f32.const inf
-  f32.const -inf
-  f32.const 0
+  f32.const inf
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35509,9 +35635,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const 3
-  f32.const inf
+  f32.const 1.5
+  f32.const -inf
+  f32.const 0
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35523,9 +35649,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const 2
-  f32.const inf
+  f32.const 1.5
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35538,8 +35664,8 @@
    unreachable
   end
   f32.const inf
-  f32.const 1
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35552,7 +35678,7 @@
    unreachable
   end
   f32.const inf
-  f32.const 0.5
+  f32.const inf
   f32.const inf
   f32.const 0
   call $std/math/test_powf
@@ -35566,7 +35692,7 @@
    unreachable
   end
   f32.const inf
-  f32.const -0.5
+  f32.const -inf
   f32.const 0
   f32.const 0
   call $std/math/test_powf
@@ -35580,6 +35706,76 @@
    unreachable
   end
   f32.const inf
+  f32.const 3
+  f32.const inf
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2710
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const 2
+  f32.const inf
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2711
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const 1
+  f32.const inf
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2712
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const 0.5
+  f32.const inf
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2713
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const -0.5
+  f32.const 0
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2714
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
   f32.const -1
   f32.const 0
   f32.const 0
@@ -35588,7 +35784,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2710
+   i32.const 2715
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35602,84 +35798,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2711
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2712
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2713
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -inf
-  f32.const 0
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2714
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const 3
-  f32.const -inf
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2715
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const 2
-  f32.const inf
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2716
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -inf
-  f32.const 1
-  f32.const -inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -35692,7 +35818,7 @@
    unreachable
   end
   f32.const -inf
-  f32.const 0.5
+  f32.const inf
   f32.const inf
   f32.const 0
   call $std/math/test_powf
@@ -35706,7 +35832,7 @@
    unreachable
   end
   f32.const -inf
-  f32.const -0.5
+  f32.const -inf
   f32.const 0
   f32.const 0
   call $std/math/test_powf
@@ -35720,6 +35846,76 @@
    unreachable
   end
   f32.const -inf
+  f32.const 3
+  f32.const -inf
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2720
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const 2
+  f32.const inf
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2721
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const 1
+  f32.const -inf
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2722
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const 0.5
+  f32.const inf
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2723
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -0.5
+  f32.const 0
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2724
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
   f32.const -1
   f32.const -0
   f32.const 0
@@ -35728,7 +35924,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2720
+   i32.const 2725
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35742,7 +35938,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2721
+   i32.const 2726
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35756,7 +35952,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2722
+   i32.const 2727
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35770,7 +35966,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2723
+   i32.const 2728
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35784,7 +35980,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2724
+   i32.const 2729
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35798,7 +35994,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2725
+   i32.const 2730
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35834,7 +36030,7 @@
     else
      i32.const 0
      i32.const 24
-     i32.const 2734
+     i32.const 2739
      i32.const 2
      call $~lib/builtins/abort
      unreachable
@@ -35875,7 +36071,7 @@
     else
      i32.const 0
      i32.const 24
-     i32.const 2742
+     i32.const 2747
      i32.const 2
      call $~lib/builtins/abort
      unreachable
@@ -35890,7 +36086,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2756
+   i32.const 2761
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35902,7 +36098,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2757
+   i32.const 2762
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35914,7 +36110,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2758
+   i32.const 2763
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35926,7 +36122,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2759
+   i32.const 2764
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35938,7 +36134,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2760
+   i32.const 2765
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35950,7 +36146,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2761
+   i32.const 2766
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35962,7 +36158,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2762
+   i32.const 2767
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35974,7 +36170,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2763
+   i32.const 2768
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35986,7 +36182,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2764
+   i32.const 2769
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35998,73 +36194,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2765
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2768
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2769
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -inf
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2770
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2771
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2772
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_round
   i32.eqz
   if
@@ -36075,6 +36211,66 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
+  f64.const inf
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2774
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -inf
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2775
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2776
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2777
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 1
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2778
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -1
   f64.const -1
   call $std/math/test_round
@@ -36082,7 +36278,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2774
+   i32.const 2779
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36094,7 +36290,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2775
+   i32.const 2780
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36106,7 +36302,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2776
+   i32.const 2781
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36118,7 +36314,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2777
+   i32.const 2782
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36130,7 +36326,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2778
+   i32.const 2783
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36142,7 +36338,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2779
+   i32.const 2784
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36154,7 +36350,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2780
+   i32.const 2785
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36166,7 +36362,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2781
+   i32.const 2786
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36178,7 +36374,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2782
+   i32.const 2787
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36190,7 +36386,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2783
+   i32.const 2788
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36202,7 +36398,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2784
+   i32.const 2789
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36214,7 +36410,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2793
+   i32.const 2798
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36226,7 +36422,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2794
+   i32.const 2799
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36238,7 +36434,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2795
+   i32.const 2800
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36250,7 +36446,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2796
+   i32.const 2801
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36262,7 +36458,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2797
+   i32.const 2802
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36274,7 +36470,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2798
+   i32.const 2803
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36286,7 +36482,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2799
+   i32.const 2804
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36298,7 +36494,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2800
+   i32.const 2805
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36310,7 +36506,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2801
+   i32.const 2806
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36322,73 +36518,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2802
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2805
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2806
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -inf
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2807
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2808
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2809
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   call $std/math/test_roundf
   i32.eqz
   if
@@ -36399,6 +36535,66 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
+  f32.const inf
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2811
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -inf
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2812
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2813
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2814
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 1
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2815
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -1
   f32.const -1
   call $std/math/test_roundf
@@ -36406,7 +36602,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2811
+   i32.const 2816
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36418,7 +36614,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2812
+   i32.const 2817
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36430,7 +36626,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2813
+   i32.const 2818
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36442,7 +36638,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2814
+   i32.const 2819
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36454,7 +36650,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2815
+   i32.const 2820
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36466,7 +36662,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2816
+   i32.const 2821
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36478,7 +36674,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2817
+   i32.const 2822
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36490,7 +36686,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2818
+   i32.const 2823
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36502,7 +36698,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2819
+   i32.const 2824
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36514,7 +36710,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2820
+   i32.const 2825
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36526,7 +36722,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2821
+   i32.const 2826
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36538,7 +36734,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2832
+   i32.const 2837
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36550,7 +36746,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2833
+   i32.const 2838
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36562,7 +36758,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2834
+   i32.const 2839
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36574,7 +36770,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2835
+   i32.const 2840
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36586,7 +36782,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2836
+   i32.const 2841
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36598,7 +36794,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2837
+   i32.const 2842
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36610,7 +36806,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2838
+   i32.const 2843
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36622,7 +36818,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2839
+   i32.const 2844
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36634,7 +36830,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2840
+   i32.const 2845
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36646,7 +36842,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2848
+   i32.const 2853
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36658,7 +36854,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2849
+   i32.const 2854
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36670,7 +36866,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2850
+   i32.const 2855
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36682,7 +36878,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2851
+   i32.const 2856
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36694,7 +36890,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2852
+   i32.const 2857
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36706,7 +36902,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2853
+   i32.const 2858
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36718,7 +36914,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2854
+   i32.const 2859
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36730,7 +36926,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2855
+   i32.const 2860
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36742,7 +36938,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2856
+   i32.const 2861
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36755,7 +36951,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2893
+   i32.const 2898
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36768,7 +36964,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2894
+   i32.const 2899
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36781,7 +36977,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2895
+   i32.const 2900
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36794,7 +36990,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2896
+   i32.const 2901
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36807,7 +37003,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2897
+   i32.const 2902
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36820,7 +37016,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2898
+   i32.const 2903
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36833,7 +37029,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2899
+   i32.const 2904
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36846,7 +37042,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2900
+   i32.const 2905
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36859,7 +37055,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2901
+   i32.const 2906
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36872,79 +37068,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2902
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2905
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const 1
-  f64.const -0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2906
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const 1
-  f64.const 0.5
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2907
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
-  f64.const 1
-  f64.const -0.5
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2908
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
+  f64.const 0
   f64.const 1
   f64.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2909
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const 1
-  f64.const -0
   call $std/math/test_rem
   i32.eqz
   if
@@ -36955,9 +37086,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5
+  f64.const -0
   f64.const 1
-  f64.const -0.5
+  f64.const -0
   call $std/math/test_rem
   i32.eqz
   if
@@ -36968,7 +37099,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.5
+  f64.const 0.5
   f64.const 1
   f64.const 0.5
   call $std/math/test_rem
@@ -36981,6 +37112,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0.5
+  f64.const 1
+  f64.const -0.5
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2913
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 1
+  f64.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2914
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const 1
+  f64.const -0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2915
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.5
+  f64.const 1
+  f64.const -0.5
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2916
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.5
+  f64.const 1
+  f64.const 0.5
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2917
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 2
   f64.const 1
   f64.const 0
@@ -36989,7 +37185,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2913
+   i32.const 2918
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37002,7 +37198,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2914
+   i32.const 2919
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37015,7 +37211,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2915
+   i32.const 2920
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37028,79 +37224,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2916
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2917
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -1
-  f64.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2918
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -1
-  f64.const -0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2919
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const -1
-  f64.const 0.5
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2920
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const -1
-  f64.const -0.5
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2921
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const nan:0x8000000000000
   f64.const 1
-  f64.const -1
-  f64.const 0
+  f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
   if
@@ -37111,9 +37242,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0
   f64.const -1
-  f64.const -1
-  f64.const -0
+  f64.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -37124,9 +37255,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5
+  f64.const -0
   f64.const -1
-  f64.const -0.5
+  f64.const -0
   call $std/math/test_rem
   i32.eqz
   if
@@ -37137,7 +37268,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.5
+  f64.const 0.5
   f64.const -1
   f64.const 0.5
   call $std/math/test_rem
@@ -37150,6 +37281,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0.5
+  f64.const -1
+  f64.const -0.5
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2926
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const -1
+  f64.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2927
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const -1
+  f64.const -0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2928
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.5
+  f64.const -1
+  f64.const -0.5
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2929
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.5
+  f64.const -1
+  f64.const 0.5
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2930
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 2
   f64.const -1
   f64.const 0
@@ -37158,7 +37354,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2926
+   i32.const 2931
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37171,79 +37367,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2927
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -1
-  f64.const nan:0x8000000000000
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2928
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -1
-  f64.const nan:0x8000000000000
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2929
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const -1
-  f64.const nan:0x8000000000000
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2930
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const nan:0x8000000000000
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2931
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -0
-  f64.const nan:0x8000000000000
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2932
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const inf
-  f64.const 0
+  f64.const -1
+  f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
   if
@@ -37254,9 +37385,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const -inf
-  f64.const 0
+  f64.const -1
+  f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
   if
@@ -37267,8 +37398,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const nan:0x8000000000000
+  f64.const -1
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37280,7 +37411,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
@@ -37293,7 +37424,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
@@ -37306,9 +37437,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const inf
-  f64.const -0
+  f64.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -37319,9 +37450,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const -inf
-  f64.const -0
+  f64.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -37332,7 +37463,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_rem
@@ -37345,7 +37476,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -0
   f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
@@ -37358,8 +37489,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const 0
+  f64.const -0
+  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37371,9 +37502,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const inf
-  f64.const 0
-  f64.const nan:0x8000000000000
+  f64.const -0
   call $std/math/test_rem
   i32.eqz
   if
@@ -37384,9 +37515,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const -inf
-  f64.const 0
-  f64.const nan:0x8000000000000
+  f64.const -0
   call $std/math/test_rem
   i32.eqz
   if
@@ -37397,8 +37528,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const nan:0x8000000000000
-  f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37410,8 +37541,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -0
+  f64.const 1
+  f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37423,8 +37554,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const -0
+  f64.const -1
+  f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37436,8 +37567,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -0
+  f64.const inf
+  f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37449,8 +37580,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -0
+  f64.const -inf
+  f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37462,8 +37593,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 2
+  f64.const nan:0x8000000000000
+  f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37475,8 +37606,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const -0.5
+  f64.const -1
+  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37489,7 +37620,7 @@
    unreachable
   end
   f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37502,7 +37633,7 @@
    unreachable
   end
   f64.const -inf
-  f64.const 2
+  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37514,8 +37645,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -0.5
+  f64.const nan:0x8000000000000
+  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37527,8 +37658,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const 2
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37540,8 +37671,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const -0.5
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37553,7 +37684,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const inf
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_rem
@@ -37566,8 +37697,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const 2
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37579,9 +37710,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const inf
-  f64.const 1
+  f64.const -inf
+  f64.const -0.5
+  f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
   if
@@ -37592,9 +37723,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const inf
-  f64.const -1
+  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
   if
@@ -37605,8 +37736,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37618,8 +37749,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const inf
+  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37631,9 +37762,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const -inf
-  f64.const 1
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
   if
@@ -37644,9 +37775,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -inf
-  f64.const -1
+  f64.const 1
+  f64.const inf
+  f64.const 1
   call $std/math/test_rem
   i32.eqz
   if
@@ -37657,9 +37788,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
   f64.const inf
-  f64.const -inf
-  f64.const nan:0x8000000000000
+  f64.const -1
   call $std/math/test_rem
   i32.eqz
   if
@@ -37670,8 +37801,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
+  f64.const inf
+  f64.const inf
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -37683,9 +37814,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const 0.5
-  f64.const -0.25
+  f64.const -inf
+  f64.const inf
+  f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
   if
@@ -37696,6 +37827,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
+  f64.const -inf
+  f64.const 1
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2968
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const -inf
+  f64.const -1
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2969
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const -inf
+  f64.const nan:0x8000000000000
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2970
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -inf
+  f64.const nan:0x8000000000000
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2971
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.75
+  f64.const 0.5
+  f64.const -0.25
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2972
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -1.75
   f64.const 0.5
   f64.const 0.25
@@ -37704,7 +37900,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2968
+   i32.const 2973
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37717,7 +37913,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2969
+   i32.const 2974
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37730,7 +37926,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2970
+   i32.const 2975
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37743,7 +37939,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2971
+   i32.const 2976
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37756,7 +37952,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2980
+   i32.const 2985
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37769,7 +37965,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2981
+   i32.const 2986
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37782,7 +37978,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2982
+   i32.const 2987
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37795,7 +37991,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2983
+   i32.const 2988
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37808,7 +38004,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2984
+   i32.const 2989
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37821,7 +38017,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2985
+   i32.const 2990
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37834,7 +38030,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2986
+   i32.const 2991
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37847,7 +38043,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2987
+   i32.const 2992
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37860,7 +38056,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2988
+   i32.const 2993
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37873,79 +38069,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2989
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2992
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 1
-  f32.const -0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2993
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const 1
-  f32.const 0.5
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2994
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const 1
-  f32.const -0.5
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2995
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
+  f32.const 0
   f32.const 1
   f32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2996
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const 1
-  f32.const -0
   call $std/math/test_remf
   i32.eqz
   if
@@ -37956,9 +38087,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.5
+  f32.const -0
   f32.const 1
-  f32.const -0.5
+  f32.const -0
   call $std/math/test_remf
   i32.eqz
   if
@@ -37969,7 +38100,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.5
+  f32.const 0.5
   f32.const 1
   f32.const 0.5
   call $std/math/test_remf
@@ -37982,6 +38113,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0.5
+  f32.const 1
+  f32.const -0.5
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3000
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 1
+  f32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3001
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const 1
+  f32.const -0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3002
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.5
+  f32.const 1
+  f32.const -0.5
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3003
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.5
+  f32.const 1
+  f32.const 0.5
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3004
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 2
   f32.const 1
   f32.const 0
@@ -37990,7 +38186,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3000
+   i32.const 3005
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38003,7 +38199,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3001
+   i32.const 3006
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38016,7 +38212,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3002
+   i32.const 3007
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38029,79 +38225,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3003
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 1
-  f32.const nan:0x400000
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3004
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -1
-  f32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3005
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -1
-  f32.const -0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3006
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const -1
-  f32.const 0.5
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3007
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const -1
-  f32.const -0.5
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3008
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const nan:0x400000
   f32.const 1
-  f32.const -1
-  f32.const 0
+  f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
   if
@@ -38112,9 +38243,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 0
   f32.const -1
-  f32.const -1
-  f32.const -0
+  f32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -38125,9 +38256,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.5
+  f32.const -0
   f32.const -1
-  f32.const -0.5
+  f32.const -0
   call $std/math/test_remf
   i32.eqz
   if
@@ -38138,7 +38269,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.5
+  f32.const 0.5
   f32.const -1
   f32.const 0.5
   call $std/math/test_remf
@@ -38151,6 +38282,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0.5
+  f32.const -1
+  f32.const -0.5
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3013
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const -1
+  f32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3014
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const -1
+  f32.const -0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3015
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.5
+  f32.const -1
+  f32.const -0.5
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3016
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.5
+  f32.const -1
+  f32.const 0.5
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3017
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 2
   f32.const -1
   f32.const 0
@@ -38159,7 +38355,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3013
+   i32.const 3018
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38172,79 +38368,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3014
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -1
-  f32.const nan:0x400000
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3015
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -1
-  f32.const nan:0x400000
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3016
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const -1
-  f32.const nan:0x400000
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3017
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const nan:0x400000
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3018
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -0
-  f32.const nan:0x400000
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3019
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
   f32.const inf
-  f32.const 0
+  f32.const -1
+  f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
   if
@@ -38255,9 +38386,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
   f32.const -inf
-  f32.const 0
+  f32.const -1
+  f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
   if
@@ -38268,8 +38399,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
   f32.const nan:0x400000
+  f32.const -1
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38281,7 +38412,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const 0
   f32.const nan:0x400000
   call $std/math/test_remf
@@ -38294,7 +38425,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const -0
   f32.const nan:0x400000
   call $std/math/test_remf
@@ -38307,9 +38438,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const inf
-  f32.const -0
+  f32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -38320,9 +38451,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const -inf
-  f32.const -0
+  f32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -38333,7 +38464,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_remf
@@ -38346,7 +38477,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -0
   f32.const 0
   f32.const nan:0x400000
   call $std/math/test_remf
@@ -38359,8 +38490,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const 0
+  f32.const -0
+  f32.const -0
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38372,9 +38503,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const inf
-  f32.const 0
-  f32.const nan:0x400000
+  f32.const -0
   call $std/math/test_remf
   i32.eqz
   if
@@ -38385,9 +38516,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const -inf
-  f32.const 0
-  f32.const nan:0x400000
+  f32.const -0
   call $std/math/test_remf
   i32.eqz
   if
@@ -38398,8 +38529,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const nan:0x400000
-  f32.const 0
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38411,8 +38542,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -0
+  f32.const 1
+  f32.const 0
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38424,8 +38555,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const -0
+  f32.const -1
+  f32.const 0
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38437,8 +38568,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -0
+  f32.const inf
+  f32.const 0
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38450,8 +38581,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -0
+  f32.const -inf
+  f32.const 0
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38463,8 +38594,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const 2
+  f32.const nan:0x400000
+  f32.const 0
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38476,8 +38607,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const -0.5
+  f32.const -1
+  f32.const -0
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38490,7 +38621,7 @@
    unreachable
   end
   f32.const inf
-  f32.const nan:0x400000
+  f32.const -0
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38503,7 +38634,7 @@
    unreachable
   end
   f32.const -inf
-  f32.const 2
+  f32.const -0
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38515,8 +38646,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -0.5
+  f32.const nan:0x400000
+  f32.const -0
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38528,8 +38659,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const 2
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38541,8 +38672,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const -0.5
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38554,7 +38685,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const inf
   f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_remf
@@ -38567,8 +38698,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const 2
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38580,9 +38711,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const inf
-  f32.const 1
+  f32.const -inf
+  f32.const -0.5
+  f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
   if
@@ -38593,9 +38724,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const inf
-  f32.const -1
+  f32.const -inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
   if
@@ -38606,8 +38737,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38619,8 +38750,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const inf
+  f32.const 1
+  f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38632,9 +38763,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const -inf
-  f32.const 1
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
   if
@@ -38645,9 +38776,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -inf
-  f32.const -1
+  f32.const 1
+  f32.const inf
+  f32.const 1
   call $std/math/test_remf
   i32.eqz
   if
@@ -38658,9 +38789,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
   f32.const inf
-  f32.const -inf
-  f32.const nan:0x400000
+  f32.const -1
   call $std/math/test_remf
   i32.eqz
   if
@@ -38671,8 +38802,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const inf
+  f32.const inf
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -38684,9 +38815,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
-  f32.const 0.5
-  f32.const -0.25
+  f32.const -inf
+  f32.const inf
+  f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
   if
@@ -38697,6 +38828,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1
+  f32.const -inf
+  f32.const 1
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3055
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const -inf
+  f32.const -1
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3056
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const -inf
+  f32.const nan:0x400000
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3057
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -inf
+  f32.const nan:0x400000
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3058
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.75
+  f32.const 0.5
+  f32.const -0.25
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3059
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -1.75
   f32.const 0.5
   f32.const 0.25
@@ -38705,7 +38901,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3055
+   i32.const 3060
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38718,7 +38914,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3056
+   i32.const 3061
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38731,7 +38927,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3057
+   i32.const 3062
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38744,7 +38940,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3058
+   i32.const 3063
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38757,7 +38953,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3070
+   i32.const 3075
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38770,7 +38966,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3071
+   i32.const 3076
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38783,7 +38979,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3072
+   i32.const 3077
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38796,7 +38992,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3073
+   i32.const 3078
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38809,7 +39005,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3074
+   i32.const 3079
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38822,7 +39018,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3075
+   i32.const 3080
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38835,7 +39031,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3076
+   i32.const 3081
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38848,7 +39044,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3077
+   i32.const 3082
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38861,7 +39057,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3078
+   i32.const 3083
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38874,7 +39070,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3079
+   i32.const 3084
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38887,7 +39083,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3082
+   i32.const 3087
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38900,78 +39096,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3083
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072014e-308
-  f64.const 2.2250738585072014e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3084
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3085
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 5e-324
-  f64.const 5e-324
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3086
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -5e-324
-  f64.const -5e-324
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3087
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3088
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 2.2250738585072014e-308
+  f64.const 2.2250738585072014e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -38983,8 +39114,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507202e-308
-  f64.const 2.225073858507202e-308
+  f64.const -2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -38996,8 +39127,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072024e-308
-  f64.const 2.2250738585072024e-308
+  f64.const 5e-324
+  f64.const 5e-324
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39009,8 +39140,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4501477170144003e-308
-  f64.const 4.4501477170144003e-308
+  f64.const -5e-324
+  f64.const -5e-324
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39022,8 +39153,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.450147717014403e-308
-  f64.const 4.450147717014403e-308
+  f64.const 0
+  f64.const 0
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39035,6 +39166,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3094
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.225073858507202e-308
+  f64.const 2.225073858507202e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3095
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.2250738585072024e-308
+  f64.const 2.2250738585072024e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3096
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.4501477170144003e-308
+  f64.const 4.4501477170144003e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3097
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.450147717014403e-308
+  f64.const 4.450147717014403e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3098
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 4.450147717014406e-308
   f64.const 4.450147717014406e-308
   f64.const 0
@@ -39043,7 +39239,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3094
+   i32.const 3099
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39056,7 +39252,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3095
+   i32.const 3100
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39069,7 +39265,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3096
+   i32.const 3101
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39082,78 +39278,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3097
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.225073858507202e-308
-  f64.const -2.225073858507202e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3098
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.2250738585072024e-308
-  f64.const -2.2250738585072024e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3099
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.4501477170144003e-308
-  f64.const -4.4501477170144003e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3100
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.450147717014403e-308
-  f64.const -4.450147717014403e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3101
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.450147717014406e-308
-  f64.const -4.450147717014406e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3102
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8.900295434028806e-308
-  f64.const -8.900295434028806e-308
+  f64.const -2.225073858507202e-308
+  f64.const -2.225073858507202e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39161,6 +39292,71 @@
    i32.const 0
    i32.const 24
    i32.const 3103
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072024e-308
+  f64.const -2.2250738585072024e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3104
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.4501477170144003e-308
+  f64.const -4.4501477170144003e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3105
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.450147717014403e-308
+  f64.const -4.450147717014403e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3106
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.450147717014406e-308
+  f64.const -4.450147717014406e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3107
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -8.900295434028806e-308
+  f64.const -8.900295434028806e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3108
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39173,79 +39369,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3104
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.4901161193847656e-08
-  f64.const -1.4901161193847656e-08
-  f64.const -0.1666666716337204
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3105
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.4901161193847656e-08
-  f64.const -1.4901161193847656e-08
-  f64.const -0.1666666716337204
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3106
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1e-323
-  f64.const 1e-323
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3107
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.4e-323
-  f64.const 4.4e-323
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3108
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 5.562684646268003e-309
-  f64.const 5.562684646268003e-309
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3109
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.1125369292536007e-308
-  f64.const 1.1125369292536007e-308
-  f64.const 0
+  f64.const -1.4901161193847656e-08
+  f64.const -1.4901161193847656e-08
+  f64.const -0.1666666716337204
   call $std/math/test_sin
   i32.eqz
   if
@@ -39256,9 +39387,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072004e-308
-  f64.const 2.2250738585072004e-308
-  f64.const 0
+  f64.const -1.4901161193847656e-08
+  f64.const -1.4901161193847656e-08
+  f64.const -0.1666666716337204
   call $std/math/test_sin
   i32.eqz
   if
@@ -39269,8 +39400,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507201e-308
-  f64.const 2.225073858507201e-308
+  f64.const 1e-323
+  f64.const 1e-323
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39282,8 +39413,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1e-323
-  f64.const -1e-323
+  f64.const 4.4e-323
+  f64.const 4.4e-323
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39295,8 +39426,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4e-323
-  f64.const -4.4e-323
+  f64.const 5.562684646268003e-309
+  f64.const 5.562684646268003e-309
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39308,8 +39439,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5.562684646268003e-309
-  f64.const -5.562684646268003e-309
+  f64.const 1.1125369292536007e-308
+  f64.const 1.1125369292536007e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39321,8 +39452,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.1125369292536007e-308
-  f64.const -1.1125369292536007e-308
+  f64.const 2.2250738585072004e-308
+  f64.const 2.2250738585072004e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39334,8 +39465,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072004e-308
-  f64.const -2.2250738585072004e-308
+  f64.const 2.225073858507201e-308
+  f64.const 2.225073858507201e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39347,8 +39478,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.225073858507201e-308
-  f64.const -2.225073858507201e-308
+  f64.const -1e-323
+  f64.const -1e-323
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -39360,6 +39491,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -4.4e-323
+  f64.const -4.4e-323
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3119
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -5.562684646268003e-309
+  f64.const -5.562684646268003e-309
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3120
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.1125369292536007e-308
+  f64.const -1.1125369292536007e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3121
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072004e-308
+  f64.const -2.2250738585072004e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3122
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.225073858507201e-308
+  f64.const -2.225073858507201e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3123
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0
   f64.const 0
   f64.const 0
@@ -39368,7 +39564,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3121
+   i32.const 3126
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39381,7 +39577,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3122
+   i32.const 3127
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39394,7 +39590,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3123
+   i32.const 3128
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39407,7 +39603,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3124
+   i32.const 3129
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39420,7 +39616,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3125
+   i32.const 3130
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39429,48 +39625,48 @@
   call $~lib/math/NativeMath.sin
   f64.const 1.5707963267948966
   call $~lib/bindings/Math/sin
-  f64.ne
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3128
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 3.141592653589793
-  call $~lib/math/NativeMath.sin
-  f64.const 3.141592653589793
-  call $~lib/bindings/Math/sin
-  f64.ne
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3129
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.3283064365386963e-10
-  f64.const 2.3283064365386963e-10
-  call $~lib/math/NativeMath.sin
-  f64.ne
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3132
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.3283064365386963e-10
-  f64.const -2.3283064365386963e-10
-  call $~lib/math/NativeMath.sin
   f64.ne
   if
    i32.const 0
    i32.const 24
    i32.const 3133
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 3.141592653589793
+  call $~lib/math/NativeMath.sin
+  f64.const 3.141592653589793
+  call $~lib/bindings/Math/sin
+  f64.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3134
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.3283064365386963e-10
+  f64.const 2.3283064365386963e-10
+  call $~lib/math/NativeMath.sin
+  f64.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3137
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.3283064365386963e-10
+  f64.const -2.3283064365386963e-10
+  call $~lib/math/NativeMath.sin
+  f64.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3138
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39482,7 +39678,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3135
+   i32.const 3140
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39494,7 +39690,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3136
+   i32.const 3141
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39506,7 +39702,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3139
+   i32.const 3144
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39518,7 +39714,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3140
+   i32.const 3145
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39530,7 +39726,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3141
+   i32.const 3146
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39542,7 +39738,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3142
+   i32.const 3147
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39554,7 +39750,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3144
+   i32.const 3149
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39566,7 +39762,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3145
+   i32.const 3150
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39578,7 +39774,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3147
+   i32.const 3152
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39590,7 +39786,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3148
+   i32.const 3153
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39602,7 +39798,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3149
+   i32.const 3154
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39614,7 +39810,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3150
+   i32.const 3155
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39626,7 +39822,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3151
+   i32.const 3156
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39638,7 +39834,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3154
+   i32.const 3159
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39650,7 +39846,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3155
+   i32.const 3160
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39663,7 +39859,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3164
+   i32.const 3169
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39676,7 +39872,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3165
+   i32.const 3170
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39689,7 +39885,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3166
+   i32.const 3171
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39702,7 +39898,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3167
+   i32.const 3172
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39715,7 +39911,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3168
+   i32.const 3173
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39728,7 +39924,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3169
+   i32.const 3174
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39741,7 +39937,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3170
+   i32.const 3175
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39754,7 +39950,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3171
+   i32.const 3176
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39767,7 +39963,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3172
+   i32.const 3177
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39780,7 +39976,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3173
+   i32.const 3178
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39793,7 +39989,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3176
+   i32.const 3181
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39806,7 +40002,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3177
+   i32.const 3182
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39819,7 +40015,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3178
+   i32.const 3183
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39832,7 +40028,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3179
+   i32.const 3184
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39845,7 +40041,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3180
+   i32.const 3185
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39858,7 +40054,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3183
+   i32.const 3188
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39871,78 +40067,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3184
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754943508222875e-38
-  f32.const 1.1754943508222875e-38
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3185
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754943508222875e-38
-  f32.const -1.1754943508222875e-38
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3186
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.401298464324817e-45
-  f32.const 1.401298464324817e-45
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3187
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.401298464324817e-45
-  f32.const -1.401298464324817e-45
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3188
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.175494490952134e-38
-  f32.const 1.175494490952134e-38
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3189
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754946310819804e-38
-  f32.const 1.1754946310819804e-38
+  f32.const 1.1754943508222875e-38
+  f32.const 1.1754943508222875e-38
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -39954,8 +40085,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509880009953429e-38
-  f32.const 2.3509880009953429e-38
+  f32.const -1.1754943508222875e-38
+  f32.const -1.1754943508222875e-38
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -39967,8 +40098,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.350988701644575e-38
-  f32.const 2.350988701644575e-38
+  f32.const 1.401298464324817e-45
+  f32.const 1.401298464324817e-45
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -39980,6 +40111,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1.401298464324817e-45
+  f32.const -1.401298464324817e-45
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3193
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.175494490952134e-38
+  f32.const 1.175494490952134e-38
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3194
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.1754946310819804e-38
+  f32.const 1.1754946310819804e-38
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3195
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.3509880009953429e-38
+  f32.const 2.3509880009953429e-38
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3196
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.350988701644575e-38
+  f32.const 2.350988701644575e-38
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3197
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 2.3509895424236536e-38
   f32.const 2.3509895424236536e-38
   f32.const 0
@@ -39988,7 +40184,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3193
+   i32.const 3198
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40001,7 +40197,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3194
+   i32.const 3199
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40014,7 +40210,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3195
+   i32.const 3200
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40027,7 +40223,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3196
+   i32.const 3201
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40040,7 +40236,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3197
+   i32.const 3202
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40053,78 +40249,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3198
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.175494490952134e-38
-  f32.const -1.175494490952134e-38
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3199
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754946310819804e-38
-  f32.const -1.1754946310819804e-38
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3200
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.3509880009953429e-38
-  f32.const -2.3509880009953429e-38
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3201
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.350988701644575e-38
-  f32.const -2.350988701644575e-38
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3202
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.3509895424236536e-38
-  f32.const -2.3509895424236536e-38
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3203
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -4.70197740328915e-38
-  f32.const -4.70197740328915e-38
+  f32.const -1.175494490952134e-38
+  f32.const -1.175494490952134e-38
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40132,6 +40263,71 @@
    i32.const 0
    i32.const 24
    i32.const 3204
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754946310819804e-38
+  f32.const -1.1754946310819804e-38
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3205
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.3509880009953429e-38
+  f32.const -2.3509880009953429e-38
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3206
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.350988701644575e-38
+  f32.const -2.350988701644575e-38
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3207
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.3509895424236536e-38
+  f32.const -2.3509895424236536e-38
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3208
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -4.70197740328915e-38
+  f32.const -4.70197740328915e-38
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3209
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40144,7 +40340,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3205
+   i32.const 3210
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40157,7 +40353,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3206
+   i32.const 3211
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40170,7 +40366,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3207
+   i32.const 3212
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40183,78 +40379,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3208
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.802596928649634e-45
-  f32.const 2.802596928649634e-45
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3209
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.2611686178923354e-44
-  f32.const 1.2611686178923354e-44
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3210
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.938735877055719e-39
-  f32.const 2.938735877055719e-39
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3211
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 5.877471754111438e-39
-  f32.const 5.877471754111438e-39
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3212
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754940705625946e-38
-  f32.const 1.1754940705625946e-38
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3213
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754942106924411e-38
-  f32.const 1.1754942106924411e-38
+  f32.const 2.802596928649634e-45
+  f32.const 2.802596928649634e-45
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40266,8 +40397,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.802596928649634e-45
-  f32.const -2.802596928649634e-45
+  f32.const 1.2611686178923354e-44
+  f32.const 1.2611686178923354e-44
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40279,8 +40410,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.2611686178923354e-44
-  f32.const -1.2611686178923354e-44
+  f32.const 2.938735877055719e-39
+  f32.const 2.938735877055719e-39
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40292,8 +40423,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.938735877055719e-39
-  f32.const -2.938735877055719e-39
+  f32.const 5.877471754111438e-39
+  f32.const 5.877471754111438e-39
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40305,8 +40436,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -5.877471754111438e-39
-  f32.const -5.877471754111438e-39
+  f32.const 1.1754940705625946e-38
+  f32.const 1.1754940705625946e-38
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -40318,6 +40449,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1.1754942106924411e-38
+  f32.const 1.1754942106924411e-38
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3219
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.802596928649634e-45
+  f32.const -2.802596928649634e-45
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3220
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.2611686178923354e-44
+  f32.const -1.2611686178923354e-44
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3221
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.938735877055719e-39
+  f32.const -2.938735877055719e-39
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3222
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -5.877471754111438e-39
+  f32.const -5.877471754111438e-39
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3223
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -1.1754940705625946e-38
   f32.const -1.1754940705625946e-38
   f32.const 0
@@ -40326,7 +40522,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3219
+   i32.const 3224
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40339,7 +40535,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3220
+   i32.const 3225
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40352,7 +40548,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3223
+   i32.const 3228
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40365,7 +40561,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3224
+   i32.const 3229
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40378,7 +40574,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3225
+   i32.const 3230
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40391,7 +40587,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3226
+   i32.const 3231
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40404,7 +40600,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3227
+   i32.const 3232
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40417,7 +40613,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3228
+   i32.const 3233
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40430,7 +40626,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3229
+   i32.const 3234
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40443,7 +40639,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3230
+   i32.const 3235
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40456,7 +40652,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3231
+   i32.const 3236
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40469,7 +40665,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3232
+   i32.const 3237
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40482,7 +40678,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3233
+   i32.const 3238
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40495,7 +40691,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3234
+   i32.const 3239
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40508,7 +40704,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3235
+   i32.const 3240
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40521,7 +40717,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3236
+   i32.const 3241
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40534,7 +40730,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3248
+   i32.const 3253
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40547,7 +40743,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3249
+   i32.const 3254
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40560,7 +40756,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3250
+   i32.const 3255
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40573,7 +40769,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3251
+   i32.const 3256
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40586,7 +40782,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3252
+   i32.const 3257
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40599,7 +40795,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3253
+   i32.const 3258
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40612,7 +40808,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3254
+   i32.const 3259
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40625,7 +40821,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3255
+   i32.const 3260
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40638,7 +40834,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3256
+   i32.const 3261
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40651,50 +40847,50 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3257
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  call $std/math/test_sinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3260
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  call $std/math/test_sinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3261
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  f64.const 0
-  call $std/math/test_sinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3262
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  call $std/math/test_sinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3265
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  call $std/math/test_sinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3266
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  call $std/math/test_sinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3267
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -inf
   f64.const -inf
   f64.const 0
@@ -40703,7 +40899,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3263
+   i32.const 3268
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40716,7 +40912,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3264
+   i32.const 3269
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40729,7 +40925,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3273
+   i32.const 3278
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40742,7 +40938,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3274
+   i32.const 3279
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40755,7 +40951,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3275
+   i32.const 3280
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40768,7 +40964,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3276
+   i32.const 3281
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40781,7 +40977,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3277
+   i32.const 3282
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40794,7 +40990,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3278
+   i32.const 3283
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40807,7 +41003,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3279
+   i32.const 3284
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40820,7 +41016,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3280
+   i32.const 3285
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40833,7 +41029,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3281
+   i32.const 3286
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40846,50 +41042,50 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3282
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  call $std/math/test_sinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3285
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  call $std/math/test_sinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3286
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  call $std/math/test_sinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3287
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  call $std/math/test_sinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3290
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  call $std/math/test_sinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3291
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  call $std/math/test_sinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3292
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -inf
   f32.const -inf
   f32.const 0
@@ -40898,7 +41094,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3288
+   i32.const 3293
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40911,7 +41107,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3289
+   i32.const 3294
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40924,7 +41120,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3301
+   i32.const 3306
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40937,7 +41133,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3302
+   i32.const 3307
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40950,7 +41146,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3303
+   i32.const 3308
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40963,7 +41159,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3304
+   i32.const 3309
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40976,7 +41172,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3305
+   i32.const 3310
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40989,7 +41185,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3306
+   i32.const 3311
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41002,7 +41198,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3307
+   i32.const 3312
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41015,7 +41211,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3308
+   i32.const 3313
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41028,7 +41224,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3309
+   i32.const 3314
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41041,7 +41237,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3310
+   i32.const 3315
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41054,7 +41250,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3313
+   i32.const 3318
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41067,7 +41263,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3314
+   i32.const 3319
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41080,7 +41276,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3315
+   i32.const 3320
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41093,7 +41289,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3316
+   i32.const 3321
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41106,7 +41302,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3317
+   i32.const 3322
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41119,7 +41315,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3318
+   i32.const 3323
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41132,7 +41328,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3319
+   i32.const 3324
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41145,7 +41341,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3320
+   i32.const 3325
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41158,7 +41354,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3321
+   i32.const 3326
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41171,7 +41367,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3322
+   i32.const 3327
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41184,7 +41380,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3323
+   i32.const 3328
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41192,71 +41388,6 @@
   f64.const -5e-324
   f64.const nan:0x8000000000000
   f64.const 0
-  call $std/math/test_sqrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3324
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.9999999999999999
-  f64.const 0.9999999999999999
-  f64.const -0.5
-  call $std/math/test_sqrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3325
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.9999999999999998
-  f64.const 1.414213562373095
-  f64.const -0.21107041835784912
-  call $std/math/test_sqrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3326
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.0000000000000002
-  f64.const 1
-  f64.const -0.5
-  call $std/math/test_sqrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3327
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.0000000000000004
-  f64.const 1.4142135623730951
-  f64.const -0.27173060178756714
-  call $std/math/test_sqrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3328
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.0000000000000002
-  f64.const 1
-  f64.const -0.5
   call $std/math/test_sqrt
   i32.eqz
   if
@@ -41280,6 +41411,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1.9999999999999998
+  f64.const 1.414213562373095
+  f64.const -0.21107041835784912
+  call $std/math/test_sqrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3331
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.0000000000000002
+  f64.const 1
+  f64.const -0.5
+  call $std/math/test_sqrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3332
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.0000000000000004
+  f64.const 1.4142135623730951
+  f64.const -0.27173060178756714
+  call $std/math/test_sqrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3333
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.0000000000000002
+  f64.const 1
+  f64.const -0.5
+  call $std/math/test_sqrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3334
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.9999999999999999
+  f64.const 0.9999999999999999
+  f64.const -0.5
+  call $std/math/test_sqrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3335
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -1797693134862315708145274e284
   f64.const nan:0x8000000000000
   f64.const 0
@@ -41288,7 +41484,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3331
+   i32.const 3336
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41301,7 +41497,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3332
+   i32.const 3337
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41314,7 +41510,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3333
+   i32.const 3338
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41327,7 +41523,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3334
+   i32.const 3339
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41340,7 +41536,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3335
+   i32.const 3340
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41353,7 +41549,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3336
+   i32.const 3341
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41366,7 +41562,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3337
+   i32.const 3342
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41379,7 +41575,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3338
+   i32.const 3343
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41392,7 +41588,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3339
+   i32.const 3344
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41405,7 +41601,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3340
+   i32.const 3345
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41418,7 +41614,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3341
+   i32.const 3346
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41431,7 +41627,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3342
+   i32.const 3347
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41444,7 +41640,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3343
+   i32.const 3348
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41457,7 +41653,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3344
+   i32.const 3349
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41470,7 +41666,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3345
+   i32.const 3350
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41483,7 +41679,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3346
+   i32.const 3351
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41496,7 +41692,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3347
+   i32.const 3352
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41509,7 +41705,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3348
+   i32.const 3353
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41522,7 +41718,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3349
+   i32.const 3354
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41535,7 +41731,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3350
+   i32.const 3355
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41548,7 +41744,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3351
+   i32.const 3356
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41561,7 +41757,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3352
+   i32.const 3357
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41574,7 +41770,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3353
+   i32.const 3358
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41587,7 +41783,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3354
+   i32.const 3359
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41600,7 +41796,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3355
+   i32.const 3360
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41613,7 +41809,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3356
+   i32.const 3361
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41626,7 +41822,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3357
+   i32.const 3362
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41639,7 +41835,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3358
+   i32.const 3363
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41652,7 +41848,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3359
+   i32.const 3364
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41665,7 +41861,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3360
+   i32.const 3365
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41678,7 +41874,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3361
+   i32.const 3366
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41691,7 +41887,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3362
+   i32.const 3367
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41704,7 +41900,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3363
+   i32.const 3368
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41717,7 +41913,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3364
+   i32.const 3369
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41730,7 +41926,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3365
+   i32.const 3370
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41743,7 +41939,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3366
+   i32.const 3371
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41756,7 +41952,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3367
+   i32.const 3372
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41769,7 +41965,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3368
+   i32.const 3373
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41782,7 +41978,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3369
+   i32.const 3374
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41795,7 +41991,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3370
+   i32.const 3375
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41808,7 +42004,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3371
+   i32.const 3376
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41821,7 +42017,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3372
+   i32.const 3377
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41834,7 +42030,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3373
+   i32.const 3378
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41847,7 +42043,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3374
+   i32.const 3379
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41860,7 +42056,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3375
+   i32.const 3380
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41873,7 +42069,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3376
+   i32.const 3381
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41886,7 +42082,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3377
+   i32.const 3382
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41899,7 +42095,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3378
+   i32.const 3383
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41912,7 +42108,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3379
+   i32.const 3384
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41925,7 +42121,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3380
+   i32.const 3385
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41938,7 +42134,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3381
+   i32.const 3386
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41951,7 +42147,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3382
+   i32.const 3387
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41964,7 +42160,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3383
+   i32.const 3388
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41977,7 +42173,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3384
+   i32.const 3389
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41990,7 +42186,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3385
+   i32.const 3390
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42003,7 +42199,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3386
+   i32.const 3391
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42016,7 +42212,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3395
+   i32.const 3400
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42029,7 +42225,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3396
+   i32.const 3401
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42042,7 +42238,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3397
+   i32.const 3402
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42055,7 +42251,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3398
+   i32.const 3403
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42068,7 +42264,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3399
+   i32.const 3404
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42081,7 +42277,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3400
+   i32.const 3405
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42094,7 +42290,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3401
+   i32.const 3406
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42107,7 +42303,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3402
+   i32.const 3407
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42120,51 +42316,12 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3403
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.6787636876106262
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_sqrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3404
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_sqrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3407
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  call $std/math/test_sqrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3408
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const -0.6787636876106262
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_sqrtf
@@ -42177,34 +42334,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  call $std/math/test_sqrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3410
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  call $std/math/test_sqrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3411
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_sqrtf
   i32.eqz
@@ -42216,8 +42347,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const inf
   f32.const 0
   call $std/math/test_sqrtf
   i32.eqz
@@ -42229,8 +42360,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4
-  f32.const 2
+  f32.const -inf
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_sqrtf
   i32.eqz
@@ -42242,8 +42373,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.802596928649634e-45
-  f32.const 5.293955920339377e-23
+  f32.const 0
+  f32.const 0
   f32.const 0
   call $std/math/test_sqrtf
   i32.eqz
@@ -42255,9 +42386,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.203895392974451e-45
-  f32.const 6.483745598763743e-23
-  f32.const 0.37388554215431213
+  f32.const -0
+  f32.const -0
+  f32.const 0
   call $std/math/test_sqrtf
   i32.eqz
   if
@@ -42268,9 +42399,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.401298464324817e-45
-  f32.const 3.743392066509216e-23
-  f32.const -0.20303145051002502
+  f32.const 1
+  f32.const 1
+  f32.const 0
   call $std/math/test_sqrtf
   i32.eqz
   if
@@ -42281,7 +42412,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.401298464324817e-45
+  f32.const -1
   f32.const nan:0x400000
   f32.const 0
   call $std/math/test_sqrtf
@@ -42294,6 +42425,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 4
+  f32.const 2
+  f32.const 0
+  call $std/math/test_sqrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3419
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.802596928649634e-45
+  f32.const 5.293955920339377e-23
+  f32.const 0
+  call $std/math/test_sqrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3420
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4.203895392974451e-45
+  f32.const 6.483745598763743e-23
+  f32.const 0.37388554215431213
+  call $std/math/test_sqrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3421
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.401298464324817e-45
+  f32.const 3.743392066509216e-23
+  f32.const -0.20303145051002502
+  call $std/math/test_sqrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3422
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.401298464324817e-45
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_sqrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3423
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 3402823466385288598117041e14
   f32.const 18446742974197923840
   f32.const -0.5
@@ -42302,7 +42498,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3419
+   i32.const 3424
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42315,7 +42511,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3420
+   i32.const 3425
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42328,7 +42524,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3421
+   i32.const 3426
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42341,7 +42537,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3422
+   i32.const 3427
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42354,7 +42550,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3423
+   i32.const 3428
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42367,7 +42563,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3424
+   i32.const 3429
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42380,7 +42576,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3425
+   i32.const 3430
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42393,7 +42589,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3426
+   i32.const 3431
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42406,7 +42602,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3427
+   i32.const 3432
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42419,7 +42615,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3428
+   i32.const 3433
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42432,7 +42628,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3440
+   i32.const 3445
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42445,7 +42641,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3441
+   i32.const 3446
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42458,7 +42654,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3442
+   i32.const 3447
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42471,7 +42667,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3443
+   i32.const 3448
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42484,7 +42680,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3444
+   i32.const 3449
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42497,7 +42693,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3445
+   i32.const 3450
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42510,7 +42706,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3446
+   i32.const 3451
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42523,7 +42719,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3447
+   i32.const 3452
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42536,7 +42732,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3448
+   i32.const 3453
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42549,7 +42745,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3449
+   i32.const 3454
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42562,7 +42758,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3452
+   i32.const 3457
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42575,78 +42771,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3453
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072014e-308
-  f64.const 2.2250738585072014e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3454
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3455
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 5e-324
-  f64.const 5e-324
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3456
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -5e-324
-  f64.const -5e-324
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3457
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3458
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 2.2250738585072014e-308
+  f64.const 2.2250738585072014e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -42654,6 +42785,71 @@
    i32.const 0
    i32.const 24
    i32.const 3459
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3460
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 5e-324
+  f64.const 5e-324
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3461
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -5e-324
+  f64.const -5e-324
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3462
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3463
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3464
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42666,7 +42862,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3460
+   i32.const 3465
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42679,78 +42875,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3461
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507202e-308
-  f64.const 2.225073858507202e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3462
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072024e-308
-  f64.const 2.2250738585072024e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3463
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.4501477170144003e-308
-  f64.const 4.4501477170144003e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3464
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.450147717014403e-308
-  f64.const 4.450147717014403e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3465
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.450147717014406e-308
-  f64.const 4.450147717014406e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3466
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 8.900295434028806e-308
-  f64.const 8.900295434028806e-308
+  f64.const 2.225073858507202e-308
+  f64.const 2.225073858507202e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -42758,6 +42889,71 @@
    i32.const 0
    i32.const 24
    i32.const 3467
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.2250738585072024e-308
+  f64.const 2.2250738585072024e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3468
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.4501477170144003e-308
+  f64.const 4.4501477170144003e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3469
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.450147717014403e-308
+  f64.const 4.450147717014403e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3470
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.450147717014406e-308
+  f64.const 4.450147717014406e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3471
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 8.900295434028806e-308
+  f64.const 8.900295434028806e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3472
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42770,7 +42966,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3468
+   i32.const 3473
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42783,78 +42979,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3469
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.225073858507202e-308
-  f64.const -2.225073858507202e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3470
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.2250738585072024e-308
-  f64.const -2.2250738585072024e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3471
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.4501477170144003e-308
-  f64.const -4.4501477170144003e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3472
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.450147717014403e-308
-  f64.const -4.450147717014403e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3473
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.450147717014406e-308
-  f64.const -4.450147717014406e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3474
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8.900295434028806e-308
-  f64.const -8.900295434028806e-308
+  f64.const -2.225073858507202e-308
+  f64.const -2.225073858507202e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -42862,6 +42993,71 @@
    i32.const 0
    i32.const 24
    i32.const 3475
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072024e-308
+  f64.const -2.2250738585072024e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3476
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.4501477170144003e-308
+  f64.const -4.4501477170144003e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3477
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.450147717014403e-308
+  f64.const -4.450147717014403e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3478
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.450147717014406e-308
+  f64.const -4.450147717014406e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3479
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -8.900295434028806e-308
+  f64.const -8.900295434028806e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3480
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42874,7 +43070,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3476
+   i32.const 3481
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42887,78 +43083,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3477
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1e-323
-  f64.const 1e-323
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3478
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.4e-323
-  f64.const 4.4e-323
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3479
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 5.562684646268003e-309
-  f64.const 5.562684646268003e-309
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3480
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.1125369292536007e-308
-  f64.const 1.1125369292536007e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3481
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072004e-308
-  f64.const 2.2250738585072004e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3482
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507201e-308
-  f64.const 2.225073858507201e-308
+  f64.const 1e-323
+  f64.const 1e-323
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -42970,8 +43101,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1e-323
-  f64.const -1e-323
+  f64.const 4.4e-323
+  f64.const 4.4e-323
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -42983,8 +43114,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4e-323
-  f64.const -4.4e-323
+  f64.const 5.562684646268003e-309
+  f64.const 5.562684646268003e-309
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -42996,8 +43127,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5.562684646268003e-309
-  f64.const -5.562684646268003e-309
+  f64.const 1.1125369292536007e-308
+  f64.const 1.1125369292536007e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -43009,8 +43140,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.1125369292536007e-308
-  f64.const -1.1125369292536007e-308
+  f64.const 2.2250738585072004e-308
+  f64.const 2.2250738585072004e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -43022,8 +43153,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072004e-308
-  f64.const -2.2250738585072004e-308
+  f64.const 2.225073858507201e-308
+  f64.const 2.225073858507201e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -43035,8 +43166,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.225073858507201e-308
-  f64.const -2.225073858507201e-308
+  f64.const -1e-323
+  f64.const -1e-323
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -43048,11 +43179,37 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.3283064365386963e-10
-  call $~lib/math/NativeMath.tan
-  f64.const 2.3283064365386963e-10
-  call $~lib/bindings/Math/tan
-  f64.ne
+  f64.const -4.4e-323
+  f64.const -4.4e-323
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3490
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -5.562684646268003e-309
+  f64.const -5.562684646268003e-309
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3491
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.1125369292536007e-308
+  f64.const -1.1125369292536007e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
   if
    i32.const 0
    i32.const 24
@@ -43061,11 +43218,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.3283064365386963e-10
-  call $~lib/math/NativeMath.tan
-  f64.const -2.3283064365386963e-10
-  call $~lib/bindings/Math/tan
-  f64.ne
+  f64.const -2.2250738585072004e-308
+  f64.const -2.2250738585072004e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
   if
    i32.const 0
    i32.const 24
@@ -43074,11 +43231,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.6875
-  call $~lib/math/NativeMath.tan
-  f64.const 0.6875
-  call $~lib/bindings/Math/tan
-  f64.ne
+  f64.const -2.225073858507201e-308
+  f64.const -2.225073858507201e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
   if
    i32.const 0
    i32.const 24
@@ -43087,35 +43244,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.6875
+  f64.const 2.3283064365386963e-10
   call $~lib/math/NativeMath.tan
-  f64.const -0.6875
-  call $~lib/bindings/Math/tan
-  f64.ne
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3495
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.39269908169872414
-  call $~lib/math/NativeMath.tan
-  f64.const 0.39269908169872414
-  call $~lib/bindings/Math/tan
-  f64.ne
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3496
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.6743358
-  call $~lib/math/NativeMath.tan
-  f64.const 0.6743358
+  f64.const 2.3283064365386963e-10
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -43126,9 +43257,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 3.725290298461914e-09
+  f64.const -2.3283064365386963e-10
   call $~lib/math/NativeMath.tan
-  f64.const 3.725290298461914e-09
+  f64.const -2.3283064365386963e-10
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -43139,9 +43270,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5707963267948966
+  f64.const 0.6875
   call $~lib/math/NativeMath.tan
-  f64.const 1.5707963267948966
+  f64.const 0.6875
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -43152,9 +43283,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0.6875
   call $~lib/math/NativeMath.tan
-  f64.const 0.5
+  f64.const -0.6875
+  call $~lib/bindings/Math/tan
+  f64.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3500
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.39269908169872414
+  call $~lib/math/NativeMath.tan
+  f64.const 0.39269908169872414
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -43165,9 +43309,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.107148717794091
+  f64.const 0.6743358
   call $~lib/math/NativeMath.tan
-  f64.const 1.107148717794091
+  f64.const 0.6743358
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -43178,9 +43322,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5.497787143782138
+  f64.const 3.725290298461914e-09
   call $~lib/math/NativeMath.tan
-  f64.const 5.497787143782138
+  f64.const 3.725290298461914e-09
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -43191,9 +43335,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 7.0685834705770345
+  f64.const 1.5707963267948966
   call $~lib/math/NativeMath.tan
-  f64.const 7.0685834705770345
+  f64.const 1.5707963267948966
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -43204,22 +43348,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1647099.3291652855
+  f64.const 0.5
   call $~lib/math/NativeMath.tan
-  f64.const 1647099.3291652855
-  call $~lib/bindings/Math/tan
-  f64.ne
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3505
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1647097.7583689587
-  call $~lib/math/NativeMath.tan
-  f64.const 1647097.7583689587
+  f64.const 0.5
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -43230,9 +43361,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1329227995784915872903807e12
+  f64.const 1.107148717794091
   call $~lib/math/NativeMath.tan
-  f64.const 1329227995784915872903807e12
+  f64.const 1.107148717794091
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -43243,9 +43374,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1329227995784915872903807e12
+  f64.const 5.497787143782138
   call $~lib/math/NativeMath.tan
-  f64.const -1329227995784915872903807e12
+  f64.const 5.497787143782138
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -43256,6 +43387,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 7.0685834705770345
+  call $~lib/math/NativeMath.tan
+  f64.const 7.0685834705770345
+  call $~lib/bindings/Math/tan
+  f64.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3509
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1647099.3291652855
+  call $~lib/math/NativeMath.tan
+  f64.const 1647099.3291652855
+  call $~lib/bindings/Math/tan
+  f64.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3510
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1647097.7583689587
+  call $~lib/math/NativeMath.tan
+  f64.const 1647097.7583689587
+  call $~lib/bindings/Math/tan
+  f64.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3511
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1329227995784915872903807e12
+  call $~lib/math/NativeMath.tan
+  f64.const 1329227995784915872903807e12
+  call $~lib/bindings/Math/tan
+  f64.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3512
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1329227995784915872903807e12
+  call $~lib/math/NativeMath.tan
+  f64.const -1329227995784915872903807e12
+  call $~lib/bindings/Math/tan
+  f64.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3513
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0
   f64.const 0
   f64.const 0
@@ -43264,7 +43460,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3511
+   i32.const 3516
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43277,7 +43473,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3512
+   i32.const 3517
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43290,7 +43486,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3513
+   i32.const 3518
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43303,7 +43499,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3514
+   i32.const 3519
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43316,7 +43512,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3515
+   i32.const 3520
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43329,7 +43525,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3524
+   i32.const 3529
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43342,7 +43538,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3525
+   i32.const 3530
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43355,7 +43551,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3526
+   i32.const 3531
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43368,7 +43564,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3527
+   i32.const 3532
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43381,7 +43577,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3528
+   i32.const 3533
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43394,7 +43590,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3529
+   i32.const 3534
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43407,7 +43603,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3530
+   i32.const 3535
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43420,7 +43616,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3531
+   i32.const 3536
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43433,7 +43629,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3532
+   i32.const 3537
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43446,7 +43642,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3533
+   i32.const 3538
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43459,7 +43655,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3536
+   i32.const 3541
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43472,7 +43668,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3537
+   i32.const 3542
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43485,7 +43681,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3538
+   i32.const 3543
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43498,7 +43694,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3539
+   i32.const 3544
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43511,7 +43707,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3540
+   i32.const 3545
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43524,7 +43720,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3543
+   i32.const 3548
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43537,78 +43733,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3544
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754943508222875e-38
-  f32.const 1.1754943508222875e-38
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3545
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754943508222875e-38
-  f32.const -1.1754943508222875e-38
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3546
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.401298464324817e-45
-  f32.const 1.401298464324817e-45
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3547
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.401298464324817e-45
-  f32.const -1.401298464324817e-45
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3548
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.175494490952134e-38
-  f32.const 1.175494490952134e-38
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3549
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754946310819804e-38
-  f32.const 1.1754946310819804e-38
+  f32.const 1.1754943508222875e-38
+  f32.const 1.1754943508222875e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -43620,8 +43751,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509880009953429e-38
-  f32.const 2.3509880009953429e-38
+  f32.const -1.1754943508222875e-38
+  f32.const -1.1754943508222875e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -43633,8 +43764,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.350988701644575e-38
-  f32.const 2.350988701644575e-38
+  f32.const 1.401298464324817e-45
+  f32.const 1.401298464324817e-45
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -43646,6 +43777,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1.401298464324817e-45
+  f32.const -1.401298464324817e-45
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3553
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.175494490952134e-38
+  f32.const 1.175494490952134e-38
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3554
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.1754946310819804e-38
+  f32.const 1.1754946310819804e-38
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3555
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.3509880009953429e-38
+  f32.const 2.3509880009953429e-38
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3556
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.350988701644575e-38
+  f32.const 2.350988701644575e-38
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3557
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 2.3509895424236536e-38
   f32.const 2.3509895424236536e-38
   f32.const 0
@@ -43654,7 +43850,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3553
+   i32.const 3558
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43667,7 +43863,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3554
+   i32.const 3559
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43680,7 +43876,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3555
+   i32.const 3560
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43693,7 +43889,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3556
+   i32.const 3561
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43706,78 +43902,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3557
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.175494490952134e-38
-  f32.const -1.175494490952134e-38
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3558
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754946310819804e-38
-  f32.const -1.1754946310819804e-38
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3559
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.3509880009953429e-38
-  f32.const -2.3509880009953429e-38
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3560
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.350988701644575e-38
-  f32.const 2.350988701644575e-38
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3561
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.3509895424236536e-38
-  f32.const -2.3509895424236536e-38
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3562
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -4.70197740328915e-38
-  f32.const -4.70197740328915e-38
+  f32.const -1.175494490952134e-38
+  f32.const -1.175494490952134e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -43785,6 +43916,71 @@
    i32.const 0
    i32.const 24
    i32.const 3563
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754946310819804e-38
+  f32.const -1.1754946310819804e-38
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3564
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.3509880009953429e-38
+  f32.const -2.3509880009953429e-38
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3565
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.350988701644575e-38
+  f32.const 2.350988701644575e-38
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3566
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.3509895424236536e-38
+  f32.const -2.3509895424236536e-38
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3567
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -4.70197740328915e-38
+  f32.const -4.70197740328915e-38
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3568
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43797,7 +43993,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3564
+   i32.const 3569
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43810,7 +44006,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3565
+   i32.const 3570
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43823,78 +44019,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3566
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.802596928649634e-45
-  f32.const 2.802596928649634e-45
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3567
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.2611686178923354e-44
-  f32.const 1.2611686178923354e-44
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3568
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.938735877055719e-39
-  f32.const 2.938735877055719e-39
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3569
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 5.877471754111438e-39
-  f32.const 5.877471754111438e-39
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3570
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754940705625946e-38
-  f32.const 1.1754940705625946e-38
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3571
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754942106924411e-38
-  f32.const 1.1754942106924411e-38
+  f32.const 2.802596928649634e-45
+  f32.const 2.802596928649634e-45
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -43906,8 +44037,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.802596928649634e-45
-  f32.const -2.802596928649634e-45
+  f32.const 1.2611686178923354e-44
+  f32.const 1.2611686178923354e-44
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -43919,8 +44050,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.2611686178923354e-44
-  f32.const -1.2611686178923354e-44
+  f32.const 2.938735877055719e-39
+  f32.const 2.938735877055719e-39
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -43932,8 +44063,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.938735877055719e-39
-  f32.const -2.938735877055719e-39
+  f32.const 5.877471754111438e-39
+  f32.const 5.877471754111438e-39
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -43945,8 +44076,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -5.877471754111438e-39
-  f32.const -5.877471754111438e-39
+  f32.const 1.1754940705625946e-38
+  f32.const 1.1754940705625946e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -43958,6 +44089,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1.1754942106924411e-38
+  f32.const 1.1754942106924411e-38
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3577
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.802596928649634e-45
+  f32.const -2.802596928649634e-45
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3578
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.2611686178923354e-44
+  f32.const -1.2611686178923354e-44
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3579
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.938735877055719e-39
+  f32.const -2.938735877055719e-39
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3580
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -5.877471754111438e-39
+  f32.const -5.877471754111438e-39
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3581
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -1.1754940705625946e-38
   f32.const -1.1754940705625946e-38
   f32.const 0
@@ -43966,7 +44162,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3577
+   i32.const 3582
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43979,7 +44175,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3578
+   i32.const 3583
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43992,7 +44188,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3590
+   i32.const 3595
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44005,7 +44201,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3591
+   i32.const 3596
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44018,7 +44214,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3592
+   i32.const 3597
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44031,7 +44227,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3593
+   i32.const 3598
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44044,7 +44240,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3594
+   i32.const 3599
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44057,7 +44253,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3595
+   i32.const 3600
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44070,7 +44266,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3596
+   i32.const 3601
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44083,7 +44279,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3597
+   i32.const 3602
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44096,7 +44292,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3598
+   i32.const 3603
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44109,7 +44305,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3599
+   i32.const 3604
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44122,7 +44318,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3602
+   i32.const 3607
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44135,7 +44331,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3603
+   i32.const 3608
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44148,7 +44344,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3604
+   i32.const 3609
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44161,7 +44357,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3605
+   i32.const 3610
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44174,7 +44370,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3606
+   i32.const 3611
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44187,7 +44383,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3615
+   i32.const 3620
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44200,7 +44396,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3616
+   i32.const 3621
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44213,7 +44409,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3617
+   i32.const 3622
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44226,7 +44422,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3618
+   i32.const 3623
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44239,7 +44435,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3619
+   i32.const 3624
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44252,7 +44448,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3620
+   i32.const 3625
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44265,7 +44461,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3621
+   i32.const 3626
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44278,7 +44474,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3622
+   i32.const 3627
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44291,7 +44487,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3623
+   i32.const 3628
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44304,7 +44500,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3624
+   i32.const 3629
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44317,7 +44513,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3627
+   i32.const 3632
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44330,7 +44526,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3628
+   i32.const 3633
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44343,7 +44539,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3629
+   i32.const 3634
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44356,7 +44552,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3630
+   i32.const 3635
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44369,7 +44565,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3631
+   i32.const 3636
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44381,7 +44577,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3643
+   i32.const 3648
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44393,7 +44589,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3644
+   i32.const 3649
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44405,7 +44601,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3645
+   i32.const 3650
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44417,7 +44613,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3646
+   i32.const 3651
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44429,7 +44625,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3647
+   i32.const 3652
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44441,7 +44637,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3648
+   i32.const 3653
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44453,7 +44649,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3649
+   i32.const 3654
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44465,7 +44661,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3650
+   i32.const 3655
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44477,7 +44673,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3651
+   i32.const 3656
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44489,73 +44685,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3652
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3655
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3656
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -inf
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3657
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3658
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3659
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   call $std/math/test_trunc
   i32.eqz
   if
@@ -44566,6 +44702,66 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
+  f64.const inf
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3661
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -inf
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3662
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3663
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3664
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 1
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3665
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -1
   f64.const -1
   call $std/math/test_trunc
@@ -44573,7 +44769,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3661
+   i32.const 3666
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44585,7 +44781,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3662
+   i32.const 3667
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44597,7 +44793,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3663
+   i32.const 3668
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44609,7 +44805,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3664
+   i32.const 3669
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44621,7 +44817,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3665
+   i32.const 3670
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44633,7 +44829,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3666
+   i32.const 3671
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44645,7 +44841,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3667
+   i32.const 3672
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44657,7 +44853,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3668
+   i32.const 3673
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44669,7 +44865,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3669
+   i32.const 3674
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44681,7 +44877,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3678
+   i32.const 3683
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44693,7 +44889,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3679
+   i32.const 3684
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44705,7 +44901,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3680
+   i32.const 3685
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44717,7 +44913,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3681
+   i32.const 3686
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44729,7 +44925,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3682
+   i32.const 3687
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44741,7 +44937,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3683
+   i32.const 3688
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44753,7 +44949,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3684
+   i32.const 3689
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44765,7 +44961,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3685
+   i32.const 3690
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44777,7 +44973,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3686
+   i32.const 3691
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44789,73 +44985,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3687
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3690
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3691
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -inf
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3692
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3693
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3694
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   call $std/math/test_truncf
   i32.eqz
   if
@@ -44866,6 +45002,66 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
+  f32.const inf
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3696
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -inf
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3697
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3698
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3699
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 1
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3700
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -1
   f32.const -1
   call $std/math/test_truncf
@@ -44873,7 +45069,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3696
+   i32.const 3701
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44885,7 +45081,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3697
+   i32.const 3702
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44897,7 +45093,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3698
+   i32.const 3703
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44909,7 +45105,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3699
+   i32.const 3704
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44921,7 +45117,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3700
+   i32.const 3705
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44933,7 +45129,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3701
+   i32.const 3706
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44945,7 +45141,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3702
+   i32.const 3707
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44957,7 +45153,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3703
+   i32.const 3708
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44969,7 +45165,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3704
+   i32.const 3709
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45042,7 +45238,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3745
+   i32.const 3750
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45055,7 +45251,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3746
+   i32.const 3751
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45068,7 +45264,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3747
+   i32.const 3752
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45081,7 +45277,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3748
+   i32.const 3753
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45094,7 +45290,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3749
+   i32.const 3754
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45107,7 +45303,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3750
+   i32.const 3755
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45120,7 +45316,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3751
+   i32.const 3756
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45133,7 +45329,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3752
+   i32.const 3757
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45146,7 +45342,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3753
+   i32.const 3758
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45159,7 +45355,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3754
+   i32.const 3759
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45172,7 +45368,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3755
+   i32.const 3760
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45185,7 +45381,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3756
+   i32.const 3761
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45197,7 +45393,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3760
+   i32.const 3765
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45209,7 +45405,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3761
+   i32.const 3766
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45221,7 +45417,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3762
+   i32.const 3767
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45233,7 +45429,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3763
+   i32.const 3768
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45245,7 +45441,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3764
+   i32.const 3769
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45257,7 +45453,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3765
+   i32.const 3770
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45269,7 +45465,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3766
+   i32.const 3771
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45281,7 +45477,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3767
+   i32.const 3772
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45293,7 +45489,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3768
+   i32.const 3773
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45305,7 +45501,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3769
+   i32.const 3774
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45317,7 +45513,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3770
+   i32.const 3775
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45329,7 +45525,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3771
+   i32.const 3776
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45341,7 +45537,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3772
+   i32.const 3777
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45353,7 +45549,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3773
+   i32.const 3778
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45365,7 +45561,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3774
+   i32.const 3779
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45377,64 +45573,12 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3775
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 0
-  i32.const 0
-  call $~lib/math/ipow64
-  i64.const 1
-  i64.ne
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3779
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 0
-  i32.const 1
-  call $~lib/math/ipow64
-  i64.const 0
-  i64.ne
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3780
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 0
-  i32.const 2
-  call $~lib/math/ipow64
-  i64.const 0
-  i64.ne
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3781
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 0
-  i32.const 3
-  call $~lib/math/ipow64
-  i64.const 0
-  i64.ne
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3782
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 1
   i32.const 0
   call $~lib/math/ipow64
   i64.const 1
@@ -45447,10 +45591,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 1
+  i64.const 0
   i32.const 1
   call $~lib/math/ipow64
-  i64.const 1
+  i64.const 0
   i64.ne
   if
    i32.const 0
@@ -45460,10 +45604,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 1
+  i64.const 0
   i32.const 2
   call $~lib/math/ipow64
-  i64.const 1
+  i64.const 0
   i64.ne
   if
    i32.const 0
@@ -45473,10 +45617,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 1
+  i64.const 0
   i32.const 3
   call $~lib/math/ipow64
-  i64.const 1
+  i64.const 0
   i64.ne
   if
    i32.const 0
@@ -45486,7 +45630,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 2
+  i64.const 1
   i32.const 0
   call $~lib/math/ipow64
   i64.const 1
@@ -45499,10 +45643,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 2
+  i64.const 1
   i32.const 1
   call $~lib/math/ipow64
-  i64.const 2
+  i64.const 1
   i64.ne
   if
    i32.const 0
@@ -45512,10 +45656,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 2
+  i64.const 1
   i32.const 2
   call $~lib/math/ipow64
-  i64.const 4
+  i64.const 1
   i64.ne
   if
    i32.const 0
@@ -45525,10 +45669,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 2
+  i64.const 1
   i32.const 3
   call $~lib/math/ipow64
-  i64.const 8
+  i64.const 1
   i64.ne
   if
    i32.const 0
@@ -45538,7 +45682,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const -1
+  i64.const 2
   i32.const 0
   call $~lib/math/ipow64
   i64.const 1
@@ -45551,10 +45695,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const -1
+  i64.const 2
   i32.const 1
   call $~lib/math/ipow64
-  i64.const -1
+  i64.const 2
   i64.ne
   if
    i32.const 0
@@ -45564,10 +45708,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const -1
+  i64.const 2
   i32.const 2
   call $~lib/math/ipow64
-  i64.const 1
+  i64.const 4
   i64.ne
   if
    i32.const 0
@@ -45577,10 +45721,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const -1
+  i64.const 2
   i32.const 3
   call $~lib/math/ipow64
-  i64.const -1
+  i64.const 8
   i64.ne
   if
    i32.const 0
@@ -45590,7 +45734,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const -2
+  i64.const -1
   i32.const 0
   call $~lib/math/ipow64
   i64.const 1
@@ -45603,6 +45747,58 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i64.const -1
+  i32.const 1
+  call $~lib/math/ipow64
+  i64.const -1
+  i64.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3800
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const -1
+  i32.const 2
+  call $~lib/math/ipow64
+  i64.const 1
+  i64.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3801
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const -1
+  i32.const 3
+  call $~lib/math/ipow64
+  i64.const -1
+  i64.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3802
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const -2
+  i32.const 0
+  call $~lib/math/ipow64
+  i64.const 1
+  i64.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3804
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   i64.const -2
   i32.const 1
   call $~lib/math/ipow64
@@ -45611,7 +45807,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3800
+   i32.const 3805
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45624,7 +45820,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3801
+   i32.const 3806
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45637,7 +45833,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3802
+   i32.const 3807
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45650,7 +45846,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3804
+   i32.const 3809
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45663,7 +45859,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3805
+   i32.const 3810
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45676,7 +45872,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3806
+   i32.const 3811
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45689,7 +45885,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3807
+   i32.const 3812
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45702,7 +45898,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3808
+   i32.const 3813
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45715,7 +45911,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3809
+   i32.const 3814
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45728,7 +45924,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3810
+   i32.const 3815
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45745,77 +45941,12 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3812
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  i32.const 0
-  call $~lib/math/ipow32f
-  f32.const 1
-  f32.ne
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3816
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  i32.const 0
-  call $~lib/math/ipow32f
-  f32.const 1
-  f32.ne
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3817
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  i32.const 1
-  call $~lib/math/ipow32f
-  call $~lib/number/isNaN<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3818
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  i32.const -1
-  call $~lib/math/ipow32f
-  call $~lib/number/isNaN<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3819
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  i32.const 2
-  call $~lib/math/ipow32f
-  call $~lib/number/isNaN<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3820
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
+  f32.const 0
   i32.const 0
   call $~lib/math/ipow32f
   f32.const 1
@@ -45828,10 +45959,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  i32.const 1
+  f32.const nan:0x400000
+  i32.const 0
   call $~lib/math/ipow32f
-  f32.const inf
+  f32.const 1
   f32.ne
   if
    i32.const 0
@@ -45841,11 +45972,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  i32.const 0
+  f32.const nan:0x400000
+  i32.const 1
   call $~lib/math/ipow32f
-  f32.const 1
-  f32.ne
+  call $~lib/number/isNaN<f32>
+  i32.eqz
   if
    i32.const 0
    i32.const 24
@@ -45854,11 +45985,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  i32.const 1
+  f32.const nan:0x400000
+  i32.const -1
   call $~lib/math/ipow32f
-  f32.const -inf
-  f32.ne
+  call $~lib/number/isNaN<f32>
+  i32.eqz
   if
    i32.const 0
    i32.const 24
@@ -45867,11 +45998,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   i32.const 2
   call $~lib/math/ipow32f
-  f32.const inf
-  f32.ne
+  call $~lib/number/isNaN<f32>
+  i32.eqz
   if
    i32.const 0
    i32.const 24
@@ -45880,7 +46011,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const inf
   i32.const 0
   call $~lib/math/ipow32f
   f32.const 1
@@ -45893,6 +46024,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
+  i32.const 1
+  call $~lib/math/ipow32f
+  f32.const inf
+  f32.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3827
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  i32.const 0
+  call $~lib/math/ipow32f
+  f32.const 1
+  f32.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3828
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  i32.const 1
+  call $~lib/math/ipow32f
+  f32.const -inf
+  f32.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3829
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  i32.const 2
+  call $~lib/math/ipow32f
+  f32.const inf
+  f32.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3830
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  i32.const 0
+  call $~lib/math/ipow32f
+  f32.const 1
+  f32.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3831
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 3402823466385288598117041e14
   i32.const 2
   call $~lib/math/ipow32f
@@ -45901,7 +46097,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3827
+   i32.const 3832
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45914,7 +46110,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3828
+   i32.const 3833
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45927,7 +46123,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3829
+   i32.const 3834
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45940,7 +46136,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3830
+   i32.const 3835
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45953,77 +46149,12 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3831
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  i32.const 0
-  call $~lib/math/ipow64f
-  f64.const 1
-  f64.ne
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3835
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  i32.const 0
-  call $~lib/math/ipow64f
-  f64.const 1
-  f64.ne
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3836
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  i32.const 1
-  call $~lib/math/ipow64f
-  call $~lib/number/isNaN<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3837
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  i32.const -1
-  call $~lib/math/ipow64f
-  call $~lib/number/isNaN<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3838
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  i32.const 2
-  call $~lib/math/ipow64f
-  call $~lib/number/isNaN<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3839
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
+  f64.const 0
   i32.const 0
   call $~lib/math/ipow64f
   f64.const 1
@@ -46036,10 +46167,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  i32.const 1
+  f64.const nan:0x8000000000000
+  i32.const 0
   call $~lib/math/ipow64f
-  f64.const inf
+  f64.const 1
   f64.ne
   if
    i32.const 0
@@ -46049,11 +46180,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  i32.const 0
+  f64.const nan:0x8000000000000
+  i32.const 1
   call $~lib/math/ipow64f
-  f64.const 1
-  f64.ne
+  call $~lib/number/isNaN<f64>
+  i32.eqz
   if
    i32.const 0
    i32.const 24
@@ -46062,11 +46193,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  i32.const 1
+  f64.const nan:0x8000000000000
+  i32.const -1
   call $~lib/math/ipow64f
-  f64.const -inf
-  f64.ne
+  call $~lib/number/isNaN<f64>
+  i32.eqz
   if
    i32.const 0
    i32.const 24
@@ -46075,11 +46206,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   i32.const 2
   call $~lib/math/ipow64f
-  f64.const inf
-  f64.ne
+  call $~lib/number/isNaN<f64>
+  i32.eqz
   if
    i32.const 0
    i32.const 24
@@ -46088,7 +46219,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const inf
   i32.const 0
   call $~lib/math/ipow64f
   f64.const 1
@@ -46101,6 +46232,71 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
+  i32.const 1
+  call $~lib/math/ipow64f
+  f64.const inf
+  f64.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3846
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  i32.const 0
+  call $~lib/math/ipow64f
+  f64.const 1
+  f64.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3847
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  i32.const 1
+  call $~lib/math/ipow64f
+  f64.const -inf
+  f64.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3848
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  i32.const 2
+  call $~lib/math/ipow64f
+  f64.const inf
+  f64.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3849
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  i32.const 0
+  call $~lib/math/ipow64f
+  f64.const 1
+  f64.ne
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3850
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1797693134862315708145274e284
   i32.const 2
   call $~lib/math/ipow64f
@@ -46109,7 +46305,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3846
+   i32.const 3851
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46122,7 +46318,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3847
+   i32.const 3852
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46135,7 +46331,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3848
+   i32.const 3853
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46148,7 +46344,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3849
+   i32.const 3854
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46161,7 +46357,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3850
+   i32.const 3855
    i32.const 0
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/math.ts
+++ b/tests/compiler/std/math.ts
@@ -30,7 +30,7 @@
   and src/math/crlibm/* for details
 */
 
-var js = true; // also test, and thus compare to, JS math?
+const js = true; // also test, and thus compare to, JS math?
 
 // these flags are unused, but kept in case these might just so happen to become useful
 const INEXACT   = 1 << 0;
@@ -1613,8 +1613,10 @@ assert(test_floorf(-7.888609052e-31, -1.0, 0.0, INEXACT));
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 function test_hypot(value1: f64, value2: f64, expected: f64, error: f64, flags: i32): bool {
-  return  check<f64>(NativeMath.hypot(value1, value2), expected, error, flags) &&
-  (!js || check<f64>(    JSMath.hypot(value1, value2), expected, error, flags));
+  return  check<f64>(NativeMath.hypot(value1, value2), expected, error, flags) /*&&
+  (!js || check<f64>(    JSMath.hypot(value1, value2), expected, error, flags))*/;
+  // ^ FIXME: Math.hypot is broken in v8 7.7 (node 12.11) due to
+  //   https://bugs.chromium.org/p/v8/issues/detail?id=9546
 }
 
 // sanity
@@ -1641,19 +1643,16 @@ assert(test_hypot(4.94065645841246544e-324, 0.0, 4.94065645841246544e-324, 0.0, 
 assert(test_hypot(4.94065645841246544e-324, -0.0, 4.94065645841246544e-324, 0.0, 0));
 assert(test_hypot(Infinity, 1.0, Infinity, 0.0, 0));
 assert(test_hypot(1.0, Infinity, Infinity, 0.0, 0));
-js = false; assert(test_hypot(Infinity, NaN, Infinity, 0.0, 0)); js = true;
+assert(test_hypot(Infinity, NaN, Infinity, 0.0, 0));
 assert(test_hypot(NaN, Infinity, Infinity, 0.0, 0));
 assert(test_hypot(-Infinity, 1.0, Infinity, 0.0, 0));
 assert(test_hypot(1.0, -Infinity, Infinity, 0.0, 0));
-js = false; assert(test_hypot(-Infinity, NaN, Infinity, 0.0, 0)); js = true;
+assert(test_hypot(-Infinity, NaN, Infinity, 0.0, 0));
 assert(test_hypot(NaN, -Infinity, Infinity, 0.0, 0));
 assert(test_hypot(NaN, 1.0, NaN, 0.0, 0));
 assert(test_hypot(1.0, NaN, NaN, 0.0, 0));
-js = false; assert(test_hypot(NaN, 0.0, NaN, 0.0, 0)); js = true;
+assert(test_hypot(NaN, 0.0, NaN, 0.0, 0));
 assert(test_hypot(0.0, NaN, NaN, 0.0, 0));
-
-// ^ FIXME: Math.hypot is broken in v8 7.7 (node 12.11) due to
-//   https://bugs.chromium.org/p/v8/issues/detail?id=9546
 
 // Mathf.hypot /////////////////////////////////////////////////////////////////////////////////////
 

--- a/tests/compiler/std/math.ts
+++ b/tests/compiler/std/math.ts
@@ -30,7 +30,7 @@
   and src/math/crlibm/* for details
 */
 
-const js = true; // also test, and thus compare to, JS math?
+var js = true; // also test, and thus compare to, JS math?
 
 // these flags are unused, but kept in case these might just so happen to become useful
 const INEXACT   = 1 << 0;
@@ -1641,14 +1641,19 @@ assert(test_hypot(4.94065645841246544e-324, 0.0, 4.94065645841246544e-324, 0.0, 
 assert(test_hypot(4.94065645841246544e-324, -0.0, 4.94065645841246544e-324, 0.0, 0));
 assert(test_hypot(Infinity, 1.0, Infinity, 0.0, 0));
 assert(test_hypot(1.0, Infinity, Infinity, 0.0, 0));
-assert(test_hypot(Infinity, NaN, Infinity, 0.0, 0));
+js = false; assert(test_hypot(Infinity, NaN, Infinity, 0.0, 0)); js = true;
 assert(test_hypot(NaN, Infinity, Infinity, 0.0, 0));
 assert(test_hypot(-Infinity, 1.0, Infinity, 0.0, 0));
 assert(test_hypot(1.0, -Infinity, Infinity, 0.0, 0));
-assert(test_hypot(-Infinity, NaN, Infinity, 0.0, 0));
+js = false; assert(test_hypot(-Infinity, NaN, Infinity, 0.0, 0)); js = true;
 assert(test_hypot(NaN, -Infinity, Infinity, 0.0, 0));
 assert(test_hypot(NaN, 1.0, NaN, 0.0, 0));
 assert(test_hypot(1.0, NaN, NaN, 0.0, 0));
+js = false; assert(test_hypot(NaN, 0.0, NaN, 0.0, 0)); js = true;
+assert(test_hypot(0.0, NaN, NaN, 0.0, 0));
+
+// ^ FIXME: Math.hypot is broken in v8 7.7 (node 12.11) due to
+//   https://bugs.chromium.org/p/v8/issues/detail?id=9546
 
 // Mathf.hypot /////////////////////////////////////////////////////////////////////////////////////
 

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -50,7 +50,6 @@
  (import "Math" "exp" (func $~lib/bindings/Math/exp (param f64) (result f64)))
  (import "Math" "expm1" (func $~lib/bindings/Math/expm1 (param f64) (result f64)))
  (import "Math" "floor" (func $~lib/bindings/Math/floor (param f64) (result f64)))
- (import "Math" "hypot" (func $~lib/bindings/Math/hypot (param f64 f64) (result f64)))
  (import "Math" "log" (func $~lib/bindings/Math/log (param f64) (result f64)))
  (import "Math" "log10" (func $~lib/bindings/Math/log10 (param f64) (result f64)))
  (import "Math" "log1p" (func $~lib/bindings/Math/log1p (param f64) (result f64)))
@@ -77,7 +76,7 @@
  (data (i32.const 408) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00P\00R\00N\00G\00 \00m\00u\00s\00t\00 \00b\00e\00 \00s\00e\00e\00d\00e\00d\00.\00")
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
- (global $std/math/js (mut i32) (i32.const 1))
+ (global $std/math/js i32 (i32.const 1))
  (global $std/math/INEXACT i32 (i32.const 1))
  (global $std/math/INVALID i32 (i32.const 2))
  (global $std/math/DIVBYZERO i32 (i32.const 4))
@@ -121,19 +120,19 @@
  (global $~lib/builtins/f32.MIN_VALUE f32 (f32.const 1.401298464324817e-45))
  (export "memory" (memory $0))
  (start $start)
- (func $~lib/number/isNaN<f64> (; 33 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/number/isNaN<f64> (; 32 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   local.get $0
   f64.ne
  )
- (func $~lib/number/isFinite<f64> (; 34 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/number/isFinite<f64> (; 33 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   local.get $0
   f64.sub
   f64.const 0
   f64.eq
  )
- (func $std/math/eulp (; 35 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $std/math/eulp (; 34 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   (local $1 i64)
   (local $2 i32)
   local.get $0
@@ -160,7 +159,7 @@
   i32.const 52
   i32.sub
  )
- (func $~lib/math/NativeMath.scalbn (; 36 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/NativeMath.scalbn (; 35 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
@@ -251,7 +250,7 @@
   f64.reinterpret_i64
   f64.mul
  )
- (func $std/math/ulperr (; 37 ;) (type $FUNCSIG$dddd) (param $0 f64) (param $1 f64) (param $2 f64) (result f64)
+ (func $std/math/ulperr (; 36 ;) (type $FUNCSIG$dddd) (param $0 f64) (param $1 f64) (param $2 f64) (result f64)
   (local $3 f64)
   local.get $0
   call $~lib/number/isNaN<f64>
@@ -327,7 +326,7 @@
   local.get $2
   f64.add
  )
- (func $std/math/check<f64> (; 38 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/check<f64> (; 37 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   local.get $0
   local.get $1
@@ -358,19 +357,19 @@
   end
   i32.const 1
  )
- (func $~lib/number/isNaN<f32> (; 39 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
+ (func $~lib/number/isNaN<f32> (; 38 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
   local.get $0
   local.get $0
   f32.ne
  )
- (func $~lib/number/isFinite<f32> (; 40 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
+ (func $~lib/number/isFinite<f32> (; 39 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
   local.get $0
   local.get $0
   f32.sub
   f32.const 0
   f32.eq
  )
- (func $std/math/eulpf (; 41 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
+ (func $std/math/eulpf (; 40 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -396,7 +395,7 @@
   i32.const 23
   i32.sub
  )
- (func $~lib/math/NativeMathf.scalbn (; 42 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
+ (func $~lib/math/NativeMathf.scalbn (; 41 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
   (local $2 f32)
   (local $3 i32)
   (local $4 i32)
@@ -486,7 +485,7 @@
   f32.reinterpret_i32
   f32.mul
  )
- (func $std/math/ulperrf (; 43 ;) (type $FUNCSIG$ffff) (param $0 f32) (param $1 f32) (param $2 f32) (result f32)
+ (func $std/math/ulperrf (; 42 ;) (type $FUNCSIG$ffff) (param $0 f32) (param $1 f32) (param $2 f32) (result f32)
   (local $3 f32)
   local.get $0
   call $~lib/number/isNaN<f32>
@@ -560,7 +559,7 @@
   local.get $2
   f32.add
  )
- (func $std/math/check<f32> (; 44 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/check<f32> (; 43 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   local.get $0
   local.get $1
@@ -591,7 +590,7 @@
   end
   i32.const 1
  )
- (func $std/math/test_scalbn (; 45 ;) (type $FUNCSIG$ididdi) (param $0 f64) (param $1 i32) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_scalbn (; 44 ;) (type $FUNCSIG$ididdi) (param $0 f64) (param $1 i32) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.scalbn
@@ -600,7 +599,7 @@
   local.get $4
   call $std/math/check<f64>
  )
- (func $std/math/test_scalbnf (; 46 ;) (type $FUNCSIG$ififfi) (param $0 f32) (param $1 i32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_scalbnf (; 45 ;) (type $FUNCSIG$ififfi) (param $0 f32) (param $1 i32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.scalbn
@@ -609,7 +608,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $std/math/test_abs (; 47 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_abs (; 46 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   local.get $0
   local.set $4
@@ -636,7 +635,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_absf (; 48 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_absf (; 47 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   local.get $0
   local.set $4
@@ -647,7 +646,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/R (; 49 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/R (; 48 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   local.get $0
@@ -696,7 +695,7 @@
   local.get $2
   f64.div
  )
- (func $~lib/math/NativeMath.acos (; 50 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.acos (; 49 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -848,7 +847,7 @@
   f64.add
   f64.mul
  )
- (func $std/math/test_acos (; 51 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_acos (; 50 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.acos
   local.get $1
@@ -872,7 +871,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/Rf (; 52 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/Rf (; 51 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 f32)
   local.get $0
@@ -897,7 +896,7 @@
   local.get $2
   f32.div
  )
- (func $~lib/math/NativeMathf.acos (; 53 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.acos (; 52 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -1037,7 +1036,7 @@
   f32.add
   f32.mul
  )
- (func $std/math/test_acosf (; 54 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_acosf (; 53 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.acos
   local.get $1
@@ -1045,7 +1044,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log1p (; 55 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log1p (; 54 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -1287,7 +1286,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.log (; 56 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log (; 55 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -1496,7 +1495,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.acosh (; 57 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.acosh (; 56 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   local.get $0
   i64.reinterpret_f64
@@ -1556,7 +1555,7 @@
   f64.const 0.6931471805599453
   f64.add
  )
- (func $std/math/test_acosh (; 58 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_acosh (; 57 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.acosh
   local.get $1
@@ -1580,7 +1579,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.log1p (; 59 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log1p (; 58 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -1789,7 +1788,7 @@
   f32.mul
   f32.add
  )
- (func $~lib/math/NativeMathf.log (; 60 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log (; 59 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -1957,7 +1956,7 @@
   f32.mul
   f32.add
  )
- (func $~lib/math/NativeMathf.acosh (; 61 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.acosh (; 60 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -2013,7 +2012,7 @@
   f32.const 0.6931471824645996
   f32.add
  )
- (func $std/math/test_acoshf (; 62 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_acoshf (; 61 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.acosh
   local.get $1
@@ -2021,7 +2020,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.asin (; 63 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.asin (; 62 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2180,7 +2179,7 @@
   end
   local.get $0
  )
- (func $std/math/test_asin (; 64 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_asin (; 63 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.asin
   local.get $1
@@ -2204,7 +2203,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.asin (; 65 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.asin (; 64 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 f32)
@@ -2296,7 +2295,7 @@
   local.get $1
   f32.copysign
  )
- (func $std/math/test_asinf (; 66 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_asinf (; 65 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.asin
   local.get $1
@@ -2304,7 +2303,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.asinh (; 67 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.asinh (; 66 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i64)
   (local $3 f64)
@@ -2380,7 +2379,7 @@
   local.get $0
   f64.copysign
  )
- (func $std/math/test_asinh (; 68 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_asinh (; 67 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.asinh
   local.get $1
@@ -2404,7 +2403,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.asinh (; 69 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.asinh (; 68 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   local.get $0
@@ -2473,7 +2472,7 @@
   local.get $0
   f32.copysign
  )
- (func $std/math/test_asinhf (; 70 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_asinhf (; 69 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.asinh
   local.get $1
@@ -2481,7 +2480,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atan (; 71 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atan (; 70 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 f64)
   (local $3 f64)
@@ -2738,7 +2737,7 @@
   local.get $2
   f64.copysign
  )
- (func $std/math/test_atan (; 72 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_atan (; 71 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.atan
   local.get $1
@@ -2762,7 +2761,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.atan (; 73 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.atan (; 72 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -2991,7 +2990,7 @@
   local.get $2
   f32.copysign
  )
- (func $std/math/test_atanf (; 74 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_atanf (; 73 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.atan
   local.get $1
@@ -2999,7 +2998,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atanh (; 75 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atanh (; 74 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i64)
   (local $3 f64)
@@ -3058,7 +3057,7 @@
   local.get $0
   f64.copysign
  )
- (func $std/math/test_atanh (; 76 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_atanh (; 75 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.atanh
   local.get $1
@@ -3082,7 +3081,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.atanh (; 77 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.atanh (; 76 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   local.get $0
@@ -3132,7 +3131,7 @@
   local.get $0
   f32.copysign
  )
- (func $std/math/test_atanhf (; 78 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_atanhf (; 77 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.atanh
   local.get $1
@@ -3140,7 +3139,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atan2 (; 79 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.atan2 (; 78 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -3439,7 +3438,7 @@
   end
   unreachable
  )
- (func $std/math/test_atan2 (; 80 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_atan2 (; 79 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.atan2
@@ -3465,7 +3464,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.atan2 (; 81 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.atan2 (; 80 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3735,7 +3734,7 @@
   end
   unreachable
  )
- (func $std/math/test_atan2f (; 82 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_atan2f (; 81 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.atan2
@@ -3744,7 +3743,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.cbrt (; 83 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cbrt (; 82 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 f64)
@@ -3888,7 +3887,7 @@
   local.set $3
   local.get $3
  )
- (func $std/math/test_cbrt (; 84 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_cbrt (; 83 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.cbrt
   local.get $1
@@ -3912,7 +3911,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.cbrt (; 85 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cbrt (; 84 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -4028,7 +4027,7 @@
   local.get $3
   f32.demote_f64
  )
- (func $std/math/test_cbrtf (; 86 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_cbrtf (; 85 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.cbrt
   local.get $1
@@ -4036,7 +4035,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_ceil (; 87 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_ceil (; 86 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   local.get $0
   local.set $4
@@ -4063,7 +4062,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_ceilf (; 88 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_ceilf (; 87 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   local.get $0
   local.set $4
@@ -4074,7 +4073,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/pio2_large_quot (; 89 ;) (type $FUNCSIG$idj) (param $0 f64) (param $1 i64) (result i32)
+ (func $~lib/math/pio2_large_quot (; 88 ;) (type $FUNCSIG$idj) (param $0 f64) (param $1 i64) (result i32)
   (local $2 i32)
   (local $3 i64)
   (local $4 i64)
@@ -4476,7 +4475,7 @@
   local.get $31
   i32.wrap_i64
  )
- (func $~lib/math/NativeMath.cos (; 90 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cos (; 89 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -4994,7 +4993,7 @@
    local.get $0
   end
  )
- (func $std/math/test_cos (; 91 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_cos (; 90 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.cos
   local.get $1
@@ -5018,7 +5017,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.cos (; 92 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cos (; 91 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -5636,7 +5635,7 @@
    local.get $27
   end
  )
- (func $std/math/test_cosf (; 93 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_cosf (; 92 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.cos
   local.get $1
@@ -5644,7 +5643,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.expm1 (; 94 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.expm1 (; 93 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -5956,7 +5955,7 @@
   local.get $14
   f64.mul
  )
- (func $~lib/math/NativeMath.exp (; 95 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.exp (; 94 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -6121,7 +6120,7 @@
   local.get $5
   call $~lib/math/NativeMath.scalbn
  )
- (func $~lib/math/NativeMath.cosh (; 96 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cosh (; 95 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 f64)
@@ -6210,7 +6209,7 @@
   local.set $3
   local.get $3
  )
- (func $std/math/test_cosh (; 97 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_cosh (; 96 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.cosh
   local.get $1
@@ -6234,7 +6233,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.expm1 (; 98 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.expm1 (; 97 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6527,7 +6526,7 @@
   local.get $13
   f32.mul
  )
- (func $~lib/math/NativeMathf.exp (; 99 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.exp (; 98 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -6671,7 +6670,7 @@
   local.get $5
   call $~lib/math/NativeMathf.scalbn
  )
- (func $~lib/math/NativeMathf.cosh (; 100 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cosh (; 99 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -6748,7 +6747,7 @@
   local.get $3
   f32.mul
  )
- (func $std/math/test_coshf (; 101 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_coshf (; 100 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.cosh
   local.get $1
@@ -6756,7 +6755,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_exp (; 102 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_exp (; 101 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.exp
   local.get $1
@@ -6780,7 +6779,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_expf (; 103 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_expf (; 102 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.exp
   local.get $1
@@ -6788,7 +6787,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_expm1 (; 104 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_expm1 (; 103 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.expm1
   local.get $1
@@ -6812,7 +6811,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_expm1f (; 105 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_expm1f (; 104 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.expm1
   local.get $1
@@ -6820,7 +6819,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_floor (; 106 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_floor (; 105 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   local.get $0
   local.set $4
@@ -6847,7 +6846,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_floorf (; 107 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_floorf (; 106 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   local.get $0
   local.set $4
@@ -6858,7 +6857,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.hypot (; 108 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.hypot (; 107 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -7053,7 +7052,7 @@
   f64.sqrt
   f64.mul
  )
- (func $std/math/test_hypot (; 109 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_hypot (; 108 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.hypot
@@ -7061,25 +7060,8 @@
   local.get $3
   local.get $4
   call $std/math/check<f64>
-  if (result i32)
-   global.get $std/math/js
-   i32.eqz
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    local.get $1
-    call $~lib/bindings/Math/hypot
-    local.get $2
-    local.get $3
-    local.get $4
-    call $std/math/check<f64>
-   end
-  else
-   i32.const 0
-  end
  )
- (func $~lib/math/NativeMathf.hypot (; 110 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.hypot (; 109 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7196,7 +7178,7 @@
   f32.sqrt
   f32.mul
  )
- (func $std/math/test_hypotf (; 111 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_hypotf (; 110 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.hypot
@@ -7205,7 +7187,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $std/math/test_log (; 112 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_log (; 111 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.log
   local.get $1
@@ -7229,7 +7211,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_logf (; 113 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_logf (; 112 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log
   local.get $1
@@ -7237,7 +7219,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log10 (; 114 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log10 (; 113 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -7497,7 +7479,7 @@
   local.get $8
   f64.add
  )
- (func $std/math/test_log10 (; 115 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_log10 (; 114 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.log10
   local.get $1
@@ -7521,7 +7503,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.log10 (; 116 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log10 (; 115 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -7721,7 +7703,7 @@
   f32.mul
   f32.add
  )
- (func $std/math/test_log10f (; 117 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_log10f (; 116 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log10
   local.get $1
@@ -7729,7 +7711,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_log1p (; 118 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_log1p (; 117 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.log1p
   local.get $1
@@ -7753,7 +7735,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_log1pf (; 119 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_log1pf (; 118 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log1p
   local.get $1
@@ -7761,7 +7743,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log2 (; 120 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log2 (; 119 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -8014,7 +7996,7 @@
   local.get $14
   f64.add
  )
- (func $std/math/test_log2 (; 121 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_log2 (; 120 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.log2
   local.get $1
@@ -8038,7 +8020,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.log2 (; 122 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log2 (; 121 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -8233,7 +8215,7 @@
   local.get $14
   f32.add
  )
- (func $std/math/test_log2f (; 123 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_log2f (; 122 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log2
   local.get $1
@@ -8241,7 +8223,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_max (; 124 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_max (; 123 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   (local $5 f64)
   (local $6 f64)
   local.get $0
@@ -8273,7 +8255,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_maxf (; 125 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_maxf (; 124 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   (local $5 f32)
   (local $6 f32)
   local.get $0
@@ -8288,7 +8270,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $std/math/test_min (; 126 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_min (; 125 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   (local $5 f64)
   (local $6 f64)
   local.get $0
@@ -8320,7 +8302,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_minf (; 127 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_minf (; 126 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   (local $5 f32)
   (local $6 f32)
   local.get $0
@@ -8335,7 +8317,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.mod (; 128 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (; 127 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -8584,7 +8566,7 @@
   local.get $2
   f64.reinterpret_i64
  )
- (func $std/math/test_mod (; 129 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_mod (; 128 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.mod
@@ -8610,7 +8592,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.mod (; 130 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (; 129 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8857,7 +8839,7 @@
   local.get $2
   f32.reinterpret_i32
  )
- (func $std/math/test_modf (; 131 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_modf (; 130 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.mod
@@ -8866,7 +8848,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.pow (; 132 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.pow (; 131 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -9946,7 +9928,7 @@
   local.get $16
   f64.mul
  )
- (func $std/math/test_pow (; 133 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_pow (; 132 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.pow
@@ -9972,7 +9954,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.pow (; 134 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.pow (; 133 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10906,7 +10888,7 @@
   local.get $11
   f32.mul
  )
- (func $std/math/test_powf (; 135 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_powf (; 134 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.pow
@@ -10915,7 +10897,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $~lib/math/murmurHash3 (; 136 ;) (type $FUNCSIG$jj) (param $0 i64) (result i64)
+ (func $~lib/math/murmurHash3 (; 135 ;) (type $FUNCSIG$jj) (param $0 i64) (result i64)
   local.get $0
   local.get $0
   i64.const 33
@@ -10944,7 +10926,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/math/splitMix32 (; 137 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/math/splitMix32 (; 136 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 1831565813
   i32.add
@@ -10979,7 +10961,7 @@
   i32.shr_u
   i32.xor
  )
- (func $~lib/math/NativeMath.seedRandom (; 138 ;) (type $FUNCSIG$vj) (param $0 i64)
+ (func $~lib/math/NativeMath.seedRandom (; 137 ;) (type $FUNCSIG$vj) (param $0 i64)
   i32.const 1
   global.set $~lib/math/random_seeded
   local.get $0
@@ -11031,7 +11013,7 @@
    unreachable
   end
  )
- (func $~lib/math/NativeMath.random (; 139 ;) (type $FUNCSIG$d) (result f64)
+ (func $~lib/math/NativeMath.random (; 138 ;) (type $FUNCSIG$d) (result f64)
   (local $0 i64)
   (local $1 i64)
   (local $2 i64)
@@ -11086,7 +11068,7 @@
   f64.const 1
   f64.sub
  )
- (func $~lib/math/NativeMathf.random (; 140 ;) (type $FUNCSIG$f) (result f32)
+ (func $~lib/math/NativeMathf.random (; 139 ;) (type $FUNCSIG$f) (result f32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11141,7 +11123,7 @@
   f32.const 1
   f32.sub
  )
- (func $std/math/test_round (; 141 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_round (; 140 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   local.get $0
   local.set $4
@@ -11156,7 +11138,7 @@
   local.get $3
   call $std/math/check<f64>
  )
- (func $std/math/test_roundf (; 142 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_roundf (; 141 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   local.get $0
   local.set $4
@@ -11171,7 +11153,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_sign (; 143 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_sign (; 142 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   block $~lib/math/NativeMath.sign|inlined.0 (result f64)
    local.get $0
@@ -11214,7 +11196,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_signf (; 144 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_signf (; 143 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   block $~lib/math/NativeMathf.sign|inlined.0 (result f32)
    local.get $0
@@ -11241,7 +11223,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.rem (; 145 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.rem (; 144 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -11551,7 +11533,7 @@
    local.get $0
   end
  )
- (func $std/math/test_rem (; 146 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_rem (; 145 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.rem
@@ -11560,7 +11542,7 @@
   local.get $4
   call $std/math/check<f64>
  )
- (func $~lib/math/NativeMathf.rem (; 147 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.rem (; 146 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11868,7 +11850,7 @@
    local.get $0
   end
  )
- (func $std/math/test_remf (; 148 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_remf (; 147 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.rem
@@ -11877,7 +11859,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.sin (; 149 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.sin (; 148 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -12406,7 +12388,7 @@
    local.get $0
   end
  )
- (func $std/math/test_sin (; 150 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_sin (; 149 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.sin
   local.get $1
@@ -12430,7 +12412,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.sin (; 151 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.sin (; 150 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -13040,7 +13022,7 @@
    local.get $27
   end
  )
- (func $std/math/test_sinf (; 152 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_sinf (; 151 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.sin
   local.get $1
@@ -13048,7 +13030,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.sinh (; 153 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.sinh (; 152 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 f64)
   (local $3 i32)
@@ -13146,7 +13128,7 @@
   local.set $4
   local.get $4
  )
- (func $std/math/test_sinh (; 154 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_sinh (; 153 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.sinh
   local.get $1
@@ -13170,7 +13152,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.sinh (; 155 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.sinh (; 154 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -13259,7 +13241,7 @@
   local.set $3
   local.get $3
  )
- (func $std/math/test_sinhf (; 156 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_sinhf (; 155 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.sinh
   local.get $1
@@ -13267,7 +13249,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_sqrt (; 157 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_sqrt (; 156 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   local.get $0
   local.set $4
@@ -13294,7 +13276,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_sqrtf (; 158 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_sqrtf (; 157 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   local.get $0
   local.set $4
@@ -13305,7 +13287,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/tan_kern (; 159 ;) (type $FUNCSIG$dddi) (param $0 f64) (param $1 f64) (param $2 i32) (result f64)
+ (func $~lib/math/tan_kern (; 158 ;) (type $FUNCSIG$dddi) (param $0 f64) (param $1 f64) (param $2 i32) (result f64)
   (local $3 f64)
   (local $4 f64)
   (local $5 f64)
@@ -13518,7 +13500,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.tan (; 160 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.tan (; 159 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -13830,7 +13812,7 @@
   i32.sub
   call $~lib/math/tan_kern
  )
- (func $std/math/test_tan (; 161 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_tan (; 160 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.tan
   local.get $1
@@ -13854,7 +13836,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.tan (; 162 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.tan (; 161 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -14505,7 +14487,7 @@
   end
   f32.demote_f64
  )
- (func $std/math/test_tanf (; 163 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_tanf (; 162 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.tan
   local.get $1
@@ -14513,7 +14495,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.tanh (; 164 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.tanh (; 163 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 f64)
   (local $3 i32)
@@ -14605,7 +14587,7 @@
   local.get $0
   f64.copysign
  )
- (func $std/math/test_tanh (; 165 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_tanh (; 164 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.tanh
   local.get $1
@@ -14629,7 +14611,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.tanh (; 166 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.tanh (; 165 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -14715,7 +14697,7 @@
   local.get $0
   f32.copysign
  )
- (func $std/math/test_tanhf (; 167 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_tanhf (; 166 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.tanh
   local.get $1
@@ -14723,7 +14705,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_trunc (; 168 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_trunc (; 167 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   local.get $0
   local.set $4
@@ -14750,7 +14732,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_truncf (; 169 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_truncf (; 168 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   local.get $0
   local.set $4
@@ -14761,7 +14743,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.sincos (; 170 ;) (type $FUNCSIG$vd) (param $0 f64)
+ (func $~lib/math/NativeMath.sincos (; 169 ;) (type $FUNCSIG$vd) (param $0 f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -15380,7 +15362,7 @@
   local.get $23
   global.set $~lib/math/NativeMath.sincos_cos
  )
- (func $std/math/test_sincos (; 171 ;) (type $FUNCSIG$ijjjjji) (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64) (param $5 i32) (result i32)
+ (func $std/math/test_sincos (; 170 ;) (type $FUNCSIG$ijjjjji) (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64) (param $5 i32) (result i32)
   (local $6 f64)
   (local $7 f64)
   (local $8 f64)
@@ -15418,7 +15400,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/dtoi32 (; 172 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/math/dtoi32 (; 171 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i64)
   (local $3 i64)
@@ -15489,7 +15471,7 @@
   local.get $1
   return
  )
- (func $~lib/math/NativeMath.imul (; 173 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.imul (; 172 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   f64.add
@@ -15506,7 +15488,7 @@
   i32.mul
   f64.convert_i32_s
  )
- (func $~lib/math/NativeMath.clz32 (; 174 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.clz32 (; 173 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/number/isFinite<f64>
   i32.eqz
@@ -15519,7 +15501,7 @@
   i32.clz
   f64.convert_i32_s
  )
- (func $~lib/math/ipow64 (; 175 ;) (type $FUNCSIG$jji) (param $0 i64) (param $1 i32) (result i64)
+ (func $~lib/math/ipow64 (; 174 ;) (type $FUNCSIG$jji) (param $0 i64) (param $1 i32) (result i64)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -15740,7 +15722,7 @@
   end
   local.get $2
  )
- (func $~lib/math/ipow32f (; 176 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
+ (func $~lib/math/ipow32f (; 175 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
   (local $2 i32)
   (local $3 f32)
   local.get $1
@@ -15790,7 +15772,7 @@
    local.get $3
   end
  )
- (func $~lib/math/ipow64f (; 177 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/ipow64f (; 176 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
   (local $2 i32)
   (local $3 f64)
   local.get $1
@@ -15840,7 +15822,7 @@
    local.get $3
   end
  )
- (func $start:std/math (; 178 ;) (type $FUNCSIG$v)
+ (func $start:std/math (; 177 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f64)
   (local $2 i64)
@@ -29462,7 +29444,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1621
+   i32.const 1623
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29477,7 +29459,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1622
+   i32.const 1624
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29492,7 +29474,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1623
+   i32.const 1625
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29507,7 +29489,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1624
+   i32.const 1626
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29522,7 +29504,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1625
+   i32.const 1627
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29537,7 +29519,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1626
+   i32.const 1628
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29552,7 +29534,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1627
+   i32.const 1629
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29567,7 +29549,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1628
+   i32.const 1630
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29582,7 +29564,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1629
+   i32.const 1631
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29597,43 +29579,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1630
+   i32.const 1632
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 3
   f64.const 4
-  f64.const 5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_hypot
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1633
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -3
-  f64.const 4
-  f64.const 5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_hypot
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1634
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4
-  f64.const 3
   f64.const 5
   f64.const 0
   i32.const 0
@@ -29647,6 +29599,36 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -3
+  f64.const 4
+  f64.const 5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_hypot
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1636
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4
+  f64.const 3
+  f64.const 5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_hypot
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1637
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 4
   f64.const -3
   f64.const 5
@@ -29657,7 +29639,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1636
+   i32.const 1638
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29672,44 +29654,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1637
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1797693134862315708145274e284
-  f64.const 0
-  f64.const 1797693134862315708145274e284
-  f64.const 0
-  i32.const 0
-  call $std/math/test_hypot
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1638
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1797693134862315708145274e284
-  f64.const -0
-  f64.const 1797693134862315708145274e284
-  f64.const 0
-  i32.const 0
-  call $std/math/test_hypot
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 1639
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5e-324
+  f64.const 1797693134862315708145274e284
   f64.const 0
-  f64.const 5e-324
+  f64.const 1797693134862315708145274e284
   f64.const 0
   i32.const 0
   call $std/math/test_hypot
@@ -29722,9 +29674,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5e-324
+  f64.const 1797693134862315708145274e284
   f64.const -0
-  f64.const 5e-324
+  f64.const 1797693134862315708145274e284
   f64.const 0
   i32.const 0
   call $std/math/test_hypot
@@ -29737,9 +29689,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 1
-  f64.const inf
+  f64.const 5e-324
+  f64.const 0
+  f64.const 5e-324
   f64.const 0
   i32.const 0
   call $std/math/test_hypot
@@ -29752,9 +29704,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const inf
-  f64.const inf
+  f64.const 5e-324
+  f64.const -0
+  f64.const 5e-324
   f64.const 0
   i32.const 0
   call $std/math/test_hypot
@@ -29767,10 +29719,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 0
-  global.set $std/math/js
   f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const inf
   f64.const 0
   i32.const 0
@@ -29780,13 +29730,11 @@
    i32.const 0
    i32.const 24
    i32.const 1644
-   i32.const 12
+   i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  global.set $std/math/js
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const inf
   f64.const inf
   f64.const 0
@@ -29801,8 +29749,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const 1
+  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const inf
   f64.const 0
   i32.const 0
@@ -29816,8 +29764,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const inf
   f64.const inf
   f64.const 0
   i32.const 0
@@ -29831,10 +29779,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 0
-  global.set $std/math/js
   f64.const -inf
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const inf
   f64.const 0
   i32.const 0
@@ -29844,13 +29790,11 @@
    i32.const 0
    i32.const 24
    i32.const 1648
-   i32.const 12
+   i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  global.set $std/math/js
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const -inf
   f64.const inf
   f64.const 0
@@ -29865,9 +29809,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -inf
   f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_hypot
@@ -29880,9 +29824,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_hypot
@@ -29895,10 +29839,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 0
-  global.set $std/math/js
   f64.const nan:0x8000000000000
-  f64.const 0
+  f64.const 1
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
@@ -29908,13 +29850,11 @@
    i32.const 0
    i32.const 24
    i32.const 1652
-   i32.const 12
+   i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 1
-  global.set $std/math/js
-  f64.const 0
+  f64.const 1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -29929,6 +29869,36 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_hypot
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1654
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_hypot
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1655
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -8.066848754882812
   f32.const 4.535662651062012
   f32.const 9.254528045654297
@@ -29939,7 +29909,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1665
+   i32.const 1664
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29954,7 +29924,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1666
+   i32.const 1665
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29969,7 +29939,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1667
+   i32.const 1666
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29984,7 +29954,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1668
+   i32.const 1667
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29999,7 +29969,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1669
+   i32.const 1668
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30014,7 +29984,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1670
+   i32.const 1669
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30029,7 +29999,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1671
+   i32.const 1670
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30044,7 +30014,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1672
+   i32.const 1671
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30059,7 +30029,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1673
+   i32.const 1672
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30074,12 +30044,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1674
+   i32.const 1673
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 3
+  f32.const 4
+  f32.const 5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1676
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -3
   f32.const 4
   f32.const 5
   f32.const 0
@@ -30094,8 +30079,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -3
   f32.const 4
+  f32.const 3
   f32.const 5
   f32.const 0
   i32.const 0
@@ -30110,21 +30095,6 @@
    unreachable
   end
   f32.const 4
-  f32.const 3
-  f32.const 5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1679
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 4
   f32.const -3
   f32.const 5
   f32.const 0
@@ -30134,7 +30104,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1680
+   i32.const 1679
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30149,13 +30119,28 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1681
+   i32.const 1680
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 3402823466385288598117041e14
   f32.const 0
+  f32.const 3402823466385288598117041e14
+  f32.const 0
+  i32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1681
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 3402823466385288598117041e14
+  f32.const -0
   f32.const 3402823466385288598117041e14
   f32.const 0
   i32.const 0
@@ -30169,9 +30154,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 3402823466385288598117041e14
-  f32.const -0
-  f32.const 3402823466385288598117041e14
+  f32.const 1.401298464324817e-45
+  f32.const 0
+  f32.const 1.401298464324817e-45
   f32.const 0
   i32.const 0
   call $std/math/test_hypotf
@@ -30185,7 +30170,7 @@
    unreachable
   end
   f32.const 1.401298464324817e-45
-  f32.const 0
+  f32.const -0
   f32.const 1.401298464324817e-45
   f32.const 0
   i32.const 0
@@ -30199,9 +30184,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.401298464324817e-45
-  f32.const -0
-  f32.const 1.401298464324817e-45
+  f32.const inf
+  f32.const 1
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_hypotf
@@ -30214,8 +30199,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
   f32.const 1
+  f32.const inf
   f32.const inf
   f32.const 0
   i32.const 0
@@ -30229,8 +30214,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const inf
+  f32.const nan:0x400000
   f32.const inf
   f32.const 0
   i32.const 0
@@ -30244,8 +30229,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
   f32.const nan:0x400000
+  f32.const inf
   f32.const inf
   f32.const 0
   i32.const 0
@@ -30259,8 +30244,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const inf
+  f32.const -inf
+  f32.const 1
   f32.const inf
   f32.const 0
   i32.const 0
@@ -30274,8 +30259,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
   f32.const 1
+  f32.const -inf
   f32.const inf
   f32.const 0
   i32.const 0
@@ -30289,8 +30274,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const -inf
+  f32.const nan:0x400000
   f32.const inf
   f32.const 0
   i32.const 0
@@ -30304,8 +30289,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
   f32.const nan:0x400000
+  f32.const -inf
   f32.const inf
   f32.const 0
   i32.const 0
@@ -30320,8 +30305,8 @@
    unreachable
   end
   f32.const nan:0x400000
-  f32.const -inf
-  f32.const inf
+  f32.const 1
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_hypotf
@@ -30334,8 +30319,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
   f32.const 1
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
   i32.const 0
@@ -30349,21 +30334,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1695
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -8.06684839057968
   f64.const nan:0x8000000000000
   f64.const 0
@@ -30373,7 +30343,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1707
+   i32.const 1706
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30387,12 +30357,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1708
+   i32.const 1707
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.38143342755525
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 2
+  call $std/math/test_log
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1708
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -6.531673581913484
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -30406,20 +30390,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -6.531673581913484
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
-  call $std/math/test_log
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1710
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const 9.267056966972586
   f64.const 2.2264658498795615
   f64.const 0.3638114035129547
@@ -30429,7 +30399,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1711
+   i32.const 1710
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30443,7 +30413,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1712
+   i32.const 1711
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30457,7 +30427,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1713
+   i32.const 1712
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30471,7 +30441,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1714
+   i32.const 1713
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30485,7 +30455,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1715
+   i32.const 1714
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30499,12 +30469,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1716
+   i32.const 1715
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
+  f64.const -inf
+  f64.const 0
+  i32.const 4
+  call $std/math/test_log
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1718
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
   f64.const -inf
   f64.const 0
   i32.const 4
@@ -30518,20 +30502,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -inf
-  f64.const 0
-  i32.const 4
-  call $std/math/test_log
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1720
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -7.888609052210118e-31
   f64.const nan:0x8000000000000
   f64.const 0
@@ -30541,7 +30511,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1721
+   i32.const 1720
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30555,7 +30525,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1722
+   i32.const 1721
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30569,7 +30539,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1723
+   i32.const 1722
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30583,7 +30553,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1724
+   i32.const 1723
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30597,7 +30567,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1725
+   i32.const 1724
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30611,12 +30581,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1726
+   i32.const 1725
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
+  f32.const -inf
+  f32.const 0
+  i32.const 4
+  call $std/math/test_logf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1734
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
   f32.const -inf
   f32.const 0
   i32.const 4
@@ -30630,20 +30614,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -inf
-  f32.const 0
-  i32.const 4
-  call $std/math/test_logf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1736
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -7.888609052210118e-31
   f32.const nan:0x400000
   f32.const 0
@@ -30653,7 +30623,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1737
+   i32.const 1736
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30667,7 +30637,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1738
+   i32.const 1737
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30681,7 +30651,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1739
+   i32.const 1738
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30695,7 +30665,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1740
+   i32.const 1739
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30709,7 +30679,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1741
+   i32.const 1740
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30723,12 +30693,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1742
+   i32.const 1741
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
+  f32.const -inf
+  f32.const 0
+  i32.const 4
+  call $std/math/test_logf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1744
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
   f32.const -inf
   f32.const 0
   i32.const 4
@@ -30742,20 +30726,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -inf
-  f32.const 0
-  i32.const 4
-  call $std/math/test_logf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1746
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -7.888609052210118e-31
   f32.const nan:0x400000
   f32.const 0
@@ -30765,7 +30735,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1747
+   i32.const 1746
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30779,7 +30749,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1748
+   i32.const 1747
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30793,7 +30763,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1749
+   i32.const 1748
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30807,7 +30777,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1750
+   i32.const 1749
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30821,7 +30791,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1751
+   i32.const 1750
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30835,7 +30805,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1752
+   i32.const 1751
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30849,7 +30819,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1764
+   i32.const 1763
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30863,12 +30833,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1765
+   i32.const 1764
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.38143342755525
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 2
+  call $std/math/test_log10
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1765
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -6.531673581913484
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -30882,20 +30866,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -6.531673581913484
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
-  call $std/math/test_log10
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1767
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const 9.267056966972586
   f64.const 0.9669418327487274
   f64.const -0.06120431795716286
@@ -30905,7 +30875,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1768
+   i32.const 1767
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30919,7 +30889,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1769
+   i32.const 1768
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30933,7 +30903,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1770
+   i32.const 1769
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30947,7 +30917,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1771
+   i32.const 1770
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30961,7 +30931,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1772
+   i32.const 1771
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30975,12 +30945,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1773
+   i32.const 1772
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
+  f64.const -inf
+  f64.const 0
+  i32.const 4
+  call $std/math/test_log10
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1775
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
   f64.const -inf
   f64.const 0
   i32.const 4
@@ -30994,20 +30978,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -inf
-  f64.const 0
-  i32.const 4
-  call $std/math/test_log10
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1777
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -7.888609052210118e-31
   f64.const nan:0x8000000000000
   f64.const 0
@@ -31017,7 +30987,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1778
+   i32.const 1777
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31031,7 +31001,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1779
+   i32.const 1778
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31045,7 +31015,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1780
+   i32.const 1779
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31059,7 +31029,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1781
+   i32.const 1780
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31073,7 +31043,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1782
+   i32.const 1781
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31087,7 +31057,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1783
+   i32.const 1782
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31101,7 +31071,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1792
+   i32.const 1791
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31115,12 +31085,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1793
+   i32.const 1792
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8.381433486938477
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 2
+  call $std/math/test_log10f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1793
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -6.531673431396484
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -31134,20 +31118,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.531673431396484
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_log10f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1795
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const 9.267057418823242
   f32.const 0.9669418334960938
   f32.const -0.34273025393486023
@@ -31157,7 +31127,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1796
+   i32.const 1795
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31171,7 +31141,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1797
+   i32.const 1796
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31185,7 +31155,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1798
+   i32.const 1797
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31199,7 +31169,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1799
+   i32.const 1798
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31213,7 +31183,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1800
+   i32.const 1799
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31227,12 +31197,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1801
+   i32.const 1800
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
+  f32.const -inf
+  f32.const 0
+  i32.const 4
+  call $std/math/test_log10f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1803
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
   f32.const -inf
   f32.const 0
   i32.const 4
@@ -31246,20 +31230,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -inf
-  f32.const 0
-  i32.const 4
-  call $std/math/test_log10f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1805
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -7.888609052210118e-31
   f32.const nan:0x400000
   f32.const 0
@@ -31269,7 +31239,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1806
+   i32.const 1805
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31283,7 +31253,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1807
+   i32.const 1806
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31297,7 +31267,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1808
+   i32.const 1807
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31311,7 +31281,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1809
+   i32.const 1808
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31325,7 +31295,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1810
+   i32.const 1809
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31339,7 +31309,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1811
+   i32.const 1810
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31353,7 +31323,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1823
+   i32.const 1822
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31367,12 +31337,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1824
+   i32.const 1823
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.38143342755525
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 2
+  call $std/math/test_log1p
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1824
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -6.531673581913484
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -31386,20 +31370,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -6.531673581913484
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
-  call $std/math/test_log1p
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1826
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const 9.267056966972586
   f64.const 2.3289404168523826
   f64.const -0.411114901304245
@@ -31409,7 +31379,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1827
+   i32.const 1826
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31423,7 +31393,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1828
+   i32.const 1827
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31437,7 +31407,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1829
+   i32.const 1828
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31451,7 +31421,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1830
+   i32.const 1829
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31465,7 +31435,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1831
+   i32.const 1830
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31479,13 +31449,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1832
+   i32.const 1831
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_log1p
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1834
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_log1p
@@ -31494,20 +31478,6 @@
    i32.const 0
    i32.const 24
    i32.const 1835
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_log1p
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1836
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31521,7 +31491,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1837
+   i32.const 1836
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31535,7 +31505,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1838
+   i32.const 1837
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31549,7 +31519,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1839
+   i32.const 1838
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31563,7 +31533,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1840
+   i32.const 1839
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31577,7 +31547,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1841
+   i32.const 1840
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31591,7 +31561,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1842
+   i32.const 1841
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31605,7 +31575,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1851
+   i32.const 1850
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31619,12 +31589,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1852
+   i32.const 1851
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8.381433486938477
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 2
+  call $std/math/test_log1pf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1852
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -6.531673431396484
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -31638,20 +31622,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.531673431396484
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_log1pf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1854
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const 9.267057418823242
   f32.const 2.3289403915405273
   f32.const -0.29075589776039124
@@ -31661,7 +31631,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1855
+   i32.const 1854
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31675,7 +31645,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1856
+   i32.const 1855
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31689,7 +31659,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1857
+   i32.const 1856
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31703,7 +31673,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1858
+   i32.const 1857
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31717,7 +31687,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1859
+   i32.const 1858
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31731,13 +31701,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1860
+   i32.const 1859
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_log1pf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1862
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_log1pf
@@ -31746,20 +31730,6 @@
    i32.const 0
    i32.const 24
    i32.const 1863
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_log1pf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1864
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31773,7 +31743,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1865
+   i32.const 1864
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31787,7 +31757,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1866
+   i32.const 1865
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31801,7 +31771,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1867
+   i32.const 1866
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31815,7 +31785,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1868
+   i32.const 1867
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31829,7 +31799,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1869
+   i32.const 1868
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31843,7 +31813,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1870
+   i32.const 1869
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31857,7 +31827,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1871
+   i32.const 1870
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31871,7 +31841,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1883
+   i32.const 1882
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31885,7 +31855,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1884
+   i32.const 1883
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31899,7 +31869,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1885
+   i32.const 1884
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31913,7 +31883,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1886
+   i32.const 1885
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31927,7 +31897,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1887
+   i32.const 1886
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31941,7 +31911,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1888
+   i32.const 1887
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31955,7 +31925,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1889
+   i32.const 1888
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31969,7 +31939,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1890
+   i32.const 1889
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31983,7 +31953,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1891
+   i32.const 1890
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31997,7 +31967,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1892
+   i32.const 1891
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32011,7 +31981,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1895
+   i32.const 1894
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32025,7 +31995,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1896
+   i32.const 1895
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32039,7 +32009,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1897
+   i32.const 1896
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32053,7 +32023,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1898
+   i32.const 1897
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32067,7 +32037,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1899
+   i32.const 1898
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32081,7 +32051,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1900
+   i32.const 1899
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32095,7 +32065,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1901
+   i32.const 1900
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32109,7 +32079,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1902
+   i32.const 1901
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32123,7 +32093,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1911
+   i32.const 1910
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32137,7 +32107,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1912
+   i32.const 1911
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32151,7 +32121,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1913
+   i32.const 1912
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32165,7 +32135,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1914
+   i32.const 1913
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32179,7 +32149,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1915
+   i32.const 1914
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32193,7 +32163,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1916
+   i32.const 1915
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32207,7 +32177,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1917
+   i32.const 1916
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32221,7 +32191,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1918
+   i32.const 1917
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32235,7 +32205,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1919
+   i32.const 1918
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32249,7 +32219,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1920
+   i32.const 1919
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32263,7 +32233,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1923
+   i32.const 1922
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32277,7 +32247,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1924
+   i32.const 1923
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32291,7 +32261,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1925
+   i32.const 1924
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32305,7 +32275,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1926
+   i32.const 1925
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32319,7 +32289,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1927
+   i32.const 1926
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32333,7 +32303,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1928
+   i32.const 1927
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32347,7 +32317,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1929
+   i32.const 1928
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32361,7 +32331,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1930
+   i32.const 1929
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32376,7 +32346,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1942
+   i32.const 1941
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32391,7 +32361,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1943
+   i32.const 1942
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32406,7 +32376,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1944
+   i32.const 1943
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32421,7 +32391,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1945
+   i32.const 1944
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32436,7 +32406,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1946
+   i32.const 1945
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32451,7 +32421,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1947
+   i32.const 1946
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32466,7 +32436,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1948
+   i32.const 1947
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32481,7 +32451,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1949
+   i32.const 1948
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32496,7 +32466,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1950
+   i32.const 1949
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32511,12 +32481,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1951
+   i32.const 1950
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
+  f64.const 1
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1953
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
   f64.const 1
   f64.const 1
   f64.const 0
@@ -32531,7 +32516,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0.5
   f64.const 1
   f64.const 1
   f64.const 0
@@ -32546,7 +32531,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0.5
   f64.const 1
   f64.const 1
   f64.const 0
@@ -32561,7 +32546,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const 1
   f64.const 1
   f64.const 1
   f64.const 0
@@ -32576,7 +32561,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const 1
   f64.const 1
   f64.const 0
@@ -32591,9 +32576,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const 1
-  f64.const 1
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32606,9 +32591,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const 1
-  f64.const inf
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32621,9 +32606,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const 1
-  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32636,9 +32621,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const -1
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32651,9 +32636,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
+  f64.const -0
   f64.const -1
-  f64.const 0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32666,9 +32651,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0.5
   f64.const -1
-  f64.const -0
+  f64.const 0.5
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32681,9 +32666,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0.5
   f64.const -1
-  f64.const 0.5
+  f64.const -0.5
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32696,9 +32681,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const 1
   f64.const -1
-  f64.const -0.5
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32711,9 +32696,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
   f64.const -1
-  f64.const 1
+  f64.const -1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32726,9 +32711,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
   f64.const -1
-  f64.const -1
-  f64.const -1
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32737,21 +32722,6 @@
    i32.const 0
    i32.const 24
    i32.const 1968
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -1
-  f64.const inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1969
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32766,7 +32736,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1970
+   i32.const 1969
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32774,6 +32744,21 @@
   f64.const nan:0x8000000000000
   f64.const -1
   f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1970
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32787,7 +32772,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 0
+  f64.const -0
   f64.const 0
   f64.const 0
   i32.const 0
@@ -32802,8 +32787,8 @@
    unreachable
   end
   f64.const 0
-  f64.const -0
-  f64.const 0
+  f64.const inf
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32817,8 +32802,8 @@
    unreachable
   end
   f64.const 0
-  f64.const inf
-  f64.const inf
+  f64.const -inf
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32832,8 +32817,8 @@
    unreachable
   end
   f64.const 0
-  f64.const -inf
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32846,9 +32831,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32862,8 +32847,8 @@
    unreachable
   end
   f64.const -0
-  f64.const 0
-  f64.const 0
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32877,8 +32862,8 @@
    unreachable
   end
   f64.const -0
-  f64.const -0
-  f64.const -0
+  f64.const inf
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32892,8 +32877,8 @@
    unreachable
   end
   f64.const -0
-  f64.const inf
-  f64.const inf
+  f64.const -inf
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32907,8 +32892,8 @@
    unreachable
   end
   f64.const -0
-  f64.const -inf
-  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32921,9 +32906,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const 0
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32936,9 +32921,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const 0
-  f64.const 1
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32951,9 +32936,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const 0
-  f64.const 0
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32966,9 +32951,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const 0
-  f64.const inf
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32981,9 +32966,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const 0
-  f64.const 0
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32992,21 +32977,6 @@
    i32.const 0
    i32.const 24
    i32.const 1985
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1986
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33021,7 +32991,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1987
+   i32.const 1986
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33036,7 +33006,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1988
+   i32.const 1987
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33051,7 +33021,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1989
+   i32.const 1988
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33059,6 +33029,21 @@
   f64.const nan:0x8000000000000
   f64.const -0
   f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1989
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const 2
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33072,7 +33057,7 @@
    unreachable
   end
   f64.const inf
-  f64.const 2
+  f64.const -0.5
   f64.const inf
   f64.const 0
   i32.const 0
@@ -33087,8 +33072,8 @@
    unreachable
   end
   f64.const inf
-  f64.const -0.5
-  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33101,9 +33086,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const 2
+  f64.const 2
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33117,8 +33102,8 @@
    unreachable
   end
   f64.const -inf
-  f64.const 2
-  f64.const 2
+  f64.const -0.5
+  f64.const -0.5
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33132,8 +33117,8 @@
    unreachable
   end
   f64.const -inf
-  f64.const -0.5
-  f64.const -0.5
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33146,7 +33131,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -33161,7 +33146,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -33176,7 +33161,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -33191,9 +33176,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const inf
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33206,7 +33191,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const inf
   f64.const inf
   f64.const 0
@@ -33221,7 +33206,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const inf
   f64.const inf
   f64.const 0
@@ -33236,7 +33221,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const inf
   f64.const inf
   f64.const 0
@@ -33251,9 +33236,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
   f64.const -inf
-  f64.const inf
-  f64.const inf
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33266,9 +33251,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const -inf
-  f64.const 1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33281,9 +33266,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const -inf
-  f64.const -1
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33296,9 +33281,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
   f64.const -inf
-  f64.const inf
+  f64.const -inf
+  f64.const -inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33311,9 +33296,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
-  f64.const -inf
+  f64.const 1.75
+  f64.const 0.5
+  f64.const 1.75
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33326,9 +33311,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
+  f64.const -1.75
   f64.const 0.5
-  f64.const 1.75
+  f64.const 0.5
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33341,9 +33326,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.75
-  f64.const 0.5
-  f64.const 0.5
+  f64.const 1.75
+  f64.const -0.5
+  f64.const 1.75
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33356,21 +33341,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const -0.5
-  f64.const 1.75
-  f64.const 0
-  i32.const 0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2010
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -1.75
   f64.const -0.5
   f64.const -0.5
@@ -33381,7 +33351,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2011
+   i32.const 2010
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33396,7 +33366,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2020
+   i32.const 2019
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33411,7 +33381,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2021
+   i32.const 2020
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33426,7 +33396,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2022
+   i32.const 2021
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33441,7 +33411,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2023
+   i32.const 2022
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33456,7 +33426,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2024
+   i32.const 2023
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33471,7 +33441,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2025
+   i32.const 2024
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33486,7 +33456,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2026
+   i32.const 2025
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33501,7 +33471,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2027
+   i32.const 2026
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33516,7 +33486,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2028
+   i32.const 2027
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33531,12 +33501,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2029
+   i32.const 2028
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
+  f32.const 1
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2031
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
   f32.const 1
   f32.const 1
   f32.const 0
@@ -33551,7 +33536,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0.5
   f32.const 1
   f32.const 1
   f32.const 0
@@ -33566,7 +33551,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -0.5
   f32.const 1
   f32.const 1
   f32.const 0
@@ -33581,7 +33566,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const 1
   f32.const 1
   f32.const 1
   f32.const 0
@@ -33596,7 +33581,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const 1
   f32.const 1
   f32.const 0
@@ -33611,9 +33596,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const inf
   f32.const 1
-  f32.const 1
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33626,9 +33611,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const 1
-  f32.const inf
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33641,9 +33626,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const 1
-  f32.const 1
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33656,9 +33641,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const 1
-  f32.const nan:0x400000
+  f32.const 0
+  f32.const -1
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33671,9 +33656,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
+  f32.const -0
   f32.const -1
-  f32.const 0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33686,9 +33671,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0.5
   f32.const -1
-  f32.const -0
+  f32.const 0.5
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33701,9 +33686,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -0.5
   f32.const -1
-  f32.const 0.5
+  f32.const -0.5
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33716,9 +33701,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const 1
   f32.const -1
-  f32.const -0.5
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33731,9 +33716,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
   f32.const -1
-  f32.const 1
+  f32.const -1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33746,9 +33731,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
   f32.const -1
-  f32.const -1
-  f32.const -1
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33757,21 +33742,6 @@
    i32.const 0
    i32.const 24
    i32.const 2046
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -1
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2047
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33786,7 +33756,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2048
+   i32.const 2047
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33794,6 +33764,21 @@
   f32.const nan:0x400000
   f32.const -1
   f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2048
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33807,7 +33792,7 @@
    unreachable
   end
   f32.const 0
-  f32.const 0
+  f32.const -0
   f32.const 0
   f32.const 0
   i32.const 0
@@ -33822,8 +33807,8 @@
    unreachable
   end
   f32.const 0
-  f32.const -0
-  f32.const 0
+  f32.const inf
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33837,8 +33822,8 @@
    unreachable
   end
   f32.const 0
-  f32.const inf
-  f32.const inf
+  f32.const -inf
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33852,8 +33837,8 @@
    unreachable
   end
   f32.const 0
-  f32.const -inf
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33866,9 +33851,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const 0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33882,8 +33867,8 @@
    unreachable
   end
   f32.const -0
-  f32.const 0
-  f32.const 0
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33897,8 +33882,8 @@
    unreachable
   end
   f32.const -0
-  f32.const -0
-  f32.const -0
+  f32.const inf
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33912,8 +33897,8 @@
    unreachable
   end
   f32.const -0
-  f32.const inf
-  f32.const inf
+  f32.const -inf
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33927,8 +33912,8 @@
    unreachable
   end
   f32.const -0
-  f32.const -inf
-  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33941,9 +33926,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 1
+  f32.const 0
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33956,9 +33941,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const 0
-  f32.const 1
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33971,9 +33956,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const inf
   f32.const 0
-  f32.const 0
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33986,9 +33971,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const 0
-  f32.const inf
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34001,9 +33986,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const 0
-  f32.const 0
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34012,21 +33997,6 @@
    i32.const 0
    i32.const 24
    i32.const 2063
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 0
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2064
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34041,7 +34011,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2065
+   i32.const 2064
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34056,7 +34026,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2066
+   i32.const 2065
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34071,7 +34041,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2067
+   i32.const 2066
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34079,6 +34049,21 @@
   f32.const nan:0x400000
   f32.const -0
   f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2067
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const 2
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34092,7 +34077,7 @@
    unreachable
   end
   f32.const inf
-  f32.const 2
+  f32.const -0.5
   f32.const inf
   f32.const 0
   i32.const 0
@@ -34107,8 +34092,8 @@
    unreachable
   end
   f32.const inf
-  f32.const -0.5
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34121,9 +34106,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const 2
+  f32.const 2
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34137,8 +34122,8 @@
    unreachable
   end
   f32.const -inf
-  f32.const 2
-  f32.const 2
+  f32.const -0.5
+  f32.const -0.5
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34152,8 +34137,8 @@
    unreachable
   end
   f32.const -inf
-  f32.const -0.5
-  f32.const -0.5
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34166,7 +34151,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -34181,7 +34166,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const 1
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -34196,7 +34181,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -34211,9 +34196,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 1
+  f32.const inf
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34226,7 +34211,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const inf
   f32.const inf
   f32.const 0
@@ -34241,7 +34226,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const inf
   f32.const inf
   f32.const inf
   f32.const 0
@@ -34256,7 +34241,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const inf
   f32.const inf
   f32.const 0
@@ -34271,9 +34256,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1
   f32.const -inf
-  f32.const inf
-  f32.const inf
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34286,9 +34271,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const -inf
-  f32.const 1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34301,9 +34286,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const inf
   f32.const -inf
-  f32.const -1
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34316,9 +34301,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
   f32.const -inf
-  f32.const inf
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34331,9 +34316,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
-  f32.const -inf
+  f32.const 1.75
+  f32.const 0.5
+  f32.const 1.75
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34346,9 +34331,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
+  f32.const -1.75
   f32.const 0.5
-  f32.const 1.75
+  f32.const 0.5
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34361,9 +34346,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.75
-  f32.const 0.5
-  f32.const 0.5
+  f32.const 1.75
+  f32.const -0.5
+  f32.const 1.75
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34376,21 +34361,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
-  f32.const -0.5
-  f32.const 1.75
-  f32.const 0
-  i32.const 0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2088
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -1.75
   f32.const -0.5
   f32.const -0.5
@@ -34401,7 +34371,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2089
+   i32.const 2088
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34416,7 +34386,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2101
+   i32.const 2100
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34431,7 +34401,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2102
+   i32.const 2101
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34446,7 +34416,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2103
+   i32.const 2102
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34461,7 +34431,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2104
+   i32.const 2103
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34476,7 +34446,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2105
+   i32.const 2104
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34491,7 +34461,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2106
+   i32.const 2105
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34506,7 +34476,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2107
+   i32.const 2106
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34521,7 +34491,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2108
+   i32.const 2107
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34536,7 +34506,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2109
+   i32.const 2108
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34551,7 +34521,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2110
+   i32.const 2109
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34559,6 +34529,21 @@
   f64.const 0
   f64.const 1
   f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2112
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const 1
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34571,9 +34556,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0.5
   f64.const 1
-  f64.const -0
+  f64.const 0.5
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34586,9 +34571,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0.5
   f64.const 1
-  f64.const 0.5
+  f64.const -0.5
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34601,9 +34586,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
   f64.const 1
-  f64.const -0.5
+  f64.const 1
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34616,9 +34601,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
   f64.const 1
-  f64.const 1
-  f64.const 1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34627,21 +34612,6 @@
    i32.const 0
    i32.const 24
    i32.const 2117
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const 1
-  f64.const -1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2118
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34656,7 +34626,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2119
+   i32.const 2118
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34664,6 +34634,21 @@
   f64.const -inf
   f64.const 1
   f64.const -inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2119
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34676,9 +34661,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const -1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34691,7 +34676,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
+  f64.const -0
   f64.const -1
   f64.const -1
   f64.const 0
@@ -34706,7 +34691,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0.5
   f64.const -1
   f64.const -1
   f64.const 0
@@ -34721,7 +34706,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0.5
   f64.const -1
   f64.const -1
   f64.const 0
@@ -34736,7 +34721,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const 1
   f64.const -1
   f64.const -1
   f64.const 0
@@ -34751,7 +34736,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const -1
   f64.const -1
   f64.const 0
@@ -34766,7 +34751,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const -1
   f64.const -1
   f64.const 0
@@ -34781,9 +34766,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const -1
-  f64.const -1
+  f64.const -inf
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34796,9 +34781,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const -1
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34811,9 +34796,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -1
-  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34827,8 +34812,8 @@
    unreachable
   end
   f64.const 0
-  f64.const 0
-  f64.const 0
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34837,21 +34822,6 @@
    i32.const 0
    i32.const 24
    i32.const 2131
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2132
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34866,7 +34836,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2133
+   i32.const 2132
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34881,7 +34851,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2134
+   i32.const 2133
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34889,6 +34859,21 @@
   f64.const 0
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2134
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const 0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34902,7 +34887,7 @@
    unreachable
   end
   f64.const -0
-  f64.const 0
+  f64.const -0
   f64.const -0
   f64.const 0
   i32.const 0
@@ -34917,7 +34902,7 @@
    unreachable
   end
   f64.const -0
-  f64.const -0
+  f64.const inf
   f64.const -0
   f64.const 0
   i32.const 0
@@ -34932,8 +34917,8 @@
    unreachable
   end
   f64.const -0
-  f64.const inf
-  f64.const -0
+  f64.const -inf
+  f64.const -inf
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34947,8 +34932,8 @@
    unreachable
   end
   f64.const -0
-  f64.const -inf
-  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34957,21 +34942,6 @@
    i32.const 0
    i32.const 24
    i32.const 2139
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2140
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34986,7 +34956,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2141
+   i32.const 2140
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34994,6 +34964,21 @@
   f64.const -1
   f64.const 0
   f64.const -1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2141
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35006,9 +34991,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const 0
-  f64.const 0
+  f64.const -inf
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35021,9 +35006,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const 0
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35032,21 +35017,6 @@
    i32.const 0
    i32.const 24
    i32.const 2144
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2145
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35061,7 +35031,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2146
+   i32.const 2145
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35076,7 +35046,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2147
+   i32.const 2146
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35091,7 +35061,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2148
+   i32.const 2147
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35099,6 +35069,21 @@
   f64.const nan:0x8000000000000
   f64.const -0
   f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2148
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const 2
+  f64.const 2
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35112,8 +35097,8 @@
    unreachable
   end
   f64.const inf
-  f64.const 2
-  f64.const 2
+  f64.const -0.5
+  f64.const -0.5
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35127,8 +35112,8 @@
    unreachable
   end
   f64.const inf
-  f64.const -0.5
-  f64.const -0.5
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35141,9 +35126,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const 2
+  f64.const -inf
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35157,7 +35142,7 @@
    unreachable
   end
   f64.const -inf
-  f64.const 2
+  f64.const -0.5
   f64.const -inf
   f64.const 0
   i32.const 0
@@ -35172,8 +35157,8 @@
    unreachable
   end
   f64.const -inf
-  f64.const -0.5
-  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35186,7 +35171,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -35201,7 +35186,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -35216,7 +35201,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -35231,9 +35216,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const inf
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35246,9 +35231,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const inf
-  f64.const 1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35261,9 +35246,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
   f64.const inf
-  f64.const -1
+  f64.const inf
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35276,9 +35261,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -inf
   f64.const inf
-  f64.const inf
-  f64.const inf
+  f64.const -inf
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35291,8 +35276,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
   f64.const -inf
-  f64.const inf
   f64.const -inf
   f64.const 0
   i32.const 0
@@ -35306,7 +35291,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const -inf
   f64.const -inf
   f64.const 0
@@ -35321,7 +35306,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const -inf
   f64.const -inf
   f64.const 0
@@ -35336,7 +35321,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const -inf
   f64.const -inf
   f64.const 0
@@ -35351,9 +35336,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
-  f64.const -inf
+  f64.const 1.75
+  f64.const 0.5
+  f64.const 0.5
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35366,9 +35351,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
+  f64.const -1.75
   f64.const 0.5
-  f64.const 0.5
+  f64.const -1.75
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35381,9 +35366,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.75
-  f64.const 0.5
-  f64.const -1.75
+  f64.const 1.75
+  f64.const -0.5
+  f64.const -0.5
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35396,9 +35381,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
+  f64.const -1.75
   f64.const -0.5
-  f64.const -0.5
+  f64.const -1.75
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35407,21 +35392,6 @@
    i32.const 0
    i32.const 24
    i32.const 2169
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.75
-  f64.const -0.5
-  f64.const -1.75
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2170
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35436,7 +35406,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2179
+   i32.const 2178
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35451,7 +35421,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2180
+   i32.const 2179
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35466,7 +35436,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2181
+   i32.const 2180
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35481,7 +35451,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2182
+   i32.const 2181
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35496,7 +35466,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2183
+   i32.const 2182
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35511,7 +35481,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2184
+   i32.const 2183
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35526,7 +35496,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2185
+   i32.const 2184
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35541,7 +35511,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2186
+   i32.const 2185
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35556,7 +35526,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2187
+   i32.const 2186
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35571,7 +35541,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2188
+   i32.const 2187
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35579,6 +35549,21 @@
   f32.const 0
   f32.const 1
   f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2190
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 1
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35591,9 +35576,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0.5
   f32.const 1
-  f32.const -0
+  f32.const 0.5
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35606,9 +35591,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -0.5
   f32.const 1
-  f32.const 0.5
+  f32.const -0.5
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35621,9 +35606,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
   f32.const 1
-  f32.const -0.5
+  f32.const 1
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35636,9 +35621,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
   f32.const 1
-  f32.const 1
-  f32.const 1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35647,21 +35632,6 @@
    i32.const 0
    i32.const 24
    i32.const 2195
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const 1
-  f32.const -1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2196
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35676,7 +35646,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2197
+   i32.const 2196
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35684,6 +35654,21 @@
   f32.const -inf
   f32.const 1
   f32.const -inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2197
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const 1
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35696,9 +35681,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const 1
-  f32.const nan:0x400000
+  f32.const 0
+  f32.const -1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35711,7 +35696,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
+  f32.const -0
   f32.const -1
   f32.const -1
   f32.const 0
@@ -35726,7 +35711,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0.5
   f32.const -1
   f32.const -1
   f32.const 0
@@ -35741,7 +35726,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -0.5
   f32.const -1
   f32.const -1
   f32.const 0
@@ -35756,7 +35741,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const 1
   f32.const -1
   f32.const -1
   f32.const 0
@@ -35771,7 +35756,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const -1
   f32.const -1
   f32.const 0
@@ -35786,7 +35771,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const inf
   f32.const -1
   f32.const -1
   f32.const 0
@@ -35801,9 +35786,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const -1
-  f32.const -1
+  f32.const -inf
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35816,9 +35801,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const -1
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35831,9 +35816,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -1
-  f32.const nan:0x400000
+  f32.const 0
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35847,8 +35832,8 @@
    unreachable
   end
   f32.const 0
-  f32.const 0
-  f32.const 0
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35857,21 +35842,6 @@
    i32.const 0
    i32.const 24
    i32.const 2209
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2210
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35886,7 +35856,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2211
+   i32.const 2210
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35901,7 +35871,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2212
+   i32.const 2211
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35909,6 +35879,21 @@
   f32.const 0
   f32.const nan:0x400000
   f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2212
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35922,7 +35907,7 @@
    unreachable
   end
   f32.const -0
-  f32.const 0
+  f32.const -0
   f32.const -0
   f32.const 0
   i32.const 0
@@ -35937,7 +35922,7 @@
    unreachable
   end
   f32.const -0
-  f32.const -0
+  f32.const inf
   f32.const -0
   f32.const 0
   i32.const 0
@@ -35952,8 +35937,8 @@
    unreachable
   end
   f32.const -0
-  f32.const inf
-  f32.const -0
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35967,8 +35952,8 @@
    unreachable
   end
   f32.const -0
-  f32.const -inf
-  f32.const -inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35977,21 +35962,6 @@
    i32.const 0
    i32.const 24
    i32.const 2217
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2218
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36006,7 +35976,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2219
+   i32.const 2218
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36014,6 +35984,21 @@
   f32.const -1
   f32.const 0
   f32.const -1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2219
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36026,9 +36011,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const 0
-  f32.const 0
+  f32.const -inf
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36041,9 +36026,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const 0
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36052,21 +36037,6 @@
    i32.const 0
    i32.const 24
    i32.const 2222
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 0
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2223
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36081,7 +36051,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2224
+   i32.const 2223
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36096,7 +36066,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2225
+   i32.const 2224
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36111,7 +36081,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2226
+   i32.const 2225
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36119,6 +36089,21 @@
   f32.const nan:0x400000
   f32.const -0
   f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2226
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const 2
+  f32.const 2
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36132,8 +36117,8 @@
    unreachable
   end
   f32.const inf
-  f32.const 2
-  f32.const 2
+  f32.const -0.5
+  f32.const -0.5
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36147,8 +36132,8 @@
    unreachable
   end
   f32.const inf
-  f32.const -0.5
-  f32.const -0.5
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36161,9 +36146,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const 2
+  f32.const -inf
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36177,7 +36162,7 @@
    unreachable
   end
   f32.const -inf
-  f32.const 2
+  f32.const -0.5
   f32.const -inf
   f32.const 0
   i32.const 0
@@ -36192,8 +36177,8 @@
    unreachable
   end
   f32.const -inf
-  f32.const -0.5
-  f32.const -inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36206,7 +36191,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -36221,7 +36206,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const 1
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -36236,7 +36221,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -36251,9 +36236,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 1
+  f32.const inf
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36266,9 +36251,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const inf
-  f32.const 1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36281,9 +36266,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
   f32.const inf
-  f32.const -1
+  f32.const inf
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36296,9 +36281,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -inf
   f32.const inf
-  f32.const inf
-  f32.const inf
+  f32.const -inf
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36311,8 +36296,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1
   f32.const -inf
-  f32.const inf
   f32.const -inf
   f32.const 0
   i32.const 0
@@ -36326,7 +36311,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const -inf
   f32.const -inf
   f32.const 0
@@ -36341,7 +36326,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const inf
   f32.const -inf
   f32.const -inf
   f32.const 0
@@ -36356,7 +36341,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const -inf
   f32.const -inf
   f32.const 0
@@ -36371,9 +36356,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
-  f32.const -inf
+  f32.const 1.75
+  f32.const 0.5
+  f32.const 0.5
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36386,9 +36371,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
+  f32.const -1.75
   f32.const 0.5
-  f32.const 0.5
+  f32.const -1.75
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36401,9 +36386,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.75
-  f32.const 0.5
-  f32.const -1.75
+  f32.const 1.75
+  f32.const -0.5
+  f32.const -0.5
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36416,9 +36401,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
+  f32.const -1.75
   f32.const -0.5
-  f32.const -0.5
+  f32.const -1.75
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36427,21 +36412,6 @@
    i32.const 0
    i32.const 24
    i32.const 2247
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.75
-  f32.const -0.5
-  f32.const -1.75
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2248
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36456,7 +36426,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2262
+   i32.const 2261
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36471,7 +36441,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2263
+   i32.const 2262
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36486,7 +36456,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2264
+   i32.const 2263
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36501,7 +36471,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2265
+   i32.const 2264
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36516,7 +36486,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2266
+   i32.const 2265
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36531,7 +36501,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2267
+   i32.const 2266
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36546,7 +36516,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2268
+   i32.const 2267
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36561,7 +36531,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2269
+   i32.const 2268
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36576,7 +36546,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2270
+   i32.const 2269
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36591,7 +36561,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2271
+   i32.const 2270
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36599,6 +36569,21 @@
   f64.const 0
   f64.const 1
   f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2273
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const 1
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -36611,9 +36596,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0.5
   f64.const 1
-  f64.const -0
+  f64.const 0.5
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -36626,9 +36611,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0.5
   f64.const 1
-  f64.const 0.5
+  f64.const -0.5
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -36641,9 +36626,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
   f64.const 1
-  f64.const -0.5
+  f64.const 1
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -36652,21 +36637,6 @@
    i32.const 0
    i32.const 24
    i32.const 2277
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2278
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36681,7 +36651,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2279
+   i32.const 2278
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36696,7 +36666,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2280
+   i32.const 2279
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36711,7 +36681,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2281
+   i32.const 2280
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36726,7 +36696,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2282
+   i32.const 2281
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36741,12 +36711,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2283
+   i32.const 2282
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
+  f64.const 1
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 2
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2283
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
   f64.const 1
   f64.const nan:0x8000000000000
   f64.const 0
@@ -36761,11 +36746,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const 1
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -36776,9 +36761,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const -1
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -36791,9 +36776,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
+  f64.const -0
   f64.const -1
-  f64.const 0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -36806,9 +36791,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0.5
   f64.const -1
-  f64.const -0
+  f64.const 0.5
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -36821,9 +36806,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0.5
   f64.const -1
-  f64.const 0.5
+  f64.const -0.5
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -36832,21 +36817,6 @@
    i32.const 0
    i32.const 24
    i32.const 2289
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const -1
-  f64.const -0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2290
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36861,7 +36831,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2291
+   i32.const 2290
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36876,7 +36846,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2292
+   i32.const 2291
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36891,7 +36861,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2293
+   i32.const 2292
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36906,7 +36876,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2294
+   i32.const 2293
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36921,7 +36891,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2295
+   i32.const 2294
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36936,12 +36906,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2296
+   i32.const 2295
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 2
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2296
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
   f64.const -1
   f64.const nan:0x8000000000000
   f64.const 0
@@ -36956,11 +36941,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const -1
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -36971,11 +36956,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -1
+  f64.const 0
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_mod
   i32.eqz
   if
@@ -36987,7 +36972,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 0
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -37002,10 +36987,10 @@
    unreachable
   end
   f64.const 0
-  f64.const -0
-  f64.const nan:0x8000000000000
+  f64.const inf
   f64.const 0
-  i32.const 2
+  f64.const 0
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -37017,7 +37002,7 @@
    unreachable
   end
   f64.const 0
-  f64.const inf
+  f64.const -inf
   f64.const 0
   f64.const 0
   i32.const 0
@@ -37032,8 +37017,8 @@
    unreachable
   end
   f64.const 0
-  f64.const -inf
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37046,11 +37031,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const 0
   f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_mod
   i32.eqz
   if
@@ -37062,7 +37047,7 @@
    unreachable
   end
   f64.const -0
-  f64.const 0
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -37077,10 +37062,10 @@
    unreachable
   end
   f64.const -0
+  f64.const inf
   f64.const -0
-  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -37092,7 +37077,7 @@
    unreachable
   end
   f64.const -0
-  f64.const inf
+  f64.const -inf
   f64.const -0
   f64.const 0
   i32.const 0
@@ -37107,8 +37092,8 @@
    unreachable
   end
   f64.const -0
-  f64.const -inf
-  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37121,11 +37106,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_mod
   i32.eqz
   if
@@ -37136,7 +37121,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -37151,7 +37136,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -37166,7 +37151,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -37181,21 +37166,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2313
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const nan:0x8000000000000
   f64.const 0
   f64.const nan:0x8000000000000
@@ -37206,12 +37176,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2314
+   i32.const 2313
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1
+  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 2
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2314
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
   f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -37226,7 +37211,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -37241,11 +37226,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -37256,11 +37241,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -0
+  f64.const inf
+  f64.const 2
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_mod
   i32.eqz
   if
@@ -37272,7 +37257,7 @@
    unreachable
   end
   f64.const inf
-  f64.const 2
+  f64.const -0.5
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -37287,10 +37272,10 @@
    unreachable
   end
   f64.const inf
-  f64.const -0.5
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -37301,11 +37286,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const 2
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_mod
   i32.eqz
   if
@@ -37317,7 +37302,7 @@
    unreachable
   end
   f64.const -inf
-  f64.const 2
+  f64.const -0.5
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -37332,10 +37317,10 @@
    unreachable
   end
   f64.const -inf
-  f64.const -0.5
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -37346,7 +37331,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -37361,7 +37346,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -37376,7 +37361,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -37391,9 +37376,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const inf
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37406,9 +37391,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const inf
-  f64.const 1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37421,11 +37406,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
   f64.const inf
-  f64.const -1
+  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_mod
   i32.eqz
   if
@@ -37436,7 +37421,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const inf
   f64.const nan:0x8000000000000
   f64.const 0
@@ -37451,11 +37436,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
   f64.const -inf
-  f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -37466,9 +37451,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const -inf
-  f64.const 1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37481,11 +37466,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const -inf
-  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_mod
   i32.eqz
   if
@@ -37496,7 +37481,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const -inf
   f64.const nan:0x8000000000000
   f64.const 0
@@ -37511,11 +37496,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
-  f64.const nan:0x8000000000000
+  f64.const 1.75
+  f64.const 0.5
+  f64.const 0.25
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -37526,9 +37511,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
+  f64.const -1.75
   f64.const 0.5
-  f64.const 0.25
+  f64.const -0.25
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37541,9 +37526,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.75
-  f64.const 0.5
-  f64.const -0.25
+  f64.const 1.75
+  f64.const -0.5
+  f64.const 0.25
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37556,9 +37541,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
+  f64.const -1.75
   f64.const -0.5
-  f64.const 0.25
+  f64.const -0.25
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37571,9 +37556,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.75
-  f64.const -0.5
-  f64.const -0.25
+  f64.const 2.2250738585072014e-308
+  f64.const 2.2250738585072014e-308
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37581,13 +37566,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2339
+   i32.const 2341
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.2250738585072014e-308
-  f64.const 2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
   f64.const 0
   f64.const 0
   i32.const 0
@@ -37601,9 +37586,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072014e-308
   f64.const -2.2250738585072014e-308
-  f64.const 0
+  f64.const 2.2250738585072014e-308
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37617,7 +37602,7 @@
    unreachable
   end
   f64.const -2.2250738585072014e-308
-  f64.const 2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
   f64.const -0
   f64.const 0
   i32.const 0
@@ -37631,9 +37616,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
-  f64.const -0
+  f64.const 1797693134862315708145274e284
+  f64.const 1797693134862315708145274e284
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37647,7 +37632,7 @@
    unreachable
   end
   f64.const 1797693134862315708145274e284
-  f64.const 1797693134862315708145274e284
+  f64.const -1797693134862315708145274e284
   f64.const 0
   f64.const 0
   i32.const 0
@@ -37661,9 +37646,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1797693134862315708145274e284
   f64.const -1797693134862315708145274e284
-  f64.const 0
+  f64.const 1797693134862315708145274e284
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37677,7 +37662,7 @@
    unreachable
   end
   f64.const -1797693134862315708145274e284
-  f64.const 1797693134862315708145274e284
+  f64.const -1797693134862315708145274e284
   f64.const -0
   f64.const 0
   i32.const 0
@@ -37691,9 +37676,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1797693134862315708145274e284
-  f64.const -1797693134862315708145274e284
-  f64.const -0
+  f64.const 0
+  f64.const 2.2250738585072014e-308
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37701,13 +37686,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2349
+   i32.const 2351
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  f64.const 2.2250738585072014e-308
+  f64.const 1797693134862315708145274e284
   f64.const 0
   f64.const 0
   i32.const 0
@@ -37722,7 +37707,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 1797693134862315708145274e284
+  f64.const -2.2250738585072014e-308
   f64.const 0
   f64.const 0
   i32.const 0
@@ -37737,7 +37722,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -2.2250738585072014e-308
+  f64.const -1797693134862315708145274e284
   f64.const 0
   f64.const 0
   i32.const 0
@@ -37751,9 +37736,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -1797693134862315708145274e284
-  f64.const 0
+  f64.const -0
+  f64.const 2.2250738585072014e-308
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37767,7 +37752,7 @@
    unreachable
   end
   f64.const -0
-  f64.const 2.2250738585072014e-308
+  f64.const 1797693134862315708145274e284
   f64.const -0
   f64.const 0
   i32.const 0
@@ -37782,7 +37767,7 @@
    unreachable
   end
   f64.const -0
-  f64.const 1797693134862315708145274e284
+  f64.const -2.2250738585072014e-308
   f64.const -0
   f64.const 0
   i32.const 0
@@ -37797,7 +37782,7 @@
    unreachable
   end
   f64.const -0
-  f64.const -2.2250738585072014e-308
+  f64.const -1797693134862315708145274e284
   f64.const -0
   f64.const 0
   i32.const 0
@@ -37811,9 +37796,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -1797693134862315708145274e284
-  f64.const -0
+  f64.const 1797693134862315708145274e284
+  f64.const 1797693134862315508561243e284
+  f64.const 1995840309534719811656372e268
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37821,14 +37806,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2359
+   i32.const 2361
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1797693134862315708145274e284
+  f64.const -1797693134862315708145274e284
   f64.const 1797693134862315508561243e284
-  f64.const 1995840309534719811656372e268
+  f64.const -1995840309534719811656372e268
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37841,21 +37826,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1797693134862315708145274e284
-  f64.const 1797693134862315508561243e284
-  f64.const -1995840309534719811656372e268
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2363
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const 1797693134862315708145274e284
   f64.const -8988465674311579538646525e283
   f64.const 8988465674311577542806216e283
@@ -37866,7 +37836,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2365
+   i32.const 2364
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37881,7 +37851,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2366
+   i32.const 2365
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37896,7 +37866,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2368
+   i32.const 2367
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37911,7 +37881,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2369
+   i32.const 2368
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37926,7 +37896,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2371
+   i32.const 2370
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37941,7 +37911,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2372
+   i32.const 2371
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37949,6 +37919,21 @@
   f64.const 8988465674311579538646525e283
   f64.const 1797693134862315708145274e284
   f64.const 8988465674311579538646525e283
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2373
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -8988465674311579538646525e283
+  f64.const 1797693134862315708145274e284
+  f64.const -8988465674311579538646525e283
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37961,9 +37946,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8988465674311579538646525e283
-  f64.const 1797693134862315708145274e284
-  f64.const -8988465674311579538646525e283
+  f64.const 8988465674311578540726371e283
+  f64.const -1797693134862315708145274e284
+  f64.const 8988465674311578540726371e283
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37971,14 +37956,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2375
+   i32.const 2376
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 8988465674311578540726371e283
+  f64.const -8988465674311578540726371e283
   f64.const -1797693134862315708145274e284
-  f64.const 8988465674311578540726371e283
+  f64.const -8988465674311578540726371e283
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37991,9 +37976,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8988465674311578540726371e283
-  f64.const -1797693134862315708145274e284
-  f64.const -8988465674311578540726371e283
+  f64.const 8988465674311577542806216e283
+  f64.const 1797693134862315708145274e284
+  f64.const 8988465674311577542806216e283
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -38001,14 +37986,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2378
+   i32.const 2379
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 8988465674311577542806216e283
+  f64.const -8988465674311577542806216e283
   f64.const 1797693134862315708145274e284
-  f64.const 8988465674311577542806216e283
+  f64.const -8988465674311577542806216e283
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -38021,9 +38006,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8988465674311577542806216e283
-  f64.const 1797693134862315708145274e284
-  f64.const -8988465674311577542806216e283
+  f64.const 1797693134862315508561243e284
+  f64.const -1797693134862315708145274e284
+  f64.const 1797693134862315508561243e284
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -38031,14 +38016,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2381
+   i32.const 2382
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1797693134862315508561243e284
+  f64.const -1797693134862315508561243e284
   f64.const -1797693134862315708145274e284
-  f64.const 1797693134862315508561243e284
+  f64.const -1797693134862315508561243e284
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -38047,21 +38032,6 @@
    i32.const 0
    i32.const 24
    i32.const 2383
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1797693134862315508561243e284
-  f64.const -1797693134862315708145274e284
-  f64.const -1797693134862315508561243e284
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2384
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38076,7 +38046,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2386
+   i32.const 2385
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38091,7 +38061,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2387
+   i32.const 2386
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38106,7 +38076,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2389
+   i32.const 2388
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38121,7 +38091,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2390
+   i32.const 2389
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38136,7 +38106,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2391
+   i32.const 2390
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38151,7 +38121,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2392
+   i32.const 2391
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38166,7 +38136,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2393
+   i32.const 2392
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38181,7 +38151,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2394
+   i32.const 2393
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38196,7 +38166,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2395
+   i32.const 2394
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38211,7 +38181,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2396
+   i32.const 2395
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38226,7 +38196,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2398
+   i32.const 2397
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38241,7 +38211,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2399
+   i32.const 2398
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38256,13 +38226,28 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2400
+   i32.const 2399
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.225073858507201e-308
   f64.const 4.4501477170144023e-308
+  f64.const 2.225073858507201e-308
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2400
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.225073858507201e-308
+  f64.const inf
   f64.const 2.225073858507201e-308
   f64.const 0
   i32.const 0
@@ -38277,21 +38262,6 @@
    unreachable
   end
   f64.const 2.225073858507201e-308
-  f64.const inf
-  f64.const 2.225073858507201e-308
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2402
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507201e-308
   f64.const -1.5e-323
   f64.const 0
   f64.const 0
@@ -38301,7 +38271,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2403
+   i32.const 2402
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38316,7 +38286,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2404
+   i32.const 2403
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38331,7 +38301,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2405
+   i32.const 2404
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38346,7 +38316,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2406
+   i32.const 2405
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38361,7 +38331,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2407
+   i32.const 2406
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38376,13 +38346,28 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2408
+   i32.const 2407
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.2250738585072024e-308
   f64.const 1.5e-323
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2408
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.2250738585072024e-308
+  f64.const -1.5e-323
   f64.const 0
   f64.const 0
   i32.const 0
@@ -38396,9 +38381,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072024e-308
-  f64.const -1.5e-323
-  f64.const 0
+  f64.const 2.225073858507203e-308
+  f64.const 1.5e-323
+  f64.const 5e-324
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -38412,21 +38397,6 @@
    unreachable
   end
   f64.const 2.225073858507203e-308
-  f64.const 1.5e-323
-  f64.const 5e-324
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2411
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507203e-308
   f64.const 2.225073858507204e-308
   f64.const 2.225073858507203e-308
   f64.const 0
@@ -38436,7 +38406,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2412
+   i32.const 2411
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38451,7 +38421,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2413
+   i32.const 2412
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38466,7 +38436,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2414
+   i32.const 2413
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38481,7 +38451,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2415
+   i32.const 2414
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38496,7 +38466,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2416
+   i32.const 2415
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38511,7 +38481,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2417
+   i32.const 2416
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38526,7 +38496,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2426
+   i32.const 2425
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38541,7 +38511,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2427
+   i32.const 2426
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38556,7 +38526,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2428
+   i32.const 2427
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38571,7 +38541,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2429
+   i32.const 2428
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38586,7 +38556,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2430
+   i32.const 2429
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38601,7 +38571,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2431
+   i32.const 2430
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38616,7 +38586,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2432
+   i32.const 2431
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38631,7 +38601,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2433
+   i32.const 2432
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38646,7 +38616,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2434
+   i32.const 2433
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38661,7 +38631,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2435
+   i32.const 2434
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38669,6 +38639,21 @@
   f32.const 0
   f32.const 1
   f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2437
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 1
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -38681,9 +38666,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0.5
   f32.const 1
-  f32.const -0
+  f32.const 0.5
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -38696,9 +38681,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -0.5
   f32.const 1
-  f32.const 0.5
+  f32.const -0.5
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -38711,9 +38696,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
   f32.const 1
-  f32.const -0.5
+  f32.const 1
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -38722,21 +38707,6 @@
    i32.const 0
    i32.const 24
    i32.const 2441
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2442
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38751,7 +38721,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2443
+   i32.const 2442
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38766,7 +38736,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2444
+   i32.const 2443
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38781,7 +38751,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2445
+   i32.const 2444
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38796,7 +38766,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2446
+   i32.const 2445
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38811,12 +38781,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2447
+   i32.const 2446
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const inf
+  f32.const 1
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 2
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2447
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
   f32.const 1
   f32.const nan:0x400000
   f32.const 0
@@ -38831,11 +38816,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const 1
   f32.const nan:0x400000
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -38846,9 +38831,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const 1
-  f32.const nan:0x400000
+  f32.const 0
+  f32.const -1
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -38861,9 +38846,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
+  f32.const -0
   f32.const -1
-  f32.const 0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -38876,9 +38861,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0.5
   f32.const -1
-  f32.const -0
+  f32.const 0.5
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -38891,9 +38876,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -0.5
   f32.const -1
-  f32.const 0.5
+  f32.const -0.5
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -38902,21 +38887,6 @@
    i32.const 0
    i32.const 24
    i32.const 2453
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const -1
-  f32.const -0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2454
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38931,7 +38901,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2455
+   i32.const 2454
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38946,7 +38916,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2456
+   i32.const 2455
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38961,7 +38931,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2457
+   i32.const 2456
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38976,7 +38946,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2458
+   i32.const 2457
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38991,7 +38961,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2459
+   i32.const 2458
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39006,12 +38976,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2460
+   i32.const 2459
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const inf
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 2
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2460
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
   f32.const -1
   f32.const nan:0x400000
   f32.const 0
@@ -39026,11 +39011,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const -1
   f32.const nan:0x400000
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -39041,11 +39026,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -1
+  f32.const 0
+  f32.const 0
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_modf
   i32.eqz
   if
@@ -39057,7 +39042,7 @@
    unreachable
   end
   f32.const 0
-  f32.const 0
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -39072,10 +39057,10 @@
    unreachable
   end
   f32.const 0
-  f32.const -0
-  f32.const nan:0x400000
+  f32.const inf
   f32.const 0
-  i32.const 2
+  f32.const 0
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -39087,7 +39072,7 @@
    unreachable
   end
   f32.const 0
-  f32.const inf
+  f32.const -inf
   f32.const 0
   f32.const 0
   i32.const 0
@@ -39102,8 +39087,8 @@
    unreachable
   end
   f32.const 0
-  f32.const -inf
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -39116,11 +39101,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const 0
   f32.const nan:0x400000
-  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_modf
   i32.eqz
   if
@@ -39132,7 +39117,7 @@
    unreachable
   end
   f32.const -0
-  f32.const 0
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -39147,10 +39132,10 @@
    unreachable
   end
   f32.const -0
+  f32.const inf
   f32.const -0
-  f32.const nan:0x400000
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -39162,7 +39147,7 @@
    unreachable
   end
   f32.const -0
-  f32.const inf
+  f32.const -inf
   f32.const -0
   f32.const 0
   i32.const 0
@@ -39177,8 +39162,8 @@
    unreachable
   end
   f32.const -0
-  f32.const -inf
-  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -39191,11 +39176,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const nan:0x400000
+  f32.const 1
+  f32.const 0
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_modf
   i32.eqz
   if
@@ -39206,7 +39191,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const 0
   f32.const nan:0x400000
   f32.const 0
@@ -39221,7 +39206,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const inf
   f32.const 0
   f32.const nan:0x400000
   f32.const 0
@@ -39236,7 +39221,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const 0
   f32.const nan:0x400000
   f32.const 0
@@ -39251,21 +39236,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const 0
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2477
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const nan:0x400000
   f32.const 0
   f32.const nan:0x400000
@@ -39276,12 +39246,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2478
+   i32.const 2477
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1
+  f32.const -0
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 2
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2478
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
   f32.const -0
   f32.const nan:0x400000
   f32.const 0
@@ -39296,7 +39281,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const -0
   f32.const nan:0x400000
   f32.const 0
@@ -39311,11 +39296,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const -0
   f32.const nan:0x400000
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -39326,11 +39311,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -0
+  f32.const inf
+  f32.const 2
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_modf
   i32.eqz
   if
@@ -39342,7 +39327,7 @@
    unreachable
   end
   f32.const inf
-  f32.const 2
+  f32.const -0.5
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -39357,21 +39342,6 @@
    unreachable
   end
   f32.const inf
-  f32.const -0.5
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2484
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -39381,7 +39351,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2485
+   i32.const 2484
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39396,7 +39366,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2486
+   i32.const 2485
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39411,12 +39381,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2487
+   i32.const 2486
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2487
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -39431,7 +39416,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const 1
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -39446,7 +39431,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -39461,9 +39446,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 1
+  f32.const inf
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -39476,9 +39461,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const inf
-  f32.const 1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -39491,11 +39476,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
   f32.const inf
-  f32.const -1
+  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_modf
   i32.eqz
   if
@@ -39506,7 +39491,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const inf
   f32.const nan:0x400000
   f32.const 0
@@ -39521,11 +39506,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1
   f32.const -inf
-  f32.const inf
-  f32.const nan:0x400000
+  f32.const 1
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -39536,9 +39521,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const -inf
-  f32.const 1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -39551,11 +39536,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const inf
   f32.const -inf
-  f32.const -1
+  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_modf
   i32.eqz
   if
@@ -39566,7 +39551,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const -inf
   f32.const nan:0x400000
   f32.const 0
@@ -39581,11 +39566,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
-  f32.const nan:0x400000
+  f32.const 1.75
+  f32.const 0.5
+  f32.const 0.25
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -39596,9 +39581,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
+  f32.const -1.75
   f32.const 0.5
-  f32.const 0.25
+  f32.const -0.25
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -39611,9 +39596,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.75
-  f32.const 0.5
-  f32.const -0.25
+  f32.const 1.75
+  f32.const -0.5
+  f32.const 0.25
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -39626,21 +39611,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
-  f32.const -0.5
-  f32.const 0.25
-  f32.const 0
-  i32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2502
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -1.75
   f32.const -0.5
   f32.const -0.25
@@ -39651,7 +39621,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2503
+   i32.const 2502
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39666,7 +39636,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2515
+   i32.const 2514
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39681,7 +39651,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2516
+   i32.const 2515
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39696,7 +39666,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2517
+   i32.const 2516
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39711,7 +39681,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2518
+   i32.const 2517
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39726,7 +39696,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2519
+   i32.const 2518
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39741,7 +39711,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2520
+   i32.const 2519
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39756,7 +39726,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2521
+   i32.const 2520
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39771,7 +39741,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2522
+   i32.const 2521
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39786,7 +39756,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2523
+   i32.const 2522
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39801,7 +39771,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2524
+   i32.const 2523
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39816,13 +39786,28 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2527
+   i32.const 2526
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const inf
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2527
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 3
   f64.const 0
   f64.const 0
   i32.const 0
@@ -39837,7 +39822,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 3
+  f64.const 2
   f64.const 0
   f64.const 0
   i32.const 0
@@ -39852,7 +39837,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 2
+  f64.const 1
   f64.const 0
   f64.const 0
   i32.const 0
@@ -39867,7 +39852,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 1
+  f64.const 0.5
   f64.const 0
   f64.const 0
   i32.const 0
@@ -39882,8 +39867,8 @@
    unreachable
   end
   f64.const 0
-  f64.const 0.5
   f64.const 0
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -39897,7 +39882,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 0
+  f64.const -0
   f64.const 1
   f64.const 0
   i32.const 0
@@ -39912,10 +39897,10 @@
    unreachable
   end
   f64.const 0
-  f64.const -0
-  f64.const 1
+  f64.const -0.5
+  f64.const inf
   f64.const 0
-  i32.const 0
+  i32.const 4
   call $std/math/test_pow
   i32.eqz
   if
@@ -39927,7 +39912,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -0.5
+  f64.const -1
   f64.const inf
   f64.const 0
   i32.const 4
@@ -39942,7 +39927,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -1
+  f64.const -2
   f64.const inf
   f64.const 0
   i32.const 4
@@ -39957,7 +39942,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -2
+  f64.const -3
   f64.const inf
   f64.const 0
   i32.const 4
@@ -39972,7 +39957,7 @@
    unreachable
   end
   f64.const 0
-  f64.const -3
+  f64.const -4
   f64.const inf
   f64.const 0
   i32.const 4
@@ -39987,10 +39972,10 @@
    unreachable
   end
   f64.const 0
-  f64.const -4
+  f64.const -inf
   f64.const inf
   f64.const 0
-  i32.const 4
+  i32.const 0
   call $std/math/test_pow
   i32.eqz
   if
@@ -40001,9 +39986,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -inf
-  f64.const inf
+  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40017,21 +40002,6 @@
    unreachable
   end
   f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2541
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
   f64.const inf
   f64.const 0
   f64.const 0
@@ -40041,7 +40011,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2542
+   i32.const 2541
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40056,7 +40026,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2543
+   i32.const 2542
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40071,7 +40041,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2544
+   i32.const 2543
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40086,7 +40056,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2545
+   i32.const 2544
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40101,13 +40071,28 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2546
+   i32.const 2545
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -0
   f64.const 0
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2546
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
   f64.const 1
   f64.const 0
   i32.const 0
@@ -40122,21 +40107,6 @@
    unreachable
   end
   f64.const -0
-  f64.const -0
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2548
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
   f64.const -0.5
   f64.const inf
   f64.const 0
@@ -40146,7 +40116,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2549
+   i32.const 2548
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40161,7 +40131,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2550
+   i32.const 2549
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40176,7 +40146,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2551
+   i32.const 2550
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40191,7 +40161,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2552
+   i32.const 2551
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40206,7 +40176,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2553
+   i32.const 2552
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40221,12 +40191,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2554
+   i32.const 2553
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2554
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
   f64.const 0
   f64.const 1
   f64.const 0
@@ -40241,7 +40226,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const 0
   f64.const 1
   f64.const 0
@@ -40256,7 +40241,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const 1
   f64.const 0
   f64.const 1
   f64.const 0
@@ -40271,7 +40256,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const 0
   f64.const 1
   f64.const 0
@@ -40286,7 +40271,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const -0.5
   f64.const 0
   f64.const 1
   f64.const 0
@@ -40301,8 +40286,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const -0
   f64.const 1
   f64.const 0
   i32.const 0
@@ -40316,7 +40301,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const inf
   f64.const -0
   f64.const 1
   f64.const 0
@@ -40331,7 +40316,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const -0
   f64.const 1
   f64.const 0
@@ -40346,7 +40331,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const 1
   f64.const -0
   f64.const 1
   f64.const 0
@@ -40361,7 +40346,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const -0
   f64.const 1
   f64.const 0
@@ -40376,7 +40361,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const -0.5
   f64.const -0
   f64.const 1
   f64.const 0
@@ -40391,9 +40376,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
-  f64.const -0
-  f64.const 1
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40407,7 +40392,7 @@
    unreachable
   end
   f64.const -1
-  f64.const nan:0x8000000000000
+  f64.const inf
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
@@ -40422,7 +40407,7 @@
    unreachable
   end
   f64.const -1
-  f64.const inf
+  f64.const -inf
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
@@ -40437,8 +40422,8 @@
    unreachable
   end
   f64.const -1
-  f64.const -inf
-  f64.const nan:0x8000000000000
+  f64.const 2
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40452,8 +40437,8 @@
    unreachable
   end
   f64.const -1
-  f64.const 2
-  f64.const 1
+  f64.const -1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40462,21 +40447,6 @@
    i32.const 0
    i32.const 24
    i32.const 2570
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -1
-  f64.const -1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2571
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40491,7 +40461,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2572
+   i32.const 2571
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40506,7 +40476,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2573
+   i32.const 2572
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40521,13 +40491,28 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2574
+   i32.const 2573
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1
   f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2574
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const inf
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
@@ -40542,7 +40527,7 @@
    unreachable
   end
   f64.const 1
-  f64.const inf
+  f64.const -inf
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
@@ -40557,8 +40542,8 @@
    unreachable
   end
   f64.const 1
-  f64.const -inf
-  f64.const nan:0x8000000000000
+  f64.const 3
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40572,7 +40557,7 @@
    unreachable
   end
   f64.const 1
-  f64.const 3
+  f64.const 0.5
   f64.const 1
   f64.const 0
   i32.const 0
@@ -40587,7 +40572,7 @@
    unreachable
   end
   f64.const 1
-  f64.const 0.5
+  f64.const -0.5
   f64.const 1
   f64.const 0
   i32.const 0
@@ -40602,7 +40587,7 @@
    unreachable
   end
   f64.const 1
-  f64.const -0.5
+  f64.const -3
   f64.const 1
   f64.const 0
   i32.const 0
@@ -40616,11 +40601,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const -3
-  f64.const 1
+  f64.const -0.5
+  f64.const 0.5
+  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_pow
   i32.eqz
   if
@@ -40632,7 +40617,7 @@
    unreachable
   end
   f64.const -0.5
-  f64.const 0.5
+  f64.const 1.5
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -40647,21 +40632,6 @@
    unreachable
   end
   f64.const -0.5
-  f64.const 1.5
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2583
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
   f64.const 2
   f64.const 0.25
   f64.const 0
@@ -40671,7 +40641,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2584
+   i32.const 2583
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40686,7 +40656,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2585
+   i32.const 2584
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40694,6 +40664,21 @@
   f64.const -0.5
   f64.const inf
   f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2585
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.5
+  f64.const -inf
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40707,8 +40692,8 @@
    unreachable
   end
   f64.const -0.5
-  f64.const -inf
-  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40721,9 +40706,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 0.5
+  f64.const inf
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40737,8 +40722,8 @@
    unreachable
   end
   f64.const 0.5
+  f64.const -inf
   f64.const inf
-  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40752,8 +40737,8 @@
    unreachable
   end
   f64.const 0.5
-  f64.const -inf
-  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40766,9 +40751,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 1.5
+  f64.const inf
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40782,8 +40767,8 @@
    unreachable
   end
   f64.const 1.5
-  f64.const inf
-  f64.const inf
+  f64.const -inf
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40797,8 +40782,8 @@
    unreachable
   end
   f64.const 1.5
-  f64.const -inf
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40811,7 +40796,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5
+  f64.const inf
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -40827,8 +40812,8 @@
    unreachable
   end
   f64.const inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40837,21 +40822,6 @@
    i32.const 0
    i32.const 24
    i32.const 2595
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  f64.const inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2596
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40866,13 +40836,28 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2597
+   i32.const 2596
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
   f64.const 3
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2597
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const 2
   f64.const inf
   f64.const 0
   i32.const 0
@@ -40887,7 +40872,7 @@
    unreachable
   end
   f64.const inf
-  f64.const 2
+  f64.const 1
   f64.const inf
   f64.const 0
   i32.const 0
@@ -40902,7 +40887,7 @@
    unreachable
   end
   f64.const inf
-  f64.const 1
+  f64.const 0.5
   f64.const inf
   f64.const 0
   i32.const 0
@@ -40917,8 +40902,8 @@
    unreachable
   end
   f64.const inf
-  f64.const 0.5
-  f64.const inf
+  f64.const -0.5
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40932,7 +40917,7 @@
    unreachable
   end
   f64.const inf
-  f64.const -0.5
+  f64.const -1
   f64.const 0
   f64.const 0
   i32.const 0
@@ -40947,7 +40932,7 @@
    unreachable
   end
   f64.const inf
-  f64.const -1
+  f64.const -2
   f64.const 0
   f64.const 0
   i32.const 0
@@ -40961,9 +40946,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const -2
-  f64.const 0
+  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40977,8 +40962,8 @@
    unreachable
   end
   f64.const -inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40992,8 +40977,8 @@
    unreachable
   end
   f64.const -inf
-  f64.const inf
-  f64.const inf
+  f64.const -inf
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -41002,21 +40987,6 @@
    i32.const 0
    i32.const 24
    i32.const 2606
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -inf
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2607
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41031,7 +41001,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2608
+   i32.const 2607
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41046,7 +41016,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2609
+   i32.const 2608
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41061,7 +41031,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2610
+   i32.const 2609
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41076,7 +41046,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2611
+   i32.const 2610
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41091,7 +41061,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2612
+   i32.const 2611
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41106,7 +41076,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2613
+   i32.const 2612
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41121,7 +41091,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2614
+   i32.const 2613
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41136,7 +41106,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2615
+   i32.const 2614
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41151,7 +41121,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2616
+   i32.const 2615
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41166,7 +41136,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2617
+   i32.const 2616
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41181,7 +41151,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2618
+   i32.const 2617
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41196,7 +41166,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2627
+   i32.const 2626
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41211,7 +41181,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2628
+   i32.const 2627
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41226,7 +41196,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2629
+   i32.const 2628
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41241,7 +41211,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2630
+   i32.const 2629
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41256,7 +41226,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2631
+   i32.const 2630
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41271,7 +41241,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2632
+   i32.const 2631
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41286,7 +41256,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2633
+   i32.const 2632
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41301,7 +41271,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2634
+   i32.const 2633
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41316,7 +41286,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2635
+   i32.const 2634
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41331,7 +41301,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2636
+   i32.const 2635
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41346,13 +41316,28 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2639
+   i32.const 2638
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const inf
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2639
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 3
   f32.const 0
   f32.const 0
   i32.const 0
@@ -41367,7 +41352,7 @@
    unreachable
   end
   f32.const 0
-  f32.const 3
+  f32.const 2
   f32.const 0
   f32.const 0
   i32.const 0
@@ -41382,7 +41367,7 @@
    unreachable
   end
   f32.const 0
-  f32.const 2
+  f32.const 1
   f32.const 0
   f32.const 0
   i32.const 0
@@ -41397,7 +41382,7 @@
    unreachable
   end
   f32.const 0
-  f32.const 1
+  f32.const 0.5
   f32.const 0
   f32.const 0
   i32.const 0
@@ -41412,8 +41397,8 @@
    unreachable
   end
   f32.const 0
-  f32.const 0.5
   f32.const 0
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -41427,7 +41412,7 @@
    unreachable
   end
   f32.const 0
-  f32.const 0
+  f32.const -0
   f32.const 1
   f32.const 0
   i32.const 0
@@ -41442,10 +41427,10 @@
    unreachable
   end
   f32.const 0
-  f32.const -0
-  f32.const 1
+  f32.const -0.5
+  f32.const inf
   f32.const 0
-  i32.const 0
+  i32.const 4
   call $std/math/test_powf
   i32.eqz
   if
@@ -41457,7 +41442,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -0.5
+  f32.const -1
   f32.const inf
   f32.const 0
   i32.const 4
@@ -41472,7 +41457,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -1
+  f32.const -2
   f32.const inf
   f32.const 0
   i32.const 4
@@ -41487,7 +41472,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -2
+  f32.const -3
   f32.const inf
   f32.const 0
   i32.const 4
@@ -41502,7 +41487,7 @@
    unreachable
   end
   f32.const 0
-  f32.const -3
+  f32.const -4
   f32.const inf
   f32.const 0
   i32.const 4
@@ -41517,10 +41502,10 @@
    unreachable
   end
   f32.const 0
-  f32.const -4
+  f32.const -inf
   f32.const inf
   f32.const 0
-  i32.const 4
+  i32.const 0
   call $std/math/test_powf
   i32.eqz
   if
@@ -41531,9 +41516,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const -inf
-  f32.const inf
+  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -41547,21 +41532,6 @@
    unreachable
   end
   f32.const -0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2653
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
   f32.const inf
   f32.const 0
   f32.const 0
@@ -41571,7 +41541,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2654
+   i32.const 2653
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41586,7 +41556,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2655
+   i32.const 2654
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41601,7 +41571,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2656
+   i32.const 2655
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41616,7 +41586,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2657
+   i32.const 2656
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41631,13 +41601,28 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2658
+   i32.const 2657
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -0
   f32.const 0
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2658
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
   f32.const 1
   f32.const 0
   i32.const 0
@@ -41652,21 +41637,6 @@
    unreachable
   end
   f32.const -0
-  f32.const -0
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2660
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
   f32.const -0.5
   f32.const inf
   f32.const 0
@@ -41676,7 +41646,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2661
+   i32.const 2660
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41691,7 +41661,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2662
+   i32.const 2661
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41706,7 +41676,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2663
+   i32.const 2662
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41721,7 +41691,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2664
+   i32.const 2663
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41736,7 +41706,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2665
+   i32.const 2664
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41751,12 +41721,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2666
+   i32.const 2665
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
+  f32.const 0
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2666
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
   f32.const 0
   f32.const 1
   f32.const 0
@@ -41771,7 +41756,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const 0
   f32.const 1
   f32.const 0
@@ -41786,7 +41771,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const 1
   f32.const 0
   f32.const 1
   f32.const 0
@@ -41801,7 +41786,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const 0
   f32.const 1
   f32.const 0
@@ -41816,7 +41801,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const -0.5
   f32.const 0
   f32.const 1
   f32.const 0
@@ -41831,8 +41816,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const -0
   f32.const 1
   f32.const 0
   i32.const 0
@@ -41846,7 +41831,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const inf
   f32.const -0
   f32.const 1
   f32.const 0
@@ -41861,7 +41846,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const -0
   f32.const 1
   f32.const 0
@@ -41876,7 +41861,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const 1
   f32.const -0
   f32.const 1
   f32.const 0
@@ -41891,7 +41876,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const -0
   f32.const 1
   f32.const 0
@@ -41906,7 +41891,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const -0.5
   f32.const -0
   f32.const 1
   f32.const 0
@@ -41921,9 +41906,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const -0
-  f32.const 1
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -41937,7 +41922,7 @@
    unreachable
   end
   f32.const -1
-  f32.const nan:0x400000
+  f32.const inf
   f32.const nan:0x400000
   f32.const 0
   i32.const 0
@@ -41952,7 +41937,7 @@
    unreachable
   end
   f32.const -1
-  f32.const inf
+  f32.const -inf
   f32.const nan:0x400000
   f32.const 0
   i32.const 0
@@ -41967,8 +41952,8 @@
    unreachable
   end
   f32.const -1
-  f32.const -inf
-  f32.const nan:0x400000
+  f32.const 2
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -41982,8 +41967,8 @@
    unreachable
   end
   f32.const -1
-  f32.const 2
-  f32.const 1
+  f32.const -1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -41992,21 +41977,6 @@
    i32.const 0
    i32.const 24
    i32.const 2682
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -1
-  f32.const -1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2683
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42021,7 +41991,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2684
+   i32.const 2683
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42036,7 +42006,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2685
+   i32.const 2684
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42051,13 +42021,28 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2686
+   i32.const 2685
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1
   f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2686
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const inf
   f32.const nan:0x400000
   f32.const 0
   i32.const 0
@@ -42072,7 +42057,7 @@
    unreachable
   end
   f32.const 1
-  f32.const inf
+  f32.const -inf
   f32.const nan:0x400000
   f32.const 0
   i32.const 0
@@ -42087,8 +42072,8 @@
    unreachable
   end
   f32.const 1
-  f32.const -inf
-  f32.const nan:0x400000
+  f32.const 3
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -42102,7 +42087,7 @@
    unreachable
   end
   f32.const 1
-  f32.const 3
+  f32.const 0.5
   f32.const 1
   f32.const 0
   i32.const 0
@@ -42117,7 +42102,7 @@
    unreachable
   end
   f32.const 1
-  f32.const 0.5
+  f32.const -0.5
   f32.const 1
   f32.const 0
   i32.const 0
@@ -42132,7 +42117,7 @@
    unreachable
   end
   f32.const 1
-  f32.const -0.5
+  f32.const -3
   f32.const 1
   f32.const 0
   i32.const 0
@@ -42146,11 +42131,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const -3
-  f32.const 1
+  f32.const -0.5
+  f32.const 0.5
+  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_powf
   i32.eqz
   if
@@ -42162,7 +42147,7 @@
    unreachable
   end
   f32.const -0.5
-  f32.const 0.5
+  f32.const 1.5
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -42177,21 +42162,6 @@
    unreachable
   end
   f32.const -0.5
-  f32.const 1.5
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2695
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
   f32.const 2
   f32.const 0.25
   f32.const 0
@@ -42201,7 +42171,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2696
+   i32.const 2695
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42216,7 +42186,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2697
+   i32.const 2696
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42224,6 +42194,21 @@
   f32.const -0.5
   f32.const inf
   f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2697
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.5
+  f32.const -inf
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -42237,8 +42222,8 @@
    unreachable
   end
   f32.const -0.5
-  f32.const -inf
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -42251,9 +42236,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 0.5
+  f32.const inf
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -42267,8 +42252,8 @@
    unreachable
   end
   f32.const 0.5
+  f32.const -inf
   f32.const inf
-  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -42282,8 +42267,8 @@
    unreachable
   end
   f32.const 0.5
-  f32.const -inf
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -42296,9 +42281,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 1.5
+  f32.const inf
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -42312,8 +42297,8 @@
    unreachable
   end
   f32.const 1.5
-  f32.const inf
-  f32.const inf
+  f32.const -inf
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -42327,8 +42312,8 @@
    unreachable
   end
   f32.const 1.5
-  f32.const -inf
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -42341,7 +42326,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.5
+  f32.const inf
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -42357,8 +42342,8 @@
    unreachable
   end
   f32.const inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -42367,21 +42352,6 @@
    i32.const 0
    i32.const 24
    i32.const 2707
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2708
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42396,13 +42366,28 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2709
+   i32.const 2708
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const inf
   f32.const 3
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2709
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const 2
   f32.const inf
   f32.const 0
   i32.const 0
@@ -42417,7 +42402,7 @@
    unreachable
   end
   f32.const inf
-  f32.const 2
+  f32.const 1
   f32.const inf
   f32.const 0
   i32.const 0
@@ -42432,7 +42417,7 @@
    unreachable
   end
   f32.const inf
-  f32.const 1
+  f32.const 0.5
   f32.const inf
   f32.const 0
   i32.const 0
@@ -42447,8 +42432,8 @@
    unreachable
   end
   f32.const inf
-  f32.const 0.5
-  f32.const inf
+  f32.const -0.5
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -42462,7 +42447,7 @@
    unreachable
   end
   f32.const inf
-  f32.const -0.5
+  f32.const -1
   f32.const 0
   f32.const 0
   i32.const 0
@@ -42477,7 +42462,7 @@
    unreachable
   end
   f32.const inf
-  f32.const -1
+  f32.const -2
   f32.const 0
   f32.const 0
   i32.const 0
@@ -42491,9 +42476,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const -2
-  f32.const 0
+  f32.const -inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -42507,8 +42492,8 @@
    unreachable
   end
   f32.const -inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -42522,8 +42507,8 @@
    unreachable
   end
   f32.const -inf
-  f32.const inf
-  f32.const inf
+  f32.const -inf
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -42532,21 +42517,6 @@
    i32.const 0
    i32.const 24
    i32.const 2718
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -inf
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2719
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42561,7 +42531,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2720
+   i32.const 2719
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42576,7 +42546,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2721
+   i32.const 2720
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42591,7 +42561,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2722
+   i32.const 2721
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42606,7 +42576,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2723
+   i32.const 2722
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42621,7 +42591,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2724
+   i32.const 2723
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42636,7 +42606,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2725
+   i32.const 2724
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42651,7 +42621,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2726
+   i32.const 2725
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42666,7 +42636,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2727
+   i32.const 2726
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42681,7 +42651,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2728
+   i32.const 2727
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42696,7 +42666,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2729
+   i32.const 2728
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42711,7 +42681,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2730
+   i32.const 2729
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42745,7 +42715,7 @@
     if
      i32.const 0
      i32.const 24
-     i32.const 2739
+     i32.const 2738
      i32.const 2
      call $~lib/builtins/abort
      unreachable
@@ -42789,7 +42759,7 @@
     if
      i32.const 0
      i32.const 24
-     i32.const 2747
+     i32.const 2746
      i32.const 2
      call $~lib/builtins/abort
      unreachable
@@ -42811,7 +42781,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2761
+   i32.const 2760
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42825,7 +42795,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2762
+   i32.const 2761
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42839,7 +42809,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2763
+   i32.const 2762
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42853,7 +42823,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2764
+   i32.const 2763
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42867,7 +42837,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2765
+   i32.const 2764
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42881,7 +42851,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2766
+   i32.const 2765
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42895,7 +42865,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2767
+   i32.const 2766
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42909,7 +42879,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2768
+   i32.const 2767
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42923,7 +42893,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2769
+   i32.const 2768
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42937,13 +42907,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2770
+   i32.const 2769
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2772
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_round
@@ -42956,8 +42940,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const -inf
+  f64.const -inf
   f64.const 0
   i32.const 0
   call $std/math/test_round
@@ -42970,8 +42954,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_round
@@ -42984,8 +42968,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_round
@@ -42998,8 +42982,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 1
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_round
@@ -43012,8 +42996,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 1
+  f64.const -1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_round
@@ -43022,20 +43006,6 @@
    i32.const 0
    i32.const 24
    i32.const 2778
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2779
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43049,7 +43019,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2780
+   i32.const 2779
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43063,7 +43033,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2781
+   i32.const 2780
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43077,7 +43047,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2782
+   i32.const 2781
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43091,7 +43061,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2783
+   i32.const 2782
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43105,7 +43075,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2784
+   i32.const 2783
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43119,7 +43089,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2785
+   i32.const 2784
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43133,7 +43103,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2786
+   i32.const 2785
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43147,7 +43117,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2787
+   i32.const 2786
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43161,7 +43131,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2788
+   i32.const 2787
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43175,7 +43145,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2789
+   i32.const 2788
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43189,7 +43159,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2798
+   i32.const 2797
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43203,7 +43173,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2799
+   i32.const 2798
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43217,7 +43187,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2800
+   i32.const 2799
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43231,7 +43201,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2801
+   i32.const 2800
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43245,7 +43215,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2802
+   i32.const 2801
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43259,7 +43229,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2803
+   i32.const 2802
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43273,7 +43243,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2804
+   i32.const 2803
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43287,7 +43257,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2805
+   i32.const 2804
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43301,7 +43271,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2806
+   i32.const 2805
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43315,13 +43285,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2807
+   i32.const 2806
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2809
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_roundf
@@ -43334,8 +43318,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   i32.const 0
   call $std/math/test_roundf
@@ -43348,8 +43332,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_roundf
@@ -43362,8 +43346,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_roundf
@@ -43376,8 +43360,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_roundf
@@ -43390,8 +43374,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_roundf
@@ -43400,20 +43384,6 @@
    i32.const 0
    i32.const 24
    i32.const 2815
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2816
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43427,7 +43397,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2817
+   i32.const 2816
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43441,7 +43411,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2818
+   i32.const 2817
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43455,7 +43425,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2819
+   i32.const 2818
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43469,7 +43439,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2820
+   i32.const 2819
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43483,7 +43453,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2821
+   i32.const 2820
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43497,7 +43467,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2822
+   i32.const 2821
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43511,7 +43481,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2823
+   i32.const 2822
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43525,7 +43495,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2824
+   i32.const 2823
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43539,7 +43509,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2825
+   i32.const 2824
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43553,13 +43523,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2826
+   i32.const 2825
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_sign
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2836
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_sign
@@ -43572,8 +43556,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 1
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_sign
@@ -43582,20 +43566,6 @@
    i32.const 0
    i32.const 24
    i32.const 2838
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_sign
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2839
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43609,7 +43579,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2840
+   i32.const 2839
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43623,7 +43593,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2841
+   i32.const 2840
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43637,7 +43607,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2842
+   i32.const 2841
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43651,7 +43621,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2843
+   i32.const 2842
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43665,7 +43635,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2844
+   i32.const 2843
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43679,13 +43649,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2845
+   i32.const 2844
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_signf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2852
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_signf
@@ -43698,8 +43682,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_signf
@@ -43708,20 +43692,6 @@
    i32.const 0
    i32.const 24
    i32.const 2854
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_signf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2855
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43735,7 +43705,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2856
+   i32.const 2855
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43749,7 +43719,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2857
+   i32.const 2856
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43763,7 +43733,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2858
+   i32.const 2857
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43777,7 +43747,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2859
+   i32.const 2858
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43791,7 +43761,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2860
+   i32.const 2859
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43805,7 +43775,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2861
+   i32.const 2860
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43829,7 +43799,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2867
+   i32.const 2866
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43853,7 +43823,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2868
+   i32.const 2867
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43877,7 +43847,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2869
+   i32.const 2868
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43901,7 +43871,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2870
+   i32.const 2869
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43925,7 +43895,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2871
+   i32.const 2870
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43949,7 +43919,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2872
+   i32.const 2871
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43973,7 +43943,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2873
+   i32.const 2872
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43997,7 +43967,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2874
+   i32.const 2873
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44020,7 +43990,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2880
+   i32.const 2879
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44043,7 +44013,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2881
+   i32.const 2880
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44066,7 +44036,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2882
+   i32.const 2881
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44089,7 +44059,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2883
+   i32.const 2882
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44112,7 +44082,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2884
+   i32.const 2883
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44135,7 +44105,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2885
+   i32.const 2884
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44158,7 +44128,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2886
+   i32.const 2885
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44181,7 +44151,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2887
+   i32.const 2886
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44196,7 +44166,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2898
+   i32.const 2897
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44211,7 +44181,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2899
+   i32.const 2898
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44226,7 +44196,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2900
+   i32.const 2899
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44241,7 +44211,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2901
+   i32.const 2900
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44256,7 +44226,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2902
+   i32.const 2901
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44271,7 +44241,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2903
+   i32.const 2902
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44286,7 +44256,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2904
+   i32.const 2903
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44301,7 +44271,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2905
+   i32.const 2904
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44316,7 +44286,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2906
+   i32.const 2905
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44331,7 +44301,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2907
+   i32.const 2906
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44339,6 +44309,21 @@
   f64.const 0
   f64.const 1
   f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2909
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const 1
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -44351,9 +44336,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0.5
   f64.const 1
-  f64.const -0
+  f64.const 0.5
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -44366,9 +44351,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0.5
   f64.const 1
-  f64.const 0.5
+  f64.const -0.5
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -44381,9 +44366,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
   f64.const 1
-  f64.const -0.5
+  f64.const 1
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -44392,21 +44377,6 @@
    i32.const 0
    i32.const 24
    i32.const 2913
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2914
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44421,7 +44391,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2915
+   i32.const 2914
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44436,7 +44406,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2916
+   i32.const 2915
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44451,7 +44421,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2917
+   i32.const 2916
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44466,7 +44436,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2918
+   i32.const 2917
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44481,12 +44451,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2919
+   i32.const 2918
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
+  f64.const 1
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 2
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2919
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
   f64.const 1
   f64.const nan:0x8000000000000
   f64.const 0
@@ -44501,11 +44486,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const 1
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -44516,9 +44501,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const -1
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -44531,9 +44516,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
+  f64.const -0
   f64.const -1
-  f64.const 0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -44546,9 +44531,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0.5
   f64.const -1
-  f64.const -0
+  f64.const 0.5
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -44561,9 +44546,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0.5
   f64.const -1
-  f64.const 0.5
+  f64.const -0.5
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -44572,21 +44557,6 @@
    i32.const 0
    i32.const 24
    i32.const 2925
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const -1
-  f64.const -0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2926
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44601,7 +44571,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2927
+   i32.const 2926
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44616,7 +44586,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2928
+   i32.const 2927
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44631,7 +44601,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2929
+   i32.const 2928
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44646,7 +44616,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2930
+   i32.const 2929
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44661,7 +44631,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2931
+   i32.const 2930
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44676,12 +44646,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2932
+   i32.const 2931
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 2
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2932
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
   f64.const -1
   f64.const nan:0x8000000000000
   f64.const 0
@@ -44696,11 +44681,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const -1
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -44711,11 +44696,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -1
+  f64.const 0
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -44727,7 +44712,7 @@
    unreachable
   end
   f64.const 0
-  f64.const 0
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -44742,10 +44727,10 @@
    unreachable
   end
   f64.const 0
-  f64.const -0
-  f64.const nan:0x8000000000000
+  f64.const inf
   f64.const 0
-  i32.const 2
+  f64.const 0
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -44757,7 +44742,7 @@
    unreachable
   end
   f64.const 0
-  f64.const inf
+  f64.const -inf
   f64.const 0
   f64.const 0
   i32.const 0
@@ -44772,8 +44757,8 @@
    unreachable
   end
   f64.const 0
-  f64.const -inf
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -44786,11 +44771,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const 0
   f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -44802,7 +44787,7 @@
    unreachable
   end
   f64.const -0
-  f64.const 0
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -44817,10 +44802,10 @@
    unreachable
   end
   f64.const -0
+  f64.const inf
   f64.const -0
-  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -44832,7 +44817,7 @@
    unreachable
   end
   f64.const -0
-  f64.const inf
+  f64.const -inf
   f64.const -0
   f64.const 0
   i32.const 0
@@ -44847,8 +44832,8 @@
    unreachable
   end
   f64.const -0
-  f64.const -inf
-  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -44861,11 +44846,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -44876,7 +44861,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -44891,7 +44876,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -44906,7 +44891,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -44921,21 +44906,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2949
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const nan:0x8000000000000
   f64.const 0
   f64.const nan:0x8000000000000
@@ -44946,12 +44916,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2950
+   i32.const 2949
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -1
+  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 2
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2950
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
   f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -44966,7 +44951,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -44981,11 +44966,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -44996,11 +44981,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -0
+  f64.const inf
+  f64.const 2
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -45012,7 +44997,7 @@
    unreachable
   end
   f64.const inf
-  f64.const 2
+  f64.const -0.5
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -45027,21 +45012,6 @@
    unreachable
   end
   f64.const inf
-  f64.const -0.5
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2956
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -45051,7 +45021,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2957
+   i32.const 2956
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45066,7 +45036,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2958
+   i32.const 2957
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45081,12 +45051,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2959
+   i32.const 2958
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2959
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -45101,7 +45086,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -45116,7 +45101,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -45131,9 +45116,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const inf
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -45146,9 +45131,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const inf
-  f64.const 1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -45161,11 +45146,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
   f64.const inf
-  f64.const -1
+  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -45176,7 +45161,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const inf
   f64.const nan:0x8000000000000
   f64.const 0
@@ -45191,11 +45176,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
   f64.const -inf
-  f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -45206,9 +45191,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -1
   f64.const -inf
-  f64.const 1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -45221,11 +45206,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const inf
   f64.const -inf
-  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -45236,7 +45221,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const -inf
   f64.const nan:0x8000000000000
   f64.const 0
@@ -45251,11 +45236,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
-  f64.const nan:0x8000000000000
+  f64.const 1.75
+  f64.const 0.5
+  f64.const -0.25
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -45266,9 +45251,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
+  f64.const -1.75
   f64.const 0.5
-  f64.const -0.25
+  f64.const 0.25
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -45281,9 +45266,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.75
-  f64.const 0.5
-  f64.const 0.25
+  f64.const 1.75
+  f64.const -0.5
+  f64.const -0.25
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -45296,21 +45281,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const -0.5
-  f64.const -0.25
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2974
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -1.75
   f64.const -0.5
   f64.const 0.25
@@ -45321,7 +45291,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2975
+   i32.const 2974
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45336,7 +45306,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2976
+   i32.const 2975
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45351,7 +45321,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2985
+   i32.const 2984
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45366,7 +45336,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2986
+   i32.const 2985
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45381,7 +45351,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2987
+   i32.const 2986
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45396,7 +45366,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2988
+   i32.const 2987
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45411,7 +45381,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2989
+   i32.const 2988
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45426,7 +45396,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2990
+   i32.const 2989
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45441,7 +45411,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2991
+   i32.const 2990
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45456,7 +45426,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2992
+   i32.const 2991
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45471,7 +45441,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2993
+   i32.const 2992
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45486,7 +45456,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2994
+   i32.const 2993
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45494,6 +45464,21 @@
   f32.const 0
   f32.const 1
   f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2996
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 1
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -45506,9 +45491,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0.5
   f32.const 1
-  f32.const -0
+  f32.const 0.5
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -45521,9 +45506,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -0.5
   f32.const 1
-  f32.const 0.5
+  f32.const -0.5
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -45536,9 +45521,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
   f32.const 1
-  f32.const -0.5
+  f32.const 1
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -45547,21 +45532,6 @@
    i32.const 0
    i32.const 24
    i32.const 3000
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3001
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45576,7 +45546,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3002
+   i32.const 3001
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45591,7 +45561,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3003
+   i32.const 3002
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45606,7 +45576,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3004
+   i32.const 3003
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45621,7 +45591,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3005
+   i32.const 3004
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45636,12 +45606,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3006
+   i32.const 3005
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const inf
+  f32.const 1
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 2
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3006
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
   f32.const 1
   f32.const nan:0x400000
   f32.const 0
@@ -45656,11 +45641,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const 1
   f32.const nan:0x400000
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -45671,9 +45656,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const 1
-  f32.const nan:0x400000
+  f32.const 0
+  f32.const -1
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -45686,9 +45671,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
+  f32.const -0
   f32.const -1
-  f32.const 0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -45701,9 +45686,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0.5
   f32.const -1
-  f32.const -0
+  f32.const 0.5
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -45716,9 +45701,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -0.5
   f32.const -1
-  f32.const 0.5
+  f32.const -0.5
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -45727,21 +45712,6 @@
    i32.const 0
    i32.const 24
    i32.const 3012
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const -1
-  f32.const -0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3013
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45756,7 +45726,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3014
+   i32.const 3013
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45771,7 +45741,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3015
+   i32.const 3014
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45786,7 +45756,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3016
+   i32.const 3015
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45801,7 +45771,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3017
+   i32.const 3016
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45816,7 +45786,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3018
+   i32.const 3017
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45831,12 +45801,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3019
+   i32.const 3018
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const inf
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 2
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3019
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
   f32.const -1
   f32.const nan:0x400000
   f32.const 0
@@ -45851,11 +45836,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const -1
   f32.const nan:0x400000
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -45866,11 +45851,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -1
+  f32.const 0
+  f32.const 0
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -45882,7 +45867,7 @@
    unreachable
   end
   f32.const 0
-  f32.const 0
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -45897,10 +45882,10 @@
    unreachable
   end
   f32.const 0
-  f32.const -0
-  f32.const nan:0x400000
+  f32.const inf
   f32.const 0
-  i32.const 2
+  f32.const 0
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -45912,7 +45897,7 @@
    unreachable
   end
   f32.const 0
-  f32.const inf
+  f32.const -inf
   f32.const 0
   f32.const 0
   i32.const 0
@@ -45927,8 +45912,8 @@
    unreachable
   end
   f32.const 0
-  f32.const -inf
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -45941,11 +45926,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const 0
   f32.const nan:0x400000
-  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -45957,7 +45942,7 @@
    unreachable
   end
   f32.const -0
-  f32.const 0
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -45972,10 +45957,10 @@
    unreachable
   end
   f32.const -0
+  f32.const inf
   f32.const -0
-  f32.const nan:0x400000
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -45987,7 +45972,7 @@
    unreachable
   end
   f32.const -0
-  f32.const inf
+  f32.const -inf
   f32.const -0
   f32.const 0
   i32.const 0
@@ -46002,8 +45987,8 @@
    unreachable
   end
   f32.const -0
-  f32.const -inf
-  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -46016,11 +46001,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const nan:0x400000
+  f32.const 1
+  f32.const 0
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -46031,7 +46016,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const 0
   f32.const nan:0x400000
   f32.const 0
@@ -46046,7 +46031,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const inf
   f32.const 0
   f32.const nan:0x400000
   f32.const 0
@@ -46061,7 +46046,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const 0
   f32.const nan:0x400000
   f32.const 0
@@ -46076,21 +46061,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const 0
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3036
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const nan:0x400000
   f32.const 0
   f32.const nan:0x400000
@@ -46101,12 +46071,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3037
+   i32.const 3036
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1
+  f32.const -0
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 2
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3037
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
   f32.const -0
   f32.const nan:0x400000
   f32.const 0
@@ -46121,7 +46106,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const -0
   f32.const nan:0x400000
   f32.const 0
@@ -46136,11 +46121,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const -0
   f32.const nan:0x400000
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -46151,11 +46136,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -0
+  f32.const inf
+  f32.const 2
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -46167,7 +46152,7 @@
    unreachable
   end
   f32.const inf
-  f32.const 2
+  f32.const -0.5
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -46182,21 +46167,6 @@
    unreachable
   end
   f32.const inf
-  f32.const -0.5
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3043
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -46206,7 +46176,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3044
+   i32.const 3043
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46221,7 +46191,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3045
+   i32.const 3044
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46236,12 +46206,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3046
+   i32.const 3045
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3046
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -46256,7 +46241,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const 1
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -46271,7 +46256,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -46286,9 +46271,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 1
+  f32.const inf
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -46301,9 +46286,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const inf
-  f32.const 1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -46316,11 +46301,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
   f32.const inf
-  f32.const -1
+  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -46331,7 +46316,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const inf
   f32.const nan:0x400000
   f32.const 0
@@ -46346,11 +46331,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1
   f32.const -inf
-  f32.const inf
-  f32.const nan:0x400000
+  f32.const 1
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -46361,9 +46346,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -1
   f32.const -inf
-  f32.const 1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -46376,11 +46361,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const inf
   f32.const -inf
-  f32.const -1
+  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -46391,7 +46376,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const -inf
   f32.const nan:0x400000
   f32.const 0
@@ -46406,11 +46391,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
-  f32.const nan:0x400000
+  f32.const 1.75
+  f32.const 0.5
+  f32.const -0.25
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -46421,9 +46406,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
+  f32.const -1.75
   f32.const 0.5
-  f32.const -0.25
+  f32.const 0.25
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -46436,9 +46421,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.75
-  f32.const 0.5
-  f32.const 0.25
+  f32.const 1.75
+  f32.const -0.5
+  f32.const -0.25
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -46451,21 +46436,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
-  f32.const -0.5
-  f32.const -0.25
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3061
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -1.75
   f32.const -0.5
   f32.const 0.25
@@ -46476,7 +46446,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3062
+   i32.const 3061
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46491,7 +46461,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3063
+   i32.const 3062
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46505,7 +46475,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3075
+   i32.const 3074
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46519,7 +46489,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3076
+   i32.const 3075
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46533,7 +46503,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3077
+   i32.const 3076
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46547,7 +46517,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3078
+   i32.const 3077
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46561,7 +46531,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3079
+   i32.const 3078
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46575,7 +46545,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3080
+   i32.const 3079
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46589,7 +46559,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3081
+   i32.const 3080
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46603,7 +46573,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3082
+   i32.const 3081
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46617,7 +46587,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3083
+   i32.const 3082
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46631,7 +46601,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3084
+   i32.const 3083
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46645,7 +46615,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3087
+   i32.const 3086
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46659,13 +46629,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3088
+   i32.const 3087
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.2250738585072014e-308
   f64.const 2.2250738585072014e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3088
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
   f64.const 0
   i32.const 1
   call $std/math/test_sin
@@ -46678,10 +46662,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
+  f64.const 5e-324
+  f64.const 5e-324
   f64.const 0
-  i32.const 1
+  i32.const 9
   call $std/math/test_sin
   i32.eqz
   if
@@ -46692,8 +46676,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5e-324
-  f64.const 5e-324
+  f64.const -5e-324
+  f64.const -5e-324
   f64.const 0
   i32.const 9
   call $std/math/test_sin
@@ -46706,10 +46690,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5e-324
-  f64.const -5e-324
   f64.const 0
-  i32.const 9
+  f64.const 0
+  f64.const 0
+  i32.const 0
   call $std/math/test_sin
   i32.eqz
   if
@@ -46720,8 +46704,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_sin
@@ -46734,10 +46718,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 2.225073858507202e-308
+  f64.const 2.225073858507202e-308
   f64.const 0
-  i32.const 0
+  i32.const 1
   call $std/math/test_sin
   i32.eqz
   if
@@ -46748,8 +46732,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507202e-308
-  f64.const 2.225073858507202e-308
+  f64.const 2.2250738585072024e-308
+  f64.const 2.2250738585072024e-308
   f64.const 0
   i32.const 1
   call $std/math/test_sin
@@ -46762,8 +46746,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072024e-308
-  f64.const 2.2250738585072024e-308
+  f64.const 4.4501477170144003e-308
+  f64.const 4.4501477170144003e-308
   f64.const 0
   i32.const 1
   call $std/math/test_sin
@@ -46776,8 +46760,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4501477170144003e-308
-  f64.const 4.4501477170144003e-308
+  f64.const 4.450147717014403e-308
+  f64.const 4.450147717014403e-308
   f64.const 0
   i32.const 1
   call $std/math/test_sin
@@ -46790,8 +46774,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.450147717014403e-308
-  f64.const 4.450147717014403e-308
+  f64.const 4.450147717014406e-308
+  f64.const 4.450147717014406e-308
   f64.const 0
   i32.const 1
   call $std/math/test_sin
@@ -46804,8 +46788,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.450147717014406e-308
-  f64.const 4.450147717014406e-308
+  f64.const 8.900295434028806e-308
+  f64.const 8.900295434028806e-308
   f64.const 0
   i32.const 1
   call $std/math/test_sin
@@ -46814,20 +46798,6 @@
    i32.const 0
    i32.const 24
    i32.const 3099
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 8.900295434028806e-308
-  f64.const 8.900295434028806e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3100
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46841,7 +46811,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3101
+   i32.const 3100
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46855,13 +46825,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3102
+   i32.const 3101
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2.225073858507202e-308
   f64.const -2.225073858507202e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3102
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072024e-308
+  f64.const -2.2250738585072024e-308
   f64.const 0
   i32.const 1
   call $std/math/test_sin
@@ -46874,8 +46858,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072024e-308
-  f64.const -2.2250738585072024e-308
+  f64.const -4.4501477170144003e-308
+  f64.const -4.4501477170144003e-308
   f64.const 0
   i32.const 1
   call $std/math/test_sin
@@ -46888,8 +46872,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4501477170144003e-308
-  f64.const -4.4501477170144003e-308
+  f64.const -4.450147717014403e-308
+  f64.const -4.450147717014403e-308
   f64.const 0
   i32.const 1
   call $std/math/test_sin
@@ -46902,8 +46886,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.450147717014403e-308
-  f64.const -4.450147717014403e-308
+  f64.const -4.450147717014406e-308
+  f64.const -4.450147717014406e-308
   f64.const 0
   i32.const 1
   call $std/math/test_sin
@@ -46916,8 +46900,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.450147717014406e-308
-  f64.const -4.450147717014406e-308
+  f64.const -8.900295434028806e-308
+  f64.const -8.900295434028806e-308
   f64.const 0
   i32.const 1
   call $std/math/test_sin
@@ -46930,9 +46914,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8.900295434028806e-308
-  f64.const -8.900295434028806e-308
-  f64.const 0
+  f64.const -1.1175870895385742e-08
+  f64.const -1.1175870895385742e-08
+  f64.const -0.140625
   i32.const 1
   call $std/math/test_sin
   i32.eqz
@@ -46944,9 +46928,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.1175870895385742e-08
-  f64.const -1.1175870895385742e-08
-  f64.const -0.140625
+  f64.const -1.4901161193847656e-08
+  f64.const -1.4901161193847656e-08
+  f64.const -0.1666666716337204
   i32.const 1
   call $std/math/test_sin
   i32.eqz
@@ -46972,10 +46956,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.4901161193847656e-08
-  f64.const -1.4901161193847656e-08
-  f64.const -0.1666666716337204
-  i32.const 1
+  f64.const 1e-323
+  f64.const 1e-323
+  f64.const 0
+  i32.const 9
   call $std/math/test_sin
   i32.eqz
   if
@@ -46986,8 +46970,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1e-323
-  f64.const 1e-323
+  f64.const 4.4e-323
+  f64.const 4.4e-323
   f64.const 0
   i32.const 9
   call $std/math/test_sin
@@ -47000,8 +46984,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4e-323
-  f64.const 4.4e-323
+  f64.const 5.562684646268003e-309
+  f64.const 5.562684646268003e-309
   f64.const 0
   i32.const 9
   call $std/math/test_sin
@@ -47014,8 +46998,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5.562684646268003e-309
-  f64.const 5.562684646268003e-309
+  f64.const 1.1125369292536007e-308
+  f64.const 1.1125369292536007e-308
   f64.const 0
   i32.const 9
   call $std/math/test_sin
@@ -47028,8 +47012,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.1125369292536007e-308
-  f64.const 1.1125369292536007e-308
+  f64.const 2.2250738585072004e-308
+  f64.const 2.2250738585072004e-308
   f64.const 0
   i32.const 9
   call $std/math/test_sin
@@ -47042,8 +47026,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072004e-308
-  f64.const 2.2250738585072004e-308
+  f64.const 2.225073858507201e-308
+  f64.const 2.225073858507201e-308
   f64.const 0
   i32.const 9
   call $std/math/test_sin
@@ -47056,8 +47040,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507201e-308
-  f64.const 2.225073858507201e-308
+  f64.const -1e-323
+  f64.const -1e-323
   f64.const 0
   i32.const 9
   call $std/math/test_sin
@@ -47070,8 +47054,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1e-323
-  f64.const -1e-323
+  f64.const -4.4e-323
+  f64.const -4.4e-323
   f64.const 0
   i32.const 9
   call $std/math/test_sin
@@ -47084,8 +47068,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4e-323
-  f64.const -4.4e-323
+  f64.const -5.562684646268003e-309
+  f64.const -5.562684646268003e-309
   f64.const 0
   i32.const 9
   call $std/math/test_sin
@@ -47098,8 +47082,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5.562684646268003e-309
-  f64.const -5.562684646268003e-309
+  f64.const -1.1125369292536007e-308
+  f64.const -1.1125369292536007e-308
   f64.const 0
   i32.const 9
   call $std/math/test_sin
@@ -47112,8 +47096,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.1125369292536007e-308
-  f64.const -1.1125369292536007e-308
+  f64.const -2.2250738585072004e-308
+  f64.const -2.2250738585072004e-308
   f64.const 0
   i32.const 9
   call $std/math/test_sin
@@ -47126,8 +47110,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072004e-308
-  f64.const -2.2250738585072004e-308
+  f64.const -2.225073858507201e-308
+  f64.const -2.225073858507201e-308
   f64.const 0
   i32.const 9
   call $std/math/test_sin
@@ -47140,22 +47124,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.225073858507201e-308
-  f64.const -2.225073858507201e-308
   f64.const 0
-  i32.const 9
+  f64.const 0
+  f64.const 0
+  i32.const 0
   call $std/math/test_sin
   i32.eqz
   if
    i32.const 0
    i32.const 24
-   i32.const 3123
+   i32.const 3125
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_sin
@@ -47168,10 +47152,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_sin
   i32.eqz
   if
@@ -47182,7 +47166,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -47196,10 +47180,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_sin
   i32.eqz
   if
@@ -47210,23 +47194,23 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_sin
+  f64.const 1.5707963267948966
+  call $~lib/math/NativeMath.sin
+  f64.const 1.5707963267948966
+  call $~lib/bindings/Math/sin
+  f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 24
-   i32.const 3130
+   i32.const 3132
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5707963267948966
+  f64.const 3.141592653589793
   call $~lib/math/NativeMath.sin
-  f64.const 1.5707963267948966
+  f64.const 3.141592653589793
   call $~lib/bindings/Math/sin
   f64.eq
   i32.eqz
@@ -47238,22 +47222,21 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 3.141592653589793
+  f64.const 2.3283064365386963e-10
+  f64.const 2.3283064365386963e-10
   call $~lib/math/NativeMath.sin
-  f64.const 3.141592653589793
-  call $~lib/bindings/Math/sin
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 24
-   i32.const 3134
+   i32.const 3136
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.3283064365386963e-10
-  f64.const 2.3283064365386963e-10
+  f64.const -2.3283064365386963e-10
+  f64.const -2.3283064365386963e-10
   call $~lib/math/NativeMath.sin
   f64.eq
   i32.eqz
@@ -47261,19 +47244,6 @@
    i32.const 0
    i32.const 24
    i32.const 3137
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.3283064365386963e-10
-  f64.const -2.3283064365386963e-10
-  call $~lib/math/NativeMath.sin
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3138
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47286,7 +47256,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3140
+   i32.const 3139
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47299,7 +47269,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3141
+   i32.const 3140
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47312,7 +47282,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3144
+   i32.const 3143
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47325,7 +47295,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3145
+   i32.const 3144
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47338,7 +47308,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3146
+   i32.const 3145
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47351,7 +47321,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3147
+   i32.const 3146
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47364,7 +47334,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3149
+   i32.const 3148
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47377,7 +47347,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3150
+   i32.const 3149
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47390,7 +47360,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3152
+   i32.const 3151
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47403,7 +47373,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3153
+   i32.const 3152
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47416,7 +47386,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3154
+   i32.const 3153
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47429,7 +47399,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3155
+   i32.const 3154
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47442,7 +47412,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3156
+   i32.const 3155
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47455,7 +47425,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3159
+   i32.const 3158
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47468,7 +47438,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3160
+   i32.const 3159
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47482,7 +47452,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3169
+   i32.const 3168
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47496,7 +47466,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3170
+   i32.const 3169
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47510,7 +47480,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3171
+   i32.const 3170
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47524,7 +47494,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3172
+   i32.const 3171
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47538,7 +47508,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3173
+   i32.const 3172
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47552,7 +47522,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3174
+   i32.const 3173
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47566,7 +47536,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3175
+   i32.const 3174
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47580,7 +47550,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3176
+   i32.const 3175
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47594,7 +47564,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3177
+   i32.const 3176
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47608,13 +47578,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3178
+   i32.const 3177
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3180
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_sinf
@@ -47627,10 +47611,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_sinf
   i32.eqz
   if
@@ -47641,7 +47625,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -47655,20 +47639,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3184
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -47678,7 +47648,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3185
+   i32.const 3184
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47692,7 +47662,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3188
+   i32.const 3187
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47706,13 +47676,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3189
+   i32.const 3188
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.1754943508222875e-38
   f32.const 1.1754943508222875e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3189
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754943508222875e-38
+  f32.const -1.1754943508222875e-38
   f32.const 0
   i32.const 1
   call $std/math/test_sinf
@@ -47725,10 +47709,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754943508222875e-38
-  f32.const -1.1754943508222875e-38
+  f32.const 1.401298464324817e-45
+  f32.const 1.401298464324817e-45
   f32.const 0
-  i32.const 1
+  i32.const 9
   call $std/math/test_sinf
   i32.eqz
   if
@@ -47739,8 +47723,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.401298464324817e-45
-  f32.const 1.401298464324817e-45
+  f32.const -1.401298464324817e-45
+  f32.const -1.401298464324817e-45
   f32.const 0
   i32.const 9
   call $std/math/test_sinf
@@ -47753,10 +47737,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.401298464324817e-45
-  f32.const -1.401298464324817e-45
+  f32.const 1.175494490952134e-38
+  f32.const 1.175494490952134e-38
   f32.const 0
-  i32.const 9
+  i32.const 1
   call $std/math/test_sinf
   i32.eqz
   if
@@ -47767,8 +47751,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.175494490952134e-38
-  f32.const 1.175494490952134e-38
+  f32.const 1.1754946310819804e-38
+  f32.const 1.1754946310819804e-38
   f32.const 0
   i32.const 1
   call $std/math/test_sinf
@@ -47781,8 +47765,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754946310819804e-38
-  f32.const 1.1754946310819804e-38
+  f32.const 2.3509880009953429e-38
+  f32.const 2.3509880009953429e-38
   f32.const 0
   i32.const 1
   call $std/math/test_sinf
@@ -47795,8 +47779,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509880009953429e-38
-  f32.const 2.3509880009953429e-38
+  f32.const 2.350988701644575e-38
+  f32.const 2.350988701644575e-38
   f32.const 0
   i32.const 1
   call $std/math/test_sinf
@@ -47809,8 +47793,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.350988701644575e-38
-  f32.const 2.350988701644575e-38
+  f32.const 2.3509895424236536e-38
+  f32.const 2.3509895424236536e-38
   f32.const 0
   i32.const 1
   call $std/math/test_sinf
@@ -47823,8 +47807,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509895424236536e-38
-  f32.const 2.3509895424236536e-38
+  f32.const 4.70197740328915e-38
+  f32.const 4.70197740328915e-38
   f32.const 0
   i32.const 1
   call $std/math/test_sinf
@@ -47833,20 +47817,6 @@
    i32.const 0
    i32.const 24
    i32.const 3198
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 4.70197740328915e-38
-  f32.const 4.70197740328915e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3199
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47860,7 +47830,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3200
+   i32.const 3199
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47874,7 +47844,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3201
+   i32.const 3200
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47888,7 +47858,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3202
+   i32.const 3201
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47902,13 +47872,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3203
+   i32.const 3202
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1.175494490952134e-38
   f32.const -1.175494490952134e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3203
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754946310819804e-38
+  f32.const -1.1754946310819804e-38
   f32.const 0
   i32.const 1
   call $std/math/test_sinf
@@ -47921,8 +47905,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754946310819804e-38
-  f32.const -1.1754946310819804e-38
+  f32.const -2.3509880009953429e-38
+  f32.const -2.3509880009953429e-38
   f32.const 0
   i32.const 1
   call $std/math/test_sinf
@@ -47935,8 +47919,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.3509880009953429e-38
-  f32.const -2.3509880009953429e-38
+  f32.const -2.350988701644575e-38
+  f32.const -2.350988701644575e-38
   f32.const 0
   i32.const 1
   call $std/math/test_sinf
@@ -47949,8 +47933,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.350988701644575e-38
-  f32.const -2.350988701644575e-38
+  f32.const -2.3509895424236536e-38
+  f32.const -2.3509895424236536e-38
   f32.const 0
   i32.const 1
   call $std/math/test_sinf
@@ -47963,8 +47947,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.3509895424236536e-38
-  f32.const -2.3509895424236536e-38
+  f32.const -4.70197740328915e-38
+  f32.const -4.70197740328915e-38
   f32.const 0
   i32.const 1
   call $std/math/test_sinf
@@ -47973,20 +47957,6 @@
    i32.const 0
    i32.const 24
    i32.const 3208
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -4.70197740328915e-38
-  f32.const -4.70197740328915e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3209
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48000,7 +47970,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3210
+   i32.const 3209
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48014,7 +47984,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3211
+   i32.const 3210
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48028,7 +47998,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3212
+   i32.const 3211
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48042,13 +48012,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3213
+   i32.const 3212
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 2.802596928649634e-45
   f32.const 2.802596928649634e-45
+  f32.const 0
+  i32.const 9
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3213
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.2611686178923354e-44
+  f32.const 1.2611686178923354e-44
   f32.const 0
   i32.const 9
   call $std/math/test_sinf
@@ -48061,8 +48045,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.2611686178923354e-44
-  f32.const 1.2611686178923354e-44
+  f32.const 2.938735877055719e-39
+  f32.const 2.938735877055719e-39
   f32.const 0
   i32.const 9
   call $std/math/test_sinf
@@ -48075,8 +48059,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.938735877055719e-39
-  f32.const 2.938735877055719e-39
+  f32.const 5.877471754111438e-39
+  f32.const 5.877471754111438e-39
   f32.const 0
   i32.const 9
   call $std/math/test_sinf
@@ -48089,8 +48073,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 5.877471754111438e-39
-  f32.const 5.877471754111438e-39
+  f32.const 1.1754940705625946e-38
+  f32.const 1.1754940705625946e-38
   f32.const 0
   i32.const 9
   call $std/math/test_sinf
@@ -48103,8 +48087,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754940705625946e-38
-  f32.const 1.1754940705625946e-38
+  f32.const 1.1754942106924411e-38
+  f32.const 1.1754942106924411e-38
   f32.const 0
   i32.const 9
   call $std/math/test_sinf
@@ -48117,8 +48101,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754942106924411e-38
-  f32.const 1.1754942106924411e-38
+  f32.const -2.802596928649634e-45
+  f32.const -2.802596928649634e-45
   f32.const 0
   i32.const 9
   call $std/math/test_sinf
@@ -48131,8 +48115,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.802596928649634e-45
-  f32.const -2.802596928649634e-45
+  f32.const -1.2611686178923354e-44
+  f32.const -1.2611686178923354e-44
   f32.const 0
   i32.const 9
   call $std/math/test_sinf
@@ -48145,8 +48129,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.2611686178923354e-44
-  f32.const -1.2611686178923354e-44
+  f32.const -2.938735877055719e-39
+  f32.const -2.938735877055719e-39
   f32.const 0
   i32.const 9
   call $std/math/test_sinf
@@ -48159,8 +48143,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.938735877055719e-39
-  f32.const -2.938735877055719e-39
+  f32.const -5.877471754111438e-39
+  f32.const -5.877471754111438e-39
   f32.const 0
   i32.const 9
   call $std/math/test_sinf
@@ -48173,8 +48157,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -5.877471754111438e-39
-  f32.const -5.877471754111438e-39
+  f32.const -1.1754940705625946e-38
+  f32.const -1.1754940705625946e-38
   f32.const 0
   i32.const 9
   call $std/math/test_sinf
@@ -48187,8 +48171,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754940705625946e-38
-  f32.const -1.1754940705625946e-38
+  f32.const -1.1754942106924411e-38
+  f32.const -1.1754942106924411e-38
   f32.const 0
   i32.const 9
   call $std/math/test_sinf
@@ -48197,20 +48181,6 @@
    i32.const 0
    i32.const 24
    i32.const 3224
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754942106924411e-38
-  f32.const -1.1754942106924411e-38
-  f32.const 0
-  i32.const 9
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3225
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48224,7 +48194,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3228
+   i32.const 3227
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48238,7 +48208,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3229
+   i32.const 3228
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48252,7 +48222,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3230
+   i32.const 3229
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48266,7 +48236,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3231
+   i32.const 3230
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48280,7 +48250,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3232
+   i32.const 3231
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48294,7 +48264,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3233
+   i32.const 3232
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48308,7 +48278,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3234
+   i32.const 3233
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48322,7 +48292,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3235
+   i32.const 3234
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48336,7 +48306,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3236
+   i32.const 3235
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48350,7 +48320,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3237
+   i32.const 3236
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48364,7 +48334,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3238
+   i32.const 3237
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48378,7 +48348,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3239
+   i32.const 3238
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48392,7 +48362,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3240
+   i32.const 3239
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48406,7 +48376,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3241
+   i32.const 3240
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48420,7 +48390,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3253
+   i32.const 3252
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48434,7 +48404,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3254
+   i32.const 3253
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48448,7 +48418,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3255
+   i32.const 3254
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48462,7 +48432,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3256
+   i32.const 3255
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48476,7 +48446,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3257
+   i32.const 3256
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48490,7 +48460,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3258
+   i32.const 3257
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48504,7 +48474,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3259
+   i32.const 3258
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48518,7 +48488,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3260
+   i32.const 3259
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48532,7 +48502,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3261
+   i32.const 3260
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48546,13 +48516,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3262
+   i32.const 3261
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_sinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3264
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_sinh
@@ -48565,8 +48549,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const inf
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_sinh
@@ -48579,8 +48563,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const -inf
+  f64.const -inf
   f64.const 0
   i32.const 0
   call $std/math/test_sinh
@@ -48593,8 +48577,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_sinh
@@ -48603,20 +48587,6 @@
    i32.const 0
    i32.const 24
    i32.const 3268
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_sinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3269
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48630,7 +48600,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3278
+   i32.const 3277
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48644,7 +48614,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3279
+   i32.const 3278
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48658,7 +48628,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3280
+   i32.const 3279
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48672,7 +48642,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3281
+   i32.const 3280
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48686,7 +48656,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3282
+   i32.const 3281
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48700,7 +48670,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3283
+   i32.const 3282
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48714,7 +48684,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3284
+   i32.const 3283
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48728,7 +48698,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3285
+   i32.const 3284
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48742,7 +48712,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3286
+   i32.const 3285
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48756,13 +48726,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3287
+   i32.const 3286
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_sinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3289
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_sinhf
@@ -48775,8 +48759,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const inf
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_sinhf
@@ -48789,8 +48773,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   i32.const 0
   call $std/math/test_sinhf
@@ -48803,8 +48787,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_sinhf
@@ -48813,20 +48797,6 @@
    i32.const 0
    i32.const 24
    i32.const 3293
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_sinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3294
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48840,7 +48810,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3306
+   i32.const 3305
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48854,12 +48824,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3307
+   i32.const 3306
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -8.38143342755525
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 2
+  call $std/math/test_sqrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3307
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -6.531673581913484
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -48873,20 +48857,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -6.531673581913484
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
-  call $std/math/test_sqrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3309
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const 9.267056966972586
   f64.const 3.0441841217266385
   f64.const -0.01546262577176094
@@ -48896,7 +48866,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3310
+   i32.const 3309
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48910,7 +48880,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3311
+   i32.const 3310
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48924,7 +48894,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3312
+   i32.const 3311
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48938,7 +48908,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3313
+   i32.const 3312
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48952,7 +48922,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3314
+   i32.const 3313
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48966,13 +48936,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3315
+   i32.const 3314
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_sqrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3317
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_sqrt
@@ -48981,20 +48965,6 @@
    i32.const 0
    i32.const 24
    i32.const 3318
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_sqrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3319
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49008,13 +48978,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3320
+   i32.const 3319
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_sqrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3320
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_sqrt
@@ -49027,8 +49011,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 1
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_sqrt
@@ -49037,20 +49021,6 @@
    i32.const 0
    i32.const 24
    i32.const 3322
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_sqrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3323
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49064,7 +49034,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3324
+   i32.const 3323
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49078,7 +49048,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3325
+   i32.const 3324
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49092,7 +49062,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3326
+   i32.const 3325
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49106,7 +49076,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3327
+   i32.const 3326
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49120,7 +49090,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3328
+   i32.const 3327
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49134,7 +49104,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3329
+   i32.const 3328
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49148,7 +49118,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3330
+   i32.const 3329
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49162,7 +49132,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3331
+   i32.const 3330
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49176,7 +49146,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3332
+   i32.const 3331
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49190,7 +49160,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3333
+   i32.const 3332
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49204,7 +49174,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3334
+   i32.const 3333
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49218,7 +49188,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3335
+   i32.const 3334
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49232,7 +49202,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3336
+   i32.const 3335
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49246,7 +49216,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3337
+   i32.const 3336
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49260,7 +49230,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3338
+   i32.const 3337
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49274,7 +49244,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3339
+   i32.const 3338
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49288,7 +49258,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3340
+   i32.const 3339
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49302,7 +49272,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3341
+   i32.const 3340
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49316,7 +49286,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3342
+   i32.const 3341
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49330,7 +49300,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3343
+   i32.const 3342
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49344,7 +49314,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3344
+   i32.const 3343
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49358,7 +49328,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3345
+   i32.const 3344
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49372,7 +49342,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3346
+   i32.const 3345
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49386,7 +49356,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3347
+   i32.const 3346
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49400,7 +49370,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3348
+   i32.const 3347
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49414,7 +49384,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3349
+   i32.const 3348
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49428,7 +49398,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3350
+   i32.const 3349
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49442,7 +49412,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3351
+   i32.const 3350
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49456,7 +49426,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3352
+   i32.const 3351
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49470,7 +49440,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3353
+   i32.const 3352
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49484,7 +49454,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3354
+   i32.const 3353
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49498,7 +49468,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3355
+   i32.const 3354
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49512,7 +49482,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3356
+   i32.const 3355
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49526,7 +49496,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3357
+   i32.const 3356
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49540,7 +49510,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3358
+   i32.const 3357
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49554,7 +49524,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3359
+   i32.const 3358
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49568,7 +49538,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3360
+   i32.const 3359
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49582,7 +49552,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3361
+   i32.const 3360
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49596,7 +49566,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3362
+   i32.const 3361
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49610,7 +49580,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3363
+   i32.const 3362
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49624,7 +49594,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3364
+   i32.const 3363
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49638,7 +49608,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3365
+   i32.const 3364
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49652,7 +49622,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3366
+   i32.const 3365
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49666,7 +49636,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3367
+   i32.const 3366
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49680,7 +49650,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3368
+   i32.const 3367
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49694,7 +49664,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3369
+   i32.const 3368
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49708,7 +49678,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3370
+   i32.const 3369
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49722,7 +49692,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3371
+   i32.const 3370
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49736,7 +49706,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3372
+   i32.const 3371
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49750,7 +49720,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3373
+   i32.const 3372
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49764,7 +49734,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3374
+   i32.const 3373
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49778,7 +49748,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3375
+   i32.const 3374
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49792,7 +49762,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3376
+   i32.const 3375
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49806,7 +49776,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3377
+   i32.const 3376
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49820,7 +49790,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3378
+   i32.const 3377
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49834,7 +49804,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3379
+   i32.const 3378
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49848,7 +49818,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3380
+   i32.const 3379
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49862,7 +49832,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3381
+   i32.const 3380
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49876,7 +49846,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3382
+   i32.const 3381
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49890,7 +49860,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3383
+   i32.const 3382
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49904,7 +49874,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3384
+   i32.const 3383
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49918,7 +49888,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3385
+   i32.const 3384
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49932,7 +49902,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3386
+   i32.const 3385
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49946,7 +49916,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3387
+   i32.const 3386
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49960,7 +49930,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3388
+   i32.const 3387
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49974,7 +49944,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3389
+   i32.const 3388
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49988,7 +49958,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3390
+   i32.const 3389
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50002,7 +49972,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3391
+   i32.const 3390
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50016,7 +49986,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3400
+   i32.const 3399
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50030,12 +50000,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3401
+   i32.const 3400
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -8.381433486938477
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 2
+  call $std/math/test_sqrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3401
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -6.531673431396484
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -50049,20 +50033,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -6.531673431396484
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_sqrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3403
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const 9.267057418823242
   f32.const 3.0441842079162598
   f32.const 0.05022354796528816
@@ -50072,7 +50042,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3404
+   i32.const 3403
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50086,7 +50056,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3405
+   i32.const 3404
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50100,7 +50070,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3406
+   i32.const 3405
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50114,7 +50084,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3407
+   i32.const 3406
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50128,7 +50098,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3408
+   i32.const 3407
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50142,13 +50112,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3409
+   i32.const 3408
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_sqrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3411
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_sqrtf
@@ -50157,20 +50141,6 @@
    i32.const 0
    i32.const 24
    i32.const 3412
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_sqrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3413
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50184,13 +50154,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3414
+   i32.const 3413
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_sqrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3414
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_sqrtf
@@ -50203,8 +50187,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_sqrtf
@@ -50213,20 +50197,6 @@
    i32.const 0
    i32.const 24
    i32.const 3416
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_sqrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3417
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50240,7 +50210,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3418
+   i32.const 3417
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50254,7 +50224,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3419
+   i32.const 3418
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50268,7 +50238,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3420
+   i32.const 3419
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50282,7 +50252,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3421
+   i32.const 3420
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50296,7 +50266,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3422
+   i32.const 3421
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50310,7 +50280,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3423
+   i32.const 3422
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50324,7 +50294,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3424
+   i32.const 3423
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50338,7 +50308,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3425
+   i32.const 3424
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50352,7 +50322,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3426
+   i32.const 3425
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50366,7 +50336,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3427
+   i32.const 3426
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50380,7 +50350,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3428
+   i32.const 3427
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50394,7 +50364,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3429
+   i32.const 3428
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50408,7 +50378,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3430
+   i32.const 3429
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50422,7 +50392,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3431
+   i32.const 3430
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50436,7 +50406,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3432
+   i32.const 3431
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50450,7 +50420,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3433
+   i32.const 3432
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50464,7 +50434,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3445
+   i32.const 3444
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50478,7 +50448,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3446
+   i32.const 3445
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50492,7 +50462,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3447
+   i32.const 3446
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50506,7 +50476,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3448
+   i32.const 3447
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50520,7 +50490,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3449
+   i32.const 3448
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50534,7 +50504,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3450
+   i32.const 3449
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50548,7 +50518,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3451
+   i32.const 3450
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50562,7 +50532,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3452
+   i32.const 3451
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50576,7 +50546,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3453
+   i32.const 3452
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50590,7 +50560,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3454
+   i32.const 3453
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50604,7 +50574,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3457
+   i32.const 3456
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50618,13 +50588,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3458
+   i32.const 3457
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.2250738585072014e-308
   f64.const 2.2250738585072014e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3458
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
   f64.const 0
   i32.const 1
   call $std/math/test_tan
@@ -50637,10 +50621,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
+  f64.const 5e-324
+  f64.const 5e-324
   f64.const 0
-  i32.const 1
+  i32.const 9
   call $std/math/test_tan
   i32.eqz
   if
@@ -50651,8 +50635,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5e-324
-  f64.const 5e-324
+  f64.const -5e-324
+  f64.const -5e-324
   f64.const 0
   i32.const 9
   call $std/math/test_tan
@@ -50665,10 +50649,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5e-324
-  f64.const -5e-324
   f64.const 0
-  i32.const 9
+  f64.const 0
+  f64.const 0
+  i32.const 0
   call $std/math/test_tan
   i32.eqz
   if
@@ -50679,8 +50663,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_tan
@@ -50689,20 +50673,6 @@
    i32.const 0
    i32.const 24
    i32.const 3463
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3464
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50716,7 +50686,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3465
+   i32.const 3464
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50730,13 +50700,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3466
+   i32.const 3465
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.225073858507202e-308
   f64.const 2.225073858507202e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3466
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.2250738585072024e-308
+  f64.const 2.2250738585072024e-308
   f64.const 0
   i32.const 1
   call $std/math/test_tan
@@ -50749,8 +50733,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072024e-308
-  f64.const 2.2250738585072024e-308
+  f64.const 4.4501477170144003e-308
+  f64.const 4.4501477170144003e-308
   f64.const 0
   i32.const 1
   call $std/math/test_tan
@@ -50763,8 +50747,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4501477170144003e-308
-  f64.const 4.4501477170144003e-308
+  f64.const 4.450147717014403e-308
+  f64.const 4.450147717014403e-308
   f64.const 0
   i32.const 1
   call $std/math/test_tan
@@ -50777,8 +50761,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.450147717014403e-308
-  f64.const 4.450147717014403e-308
+  f64.const 4.450147717014406e-308
+  f64.const 4.450147717014406e-308
   f64.const 0
   i32.const 1
   call $std/math/test_tan
@@ -50791,8 +50775,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.450147717014406e-308
-  f64.const 4.450147717014406e-308
+  f64.const 8.900295434028806e-308
+  f64.const 8.900295434028806e-308
   f64.const 0
   i32.const 1
   call $std/math/test_tan
@@ -50801,20 +50785,6 @@
    i32.const 0
    i32.const 24
    i32.const 3471
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 8.900295434028806e-308
-  f64.const 8.900295434028806e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3472
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50828,7 +50798,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3473
+   i32.const 3472
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50842,13 +50812,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3474
+   i32.const 3473
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -2.225073858507202e-308
   f64.const -2.225073858507202e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3474
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072024e-308
+  f64.const -2.2250738585072024e-308
   f64.const 0
   i32.const 1
   call $std/math/test_tan
@@ -50861,8 +50845,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072024e-308
-  f64.const -2.2250738585072024e-308
+  f64.const -4.4501477170144003e-308
+  f64.const -4.4501477170144003e-308
   f64.const 0
   i32.const 1
   call $std/math/test_tan
@@ -50875,8 +50859,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4501477170144003e-308
-  f64.const -4.4501477170144003e-308
+  f64.const -4.450147717014403e-308
+  f64.const -4.450147717014403e-308
   f64.const 0
   i32.const 1
   call $std/math/test_tan
@@ -50889,8 +50873,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.450147717014403e-308
-  f64.const -4.450147717014403e-308
+  f64.const -4.450147717014406e-308
+  f64.const -4.450147717014406e-308
   f64.const 0
   i32.const 1
   call $std/math/test_tan
@@ -50903,8 +50887,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.450147717014406e-308
-  f64.const -4.450147717014406e-308
+  f64.const -8.900295434028806e-308
+  f64.const -8.900295434028806e-308
   f64.const 0
   i32.const 1
   call $std/math/test_tan
@@ -50913,20 +50897,6 @@
    i32.const 0
    i32.const 24
    i32.const 3479
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -8.900295434028806e-308
-  f64.const -8.900295434028806e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3480
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50940,7 +50910,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3481
+   i32.const 3480
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50954,13 +50924,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3482
+   i32.const 3481
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1e-323
   f64.const 1e-323
+  f64.const 0
+  i32.const 9
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3482
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.4e-323
+  f64.const 4.4e-323
   f64.const 0
   i32.const 9
   call $std/math/test_tan
@@ -50973,8 +50957,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4e-323
-  f64.const 4.4e-323
+  f64.const 5.562684646268003e-309
+  f64.const 5.562684646268003e-309
   f64.const 0
   i32.const 9
   call $std/math/test_tan
@@ -50987,8 +50971,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5.562684646268003e-309
-  f64.const 5.562684646268003e-309
+  f64.const 1.1125369292536007e-308
+  f64.const 1.1125369292536007e-308
   f64.const 0
   i32.const 9
   call $std/math/test_tan
@@ -51001,8 +50985,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.1125369292536007e-308
-  f64.const 1.1125369292536007e-308
+  f64.const 2.2250738585072004e-308
+  f64.const 2.2250738585072004e-308
   f64.const 0
   i32.const 9
   call $std/math/test_tan
@@ -51015,8 +50999,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072004e-308
-  f64.const 2.2250738585072004e-308
+  f64.const 2.225073858507201e-308
+  f64.const 2.225073858507201e-308
   f64.const 0
   i32.const 9
   call $std/math/test_tan
@@ -51029,8 +51013,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507201e-308
-  f64.const 2.225073858507201e-308
+  f64.const -1e-323
+  f64.const -1e-323
   f64.const 0
   i32.const 9
   call $std/math/test_tan
@@ -51043,8 +51027,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1e-323
-  f64.const -1e-323
+  f64.const -4.4e-323
+  f64.const -4.4e-323
   f64.const 0
   i32.const 9
   call $std/math/test_tan
@@ -51057,8 +51041,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4e-323
-  f64.const -4.4e-323
+  f64.const -5.562684646268003e-309
+  f64.const -5.562684646268003e-309
   f64.const 0
   i32.const 9
   call $std/math/test_tan
@@ -51071,8 +51055,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5.562684646268003e-309
-  f64.const -5.562684646268003e-309
+  f64.const -1.1125369292536007e-308
+  f64.const -1.1125369292536007e-308
   f64.const 0
   i32.const 9
   call $std/math/test_tan
@@ -51085,8 +51069,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.1125369292536007e-308
-  f64.const -1.1125369292536007e-308
+  f64.const -2.2250738585072004e-308
+  f64.const -2.2250738585072004e-308
   f64.const 0
   i32.const 9
   call $std/math/test_tan
@@ -51099,8 +51083,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072004e-308
-  f64.const -2.2250738585072004e-308
+  f64.const -2.225073858507201e-308
+  f64.const -2.225073858507201e-308
   f64.const 0
   i32.const 9
   call $std/math/test_tan
@@ -51113,23 +51097,23 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.225073858507201e-308
-  f64.const -2.225073858507201e-308
-  f64.const 0
-  i32.const 9
-  call $std/math/test_tan
+  f64.const 2.3283064365386963e-10
+  call $~lib/math/NativeMath.tan
+  f64.const 2.3283064365386963e-10
+  call $~lib/bindings/Math/tan
+  f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 24
-   i32.const 3494
+   i32.const 3496
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.3283064365386963e-10
+  f64.const -2.3283064365386963e-10
   call $~lib/math/NativeMath.tan
-  f64.const 2.3283064365386963e-10
+  f64.const -2.3283064365386963e-10
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -51141,9 +51125,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.3283064365386963e-10
+  f64.const 0.6875
   call $~lib/math/NativeMath.tan
-  f64.const -2.3283064365386963e-10
+  f64.const 0.6875
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -51155,9 +51139,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.6875
+  f64.const -0.6875
   call $~lib/math/NativeMath.tan
-  f64.const 0.6875
+  f64.const -0.6875
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -51169,9 +51153,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.6875
+  f64.const 0.39269908169872414
   call $~lib/math/NativeMath.tan
-  f64.const -0.6875
+  f64.const 0.39269908169872414
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -51183,9 +51167,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.39269908169872414
+  f64.const 0.6743358
   call $~lib/math/NativeMath.tan
-  f64.const 0.39269908169872414
+  f64.const 0.6743358
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -51197,9 +51181,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.6743358
+  f64.const 3.725290298461914e-09
   call $~lib/math/NativeMath.tan
-  f64.const 0.6743358
+  f64.const 3.725290298461914e-09
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -51211,9 +51195,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 3.725290298461914e-09
+  f64.const 1.5707963267948966
   call $~lib/math/NativeMath.tan
-  f64.const 3.725290298461914e-09
+  f64.const 1.5707963267948966
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -51225,23 +51209,23 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5707963267948966
+  f64.const 0.5
   call $~lib/math/NativeMath.tan
-  f64.const 1.5707963267948966
+  f64.const 0.5
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 24
-   i32.const 3504
+   i32.const 3505
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const 1.107148717794091
   call $~lib/math/NativeMath.tan
-  f64.const 0.5
+  f64.const 1.107148717794091
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -51253,9 +51237,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.107148717794091
+  f64.const 5.497787143782138
   call $~lib/math/NativeMath.tan
-  f64.const 1.107148717794091
+  f64.const 5.497787143782138
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -51267,9 +51251,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5.497787143782138
+  f64.const 7.0685834705770345
   call $~lib/math/NativeMath.tan
-  f64.const 5.497787143782138
+  f64.const 7.0685834705770345
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -51281,9 +51265,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 7.0685834705770345
+  f64.const 1647099.3291652855
   call $~lib/math/NativeMath.tan
-  f64.const 7.0685834705770345
+  f64.const 1647099.3291652855
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -51295,9 +51279,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1647099.3291652855
+  f64.const 1647097.7583689587
   call $~lib/math/NativeMath.tan
-  f64.const 1647099.3291652855
+  f64.const 1647097.7583689587
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -51309,9 +51293,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1647097.7583689587
+  f64.const 1329227995784915872903807e12
   call $~lib/math/NativeMath.tan
-  f64.const 1647097.7583689587
+  f64.const 1329227995784915872903807e12
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -51323,9 +51307,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1329227995784915872903807e12
+  f64.const -1329227995784915872903807e12
   call $~lib/math/NativeMath.tan
-  f64.const 1329227995784915872903807e12
+  f64.const -1329227995784915872903807e12
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -51337,22 +51321,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1329227995784915872903807e12
-  call $~lib/math/NativeMath.tan
-  f64.const -1329227995784915872903807e12
-  call $~lib/bindings/Math/tan
-  f64.eq
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_tan
   i32.eqz
   if
    i32.const 0
    i32.const 24
-   i32.const 3513
+   i32.const 3515
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_tan
@@ -51365,10 +51349,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_tan
   i32.eqz
   if
@@ -51379,7 +51363,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -inf
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -51393,20 +51377,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3519
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -51416,7 +51386,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3520
+   i32.const 3519
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51430,7 +51400,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3529
+   i32.const 3528
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51444,7 +51414,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3530
+   i32.const 3529
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51458,7 +51428,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3531
+   i32.const 3530
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51472,7 +51442,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3532
+   i32.const 3531
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51486,7 +51456,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3533
+   i32.const 3532
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51500,7 +51470,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3534
+   i32.const 3533
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51514,7 +51484,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3535
+   i32.const 3534
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51528,7 +51498,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3536
+   i32.const 3535
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51542,7 +51512,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3537
+   i32.const 3536
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51556,13 +51526,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3538
+   i32.const 3537
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3540
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_tanf
@@ -51575,10 +51559,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_tanf
   i32.eqz
   if
@@ -51589,7 +51573,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -inf
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -51603,20 +51587,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3544
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -51626,7 +51596,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3545
+   i32.const 3544
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51640,7 +51610,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3548
+   i32.const 3547
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51654,13 +51624,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3549
+   i32.const 3548
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.1754943508222875e-38
   f32.const 1.1754943508222875e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3549
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754943508222875e-38
+  f32.const -1.1754943508222875e-38
   f32.const 0
   i32.const 1
   call $std/math/test_tanf
@@ -51673,10 +51657,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754943508222875e-38
-  f32.const -1.1754943508222875e-38
+  f32.const 1.401298464324817e-45
+  f32.const 1.401298464324817e-45
   f32.const 0
-  i32.const 1
+  i32.const 9
   call $std/math/test_tanf
   i32.eqz
   if
@@ -51687,8 +51671,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.401298464324817e-45
-  f32.const 1.401298464324817e-45
+  f32.const -1.401298464324817e-45
+  f32.const -1.401298464324817e-45
   f32.const 0
   i32.const 9
   call $std/math/test_tanf
@@ -51701,10 +51685,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.401298464324817e-45
-  f32.const -1.401298464324817e-45
+  f32.const 1.175494490952134e-38
+  f32.const 1.175494490952134e-38
   f32.const 0
-  i32.const 9
+  i32.const 1
   call $std/math/test_tanf
   i32.eqz
   if
@@ -51715,8 +51699,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.175494490952134e-38
-  f32.const 1.175494490952134e-38
+  f32.const 1.1754946310819804e-38
+  f32.const 1.1754946310819804e-38
   f32.const 0
   i32.const 1
   call $std/math/test_tanf
@@ -51729,8 +51713,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754946310819804e-38
-  f32.const 1.1754946310819804e-38
+  f32.const 2.3509880009953429e-38
+  f32.const 2.3509880009953429e-38
   f32.const 0
   i32.const 1
   call $std/math/test_tanf
@@ -51743,8 +51727,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509880009953429e-38
-  f32.const 2.3509880009953429e-38
+  f32.const 2.350988701644575e-38
+  f32.const 2.350988701644575e-38
   f32.const 0
   i32.const 1
   call $std/math/test_tanf
@@ -51757,8 +51741,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.350988701644575e-38
-  f32.const 2.350988701644575e-38
+  f32.const 2.3509895424236536e-38
+  f32.const 2.3509895424236536e-38
   f32.const 0
   i32.const 1
   call $std/math/test_tanf
@@ -51771,8 +51755,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509895424236536e-38
-  f32.const 2.3509895424236536e-38
+  f32.const 4.70197740328915e-38
+  f32.const 4.70197740328915e-38
   f32.const 0
   i32.const 1
   call $std/math/test_tanf
@@ -51781,20 +51765,6 @@
    i32.const 0
    i32.const 24
    i32.const 3558
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 4.70197740328915e-38
-  f32.const 4.70197740328915e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3559
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51808,7 +51778,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3560
+   i32.const 3559
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51822,7 +51792,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3561
+   i32.const 3560
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51836,13 +51806,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3562
+   i32.const 3561
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -1.175494490952134e-38
   f32.const -1.175494490952134e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3562
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754946310819804e-38
+  f32.const -1.1754946310819804e-38
   f32.const 0
   i32.const 1
   call $std/math/test_tanf
@@ -51855,8 +51839,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754946310819804e-38
-  f32.const -1.1754946310819804e-38
+  f32.const -2.3509880009953429e-38
+  f32.const -2.3509880009953429e-38
   f32.const 0
   i32.const 1
   call $std/math/test_tanf
@@ -51869,8 +51853,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.3509880009953429e-38
-  f32.const -2.3509880009953429e-38
+  f32.const 2.350988701644575e-38
+  f32.const 2.350988701644575e-38
   f32.const 0
   i32.const 1
   call $std/math/test_tanf
@@ -51883,8 +51867,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.350988701644575e-38
-  f32.const 2.350988701644575e-38
+  f32.const -2.3509895424236536e-38
+  f32.const -2.3509895424236536e-38
   f32.const 0
   i32.const 1
   call $std/math/test_tanf
@@ -51897,8 +51881,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.3509895424236536e-38
-  f32.const -2.3509895424236536e-38
+  f32.const -4.70197740328915e-38
+  f32.const -4.70197740328915e-38
   f32.const 0
   i32.const 1
   call $std/math/test_tanf
@@ -51907,20 +51891,6 @@
    i32.const 0
    i32.const 24
    i32.const 3567
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -4.70197740328915e-38
-  f32.const -4.70197740328915e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3568
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51934,7 +51904,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3569
+   i32.const 3568
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51948,7 +51918,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3570
+   i32.const 3569
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51962,13 +51932,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3571
+   i32.const 3570
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 2.802596928649634e-45
   f32.const 2.802596928649634e-45
+  f32.const 0
+  i32.const 9
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3571
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.2611686178923354e-44
+  f32.const 1.2611686178923354e-44
   f32.const 0
   i32.const 9
   call $std/math/test_tanf
@@ -51981,8 +51965,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.2611686178923354e-44
-  f32.const 1.2611686178923354e-44
+  f32.const 2.938735877055719e-39
+  f32.const 2.938735877055719e-39
   f32.const 0
   i32.const 9
   call $std/math/test_tanf
@@ -51995,8 +51979,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.938735877055719e-39
-  f32.const 2.938735877055719e-39
+  f32.const 5.877471754111438e-39
+  f32.const 5.877471754111438e-39
   f32.const 0
   i32.const 9
   call $std/math/test_tanf
@@ -52009,8 +51993,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 5.877471754111438e-39
-  f32.const 5.877471754111438e-39
+  f32.const 1.1754940705625946e-38
+  f32.const 1.1754940705625946e-38
   f32.const 0
   i32.const 9
   call $std/math/test_tanf
@@ -52023,8 +52007,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754940705625946e-38
-  f32.const 1.1754940705625946e-38
+  f32.const 1.1754942106924411e-38
+  f32.const 1.1754942106924411e-38
   f32.const 0
   i32.const 9
   call $std/math/test_tanf
@@ -52037,8 +52021,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754942106924411e-38
-  f32.const 1.1754942106924411e-38
+  f32.const -2.802596928649634e-45
+  f32.const -2.802596928649634e-45
   f32.const 0
   i32.const 9
   call $std/math/test_tanf
@@ -52051,8 +52035,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.802596928649634e-45
-  f32.const -2.802596928649634e-45
+  f32.const -1.2611686178923354e-44
+  f32.const -1.2611686178923354e-44
   f32.const 0
   i32.const 9
   call $std/math/test_tanf
@@ -52065,8 +52049,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.2611686178923354e-44
-  f32.const -1.2611686178923354e-44
+  f32.const -2.938735877055719e-39
+  f32.const -2.938735877055719e-39
   f32.const 0
   i32.const 9
   call $std/math/test_tanf
@@ -52079,8 +52063,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.938735877055719e-39
-  f32.const -2.938735877055719e-39
+  f32.const -5.877471754111438e-39
+  f32.const -5.877471754111438e-39
   f32.const 0
   i32.const 9
   call $std/math/test_tanf
@@ -52093,8 +52077,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -5.877471754111438e-39
-  f32.const -5.877471754111438e-39
+  f32.const -1.1754940705625946e-38
+  f32.const -1.1754940705625946e-38
   f32.const 0
   i32.const 9
   call $std/math/test_tanf
@@ -52107,8 +52091,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754940705625946e-38
-  f32.const -1.1754940705625946e-38
+  f32.const -1.1754942106924411e-38
+  f32.const -1.1754942106924411e-38
   f32.const 0
   i32.const 9
   call $std/math/test_tanf
@@ -52117,20 +52101,6 @@
    i32.const 0
    i32.const 24
    i32.const 3582
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754942106924411e-38
-  f32.const -1.1754942106924411e-38
-  f32.const 0
-  i32.const 9
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3583
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52144,7 +52114,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3595
+   i32.const 3594
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52158,7 +52128,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3596
+   i32.const 3595
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52172,7 +52142,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3597
+   i32.const 3596
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52186,7 +52156,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3598
+   i32.const 3597
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52200,7 +52170,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3599
+   i32.const 3598
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52214,7 +52184,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3600
+   i32.const 3599
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52228,7 +52198,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3601
+   i32.const 3600
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52242,7 +52212,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3602
+   i32.const 3601
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52256,7 +52226,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3603
+   i32.const 3602
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52270,13 +52240,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3604
+   i32.const 3603
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
   f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_tanh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3606
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_tanh
@@ -52285,20 +52269,6 @@
    i32.const 0
    i32.const 24
    i32.const 3607
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_tanh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3608
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52312,7 +52282,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3609
+   i32.const 3608
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52326,7 +52296,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3610
+   i32.const 3609
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52340,7 +52310,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3611
+   i32.const 3610
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52354,7 +52324,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3620
+   i32.const 3619
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52368,7 +52338,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3621
+   i32.const 3620
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52382,7 +52352,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3622
+   i32.const 3621
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52396,7 +52366,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3623
+   i32.const 3622
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52410,7 +52380,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3624
+   i32.const 3623
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52424,7 +52394,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3625
+   i32.const 3624
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52438,7 +52408,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3626
+   i32.const 3625
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52452,7 +52422,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3627
+   i32.const 3626
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52466,7 +52436,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3628
+   i32.const 3627
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52480,13 +52450,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3629
+   i32.const 3628
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_tanhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3631
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_tanhf
@@ -52495,20 +52479,6 @@
    i32.const 0
    i32.const 24
    i32.const 3632
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_tanhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3633
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52522,7 +52492,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3634
+   i32.const 3633
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52536,7 +52506,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3635
+   i32.const 3634
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52550,7 +52520,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3636
+   i32.const 3635
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52564,7 +52534,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3648
+   i32.const 3647
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52578,7 +52548,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3649
+   i32.const 3648
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52592,7 +52562,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3650
+   i32.const 3649
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52606,7 +52576,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3651
+   i32.const 3650
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52620,7 +52590,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3652
+   i32.const 3651
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52634,7 +52604,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3653
+   i32.const 3652
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52648,7 +52618,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3654
+   i32.const 3653
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52662,7 +52632,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3655
+   i32.const 3654
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52676,7 +52646,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3656
+   i32.const 3655
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52690,13 +52660,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3657
+   i32.const 3656
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3659
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_trunc
@@ -52709,8 +52693,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const -inf
+  f64.const -inf
   f64.const 0
   i32.const 0
   call $std/math/test_trunc
@@ -52723,8 +52707,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_trunc
@@ -52737,8 +52721,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_trunc
@@ -52751,8 +52735,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 1
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_trunc
@@ -52765,8 +52749,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 1
+  f64.const -1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_trunc
@@ -52775,20 +52759,6 @@
    i32.const 0
    i32.const 24
    i32.const 3665
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3666
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52802,7 +52772,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3667
+   i32.const 3666
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52816,7 +52786,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3668
+   i32.const 3667
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52830,7 +52800,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3669
+   i32.const 3668
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52844,7 +52814,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3670
+   i32.const 3669
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52858,7 +52828,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3671
+   i32.const 3670
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52872,7 +52842,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3672
+   i32.const 3671
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52886,7 +52856,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3673
+   i32.const 3672
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52900,7 +52870,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3674
+   i32.const 3673
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52914,7 +52884,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3683
+   i32.const 3682
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52928,7 +52898,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3684
+   i32.const 3683
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52942,7 +52912,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3685
+   i32.const 3684
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52956,7 +52926,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3686
+   i32.const 3685
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52970,7 +52940,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3687
+   i32.const 3686
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52984,7 +52954,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3688
+   i32.const 3687
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52998,7 +52968,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3689
+   i32.const 3688
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53012,7 +52982,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3690
+   i32.const 3689
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53026,7 +52996,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3691
+   i32.const 3690
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53040,13 +53010,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3692
+   i32.const 3691
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3694
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_truncf
@@ -53059,8 +53043,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const -inf
+  f32.const -inf
   f32.const 0
   i32.const 0
   call $std/math/test_truncf
@@ -53073,8 +53057,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_truncf
@@ -53087,8 +53071,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_truncf
@@ -53101,8 +53085,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const 1
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_truncf
@@ -53115,8 +53099,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const -1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_truncf
@@ -53125,20 +53109,6 @@
    i32.const 0
    i32.const 24
    i32.const 3700
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3701
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53152,7 +53122,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3702
+   i32.const 3701
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53166,7 +53136,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3703
+   i32.const 3702
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53180,7 +53150,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3704
+   i32.const 3703
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53194,7 +53164,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3705
+   i32.const 3704
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53208,7 +53178,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3706
+   i32.const 3705
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53222,7 +53192,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3707
+   i32.const 3706
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53236,7 +53206,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3708
+   i32.const 3707
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53250,7 +53220,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3709
+   i32.const 3708
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53344,7 +53314,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3750
+   i32.const 3749
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53358,7 +53328,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3751
+   i32.const 3750
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53372,7 +53342,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3752
+   i32.const 3751
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53386,7 +53356,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3753
+   i32.const 3752
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53400,7 +53370,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3754
+   i32.const 3753
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53414,12 +53384,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3755
+   i32.const 3754
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1.e+60
+  f64.const -1.e+60
+  call $~lib/math/NativeMath.imul
+  f64.const 0
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3755
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.e+60
   f64.const -1.e+60
   call $~lib/math/NativeMath.imul
   f64.const 0
@@ -53433,10 +53417,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.e+60
-  f64.const -1.e+60
+  f64.const 1.e+24
+  f64.const 100
   call $~lib/math/NativeMath.imul
-  f64.const 0
+  f64.const -2147483648
   f64.eq
   i32.eqz
   if
@@ -53447,10 +53431,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.e+24
-  f64.const 100
+  f64.const nan:0x8000000000000
+  f64.const 1
   call $~lib/math/NativeMath.imul
-  f64.const -2147483648
+  f64.const 0
   f64.eq
   i32.eqz
   if
@@ -53461,8 +53445,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
   f64.const 1
+  f64.const inf
   call $~lib/math/NativeMath.imul
   f64.const 0
   f64.eq
@@ -53475,8 +53459,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const inf
+  f64.const 1797693134862315708145274e284
+  f64.const 1797693134862315708145274e284
   call $~lib/math/NativeMath.imul
   f64.const 0
   f64.eq
@@ -53489,20 +53473,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1797693134862315708145274e284
-  f64.const 1797693134862315708145274e284
-  call $~lib/math/NativeMath.imul
-  f64.const 0
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3761
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const 0
   call $~lib/math/NativeMath.clz32
   f64.const 32
@@ -53511,7 +53481,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3765
+   i32.const 3764
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53524,7 +53494,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3766
+   i32.const 3765
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53537,7 +53507,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3767
+   i32.const 3766
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53550,7 +53520,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3768
+   i32.const 3767
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53563,7 +53533,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3769
+   i32.const 3768
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53576,7 +53546,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3770
+   i32.const 3769
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53589,7 +53559,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3771
+   i32.const 3770
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53602,7 +53572,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3772
+   i32.const 3771
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53615,7 +53585,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3773
+   i32.const 3772
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53628,7 +53598,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3774
+   i32.const 3773
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53641,7 +53611,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3775
+   i32.const 3774
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53654,7 +53624,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3776
+   i32.const 3775
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53667,7 +53637,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3777
+   i32.const 3776
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53680,7 +53650,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3778
+   i32.const 3777
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53693,7 +53663,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3779
+   i32.const 3778
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53706,7 +53676,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3780
+   i32.const 3779
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53720,13 +53690,27 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3784
+   i32.const 3783
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 0
   i32.const 1
+  call $~lib/math/ipow64
+  i64.const 0
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3784
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 0
+  i32.const 2
   call $~lib/math/ipow64
   i64.const 0
   i64.eq
@@ -53740,7 +53724,7 @@
    unreachable
   end
   i64.const 0
-  i32.const 2
+  i32.const 3
   call $~lib/math/ipow64
   i64.const 0
   i64.eq
@@ -53753,22 +53737,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 0
-  i32.const 3
+  i64.const 1
+  i32.const 0
   call $~lib/math/ipow64
-  i64.const 0
+  i64.const 1
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 24
-   i32.const 3787
+   i32.const 3788
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 1
-  i32.const 0
+  i32.const 1
   call $~lib/math/ipow64
   i64.const 1
   i64.eq
@@ -53782,7 +53766,7 @@
    unreachable
   end
   i64.const 1
-  i32.const 1
+  i32.const 2
   call $~lib/math/ipow64
   i64.const 1
   i64.eq
@@ -53796,20 +53780,6 @@
    unreachable
   end
   i64.const 1
-  i32.const 2
-  call $~lib/math/ipow64
-  i64.const 1
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3791
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 1
   i32.const 3
   call $~lib/math/ipow64
   i64.const 1
@@ -53818,7 +53788,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3792
+   i32.const 3791
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53832,7 +53802,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3794
+   i32.const 3793
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53846,7 +53816,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3795
+   i32.const 3794
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53860,7 +53830,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3796
+   i32.const 3795
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53874,7 +53844,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3797
+   i32.const 3796
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53888,7 +53858,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3799
+   i32.const 3798
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53902,7 +53872,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3800
+   i32.const 3799
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53916,7 +53886,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3801
+   i32.const 3800
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53930,7 +53900,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3802
+   i32.const 3801
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53944,7 +53914,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3804
+   i32.const 3803
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53958,7 +53928,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3805
+   i32.const 3804
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53972,7 +53942,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3806
+   i32.const 3805
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53986,7 +53956,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3807
+   i32.const 3806
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54000,7 +53970,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3809
+   i32.const 3808
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54014,7 +53984,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3810
+   i32.const 3809
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54028,7 +53998,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3811
+   i32.const 3810
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54042,7 +54012,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3812
+   i32.const 3811
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54056,7 +54026,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3813
+   i32.const 3812
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54070,7 +54040,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3814
+   i32.const 3813
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54084,7 +54054,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3815
+   i32.const 3814
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54102,12 +54072,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3817
+   i32.const 3816
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
+  i32.const 0
+  call $~lib/math/ipow32f
+  f32.const 1
+  f32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3820
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
   i32.const 0
   call $~lib/math/ipow32f
   f32.const 1
@@ -54122,20 +54106,6 @@
    unreachable
   end
   f32.const nan:0x400000
-  i32.const 0
-  call $~lib/math/ipow32f
-  f32.const 1
-  f32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3822
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
   i32.const 1
   call $~lib/math/ipow32f
   call $~lib/number/isNaN<f32>
@@ -54143,7 +54113,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3823
+   i32.const 3822
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54156,7 +54126,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3824
+   i32.const 3823
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54169,7 +54139,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3825
+   i32.const 3824
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54183,7 +54153,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3826
+   i32.const 3825
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54192,6 +54162,20 @@
   i32.const 1
   call $~lib/math/ipow32f
   f32.const inf
+  f32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3826
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  i32.const 0
+  call $~lib/math/ipow32f
+  f32.const 1
   f32.eq
   i32.eqz
   if
@@ -54203,20 +54187,6 @@
    unreachable
   end
   f32.const -inf
-  i32.const 0
-  call $~lib/math/ipow32f
-  f32.const 1
-  f32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3828
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
   i32.const 1
   call $~lib/math/ipow32f
   f32.const -inf
@@ -54225,7 +54195,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3829
+   i32.const 3828
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54239,7 +54209,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3830
+   i32.const 3829
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54253,7 +54223,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3831
+   i32.const 3830
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54267,7 +54237,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3832
+   i32.const 3831
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54281,7 +54251,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3833
+   i32.const 3832
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54295,7 +54265,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3834
+   i32.const 3833
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54309,7 +54279,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3835
+   i32.const 3834
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54323,12 +54293,26 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3836
+   i32.const 3835
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
+  i32.const 0
+  call $~lib/math/ipow64f
+  f64.const 1
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3839
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
   i32.const 0
   call $~lib/math/ipow64f
   f64.const 1
@@ -54343,20 +54327,6 @@
    unreachable
   end
   f64.const nan:0x8000000000000
-  i32.const 0
-  call $~lib/math/ipow64f
-  f64.const 1
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3841
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
   i32.const 1
   call $~lib/math/ipow64f
   call $~lib/number/isNaN<f64>
@@ -54364,7 +54334,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3842
+   i32.const 3841
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54377,7 +54347,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3843
+   i32.const 3842
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54390,7 +54360,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3844
+   i32.const 3843
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54404,7 +54374,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3845
+   i32.const 3844
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54413,6 +54383,20 @@
   i32.const 1
   call $~lib/math/ipow64f
   f64.const inf
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3845
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  i32.const 0
+  call $~lib/math/ipow64f
+  f64.const 1
   f64.eq
   i32.eqz
   if
@@ -54424,20 +54408,6 @@
    unreachable
   end
   f64.const -inf
-  i32.const 0
-  call $~lib/math/ipow64f
-  f64.const 1
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3847
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
   i32.const 1
   call $~lib/math/ipow64f
   f64.const -inf
@@ -54446,7 +54416,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3848
+   i32.const 3847
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54460,7 +54430,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3849
+   i32.const 3848
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54474,7 +54444,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3850
+   i32.const 3849
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54488,7 +54458,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3851
+   i32.const 3850
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54502,7 +54472,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3852
+   i32.const 3851
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54516,7 +54486,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3853
+   i32.const 3852
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54530,7 +54500,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3854
+   i32.const 3853
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54544,15 +54514,15 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3855
+   i32.const 3854
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
  )
- (func $start (; 179 ;) (type $FUNCSIG$v)
+ (func $start (; 178 ;) (type $FUNCSIG$v)
   call $start:std/math
  )
- (func $null (; 180 ;) (type $FUNCSIG$v)
+ (func $null (; 179 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -77,7 +77,7 @@
  (data (i32.const 408) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00P\00R\00N\00G\00 \00m\00u\00s\00t\00 \00b\00e\00 \00s\00e\00e\00d\00e\00d\00.\00")
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
- (global $std/math/js i32 (i32.const 1))
+ (global $std/math/js (mut i32) (i32.const 1))
  (global $std/math/INEXACT i32 (i32.const 1))
  (global $std/math/INVALID i32 (i32.const 2))
  (global $std/math/DIVBYZERO i32 (i32.const 4))
@@ -29767,6 +29767,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 0
+  global.set $std/math/js
   f64.const inf
   f64.const nan:0x8000000000000
   f64.const inf
@@ -29778,10 +29780,12 @@
    i32.const 0
    i32.const 24
    i32.const 1644
-   i32.const 0
+   i32.const 12
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 1
+  global.set $std/math/js
   f64.const nan:0x8000000000000
   f64.const inf
   f64.const inf
@@ -29827,6 +29831,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 0
+  global.set $std/math/js
   f64.const -inf
   f64.const nan:0x8000000000000
   f64.const inf
@@ -29838,10 +29844,12 @@
    i32.const 0
    i32.const 24
    i32.const 1648
-   i32.const 0
+   i32.const 12
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 1
+  global.set $std/math/js
   f64.const nan:0x8000000000000
   f64.const -inf
   f64.const inf
@@ -29887,6 +29895,40 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 0
+  global.set $std/math/js
+  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_hypot
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1652
+   i32.const 12
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 1
+  global.set $std/math/js
+  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_hypot
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1653
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -8.066848754882812
   f32.const 4.535662651062012
   f32.const 9.254528045654297
@@ -29897,7 +29939,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1660
+   i32.const 1665
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29912,7 +29954,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1661
+   i32.const 1666
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29927,7 +29969,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1662
+   i32.const 1667
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29942,7 +29984,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1663
+   i32.const 1668
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29957,7 +29999,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1664
+   i32.const 1669
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29972,7 +30014,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1665
+   i32.const 1670
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -29987,7 +30029,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1666
+   i32.const 1671
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30002,7 +30044,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1667
+   i32.const 1672
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30017,7 +30059,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1668
+   i32.const 1673
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30032,56 +30074,56 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1669
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 3
-  f32.const 4
-  f32.const 5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1672
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -3
-  f32.const 4
-  f32.const 5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1673
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 4
-  f32.const 3
-  f32.const 5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 1674
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 3
+  f32.const 4
+  f32.const 5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1677
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -3
+  f32.const 4
+  f32.const 5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1678
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4
+  f32.const 3
+  f32.const 5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1679
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 4
   f32.const -3
   f32.const 5
@@ -30092,7 +30134,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1675
+   i32.const 1680
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30107,89 +30149,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1676
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 3402823466385288598117041e14
-  f32.const 0
-  f32.const 3402823466385288598117041e14
-  f32.const 0
-  i32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1677
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 3402823466385288598117041e14
-  f32.const -0
-  f32.const 3402823466385288598117041e14
-  f32.const 0
-  i32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1678
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.401298464324817e-45
-  f32.const 0
-  f32.const 1.401298464324817e-45
-  f32.const 0
-  i32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1679
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.401298464324817e-45
-  f32.const -0
-  f32.const 1.401298464324817e-45
-  f32.const 0
-  i32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1680
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 1
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_hypotf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 1681
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const inf
-  f32.const inf
+  f32.const 3402823466385288598117041e14
+  f32.const 0
+  f32.const 3402823466385288598117041e14
   f32.const 0
   i32.const 0
   call $std/math/test_hypotf
@@ -30202,9 +30169,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const nan:0x400000
-  f32.const inf
+  f32.const 3402823466385288598117041e14
+  f32.const -0
+  f32.const 3402823466385288598117041e14
   f32.const 0
   i32.const 0
   call $std/math/test_hypotf
@@ -30217,9 +30184,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const inf
-  f32.const inf
+  f32.const 1.401298464324817e-45
+  f32.const 0
+  f32.const 1.401298464324817e-45
   f32.const 0
   i32.const 0
   call $std/math/test_hypotf
@@ -30232,9 +30199,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const 1
-  f32.const inf
+  f32.const 1.401298464324817e-45
+  f32.const -0
+  f32.const 1.401298464324817e-45
   f32.const 0
   i32.const 0
   call $std/math/test_hypotf
@@ -30247,8 +30214,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
   f32.const 1
-  f32.const -inf
   f32.const inf
   f32.const 0
   i32.const 0
@@ -30262,8 +30229,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const nan:0x400000
+  f32.const 1
+  f32.const inf
   f32.const inf
   f32.const 0
   i32.const 0
@@ -30277,8 +30244,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
   f32.const nan:0x400000
-  f32.const -inf
   f32.const inf
   f32.const 0
   i32.const 0
@@ -30293,6 +30260,81 @@
    unreachable
   end
   f32.const nan:0x400000
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1689
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const 1
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1690
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const -inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1691
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const nan:0x400000
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1692
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const -inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_hypotf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1693
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
   f32.const 1
   f32.const nan:0x400000
   f32.const 0
@@ -30302,7 +30344,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1689
+   i32.const 1694
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30317,7 +30359,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1690
+   i32.const 1695
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30331,7 +30373,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1702
+   i32.const 1707
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30345,7 +30387,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1703
+   i32.const 1708
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30359,7 +30401,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1704
+   i32.const 1709
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30373,7 +30415,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1705
+   i32.const 1710
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30387,7 +30429,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1706
+   i32.const 1711
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30401,7 +30443,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1707
+   i32.const 1712
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30415,7 +30457,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1708
+   i32.const 1713
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30429,7 +30471,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1709
+   i32.const 1714
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30443,54 +30485,12 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1710
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.6787637026394024
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
-  call $std/math/test_log
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1711
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -inf
-  f64.const 0
-  i32.const 4
-  call $std/math/test_log
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1714
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -inf
-  f64.const 0
-  i32.const 4
-  call $std/math/test_log
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 1715
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -7.888609052210118e-31
+  f64.const -0.6787637026394024
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -30504,6 +30504,48 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0
+  f64.const -inf
+  f64.const 0
+  i32.const 4
+  call $std/math/test_log
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1719
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -inf
+  f64.const 0
+  i32.const 4
+  call $std/math/test_log
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1720
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -7.888609052210118e-31
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 2
+  call $std/math/test_log
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1721
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1
   f64.const 0
   f64.const 0
@@ -30513,7 +30555,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1717
+   i32.const 1722
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30527,7 +30569,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1718
+   i32.const 1723
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30541,7 +30583,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1719
+   i32.const 1724
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30555,7 +30597,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1720
+   i32.const 1725
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30569,7 +30611,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1721
+   i32.const 1726
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30578,76 +30620,6 @@
   f32.const -inf
   f32.const 0
   i32.const 4
-  call $std/math/test_logf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1730
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -inf
-  f32.const 0
-  i32.const 4
-  call $std/math/test_logf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1731
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -7.888609052210118e-31
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_logf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1732
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_logf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1733
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_logf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1734
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  i32.const 0
   call $std/math/test_logf
   i32.eqz
   if
@@ -30658,48 +30630,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_logf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1736
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_logf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1737
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -inf
-  f32.const 0
-  i32.const 4
-  call $std/math/test_logf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1740
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -0
   f32.const -inf
   f32.const 0
@@ -30709,7 +30639,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1741
+   i32.const 1736
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30723,7 +30653,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1742
+   i32.const 1737
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30737,7 +30667,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1743
+   i32.const 1738
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30751,7 +30681,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1744
+   i32.const 1739
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30765,7 +30695,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1745
+   i32.const 1740
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30779,7 +30709,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1746
+   i32.const 1741
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30793,7 +30723,119 @@
   if
    i32.const 0
    i32.const 24
+   i32.const 1742
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const -inf
+  f32.const 0
+  i32.const 4
+  call $std/math/test_logf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1745
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -inf
+  f32.const 0
+  i32.const 4
+  call $std/math/test_logf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1746
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -7.888609052210118e-31
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 2
+  call $std/math/test_logf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
    i32.const 1747
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_logf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1748
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 2
+  call $std/math/test_logf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1749
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_logf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1750
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 2
+  call $std/math/test_logf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1751
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_logf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1752
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30807,7 +30849,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1759
+   i32.const 1764
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30821,7 +30863,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1760
+   i32.const 1765
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30835,7 +30877,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1761
+   i32.const 1766
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30849,7 +30891,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1762
+   i32.const 1767
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30863,7 +30905,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1763
+   i32.const 1768
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30877,7 +30919,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1764
+   i32.const 1769
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30891,7 +30933,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1765
+   i32.const 1770
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30905,7 +30947,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1766
+   i32.const 1771
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -30919,54 +30961,12 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1767
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.6787637026394024
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
-  call $std/math/test_log10
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1768
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -inf
-  f64.const 0
-  i32.const 4
-  call $std/math/test_log10
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1771
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -inf
-  f64.const 0
-  i32.const 4
-  call $std/math/test_log10
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 1772
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -7.888609052210118e-31
+  f64.const -0.6787637026394024
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -30980,6 +30980,48 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0
+  f64.const -inf
+  f64.const 0
+  i32.const 4
+  call $std/math/test_log10
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1776
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -inf
+  f64.const 0
+  i32.const 4
+  call $std/math/test_log10
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1777
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -7.888609052210118e-31
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 2
+  call $std/math/test_log10
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1778
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1
   f64.const 0
   f64.const 0
@@ -30989,7 +31031,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1774
+   i32.const 1779
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31003,7 +31045,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1775
+   i32.const 1780
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31017,7 +31059,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1776
+   i32.const 1781
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31031,7 +31073,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1777
+   i32.const 1782
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31045,7 +31087,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1778
+   i32.const 1783
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31059,7 +31101,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1787
+   i32.const 1792
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31073,7 +31115,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1788
+   i32.const 1793
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31087,7 +31129,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1789
+   i32.const 1794
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31101,7 +31143,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1790
+   i32.const 1795
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31115,7 +31157,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1791
+   i32.const 1796
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31129,7 +31171,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1792
+   i32.const 1797
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31143,7 +31185,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1793
+   i32.const 1798
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31157,7 +31199,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1794
+   i32.const 1799
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31171,54 +31213,12 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1795
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.6787636876106262
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_log10f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1796
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -inf
-  f32.const 0
-  i32.const 4
-  call $std/math/test_log10f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1799
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -inf
-  f32.const 0
-  i32.const 4
-  call $std/math/test_log10f
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 1800
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -7.888609052210118e-31
+  f32.const -0.6787636876106262
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -31232,6 +31232,48 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 0
+  f32.const -inf
+  f32.const 0
+  i32.const 4
+  call $std/math/test_log10f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1804
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -inf
+  f32.const 0
+  i32.const 4
+  call $std/math/test_log10f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1805
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -7.888609052210118e-31
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 2
+  call $std/math/test_log10f
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1806
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1
   f32.const 0
   f32.const 0
@@ -31241,7 +31283,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1802
+   i32.const 1807
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31255,7 +31297,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1803
+   i32.const 1808
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31269,7 +31311,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1804
+   i32.const 1809
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31283,7 +31325,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1805
+   i32.const 1810
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31297,7 +31339,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1806
+   i32.const 1811
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31311,7 +31353,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1818
+   i32.const 1823
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31325,7 +31367,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1819
+   i32.const 1824
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31339,7 +31381,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1820
+   i32.const 1825
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31353,7 +31395,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1821
+   i32.const 1826
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31367,7 +31409,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1822
+   i32.const 1827
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31381,7 +31423,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1823
+   i32.const 1828
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31395,7 +31437,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1824
+   i32.const 1829
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31409,7 +31451,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1825
+   i32.const 1830
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31423,7 +31465,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1826
+   i32.const 1831
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31437,7 +31479,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1827
+   i32.const 1832
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31451,7 +31493,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1830
+   i32.const 1835
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31465,7 +31507,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1831
+   i32.const 1836
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31479,7 +31521,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1832
+   i32.const 1837
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31493,7 +31535,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1833
+   i32.const 1838
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31507,7 +31549,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1834
+   i32.const 1839
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31521,7 +31563,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1835
+   i32.const 1840
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31535,7 +31577,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1836
+   i32.const 1841
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31549,7 +31591,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1837
+   i32.const 1842
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31563,7 +31605,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1846
+   i32.const 1851
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31577,7 +31619,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1847
+   i32.const 1852
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31591,7 +31633,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1848
+   i32.const 1853
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31605,7 +31647,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1849
+   i32.const 1854
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31619,7 +31661,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1850
+   i32.const 1855
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31633,7 +31675,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1851
+   i32.const 1856
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31647,7 +31689,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1852
+   i32.const 1857
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31661,7 +31703,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1853
+   i32.const 1858
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31675,7 +31717,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1854
+   i32.const 1859
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31689,7 +31731,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1855
+   i32.const 1860
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31703,7 +31745,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1858
+   i32.const 1863
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31717,7 +31759,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1859
+   i32.const 1864
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31731,7 +31773,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1860
+   i32.const 1865
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31745,7 +31787,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1861
+   i32.const 1866
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31759,7 +31801,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1862
+   i32.const 1867
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31773,7 +31815,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1863
+   i32.const 1868
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31787,7 +31829,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1864
+   i32.const 1869
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31801,7 +31843,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1865
+   i32.const 1870
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31815,7 +31857,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1866
+   i32.const 1871
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31829,7 +31871,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1878
+   i32.const 1883
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31843,7 +31885,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1879
+   i32.const 1884
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31857,7 +31899,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1880
+   i32.const 1885
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31871,7 +31913,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1881
+   i32.const 1886
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31885,7 +31927,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1882
+   i32.const 1887
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31899,7 +31941,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1883
+   i32.const 1888
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31913,7 +31955,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1884
+   i32.const 1889
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31927,7 +31969,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1885
+   i32.const 1890
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31941,7 +31983,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1886
+   i32.const 1891
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31955,7 +31997,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1887
+   i32.const 1892
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31969,7 +32011,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1890
+   i32.const 1895
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31983,7 +32025,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1891
+   i32.const 1896
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -31997,7 +32039,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1892
+   i32.const 1897
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32011,7 +32053,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1893
+   i32.const 1898
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32025,7 +32067,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1894
+   i32.const 1899
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32039,7 +32081,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1895
+   i32.const 1900
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32053,7 +32095,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1896
+   i32.const 1901
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32067,7 +32109,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1897
+   i32.const 1902
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32081,7 +32123,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1906
+   i32.const 1911
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32095,7 +32137,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1907
+   i32.const 1912
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32109,7 +32151,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1908
+   i32.const 1913
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32123,7 +32165,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1909
+   i32.const 1914
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32137,7 +32179,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1910
+   i32.const 1915
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32151,7 +32193,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1911
+   i32.const 1916
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32165,7 +32207,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1912
+   i32.const 1917
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32179,7 +32221,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1913
+   i32.const 1918
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32193,7 +32235,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1914
+   i32.const 1919
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32207,7 +32249,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1915
+   i32.const 1920
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32221,7 +32263,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1918
+   i32.const 1923
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32235,7 +32277,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1919
+   i32.const 1924
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32249,7 +32291,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1920
+   i32.const 1925
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32263,7 +32305,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1921
+   i32.const 1926
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32277,7 +32319,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1922
+   i32.const 1927
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32291,7 +32333,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1923
+   i32.const 1928
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32305,7 +32347,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1924
+   i32.const 1929
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32319,7 +32361,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1925
+   i32.const 1930
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32334,7 +32376,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1937
+   i32.const 1942
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32349,7 +32391,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1938
+   i32.const 1943
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32364,7 +32406,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1939
+   i32.const 1944
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32379,7 +32421,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1940
+   i32.const 1945
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32394,7 +32436,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1941
+   i32.const 1946
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32409,7 +32451,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1942
+   i32.const 1947
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32424,7 +32466,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1943
+   i32.const 1948
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32439,7 +32481,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1944
+   i32.const 1949
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32454,7 +32496,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1945
+   i32.const 1950
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32469,87 +32511,12 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1946
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 1
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1949
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const 1
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1950
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const 1
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 1951
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
-  f64.const 1
-  f64.const 1
   f64.const 0
-  i32.const 0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1952
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1953
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
   f64.const 1
   f64.const 1
   f64.const 0
@@ -32564,9 +32531,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -0
   f64.const 1
-  f64.const inf
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32579,7 +32546,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const 0.5
   f64.const 1
   f64.const 1
   f64.const 0
@@ -32594,9 +32561,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -0.5
   f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32609,9 +32576,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -1
-  f64.const 0
+  f64.const 1
+  f64.const 1
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32624,9 +32591,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
   f64.const -1
-  f64.const -0
+  f64.const 1
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32639,9 +32606,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
-  f64.const -1
-  f64.const 0.5
+  f64.const inf
+  f64.const 1
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32654,9 +32621,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
-  f64.const -1
-  f64.const -0.5
+  f64.const -inf
+  f64.const 1
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32669,9 +32636,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const nan:0x8000000000000
   f64.const 1
-  f64.const -1
-  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32684,9 +32651,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0
   f64.const -1
-  f64.const -1
-  f64.const -1
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32699,9 +32666,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -0
   f64.const -1
-  f64.const inf
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32714,9 +32681,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const 0.5
   f64.const -1
-  f64.const -1
+  f64.const 0.5
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32729,9 +32696,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -0.5
   f64.const -1
-  f64.const nan:0x8000000000000
+  f64.const -0.5
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32744,9 +32711,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
-  f64.const 0
+  f64.const 1
+  f64.const -1
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32759,9 +32726,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -0
-  f64.const 0
+  f64.const -1
+  f64.const -1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32774,8 +32741,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const inf
+  f64.const -1
   f64.const inf
   f64.const 0
   i32.const 0
@@ -32789,9 +32756,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const -inf
-  f64.const 0
+  f64.const -1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32804,8 +32771,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const nan:0x8000000000000
+  f64.const -1
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
@@ -32819,7 +32786,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const 0
   f64.const 0
   f64.const 0
@@ -32834,9 +32801,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0
   f64.const -0
-  f64.const -0
-  f64.const -0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32849,7 +32816,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const inf
   f64.const inf
   f64.const 0
@@ -32864,9 +32831,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const -inf
-  f64.const -0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32879,7 +32846,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -32894,9 +32861,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -0
   f64.const 0
-  f64.const 1
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32909,9 +32876,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const 0
-  f64.const 0
+  f64.const -0
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -32924,8 +32891,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const inf
-  f64.const 0
   f64.const inf
   f64.const 0
   i32.const 0
@@ -32939,6 +32906,81 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const -inf
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1980
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1981
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 0
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1982
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1983
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const 0
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 1984
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -inf
   f64.const 0
   f64.const 0
@@ -32949,7 +32991,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1980
+   i32.const 1985
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32964,7 +33006,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1981
+   i32.const 1986
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -32979,89 +33021,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 1982
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -0
-  f64.const inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1983
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1984
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1985
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 2
-  f64.const inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 1986
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -0.5
-  f64.const inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_max
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 1987
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -0
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33075,8 +33042,8 @@
    unreachable
   end
   f64.const -inf
-  f64.const 2
-  f64.const 2
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33089,9 +33056,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -0.5
-  f64.const -0.5
+  f64.const nan:0x8000000000000
+  f64.const -0
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33104,9 +33071,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const 2
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33119,9 +33086,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const -0.5
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33134,7 +33101,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const inf
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -33149,9 +33116,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const 2
+  f64.const 2
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33164,9 +33131,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const inf
-  f64.const inf
+  f64.const -inf
+  f64.const -0.5
+  f64.const -0.5
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33179,9 +33146,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const inf
-  f64.const inf
+  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33194,9 +33161,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
-  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33209,9 +33176,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const inf
-  f64.const inf
+  f64.const 1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33224,9 +33191,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const -inf
-  f64.const 1
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33239,9 +33206,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -inf
-  f64.const -1
+  f64.const 1
+  f64.const inf
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33254,8 +33221,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
   f64.const inf
-  f64.const -inf
   f64.const inf
   f64.const 0
   i32.const 0
@@ -33269,9 +33236,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
-  f64.const -inf
+  f64.const inf
+  f64.const inf
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33284,9 +33251,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const 0.5
-  f64.const 1.75
+  f64.const -inf
+  f64.const inf
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33299,9 +33266,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.75
-  f64.const 0.5
-  f64.const 0.5
+  f64.const 1
+  f64.const -inf
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_max
@@ -33314,6 +33281,81 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
+  f64.const -inf
+  f64.const -1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2005
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const -inf
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2006
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -inf
+  f64.const -inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2007
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.75
+  f64.const 0.5
+  f64.const 1.75
+  f64.const 0
+  i32.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2008
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.75
+  f64.const 0.5
+  f64.const 0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_max
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2009
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1.75
   f64.const -0.5
   f64.const 1.75
@@ -33324,7 +33366,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2005
+   i32.const 2010
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33339,7 +33381,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2006
+   i32.const 2011
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33354,7 +33396,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2015
+   i32.const 2020
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33369,7 +33411,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2016
+   i32.const 2021
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33384,7 +33426,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2017
+   i32.const 2022
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33399,7 +33441,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2018
+   i32.const 2023
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33414,7 +33456,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2019
+   i32.const 2024
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33429,7 +33471,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2020
+   i32.const 2025
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33444,7 +33486,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2021
+   i32.const 2026
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33459,7 +33501,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2022
+   i32.const 2027
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33474,7 +33516,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2023
+   i32.const 2028
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33489,87 +33531,12 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2024
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2027
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2028
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2029
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const 1
-  f32.const 1
   f32.const 0
-  i32.const 0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2030
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2031
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
   f32.const 1
   f32.const 1
   f32.const 0
@@ -33584,9 +33551,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -0
   f32.const 1
-  f32.const inf
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33599,7 +33566,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const 0.5
   f32.const 1
   f32.const 1
   f32.const 0
@@ -33614,9 +33581,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -0.5
   f32.const 1
-  f32.const nan:0x400000
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33629,9 +33596,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const -1
-  f32.const 0
+  f32.const 1
+  f32.const 1
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33644,9 +33611,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
   f32.const -1
-  f32.const -0
+  f32.const 1
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33659,9 +33626,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
-  f32.const -1
-  f32.const 0.5
+  f32.const inf
+  f32.const 1
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33674,9 +33641,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const -1
-  f32.const -0.5
+  f32.const -inf
+  f32.const 1
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33689,9 +33656,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const nan:0x400000
   f32.const 1
-  f32.const -1
-  f32.const 1
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33704,9 +33671,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 0
   f32.const -1
-  f32.const -1
-  f32.const -1
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33719,9 +33686,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -0
   f32.const -1
-  f32.const inf
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33734,9 +33701,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const 0.5
   f32.const -1
-  f32.const -1
+  f32.const 0.5
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33749,9 +33716,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -0.5
   f32.const -1
-  f32.const nan:0x400000
+  f32.const -0.5
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33764,9 +33731,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
-  f32.const 0
+  f32.const 1
+  f32.const -1
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33779,9 +33746,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const -0
-  f32.const 0
+  f32.const -1
+  f32.const -1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33794,8 +33761,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
   f32.const inf
+  f32.const -1
   f32.const inf
   f32.const 0
   i32.const 0
@@ -33809,9 +33776,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
   f32.const -inf
-  f32.const 0
+  f32.const -1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33824,8 +33791,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
   f32.const nan:0x400000
+  f32.const -1
   f32.const nan:0x400000
   f32.const 0
   i32.const 0
@@ -33839,7 +33806,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const 0
   f32.const 0
   f32.const 0
@@ -33854,9 +33821,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 0
   f32.const -0
-  f32.const -0
-  f32.const -0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33869,7 +33836,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const inf
   f32.const inf
   f32.const 0
@@ -33884,9 +33851,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const -inf
-  f32.const -0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33899,7 +33866,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -33914,9 +33881,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -0
   f32.const 0
-  f32.const 1
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33929,9 +33896,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const 0
-  f32.const 0
+  f32.const -0
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -33944,8 +33911,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const inf
-  f32.const 0
   f32.const inf
   f32.const 0
   i32.const 0
@@ -33959,6 +33926,81 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  f32.const -inf
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2058
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2059
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 0
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2060
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2061
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const 0
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2062
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -inf
   f32.const 0
   f32.const 0
@@ -33969,7 +34011,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2058
+   i32.const 2063
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33984,7 +34026,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2059
+   i32.const 2064
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -33999,89 +34041,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2060
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -0
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2061
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2062
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const -0
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2063
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 2
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2064
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -0.5
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_maxf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2065
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -0
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34095,8 +34062,8 @@
    unreachable
   end
   f32.const -inf
-  f32.const 2
-  f32.const 2
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34109,9 +34076,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -0.5
-  f32.const -0.5
+  f32.const nan:0x400000
+  f32.const -0
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34124,9 +34091,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const 2
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34139,9 +34106,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const -0.5
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34154,7 +34121,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const inf
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -34169,9 +34136,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const 2
+  f32.const 2
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34184,9 +34151,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const inf
-  f32.const inf
+  f32.const -inf
+  f32.const -0.5
+  f32.const -0.5
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34199,9 +34166,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const inf
-  f32.const inf
+  f32.const -inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34214,9 +34181,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34229,9 +34196,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const inf
-  f32.const inf
+  f32.const 1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34244,9 +34211,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const -inf
-  f32.const 1
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34259,9 +34226,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -inf
-  f32.const -1
+  f32.const 1
+  f32.const inf
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34274,8 +34241,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
   f32.const inf
-  f32.const -inf
   f32.const inf
   f32.const 0
   i32.const 0
@@ -34289,9 +34256,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
-  f32.const -inf
+  f32.const inf
+  f32.const inf
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34304,9 +34271,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
-  f32.const 0.5
-  f32.const 1.75
+  f32.const -inf
+  f32.const inf
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34319,9 +34286,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.75
-  f32.const 0.5
-  f32.const 0.5
+  f32.const 1
+  f32.const -inf
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_maxf
@@ -34334,6 +34301,81 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
+  f32.const -inf
+  f32.const -1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2083
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const -inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2084
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -inf
+  f32.const -inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2085
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.75
+  f32.const 0.5
+  f32.const 1.75
+  f32.const 0
+  i32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2086
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.75
+  f32.const 0.5
+  f32.const 0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_maxf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2087
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1.75
   f32.const -0.5
   f32.const 1.75
@@ -34344,7 +34386,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2083
+   i32.const 2088
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34359,7 +34401,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2084
+   i32.const 2089
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34374,7 +34416,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2096
+   i32.const 2101
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34389,7 +34431,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2097
+   i32.const 2102
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34404,7 +34446,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2098
+   i32.const 2103
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34419,7 +34461,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2099
+   i32.const 2104
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34434,7 +34476,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2100
+   i32.const 2105
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34449,7 +34491,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2101
+   i32.const 2106
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34464,7 +34506,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2102
+   i32.const 2107
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34479,7 +34521,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2103
+   i32.const 2108
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34494,7 +34536,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2104
+   i32.const 2109
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34509,89 +34551,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2105
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2108
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const 1
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2109
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const 1
-  f64.const 0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2110
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
-  f64.const 1
-  f64.const -0.5
   f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2111
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
   f64.const 1
   f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2112
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const 1
-  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34600,6 +34567,81 @@
    i32.const 0
    i32.const 24
    i32.const 2113
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const 1
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2114
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
+  f64.const 1
+  f64.const 0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2115
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.5
+  f64.const 1
+  f64.const -0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2116
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 1
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2117
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const 1
+  f64.const -1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2118
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -34614,89 +34656,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2114
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const 1
-  f64.const -inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2115
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2116
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -1
-  f64.const -1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2117
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -1
-  f64.const -1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2118
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const -1
-  f64.const -1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2119
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
-  f64.const -1
-  f64.const -1
+  f64.const -inf
+  f64.const 1
+  f64.const -inf
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34709,9 +34676,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const nan:0x8000000000000
   f64.const 1
-  f64.const -1
-  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34724,7 +34691,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
+  f64.const 0
   f64.const -1
   f64.const -1
   f64.const 0
@@ -34739,7 +34706,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
+  f64.const -0
   f64.const -1
   f64.const -1
   f64.const 0
@@ -34754,9 +34721,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const 0.5
   f64.const -1
-  f64.const -inf
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34769,9 +34736,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
+  f64.const -0.5
   f64.const -1
-  f64.const nan:0x8000000000000
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34784,9 +34751,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
-  f64.const 0
+  f64.const 1
+  f64.const -1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34799,9 +34766,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -0
-  f64.const -0
+  f64.const -1
+  f64.const -1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34814,9 +34781,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const inf
-  f64.const 0
+  f64.const -1
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34829,8 +34796,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const -inf
+  f64.const -1
   f64.const -inf
   f64.const 0
   i32.const 0
@@ -34844,8 +34811,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const nan:0x8000000000000
+  f64.const -1
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
@@ -34859,9 +34826,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
   f64.const 0
-  f64.const -0
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34874,7 +34841,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const -0
   f64.const -0
   f64.const 0
@@ -34889,9 +34856,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const inf
-  f64.const -0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34904,7 +34871,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const -inf
   f64.const -inf
   f64.const 0
@@ -34919,7 +34886,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -34934,9 +34901,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -0
   f64.const 0
-  f64.const 0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34949,9 +34916,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const 0
-  f64.const -1
+  f64.const -0
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34964,9 +34931,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const inf
-  f64.const 0
-  f64.const 0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -34979,8 +34946,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const -inf
-  f64.const 0
   f64.const -inf
   f64.const 0
   i32.const 0
@@ -34994,8 +34961,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const nan:0x8000000000000
-  f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
@@ -35009,9 +34976,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -0
-  f64.const -1
+  f64.const 1
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35024,9 +34991,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const -0
-  f64.const -0
+  f64.const -1
+  f64.const 0
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35039,9 +35006,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -0
-  f64.const -inf
+  f64.const inf
+  f64.const 0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35054,9 +35021,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -0
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const 0
+  f64.const -inf
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35069,9 +35036,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 2
-  f64.const 2
+  f64.const nan:0x8000000000000
+  f64.const 0
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35084,9 +35051,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const -0.5
-  f64.const -0.5
+  f64.const -1
+  f64.const -0
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35100,8 +35067,8 @@
    unreachable
   end
   f64.const inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -0
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35115,7 +35082,7 @@
    unreachable
   end
   f64.const -inf
-  f64.const 2
+  f64.const -0
   f64.const -inf
   f64.const 0
   i32.const 0
@@ -35129,9 +35096,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -0.5
-  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const -0
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35144,9 +35111,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const 2
+  f64.const 2
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35159,9 +35126,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const -0.5
+  f64.const -0.5
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35174,7 +35141,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const inf
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -35189,9 +35156,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const 2
+  f64.const -inf
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35204,9 +35171,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const inf
-  f64.const 1
+  f64.const -inf
+  f64.const -0.5
+  f64.const -inf
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35219,9 +35186,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const inf
-  f64.const -1
+  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_min
@@ -35234,6 +35201,81 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2156
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2157
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2158
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const inf
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2159
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const inf
+  f64.const -1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2160
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const inf
   f64.const inf
   f64.const inf
@@ -35244,7 +35286,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2156
+   i32.const 2161
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35259,7 +35301,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2157
+   i32.const 2162
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35274,7 +35316,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2158
+   i32.const 2163
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35289,7 +35331,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2159
+   i32.const 2164
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35304,82 +35346,82 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2160
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -inf
-  f64.const -inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2161
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.75
-  f64.const 0.5
-  f64.const 0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2162
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.75
-  f64.const 0.5
-  f64.const -1.75
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2163
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.75
-  f64.const -0.5
-  f64.const -0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2164
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.75
-  f64.const -0.5
-  f64.const -1.75
-  f64.const 0
-  i32.const 0
-  call $std/math/test_min
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2165
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -inf
+  f64.const -inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2166
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.75
+  f64.const 0.5
+  f64.const 0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2167
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.75
+  f64.const 0.5
+  f64.const -1.75
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2168
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.75
+  f64.const -0.5
+  f64.const -0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2169
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.75
+  f64.const -0.5
+  f64.const -1.75
+  f64.const 0
+  i32.const 0
+  call $std/math/test_min
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2170
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35394,7 +35436,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2174
+   i32.const 2179
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35409,7 +35451,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2175
+   i32.const 2180
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35424,7 +35466,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2176
+   i32.const 2181
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35439,7 +35481,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2177
+   i32.const 2182
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35454,7 +35496,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2178
+   i32.const 2183
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35469,7 +35511,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2179
+   i32.const 2184
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35484,7 +35526,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2180
+   i32.const 2185
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35499,7 +35541,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2181
+   i32.const 2186
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35514,7 +35556,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2182
+   i32.const 2187
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35529,89 +35571,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2183
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2186
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 1
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2187
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const 1
-  f32.const 0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2188
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const 1
-  f32.const -0.5
   f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2189
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
   f32.const 1
   f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2190
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const 1
-  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35620,6 +35587,81 @@
    i32.const 0
    i32.const 24
    i32.const 2191
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 1
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2192
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
+  f32.const 1
+  f32.const 0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2193
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.5
+  f32.const 1
+  f32.const -0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2194
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 1
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2195
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const 1
+  f32.const -1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2196
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35634,89 +35676,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2192
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const 1
-  f32.const -inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2193
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2194
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -1
-  f32.const -1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2195
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -1
-  f32.const -1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2196
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const -1
-  f32.const -1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2197
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const -1
-  f32.const -1
+  f32.const -inf
+  f32.const 1
+  f32.const -inf
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35729,9 +35696,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const nan:0x400000
   f32.const 1
-  f32.const -1
-  f32.const -1
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35744,7 +35711,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
+  f32.const 0
   f32.const -1
   f32.const -1
   f32.const 0
@@ -35759,7 +35726,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
+  f32.const -0
   f32.const -1
   f32.const -1
   f32.const 0
@@ -35774,9 +35741,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const 0.5
   f32.const -1
-  f32.const -inf
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35789,9 +35756,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
+  f32.const -0.5
   f32.const -1
-  f32.const nan:0x400000
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35804,9 +35771,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
-  f32.const 0
+  f32.const 1
+  f32.const -1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35819,9 +35786,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const -0
-  f32.const -0
+  f32.const -1
+  f32.const -1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35834,9 +35801,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
   f32.const inf
-  f32.const 0
+  f32.const -1
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35849,8 +35816,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
   f32.const -inf
+  f32.const -1
   f32.const -inf
   f32.const 0
   i32.const 0
@@ -35864,8 +35831,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
   f32.const nan:0x400000
+  f32.const -1
   f32.const nan:0x400000
   f32.const 0
   i32.const 0
@@ -35879,9 +35846,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
   f32.const 0
-  f32.const -0
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35894,7 +35861,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const -0
   f32.const -0
   f32.const 0
@@ -35909,9 +35876,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const inf
-  f32.const -0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35924,7 +35891,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const -inf
   f32.const -inf
   f32.const 0
@@ -35939,7 +35906,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -35954,9 +35921,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -0
   f32.const 0
-  f32.const 0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35969,9 +35936,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const 0
-  f32.const -1
+  f32.const -0
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35984,9 +35951,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const inf
-  f32.const 0
-  f32.const 0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -35999,8 +35966,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const -inf
-  f32.const 0
   f32.const -inf
   f32.const 0
   i32.const 0
@@ -36014,8 +35981,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const nan:0x400000
-  f32.const 0
   f32.const nan:0x400000
   f32.const 0
   i32.const 0
@@ -36029,9 +35996,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -0
-  f32.const -1
+  f32.const 1
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36044,9 +36011,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const -0
-  f32.const -0
+  f32.const -1
+  f32.const 0
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36059,9 +36026,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -0
-  f32.const -inf
+  f32.const inf
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36074,9 +36041,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -0
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const 0
+  f32.const -inf
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36089,9 +36056,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const 2
-  f32.const 2
+  f32.const nan:0x400000
+  f32.const 0
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36104,9 +36071,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const -0.5
-  f32.const -0.5
+  f32.const -1
+  f32.const -0
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36120,8 +36087,8 @@
    unreachable
   end
   f32.const inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -0
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36135,7 +36102,7 @@
    unreachable
   end
   f32.const -inf
-  f32.const 2
+  f32.const -0
   f32.const -inf
   f32.const 0
   i32.const 0
@@ -36149,9 +36116,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -0.5
-  f32.const -inf
+  f32.const nan:0x400000
+  f32.const -0
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36164,9 +36131,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const 2
+  f32.const 2
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36179,9 +36146,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const -0.5
+  f32.const -0.5
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36194,7 +36161,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const inf
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -36209,9 +36176,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const 2
+  f32.const -inf
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36224,9 +36191,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const inf
-  f32.const 1
+  f32.const -inf
+  f32.const -0.5
+  f32.const -inf
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36239,9 +36206,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const inf
-  f32.const -1
+  f32.const -inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_minf
@@ -36254,6 +36221,81 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2234
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2235
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2236
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const inf
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2237
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const inf
+  f32.const -1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2238
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const inf
   f32.const inf
   f32.const inf
@@ -36264,7 +36306,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2234
+   i32.const 2239
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36279,7 +36321,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2235
+   i32.const 2240
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36294,7 +36336,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2236
+   i32.const 2241
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36309,7 +36351,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2237
+   i32.const 2242
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36324,82 +36366,82 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2238
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -inf
-  f32.const -inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2239
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.75
-  f32.const 0.5
-  f32.const 0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2240
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.75
-  f32.const 0.5
-  f32.const -1.75
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2241
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.75
-  f32.const -0.5
-  f32.const -0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2242
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.75
-  f32.const -0.5
-  f32.const -1.75
-  f32.const 0
-  i32.const 0
-  call $std/math/test_minf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2243
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -inf
+  f32.const -inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2244
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.75
+  f32.const 0.5
+  f32.const 0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2245
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.75
+  f32.const 0.5
+  f32.const -1.75
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2246
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.75
+  f32.const -0.5
+  f32.const -0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2247
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.75
+  f32.const -0.5
+  f32.const -1.75
+  f32.const 0
+  i32.const 0
+  call $std/math/test_minf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2248
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36414,7 +36456,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2257
+   i32.const 2262
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36429,7 +36471,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2258
+   i32.const 2263
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36444,7 +36486,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2259
+   i32.const 2264
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36459,7 +36501,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2260
+   i32.const 2265
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36474,7 +36516,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2261
+   i32.const 2266
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36489,7 +36531,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2262
+   i32.const 2267
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36504,7 +36546,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2263
+   i32.const 2268
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36519,7 +36561,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2264
+   i32.const 2269
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36534,7 +36576,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2265
+   i32.const 2270
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36549,56 +36591,56 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2266
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2269
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const 1
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2270
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const 1
-  f64.const 0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2271
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0
+  f64.const 1
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2274
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const 1
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2275
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
+  f64.const 1
+  f64.const 0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2276
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -0.5
   f64.const 1
   f64.const -0.5
@@ -36609,7 +36651,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2272
+   i32.const 2277
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36624,7 +36666,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2273
+   i32.const 2278
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36639,7 +36681,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2274
+   i32.const 2279
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36654,7 +36696,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2275
+   i32.const 2280
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36669,88 +36711,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2276
+   i32.const 2281
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2
   f64.const 1
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2277
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2
-  f64.const 1
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2278
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2279
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2280
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2281
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -1
   f64.const 0
   f64.const 0
   i32.const 0
@@ -36764,8 +36731,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -1
+  f64.const -2
+  f64.const 1
   f64.const -0
   f64.const 0
   i32.const 0
@@ -36779,6 +36746,81 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
+  f64.const 1
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 2
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2284
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const 1
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 2
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2285
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  f64.const 1
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2286
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -1
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2287
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -1
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2288
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0.5
   f64.const -1
   f64.const 0.5
@@ -36789,7 +36831,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2284
+   i32.const 2289
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36804,7 +36846,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2285
+   i32.const 2290
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36819,7 +36861,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2286
+   i32.const 2291
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36834,7 +36876,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2287
+   i32.const 2292
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36849,7 +36891,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2288
+   i32.const 2293
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36864,7 +36906,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2289
+   i32.const 2294
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36879,7 +36921,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2290
+   i32.const 2295
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36894,91 +36936,16 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2291
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2292
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2293
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2294
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2295
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2296
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const inf
+  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const 0
-  f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_mod
   i32.eqz
   if
@@ -36989,11 +36956,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const -inf
+  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const 0
-  f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_mod
   i32.eqz
   if
@@ -37004,8 +36971,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const nan:0x8000000000000
+  f64.const -1
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
@@ -37019,7 +36986,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -37034,7 +37001,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -37049,9 +37016,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const inf
-  f64.const -0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37064,9 +37031,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const -inf
-  f64.const -0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37079,7 +37046,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -37094,7 +37061,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -0
   f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -37109,8 +37076,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const 0
+  f64.const -0
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -37124,11 +37091,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const inf
+  f64.const -0
   f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -37139,11 +37106,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const -inf
+  f64.const -0
   f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -37154,8 +37121,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const nan:0x8000000000000
-  f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
@@ -37169,8 +37136,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -0
+  f64.const 1
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -37184,8 +37151,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const -0
+  f64.const -1
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -37199,8 +37166,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -0
+  f64.const inf
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -37214,11 +37181,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -0
+  f64.const -inf
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_mod
   i32.eqz
   if
@@ -37229,11 +37196,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 2
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 2
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -37244,8 +37211,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const -0.5
+  f64.const -1
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -37260,10 +37227,10 @@
    unreachable
   end
   f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_mod
   i32.eqz
   if
@@ -37275,7 +37242,7 @@
    unreachable
   end
   f64.const -inf
-  f64.const 2
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -37289,11 +37256,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -0.5
+  f64.const nan:0x8000000000000
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -37304,11 +37271,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const 2
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_mod
   i32.eqz
   if
@@ -37319,11 +37286,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const -0.5
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_mod
   i32.eqz
   if
@@ -37334,7 +37301,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const inf
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -37349,11 +37316,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const 2
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_mod
   i32.eqz
   if
@@ -37364,11 +37331,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const inf
-  f64.const 1
+  f64.const -inf
+  f64.const -0.5
+  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_mod
   i32.eqz
   if
@@ -37379,9 +37346,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const inf
-  f64.const -1
+  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37394,11 +37361,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -37409,11 +37376,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const inf
+  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -37424,9 +37391,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const -inf
-  f64.const 1
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37439,9 +37406,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -inf
-  f64.const -1
+  f64.const 1
+  f64.const inf
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37454,11 +37421,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
   f64.const inf
-  f64.const -inf
-  f64.const nan:0x8000000000000
+  f64.const -1
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_mod
   i32.eqz
   if
@@ -37469,8 +37436,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
+  f64.const inf
+  f64.const inf
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -37484,11 +37451,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const 0.5
-  f64.const 0.25
+  f64.const -inf
+  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_mod
   i32.eqz
   if
@@ -37499,9 +37466,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.75
-  f64.const 0.5
-  f64.const -0.25
+  f64.const 1
+  f64.const -inf
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37514,6 +37481,81 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
+  f64.const -inf
+  f64.const -1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2333
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 2
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2334
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 2
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2335
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.75
+  f64.const 0.5
+  f64.const 0.25
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2336
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.75
+  f64.const 0.5
+  f64.const -0.25
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2337
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1.75
   f64.const -0.5
   f64.const 0.25
@@ -37524,7 +37566,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2333
+   i32.const 2338
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37539,88 +37581,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2334
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072014e-308
-  f64.const 2.2250738585072014e-308
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2337
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2338
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.2250738585072014e-308
-  f64.const 2.2250738585072014e-308
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2339
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2340
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1797693134862315708145274e284
-  f64.const 1797693134862315708145274e284
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2341
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1797693134862315708145274e284
-  f64.const -1797693134862315708145274e284
+  f64.const 2.2250738585072014e-308
+  f64.const 2.2250738585072014e-308
   f64.const 0
   f64.const 0
   i32.const 0
@@ -37634,9 +37601,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1797693134862315708145274e284
-  f64.const 1797693134862315708145274e284
-  f64.const -0
+  f64.const 2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37649,8 +37616,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1797693134862315708145274e284
-  f64.const -1797693134862315708145274e284
+  f64.const -2.2250738585072014e-308
+  f64.const 2.2250738585072014e-308
   f64.const -0
   f64.const 0
   i32.const 0
@@ -37664,8 +37631,38 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
+  f64.const -0
   f64.const 0
-  f64.const 2.2250738585072014e-308
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2345
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1797693134862315708145274e284
+  f64.const 1797693134862315708145274e284
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2346
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1797693134862315708145274e284
+  f64.const -1797693134862315708145274e284
   f64.const 0
   f64.const 0
   i32.const 0
@@ -37679,6 +37676,51 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1797693134862315708145274e284
+  f64.const 1797693134862315708145274e284
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2348
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1797693134862315708145274e284
+  f64.const -1797693134862315708145274e284
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2349
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 2.2250738585072014e-308
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2352
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0
   f64.const 1797693134862315708145274e284
   f64.const 0
@@ -37689,7 +37731,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2348
+   i32.const 2353
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37704,7 +37746,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2349
+   i32.const 2354
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37719,7 +37761,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2350
+   i32.const 2355
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37734,7 +37776,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2351
+   i32.const 2356
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37749,7 +37791,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2352
+   i32.const 2357
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37764,7 +37806,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2353
+   i32.const 2358
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37779,7 +37821,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2354
+   i32.const 2359
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37794,7 +37836,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2357
+   i32.const 2362
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37802,51 +37844,6 @@
   f64.const -1797693134862315708145274e284
   f64.const 1797693134862315508561243e284
   f64.const -1995840309534719811656372e268
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2358
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1797693134862315708145274e284
-  f64.const -8988465674311579538646525e283
-  f64.const 8988465674311577542806216e283
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2360
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1797693134862315708145274e284
-  f64.const -8988465674311579538646525e283
-  f64.const -8988465674311577542806216e283
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2361
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1797693134862315708145274e284
-  f64.const 8988465674311578540726371e283
-  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37859,6 +37856,51 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1797693134862315708145274e284
+  f64.const -8988465674311579538646525e283
+  f64.const 8988465674311577542806216e283
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2365
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1797693134862315708145274e284
+  f64.const -8988465674311579538646525e283
+  f64.const -8988465674311577542806216e283
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2366
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1797693134862315708145274e284
+  f64.const 8988465674311578540726371e283
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2368
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -1797693134862315708145274e284
   f64.const 8988465674311578540726371e283
   f64.const -0
@@ -37869,7 +37911,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2364
+   i32.const 2369
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37884,7 +37926,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2366
+   i32.const 2371
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37899,59 +37941,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2367
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 8988465674311579538646525e283
-  f64.const 1797693134862315708145274e284
-  f64.const 8988465674311579538646525e283
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2369
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -8988465674311579538646525e283
-  f64.const 1797693134862315708145274e284
-  f64.const -8988465674311579538646525e283
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2370
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 8988465674311578540726371e283
-  f64.const -1797693134862315708145274e284
-  f64.const 8988465674311578540726371e283
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2372
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8988465674311578540726371e283
-  f64.const -1797693134862315708145274e284
-  f64.const -8988465674311578540726371e283
+  f64.const 8988465674311579538646525e283
+  f64.const 1797693134862315708145274e284
+  f64.const 8988465674311579538646525e283
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37959,14 +37956,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2373
+   i32.const 2374
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 8988465674311577542806216e283
+  f64.const -8988465674311579538646525e283
   f64.const 1797693134862315708145274e284
-  f64.const 8988465674311577542806216e283
+  f64.const -8988465674311579538646525e283
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37979,9 +37976,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8988465674311577542806216e283
-  f64.const 1797693134862315708145274e284
-  f64.const -8988465674311577542806216e283
+  f64.const 8988465674311578540726371e283
+  f64.const -1797693134862315708145274e284
+  f64.const 8988465674311578540726371e283
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -37989,14 +37986,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2376
+   i32.const 2377
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1797693134862315508561243e284
+  f64.const -8988465674311578540726371e283
   f64.const -1797693134862315708145274e284
-  f64.const 1797693134862315508561243e284
+  f64.const -8988465674311578540726371e283
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -38009,6 +38006,51 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 8988465674311577542806216e283
+  f64.const 1797693134862315708145274e284
+  f64.const 8988465674311577542806216e283
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2380
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -8988465674311577542806216e283
+  f64.const 1797693134862315708145274e284
+  f64.const -8988465674311577542806216e283
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2381
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1797693134862315508561243e284
+  f64.const -1797693134862315708145274e284
+  f64.const 1797693134862315508561243e284
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2383
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -1797693134862315508561243e284
   f64.const -1797693134862315708145274e284
   f64.const -1797693134862315508561243e284
@@ -38019,7 +38061,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2379
+   i32.const 2384
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38034,7 +38076,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2381
+   i32.const 2386
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38049,7 +38091,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2382
+   i32.const 2387
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38064,7 +38106,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2384
+   i32.const 2389
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38079,7 +38121,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2385
+   i32.const 2390
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38094,7 +38136,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2386
+   i32.const 2391
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38109,7 +38151,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2387
+   i32.const 2392
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38124,7 +38166,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2388
+   i32.const 2393
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38139,7 +38181,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2389
+   i32.const 2394
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38154,7 +38196,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2390
+   i32.const 2395
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38169,7 +38211,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2391
+   i32.const 2396
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38184,7 +38226,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2393
+   i32.const 2398
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38199,7 +38241,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2394
+   i32.const 2399
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38214,7 +38256,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2395
+   i32.const 2400
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38229,7 +38271,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2396
+   i32.const 2401
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38244,7 +38286,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2397
+   i32.const 2402
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38259,7 +38301,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2398
+   i32.const 2403
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38274,7 +38316,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2399
+   i32.const 2404
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38289,7 +38331,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2400
+   i32.const 2405
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38304,7 +38346,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2401
+   i32.const 2406
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38319,7 +38361,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2402
+   i32.const 2407
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38334,89 +38376,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2403
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072024e-308
-  f64.const 1.5e-323
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2404
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072024e-308
-  f64.const -1.5e-323
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2405
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507203e-308
-  f64.const 1.5e-323
-  f64.const 5e-324
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2406
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507203e-308
-  f64.const 2.225073858507204e-308
-  f64.const 2.225073858507203e-308
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2407
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507203e-308
-  f64.const -1.5e-323
-  f64.const 5e-324
-  f64.const 0
-  i32.const 0
-  call $std/math/test_mod
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2408
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072034e-308
-  f64.const 2.225073858507204e-308
-  f64.const 2.2250738585072034e-308
+  f64.const 2.2250738585072024e-308
+  f64.const 1.5e-323
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_mod
@@ -38425,6 +38392,81 @@
    i32.const 0
    i32.const 24
    i32.const 2409
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.2250738585072024e-308
+  f64.const -1.5e-323
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2410
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.225073858507203e-308
+  f64.const 1.5e-323
+  f64.const 5e-324
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2411
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.225073858507203e-308
+  f64.const 2.225073858507204e-308
+  f64.const 2.225073858507203e-308
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2412
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.225073858507203e-308
+  f64.const -1.5e-323
+  f64.const 5e-324
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2413
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.2250738585072034e-308
+  f64.const 2.225073858507204e-308
+  f64.const 2.2250738585072034e-308
+  f64.const 0
+  i32.const 0
+  call $std/math/test_mod
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2414
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38439,7 +38481,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2410
+   i32.const 2415
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38454,7 +38496,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2411
+   i32.const 2416
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38469,7 +38511,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2412
+   i32.const 2417
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38484,7 +38526,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2421
+   i32.const 2426
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38499,7 +38541,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2422
+   i32.const 2427
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38514,7 +38556,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2423
+   i32.const 2428
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38529,7 +38571,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2424
+   i32.const 2429
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38544,7 +38586,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2425
+   i32.const 2430
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38559,7 +38601,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2426
+   i32.const 2431
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38574,7 +38616,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2427
+   i32.const 2432
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38589,7 +38631,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2428
+   i32.const 2433
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38604,7 +38646,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2429
+   i32.const 2434
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38619,56 +38661,56 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2430
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2433
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 1
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2434
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const 1
-  f32.const 0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2435
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 0
+  f32.const 1
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2438
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 1
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2439
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
+  f32.const 1
+  f32.const 0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2440
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -0.5
   f32.const 1
   f32.const -0.5
@@ -38679,7 +38721,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2436
+   i32.const 2441
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38694,7 +38736,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2437
+   i32.const 2442
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38709,7 +38751,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2438
+   i32.const 2443
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38724,7 +38766,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2439
+   i32.const 2444
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38739,88 +38781,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2440
+   i32.const 2445
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 2
   f32.const 1
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2441
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2
-  f32.const 1
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2442
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2443
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2444
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2445
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -1
   f32.const 0
   f32.const 0
   i32.const 0
@@ -38834,8 +38801,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -1
+  f32.const -2
+  f32.const 1
   f32.const -0
   f32.const 0
   i32.const 0
@@ -38849,6 +38816,81 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
+  f32.const 1
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 2
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2448
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const 1
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 2
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2449
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const 1
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2450
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const -1
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2451
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -1
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2452
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 0.5
   f32.const -1
   f32.const 0.5
@@ -38859,7 +38901,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2448
+   i32.const 2453
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38874,7 +38916,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2449
+   i32.const 2454
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38889,7 +38931,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2450
+   i32.const 2455
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38904,7 +38946,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2451
+   i32.const 2456
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38919,7 +38961,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2452
+   i32.const 2457
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38934,7 +38976,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2453
+   i32.const 2458
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38949,7 +38991,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2454
+   i32.const 2459
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38964,91 +39006,16 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2455
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2456
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2457
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2458
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2459
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -0
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_modf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2460
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
   f32.const inf
+  f32.const -1
+  f32.const nan:0x400000
   f32.const 0
-  f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_modf
   i32.eqz
   if
@@ -39059,11 +39026,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
   f32.const -inf
+  f32.const -1
+  f32.const nan:0x400000
   f32.const 0
-  f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_modf
   i32.eqz
   if
@@ -39074,8 +39041,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
   f32.const nan:0x400000
+  f32.const -1
   f32.const nan:0x400000
   f32.const 0
   i32.const 0
@@ -39089,7 +39056,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const 0
   f32.const nan:0x400000
   f32.const 0
@@ -39104,7 +39071,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const -0
   f32.const nan:0x400000
   f32.const 0
@@ -39119,9 +39086,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const inf
-  f32.const -0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -39134,9 +39101,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const -inf
-  f32.const -0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -39149,7 +39116,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -39164,7 +39131,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -0
   f32.const 0
   f32.const nan:0x400000
   f32.const 0
@@ -39179,8 +39146,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const 0
+  f32.const -0
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -39194,11 +39161,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const inf
+  f32.const -0
   f32.const 0
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -39209,11 +39176,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const -inf
+  f32.const -0
   f32.const 0
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -39224,8 +39191,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const nan:0x400000
-  f32.const 0
   f32.const nan:0x400000
   f32.const 0
   i32.const 0
@@ -39239,8 +39206,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -0
+  f32.const 1
+  f32.const 0
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -39254,8 +39221,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const -0
+  f32.const -1
+  f32.const 0
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -39269,8 +39236,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -0
+  f32.const inf
+  f32.const 0
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -39284,11 +39251,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -0
+  f32.const -inf
+  f32.const 0
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_modf
   i32.eqz
   if
@@ -39299,11 +39266,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const 2
   f32.const nan:0x400000
   f32.const 0
-  i32.const 2
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -39314,8 +39281,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const -0.5
+  f32.const -1
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -39330,10 +39297,10 @@
    unreachable
   end
   f32.const inf
-  f32.const nan:0x400000
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_modf
   i32.eqz
   if
@@ -39345,7 +39312,7 @@
    unreachable
   end
   f32.const -inf
-  f32.const 2
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -39359,11 +39326,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -0.5
+  f32.const nan:0x400000
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -39374,11 +39341,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const 2
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_modf
   i32.eqz
   if
@@ -39389,11 +39356,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const -0.5
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_modf
   i32.eqz
   if
@@ -39404,7 +39371,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const inf
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -39419,11 +39386,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const 2
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_modf
   i32.eqz
   if
@@ -39434,11 +39401,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const inf
-  f32.const 1
+  f32.const -inf
+  f32.const -0.5
+  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_modf
   i32.eqz
   if
@@ -39449,9 +39416,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const inf
-  f32.const -1
+  f32.const -inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -39464,11 +39431,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -39479,11 +39446,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const inf
+  f32.const 1
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -39494,9 +39461,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const -inf
-  f32.const 1
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -39509,9 +39476,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -inf
-  f32.const -1
+  f32.const 1
+  f32.const inf
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -39524,11 +39491,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
   f32.const inf
-  f32.const -inf
-  f32.const nan:0x400000
+  f32.const -1
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_modf
   i32.eqz
   if
@@ -39539,8 +39506,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const inf
+  f32.const inf
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -39554,11 +39521,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
-  f32.const 0.5
-  f32.const 0.25
+  f32.const -inf
+  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_modf
   i32.eqz
   if
@@ -39569,9 +39536,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.75
-  f32.const 0.5
-  f32.const -0.25
+  f32.const 1
+  f32.const -inf
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_modf
@@ -39584,6 +39551,81 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
+  f32.const -inf
+  f32.const -1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2497
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const -inf
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 2
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2498
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -inf
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 2
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2499
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.75
+  f32.const 0.5
+  f32.const 0.25
+  f32.const 0
+  i32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2500
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.75
+  f32.const 0.5
+  f32.const -0.25
+  f32.const 0
+  i32.const 0
+  call $std/math/test_modf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2501
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1.75
   f32.const -0.5
   f32.const 0.25
@@ -39594,7 +39636,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2497
+   i32.const 2502
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39609,7 +39651,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2498
+   i32.const 2503
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39624,7 +39666,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2510
+   i32.const 2515
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39639,7 +39681,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2511
+   i32.const 2516
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39654,7 +39696,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2512
+   i32.const 2517
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39669,7 +39711,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2513
+   i32.const 2518
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39684,7 +39726,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2514
+   i32.const 2519
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39699,7 +39741,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2515
+   i32.const 2520
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39714,7 +39756,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2516
+   i32.const 2521
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39729,7 +39771,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2517
+   i32.const 2522
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39744,7 +39786,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2518
+   i32.const 2523
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39759,89 +39801,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2519
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2522
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const inf
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2523
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 3
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2524
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  f64.const 2
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2525
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2526
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0.5
-  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -39855,6 +39822,81 @@
    unreachable
   end
   f64.const 0
+  f64.const inf
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2528
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 3
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2529
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 2
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2530
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 1
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2531
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0.5
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2532
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
   f64.const 0
   f64.const 1
   f64.const 0
@@ -39864,7 +39906,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2528
+   i32.const 2533
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39879,7 +39921,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2529
+   i32.const 2534
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39894,7 +39936,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2530
+   i32.const 2535
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39909,7 +39951,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2531
+   i32.const 2536
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39924,7 +39966,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2532
+   i32.const 2537
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39939,7 +39981,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2533
+   i32.const 2538
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39954,7 +39996,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2534
+   i32.const 2539
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39969,7 +40011,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2535
+   i32.const 2540
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39984,7 +40026,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2536
+   i32.const 2541
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39999,7 +40041,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2537
+   i32.const 2542
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40014,7 +40056,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2538
+   i32.const 2543
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40029,7 +40071,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2539
+   i32.const 2544
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40044,7 +40086,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2540
+   i32.const 2545
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40059,7 +40101,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2541
+   i32.const 2546
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40074,7 +40116,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2542
+   i32.const 2547
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40089,7 +40131,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2543
+   i32.const 2548
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40104,7 +40146,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2544
+   i32.const 2549
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40119,7 +40161,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2545
+   i32.const 2550
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40134,7 +40176,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2546
+   i32.const 2551
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40149,7 +40191,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2547
+   i32.const 2552
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40164,7 +40206,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2548
+   i32.const 2553
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40179,87 +40221,12 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2549
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2550
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2551
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2552
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2553
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2554
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const nan:0x8000000000000
   f64.const 0
   f64.const 1
   f64.const 0
@@ -40274,8 +40241,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -0
+  f64.const inf
+  f64.const 0
   f64.const 1
   f64.const 0
   i32.const 0
@@ -40289,8 +40256,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const -0
+  f64.const -inf
+  f64.const 0
   f64.const 1
   f64.const 0
   i32.const 0
@@ -40304,8 +40271,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -0
+  f64.const 1
+  f64.const 0
   f64.const 1
   f64.const 0
   i32.const 0
@@ -40319,8 +40286,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const -0
+  f64.const -1
+  f64.const 0
   f64.const 1
   f64.const 0
   i32.const 0
@@ -40334,8 +40301,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -0
+  f64.const -0.5
+  f64.const 0
   f64.const 1
   f64.const 0
   i32.const 0
@@ -40349,7 +40316,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const nan:0x8000000000000
   f64.const -0
   f64.const 1
   f64.const 0
@@ -40364,6 +40331,81 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
+  f64.const -0
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2562
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -0
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2563
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const -0
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2564
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const -0
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2565
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.5
+  f64.const -0
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2566
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -1
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
@@ -40374,7 +40416,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2562
+   i32.const 2567
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40389,7 +40431,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2563
+   i32.const 2568
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40404,7 +40446,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2564
+   i32.const 2569
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40419,7 +40461,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2565
+   i32.const 2570
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40434,7 +40476,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2566
+   i32.const 2571
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40449,7 +40491,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2567
+   i32.const 2572
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40464,7 +40506,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2568
+   i32.const 2573
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40479,7 +40521,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2569
+   i32.const 2574
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40494,7 +40536,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2570
+   i32.const 2575
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40509,7 +40551,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2571
+   i32.const 2576
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40524,7 +40566,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2572
+   i32.const 2577
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40539,7 +40581,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2573
+   i32.const 2578
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40554,7 +40596,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2574
+   i32.const 2579
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40569,7 +40611,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2575
+   i32.const 2580
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40584,7 +40626,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2576
+   i32.const 2581
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40599,7 +40641,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2577
+   i32.const 2582
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40614,7 +40656,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2578
+   i32.const 2583
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40629,7 +40671,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2579
+   i32.const 2584
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40644,89 +40686,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2580
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const inf
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2581
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const -inf
-  f64.const inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2582
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2583
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const inf
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2584
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const -inf
-  f64.const inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2585
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -0.5
+  f64.const inf
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40739,8 +40706,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5
-  f64.const inf
+  f64.const -0.5
+  f64.const -inf
   f64.const inf
   f64.const 0
   i32.const 0
@@ -40754,9 +40721,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5
-  f64.const -inf
-  f64.const 0
+  f64.const -0.5
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40769,9 +40736,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 0.5
+  f64.const inf
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40784,9 +40751,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0.5
+  f64.const -inf
   f64.const inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40799,9 +40766,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
-  f64.const inf
+  f64.const 0.5
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40814,9 +40781,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1.5
   f64.const inf
-  f64.const -inf
-  f64.const 0
+  f64.const inf
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40829,9 +40796,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 3
-  f64.const inf
+  f64.const 1.5
+  f64.const -inf
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40844,9 +40811,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 2
-  f64.const inf
+  f64.const 1.5
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40860,8 +40827,8 @@
    unreachable
   end
   f64.const inf
-  f64.const 1
-  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -40875,7 +40842,7 @@
    unreachable
   end
   f64.const inf
-  f64.const 0.5
+  f64.const inf
   f64.const inf
   f64.const 0
   i32.const 0
@@ -40890,7 +40857,7 @@
    unreachable
   end
   f64.const inf
-  f64.const -0.5
+  f64.const -inf
   f64.const 0
   f64.const 0
   i32.const 0
@@ -40905,6 +40872,81 @@
    unreachable
   end
   f64.const inf
+  f64.const 3
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2598
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const 2
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2599
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const 1
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2600
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const 0.5
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2601
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const -0.5
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2602
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
   f64.const -1
   f64.const 0
   f64.const 0
@@ -40914,7 +40956,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2598
+   i32.const 2603
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40929,89 +40971,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2599
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2600
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const inf
-  f64.const inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2601
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -inf
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2602
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const 3
-  f64.const -inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2603
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const 2
-  f64.const inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_pow
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2604
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const -inf
-  f64.const 1
-  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_pow
@@ -41025,7 +40992,7 @@
    unreachable
   end
   f64.const -inf
-  f64.const 0.5
+  f64.const inf
   f64.const inf
   f64.const 0
   i32.const 0
@@ -41040,7 +41007,7 @@
    unreachable
   end
   f64.const -inf
-  f64.const -0.5
+  f64.const -inf
   f64.const 0
   f64.const 0
   i32.const 0
@@ -41055,6 +41022,81 @@
    unreachable
   end
   f64.const -inf
+  f64.const 3
+  f64.const -inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2608
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const 2
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2609
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const 1
+  f64.const -inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2610
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const 0.5
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2611
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -0.5
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_pow
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2612
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
   f64.const -1
   f64.const -0
   f64.const 0
@@ -41064,7 +41106,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2608
+   i32.const 2613
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41079,7 +41121,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2609
+   i32.const 2614
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41094,7 +41136,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2610
+   i32.const 2615
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41109,7 +41151,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2611
+   i32.const 2616
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41124,7 +41166,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2612
+   i32.const 2617
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41139,7 +41181,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2613
+   i32.const 2618
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41154,7 +41196,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2622
+   i32.const 2627
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41169,7 +41211,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2623
+   i32.const 2628
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41184,7 +41226,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2624
+   i32.const 2629
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41199,7 +41241,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2625
+   i32.const 2630
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41214,7 +41256,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2626
+   i32.const 2631
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41229,7 +41271,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2627
+   i32.const 2632
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41244,7 +41286,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2628
+   i32.const 2633
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41259,7 +41301,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2629
+   i32.const 2634
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41274,7 +41316,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2630
+   i32.const 2635
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41289,89 +41331,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2631
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2634
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const inf
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2635
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 3
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2636
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
-  f32.const 2
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2637
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2638
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0.5
-  f32.const 0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -41385,6 +41352,81 @@
    unreachable
   end
   f32.const 0
+  f32.const inf
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2640
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 3
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2641
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 2
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2642
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 1
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2643
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0.5
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2644
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
   f32.const 0
   f32.const 1
   f32.const 0
@@ -41394,7 +41436,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2640
+   i32.const 2645
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41409,7 +41451,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2641
+   i32.const 2646
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41424,7 +41466,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2642
+   i32.const 2647
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41439,7 +41481,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2643
+   i32.const 2648
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41454,7 +41496,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2644
+   i32.const 2649
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41469,7 +41511,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2645
+   i32.const 2650
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41484,7 +41526,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2646
+   i32.const 2651
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41499,7 +41541,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2647
+   i32.const 2652
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41514,7 +41556,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2648
+   i32.const 2653
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41529,7 +41571,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2649
+   i32.const 2654
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41544,7 +41586,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2650
+   i32.const 2655
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41559,7 +41601,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2651
+   i32.const 2656
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41574,7 +41616,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2652
+   i32.const 2657
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41589,7 +41631,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2653
+   i32.const 2658
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41604,7 +41646,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2654
+   i32.const 2659
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41619,7 +41661,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2655
+   i32.const 2660
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41634,7 +41676,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2656
+   i32.const 2661
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41649,7 +41691,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2657
+   i32.const 2662
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41664,7 +41706,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2658
+   i32.const 2663
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41679,7 +41721,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2659
+   i32.const 2664
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41694,7 +41736,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2660
+   i32.const 2665
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41709,87 +41751,12 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2661
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2662
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2663
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2664
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2665
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2666
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const nan:0x400000
   f32.const 0
   f32.const 1
   f32.const 0
@@ -41804,8 +41771,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -0
+  f32.const inf
+  f32.const 0
   f32.const 1
   f32.const 0
   i32.const 0
@@ -41819,8 +41786,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const -0
+  f32.const -inf
+  f32.const 0
   f32.const 1
   f32.const 0
   i32.const 0
@@ -41834,8 +41801,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -0
+  f32.const 1
+  f32.const 0
   f32.const 1
   f32.const 0
   i32.const 0
@@ -41849,8 +41816,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const -0
+  f32.const -1
+  f32.const 0
   f32.const 1
   f32.const 0
   i32.const 0
@@ -41864,8 +41831,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -0
+  f32.const -0.5
+  f32.const 0
   f32.const 1
   f32.const 0
   i32.const 0
@@ -41879,7 +41846,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const nan:0x400000
   f32.const -0
   f32.const 1
   f32.const 0
@@ -41894,6 +41861,81 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
+  f32.const -0
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2674
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -0
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2675
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const -0
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2676
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const -0
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2677
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.5
+  f32.const -0
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2678
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -1
   f32.const nan:0x400000
   f32.const nan:0x400000
@@ -41904,7 +41946,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2674
+   i32.const 2679
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41919,7 +41961,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2675
+   i32.const 2680
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41934,7 +41976,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2676
+   i32.const 2681
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41949,7 +41991,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2677
+   i32.const 2682
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41964,7 +42006,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2678
+   i32.const 2683
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41979,7 +42021,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2679
+   i32.const 2684
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41994,7 +42036,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2680
+   i32.const 2685
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42009,7 +42051,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2681
+   i32.const 2686
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42024,7 +42066,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2682
+   i32.const 2687
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42039,7 +42081,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2683
+   i32.const 2688
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42054,7 +42096,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2684
+   i32.const 2689
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42069,7 +42111,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2685
+   i32.const 2690
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42084,7 +42126,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2686
+   i32.const 2691
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42099,7 +42141,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2687
+   i32.const 2692
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42114,7 +42156,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2688
+   i32.const 2693
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42129,7 +42171,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2689
+   i32.const 2694
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42144,7 +42186,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2690
+   i32.const 2695
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42159,7 +42201,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2691
+   i32.const 2696
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42174,89 +42216,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2692
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const inf
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2693
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const -inf
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2694
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2695
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const inf
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2696
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const -inf
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2697
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -0.5
+  f32.const inf
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -42269,8 +42236,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.5
-  f32.const inf
+  f32.const -0.5
+  f32.const -inf
   f32.const inf
   f32.const 0
   i32.const 0
@@ -42284,9 +42251,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.5
-  f32.const -inf
-  f32.const 0
+  f32.const -0.5
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -42299,9 +42266,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.5
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 0.5
+  f32.const inf
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -42314,9 +42281,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 0.5
+  f32.const -inf
   f32.const inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -42329,9 +42296,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
-  f32.const inf
+  f32.const 0.5
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -42344,9 +42311,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1.5
   f32.const inf
-  f32.const -inf
-  f32.const 0
+  f32.const inf
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -42359,9 +42326,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const 3
-  f32.const inf
+  f32.const 1.5
+  f32.const -inf
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -42374,9 +42341,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const 2
-  f32.const inf
+  f32.const 1.5
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -42390,8 +42357,8 @@
    unreachable
   end
   f32.const inf
-  f32.const 1
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -42405,7 +42372,7 @@
    unreachable
   end
   f32.const inf
-  f32.const 0.5
+  f32.const inf
   f32.const inf
   f32.const 0
   i32.const 0
@@ -42420,7 +42387,7 @@
    unreachable
   end
   f32.const inf
-  f32.const -0.5
+  f32.const -inf
   f32.const 0
   f32.const 0
   i32.const 0
@@ -42435,6 +42402,81 @@
    unreachable
   end
   f32.const inf
+  f32.const 3
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2710
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const 2
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2711
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const 1
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2712
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const 0.5
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2713
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const -0.5
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2714
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
   f32.const -1
   f32.const 0
   f32.const 0
@@ -42444,7 +42486,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2710
+   i32.const 2715
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42459,89 +42501,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2711
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2712
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2713
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -inf
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2714
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const 3
-  f32.const -inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2715
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const 2
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2716
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -inf
-  f32.const 1
-  f32.const -inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -42555,7 +42522,7 @@
    unreachable
   end
   f32.const -inf
-  f32.const 0.5
+  f32.const inf
   f32.const inf
   f32.const 0
   i32.const 0
@@ -42570,7 +42537,7 @@
    unreachable
   end
   f32.const -inf
-  f32.const -0.5
+  f32.const -inf
   f32.const 0
   f32.const 0
   i32.const 0
@@ -42585,6 +42552,81 @@
    unreachable
   end
   f32.const -inf
+  f32.const 3
+  f32.const -inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2720
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const 2
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2721
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const 1
+  f32.const -inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2722
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const 0.5
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2723
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -0.5
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2724
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
   f32.const -1
   f32.const -0
   f32.const 0
@@ -42594,7 +42636,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2720
+   i32.const 2725
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42609,7 +42651,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2721
+   i32.const 2726
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42624,7 +42666,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2722
+   i32.const 2727
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42639,7 +42681,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2723
+   i32.const 2728
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42654,7 +42696,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2724
+   i32.const 2729
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42669,7 +42711,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2725
+   i32.const 2730
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42703,7 +42745,7 @@
     if
      i32.const 0
      i32.const 24
-     i32.const 2734
+     i32.const 2739
      i32.const 2
      call $~lib/builtins/abort
      unreachable
@@ -42747,7 +42789,7 @@
     if
      i32.const 0
      i32.const 24
-     i32.const 2742
+     i32.const 2747
      i32.const 2
      call $~lib/builtins/abort
      unreachable
@@ -42769,7 +42811,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2756
+   i32.const 2761
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42783,7 +42825,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2757
+   i32.const 2762
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42797,7 +42839,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2758
+   i32.const 2763
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42811,7 +42853,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2759
+   i32.const 2764
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42825,7 +42867,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2760
+   i32.const 2765
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42839,7 +42881,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2761
+   i32.const 2766
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42853,7 +42895,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2762
+   i32.const 2767
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42867,7 +42909,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2763
+   i32.const 2768
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42881,7 +42923,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2764
+   i32.const 2769
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42895,83 +42937,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2765
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2768
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2769
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2770
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2771
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2772
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_round
@@ -42984,6 +42956,76 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2774
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2775
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2776
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2777
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2778
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -1
   f64.const -1
   f64.const 0
@@ -42993,7 +43035,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2774
+   i32.const 2779
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43007,7 +43049,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2775
+   i32.const 2780
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43021,7 +43063,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2776
+   i32.const 2781
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43035,7 +43077,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2777
+   i32.const 2782
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43049,7 +43091,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2778
+   i32.const 2783
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43063,7 +43105,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2779
+   i32.const 2784
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43077,7 +43119,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2780
+   i32.const 2785
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43091,7 +43133,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2781
+   i32.const 2786
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43105,7 +43147,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2782
+   i32.const 2787
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43119,7 +43161,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2783
+   i32.const 2788
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43133,7 +43175,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2784
+   i32.const 2789
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43147,7 +43189,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2793
+   i32.const 2798
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43161,7 +43203,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2794
+   i32.const 2799
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43175,7 +43217,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2795
+   i32.const 2800
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43189,7 +43231,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2796
+   i32.const 2801
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43203,7 +43245,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2797
+   i32.const 2802
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43217,7 +43259,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2798
+   i32.const 2803
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43231,7 +43273,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2799
+   i32.const 2804
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43245,7 +43287,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2800
+   i32.const 2805
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43259,7 +43301,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2801
+   i32.const 2806
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43273,83 +43315,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2802
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2805
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2806
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2807
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2808
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2809
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_roundf
@@ -43362,6 +43334,76 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2811
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2812
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2813
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2814
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2815
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -1
   f32.const -1
   f32.const 0
@@ -43371,7 +43413,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2811
+   i32.const 2816
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43385,7 +43427,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2812
+   i32.const 2817
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43399,7 +43441,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2813
+   i32.const 2818
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43413,7 +43455,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2814
+   i32.const 2819
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43427,7 +43469,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2815
+   i32.const 2820
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43441,7 +43483,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2816
+   i32.const 2821
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43455,7 +43497,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2817
+   i32.const 2822
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43469,7 +43511,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2818
+   i32.const 2823
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43483,7 +43525,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2819
+   i32.const 2824
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43497,7 +43539,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2820
+   i32.const 2825
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43511,7 +43553,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2821
+   i32.const 2826
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43525,7 +43567,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2832
+   i32.const 2837
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43539,7 +43581,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2833
+   i32.const 2838
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43553,7 +43595,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2834
+   i32.const 2839
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43567,7 +43609,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2835
+   i32.const 2840
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43581,7 +43623,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2836
+   i32.const 2841
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43595,7 +43637,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2837
+   i32.const 2842
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43609,7 +43651,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2838
+   i32.const 2843
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43623,7 +43665,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2839
+   i32.const 2844
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43637,7 +43679,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2840
+   i32.const 2845
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43651,7 +43693,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2848
+   i32.const 2853
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43665,7 +43707,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2849
+   i32.const 2854
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43679,7 +43721,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2850
+   i32.const 2855
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43693,7 +43735,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2851
+   i32.const 2856
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43707,7 +43749,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2852
+   i32.const 2857
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43721,7 +43763,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2853
+   i32.const 2858
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43735,7 +43777,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2854
+   i32.const 2859
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43749,7 +43791,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2855
+   i32.const 2860
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43763,132 +43805,12 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2856
+   i32.const 2861
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 0
-  local.set $1
-  local.get $1
-  i64.reinterpret_f64
-  i64.const 63
-  i64.shr_u
-  i32.wrap_i64
-  local.get $1
-  local.get $1
-  f64.eq
-  i32.and
-  i32.const 0
-  i32.ne
-  i32.const 0
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2862
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  local.set $1
-  local.get $1
-  i64.reinterpret_f64
-  i64.const 63
-  i64.shr_u
-  i32.wrap_i64
-  local.get $1
-  local.get $1
-  f64.eq
-  i32.and
-  i32.const 0
-  i32.ne
-  i32.const 1
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2863
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  local.set $1
-  local.get $1
-  i64.reinterpret_f64
-  i64.const 63
-  i64.shr_u
-  i32.wrap_i64
-  local.get $1
-  local.get $1
-  f64.eq
-  i32.and
-  i32.const 0
-  i32.ne
-  i32.const 0
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2864
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  local.set $1
-  local.get $1
-  i64.reinterpret_f64
-  i64.const 63
-  i64.shr_u
-  i32.wrap_i64
-  local.get $1
-  local.get $1
-  f64.eq
-  i32.and
-  i32.const 0
-  i32.ne
-  i32.const 1
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2865
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  local.set $1
-  local.get $1
-  i64.reinterpret_f64
-  i64.const 63
-  i64.shr_u
-  i32.wrap_i64
-  local.get $1
-  local.get $1
-  f64.eq
-  i32.and
-  i32.const 0
-  i32.ne
-  i32.const 0
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2866
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -nan:0x8000000000000
   local.set $1
   local.get $1
   i64.reinterpret_f64
@@ -43912,6 +43834,126 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  local.set $1
+  local.get $1
+  i64.reinterpret_f64
+  i64.const 63
+  i64.shr_u
+  i32.wrap_i64
+  local.get $1
+  local.get $1
+  f64.eq
+  i32.and
+  i32.const 0
+  i32.ne
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2868
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  local.set $1
+  local.get $1
+  i64.reinterpret_f64
+  i64.const 63
+  i64.shr_u
+  i32.wrap_i64
+  local.get $1
+  local.get $1
+  f64.eq
+  i32.and
+  i32.const 0
+  i32.ne
+  i32.const 0
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2869
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  local.set $1
+  local.get $1
+  i64.reinterpret_f64
+  i64.const 63
+  i64.shr_u
+  i32.wrap_i64
+  local.get $1
+  local.get $1
+  f64.eq
+  i32.and
+  i32.const 0
+  i32.ne
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2870
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  local.set $1
+  local.get $1
+  i64.reinterpret_f64
+  i64.const 63
+  i64.shr_u
+  i32.wrap_i64
+  local.get $1
+  local.get $1
+  f64.eq
+  i32.and
+  i32.const 0
+  i32.ne
+  i32.const 0
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2871
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -nan:0x8000000000000
+  local.set $1
+  local.get $1
+  i64.reinterpret_f64
+  i64.const 63
+  i64.shr_u
+  i32.wrap_i64
+  local.get $1
+  local.get $1
+  f64.eq
+  i32.and
+  i32.const 0
+  i32.ne
+  i32.const 0
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2872
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const inf
   local.set $1
   local.get $1
@@ -43931,7 +43973,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2868
+   i32.const 2873
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43955,127 +43997,12 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2869
+   i32.const 2874
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
-  local.set $3
-  local.get $3
-  i32.reinterpret_f32
-  i32.const 31
-  i32.shr_u
-  local.get $3
-  local.get $3
-  f32.eq
-  i32.and
-  i32.const 0
-  i32.ne
-  i32.const 0
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2875
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  local.set $3
-  local.get $3
-  i32.reinterpret_f32
-  i32.const 31
-  i32.shr_u
-  local.get $3
-  local.get $3
-  f32.eq
-  i32.and
-  i32.const 0
-  i32.ne
-  i32.const 1
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2876
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  local.set $3
-  local.get $3
-  i32.reinterpret_f32
-  i32.const 31
-  i32.shr_u
-  local.get $3
-  local.get $3
-  f32.eq
-  i32.and
-  i32.const 0
-  i32.ne
-  i32.const 0
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2877
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  local.set $3
-  local.get $3
-  i32.reinterpret_f32
-  i32.const 31
-  i32.shr_u
-  local.get $3
-  local.get $3
-  f32.eq
-  i32.and
-  i32.const 0
-  i32.ne
-  i32.const 1
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2878
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  local.set $3
-  local.get $3
-  i32.reinterpret_f32
-  i32.const 31
-  i32.shr_u
-  local.get $3
-  local.get $3
-  f32.eq
-  i32.and
-  i32.const 0
-  i32.ne
-  i32.const 0
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2879
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -nan:0x400000
   local.set $3
   local.get $3
   i32.reinterpret_f32
@@ -44098,6 +44025,121 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
+  local.set $3
+  local.get $3
+  i32.reinterpret_f32
+  i32.const 31
+  i32.shr_u
+  local.get $3
+  local.get $3
+  f32.eq
+  i32.and
+  i32.const 0
+  i32.ne
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2881
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  local.set $3
+  local.get $3
+  i32.reinterpret_f32
+  i32.const 31
+  i32.shr_u
+  local.get $3
+  local.get $3
+  f32.eq
+  i32.and
+  i32.const 0
+  i32.ne
+  i32.const 0
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2882
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  local.set $3
+  local.get $3
+  i32.reinterpret_f32
+  i32.const 31
+  i32.shr_u
+  local.get $3
+  local.get $3
+  f32.eq
+  i32.and
+  i32.const 0
+  i32.ne
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2883
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  local.set $3
+  local.get $3
+  i32.reinterpret_f32
+  i32.const 31
+  i32.shr_u
+  local.get $3
+  local.get $3
+  f32.eq
+  i32.and
+  i32.const 0
+  i32.ne
+  i32.const 0
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2884
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -nan:0x400000
+  local.set $3
+  local.get $3
+  i32.reinterpret_f32
+  i32.const 31
+  i32.shr_u
+  local.get $3
+  local.get $3
+  f32.eq
+  i32.and
+  i32.const 0
+  i32.ne
+  i32.const 0
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2885
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const inf
   local.set $3
   local.get $3
@@ -44116,7 +44158,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2881
+   i32.const 2886
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44139,7 +44181,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2882
+   i32.const 2887
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44154,7 +44196,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2893
+   i32.const 2898
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44169,7 +44211,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2894
+   i32.const 2899
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44184,7 +44226,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2895
+   i32.const 2900
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44199,7 +44241,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2896
+   i32.const 2901
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44214,7 +44256,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2897
+   i32.const 2902
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44229,7 +44271,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2898
+   i32.const 2903
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44244,7 +44286,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2899
+   i32.const 2904
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44259,7 +44301,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2900
+   i32.const 2905
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44274,7 +44316,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2901
+   i32.const 2906
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44289,89 +44331,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2902
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 1
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2905
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const 1
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2906
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const 1
-  f64.const 0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2907
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
-  f64.const 1
-  f64.const -0.5
   f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2908
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
   f64.const 1
   f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2909
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const 1
-  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -44384,9 +44351,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5
+  f64.const -0
   f64.const 1
-  f64.const -0.5
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -44399,7 +44366,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.5
+  f64.const 0.5
   f64.const 1
   f64.const 0.5
   f64.const 0
@@ -44414,6 +44381,81 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0.5
+  f64.const 1
+  f64.const -0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2913
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 1
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2914
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const 1
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2915
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.5
+  f64.const 1
+  f64.const -0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2916
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.5
+  f64.const 1
+  f64.const 0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2917
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 2
   f64.const 1
   f64.const 0
@@ -44424,7 +44466,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2913
+   i32.const 2918
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44439,7 +44481,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2914
+   i32.const 2919
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44454,7 +44496,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2915
+   i32.const 2920
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44469,89 +44511,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2916
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2917
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -1
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2918
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -1
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2919
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const -1
-  f64.const 0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2920
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const -1
-  f64.const -0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2921
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const nan:0x8000000000000
   f64.const 1
-  f64.const -1
-  f64.const 0
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -44564,9 +44531,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0
   f64.const -1
-  f64.const -1
-  f64.const -0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -44579,9 +44546,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5
+  f64.const -0
   f64.const -1
-  f64.const -0.5
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -44594,7 +44561,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.5
+  f64.const 0.5
   f64.const -1
   f64.const 0.5
   f64.const 0
@@ -44609,6 +44576,81 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0.5
+  f64.const -1
+  f64.const -0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2926
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const -1
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2927
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const -1
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2928
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.5
+  f64.const -1
+  f64.const -0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2929
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.5
+  f64.const -1
+  f64.const 0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2930
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 2
   f64.const -1
   f64.const 0
@@ -44619,7 +44661,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2926
+   i32.const 2931
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44634,91 +44676,16 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2927
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2928
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2929
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2930
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2931
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2932
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const inf
+  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const 0
-  f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -44729,11 +44696,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const -inf
+  f64.const -1
+  f64.const nan:0x8000000000000
   f64.const 0
-  f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -44744,8 +44711,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
   f64.const nan:0x8000000000000
+  f64.const -1
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
@@ -44759,7 +44726,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -44774,7 +44741,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -44789,9 +44756,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const inf
-  f64.const -0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -44804,9 +44771,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const -inf
-  f64.const -0
+  f64.const 0
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -44819,7 +44786,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -44834,7 +44801,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const -0
   f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -44849,8 +44816,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const 0
+  f64.const -0
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -44864,11 +44831,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const inf
+  f64.const -0
   f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -44879,11 +44846,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const -inf
+  f64.const -0
   f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -44894,8 +44861,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const nan:0x8000000000000
-  f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
@@ -44909,8 +44876,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -0
+  f64.const 1
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -44924,8 +44891,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const -0
+  f64.const -1
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -44939,8 +44906,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -0
+  f64.const inf
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -44954,11 +44921,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -0
+  f64.const -inf
+  f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -44969,11 +44936,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const 2
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 2
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -44984,8 +44951,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const -0.5
+  f64.const -1
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -45000,10 +44967,10 @@
    unreachable
   end
   f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -45015,7 +44982,7 @@
    unreachable
   end
   f64.const -inf
-  f64.const 2
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -45029,11 +44996,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -0.5
+  f64.const nan:0x8000000000000
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -45044,11 +45011,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const 2
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -45059,11 +45026,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const -0.5
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -45074,7 +45041,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const inf
   f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
@@ -45089,11 +45056,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const 2
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -45104,11 +45071,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const inf
-  f64.const 1
+  f64.const -inf
+  f64.const -0.5
+  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -45119,9 +45086,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const inf
-  f64.const -1
+  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -45134,11 +45101,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -45149,11 +45116,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const inf
+  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -45164,9 +45131,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const -inf
-  f64.const 1
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -45179,9 +45146,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -inf
-  f64.const -1
+  f64.const 1
+  f64.const inf
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -45194,11 +45161,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
   f64.const inf
-  f64.const -inf
-  f64.const nan:0x8000000000000
+  f64.const -1
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -45209,8 +45176,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -inf
+  f64.const inf
+  f64.const inf
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -45224,11 +45191,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.75
-  f64.const 0.5
-  f64.const -0.25
+  f64.const -inf
+  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -45239,9 +45206,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.75
-  f64.const 0.5
-  f64.const 0.25
+  f64.const 1
+  f64.const -inf
+  f64.const 1
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -45254,6 +45221,81 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
+  f64.const -inf
+  f64.const -1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2969
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 2
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2970
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -inf
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 2
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2971
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.75
+  f64.const 0.5
+  f64.const -0.25
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2972
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.75
+  f64.const 0.5
+  f64.const 0.25
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 2973
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1.75
   f64.const -0.5
   f64.const -0.25
@@ -45264,7 +45306,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2969
+   i32.const 2974
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45279,7 +45321,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2970
+   i32.const 2975
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45294,7 +45336,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2971
+   i32.const 2976
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45309,7 +45351,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2980
+   i32.const 2985
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45324,7 +45366,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2981
+   i32.const 2986
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45339,7 +45381,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2982
+   i32.const 2987
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45354,7 +45396,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2983
+   i32.const 2988
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45369,7 +45411,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2984
+   i32.const 2989
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45384,7 +45426,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2985
+   i32.const 2990
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45399,7 +45441,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2986
+   i32.const 2991
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45414,7 +45456,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2987
+   i32.const 2992
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45429,7 +45471,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2988
+   i32.const 2993
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45444,89 +45486,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 2989
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2992
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 1
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2993
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const 1
-  f32.const 0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 2994
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const 1
-  f32.const -0.5
   f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2995
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
   f32.const 1
   f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 2996
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const 1
-  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -45539,9 +45506,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.5
+  f32.const -0
   f32.const 1
-  f32.const -0.5
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -45554,7 +45521,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.5
+  f32.const 0.5
   f32.const 1
   f32.const 0.5
   f32.const 0
@@ -45569,6 +45536,81 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0.5
+  f32.const 1
+  f32.const -0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3000
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 1
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3001
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const 1
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3002
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.5
+  f32.const 1
+  f32.const -0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3003
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.5
+  f32.const 1
+  f32.const 0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3004
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 2
   f32.const 1
   f32.const 0
@@ -45579,7 +45621,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3000
+   i32.const 3005
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45594,7 +45636,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3001
+   i32.const 3006
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45609,7 +45651,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3002
+   i32.const 3007
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45624,89 +45666,14 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3003
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3004
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -1
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3005
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -1
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3006
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const -1
-  f32.const 0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3007
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const -1
-  f32.const -0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3008
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const nan:0x400000
   f32.const 1
-  f32.const -1
-  f32.const 0
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -45719,9 +45686,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 0
   f32.const -1
-  f32.const -1
-  f32.const -0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -45734,9 +45701,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.5
+  f32.const -0
   f32.const -1
-  f32.const -0.5
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -45749,7 +45716,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.5
+  f32.const 0.5
   f32.const -1
   f32.const 0.5
   f32.const 0
@@ -45764,6 +45731,81 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0.5
+  f32.const -1
+  f32.const -0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3013
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const -1
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3014
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const -1
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3015
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.5
+  f32.const -1
+  f32.const -0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3016
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.5
+  f32.const -1
+  f32.const 0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3017
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 2
   f32.const -1
   f32.const 0
@@ -45774,7 +45816,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3013
+   i32.const 3018
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45789,91 +45831,16 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3014
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3015
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3016
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3017
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3018
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -0
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3019
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
   f32.const inf
+  f32.const -1
+  f32.const nan:0x400000
   f32.const 0
-  f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -45884,11 +45851,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
   f32.const -inf
+  f32.const -1
+  f32.const nan:0x400000
   f32.const 0
-  f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -45899,8 +45866,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
   f32.const nan:0x400000
+  f32.const -1
   f32.const nan:0x400000
   f32.const 0
   i32.const 0
@@ -45914,7 +45881,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const 0
   f32.const nan:0x400000
   f32.const 0
@@ -45929,7 +45896,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const -0
   f32.const nan:0x400000
   f32.const 0
@@ -45944,9 +45911,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const inf
-  f32.const -0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -45959,9 +45926,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const -inf
-  f32.const -0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -45974,7 +45941,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const 0
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -45989,7 +45956,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const -0
   f32.const 0
   f32.const nan:0x400000
   f32.const 0
@@ -46004,8 +45971,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const 0
+  f32.const -0
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -46019,11 +45986,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const inf
+  f32.const -0
   f32.const 0
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -46034,11 +46001,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const -inf
+  f32.const -0
   f32.const 0
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -46049,8 +46016,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const nan:0x400000
-  f32.const 0
   f32.const nan:0x400000
   f32.const 0
   i32.const 0
@@ -46064,8 +46031,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -0
+  f32.const 1
+  f32.const 0
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -46079,8 +46046,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const -0
+  f32.const -1
+  f32.const 0
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -46094,8 +46061,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -0
+  f32.const inf
+  f32.const 0
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -46109,11 +46076,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -0
+  f32.const -inf
+  f32.const 0
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -46124,11 +46091,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const 2
   f32.const nan:0x400000
   f32.const 0
-  i32.const 2
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -46139,8 +46106,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const -0.5
+  f32.const -1
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -46155,10 +46122,10 @@
    unreachable
   end
   f32.const inf
-  f32.const nan:0x400000
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -46170,7 +46137,7 @@
    unreachable
   end
   f32.const -inf
-  f32.const 2
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -46184,11 +46151,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -0.5
+  f32.const nan:0x400000
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -46199,11 +46166,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const 2
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -46214,11 +46181,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const -0.5
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -46229,7 +46196,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const inf
   f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
@@ -46244,11 +46211,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const 2
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -46259,11 +46226,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const inf
-  f32.const 1
+  f32.const -inf
+  f32.const -0.5
+  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -46274,9 +46241,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const inf
-  f32.const -1
+  f32.const -inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -46289,11 +46256,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -46304,11 +46271,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const inf
+  f32.const 1
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -46319,9 +46286,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const -inf
-  f32.const 1
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -46334,9 +46301,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -inf
-  f32.const -1
+  f32.const 1
+  f32.const inf
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -46349,11 +46316,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
   f32.const inf
-  f32.const -inf
-  f32.const nan:0x400000
+  f32.const -1
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -46364,8 +46331,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -inf
+  f32.const inf
+  f32.const inf
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -46379,11 +46346,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.75
-  f32.const 0.5
-  f32.const -0.25
+  f32.const -inf
+  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -46394,9 +46361,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.75
-  f32.const 0.5
-  f32.const 0.25
+  f32.const 1
+  f32.const -inf
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -46409,6 +46376,81 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
+  f32.const -inf
+  f32.const -1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3056
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const -inf
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 2
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3057
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -inf
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 2
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3058
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.75
+  f32.const 0.5
+  f32.const -0.25
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3059
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.75
+  f32.const 0.5
+  f32.const 0.25
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3060
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 1.75
   f32.const -0.5
   f32.const -0.25
@@ -46419,7 +46461,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3056
+   i32.const 3061
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46434,7 +46476,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3057
+   i32.const 3062
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46449,7 +46491,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3058
+   i32.const 3063
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46463,7 +46505,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3070
+   i32.const 3075
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46477,7 +46519,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3071
+   i32.const 3076
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46491,7 +46533,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3072
+   i32.const 3077
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46505,7 +46547,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3073
+   i32.const 3078
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46519,7 +46561,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3074
+   i32.const 3079
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46533,7 +46575,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3075
+   i32.const 3080
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46547,7 +46589,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3076
+   i32.const 3081
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46561,7 +46603,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3077
+   i32.const 3082
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46575,7 +46617,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3078
+   i32.const 3083
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46589,7 +46631,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3079
+   i32.const 3084
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46603,7 +46645,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3082
+   i32.const 3087
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46617,85 +46659,15 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3083
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072014e-308
-  f64.const 2.2250738585072014e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3084
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3085
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 5e-324
-  f64.const 5e-324
-  f64.const 0
-  i32.const 9
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3086
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -5e-324
-  f64.const -5e-324
-  f64.const 0
-  i32.const 9
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3087
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3088
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 2.2250738585072014e-308
+  f64.const 2.2250738585072014e-308
   f64.const 0
-  i32.const 0
+  i32.const 1
   call $std/math/test_sin
   i32.eqz
   if
@@ -46706,8 +46678,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507202e-308
-  f64.const 2.225073858507202e-308
+  f64.const -2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
   f64.const 0
   i32.const 1
   call $std/math/test_sin
@@ -46720,10 +46692,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072024e-308
-  f64.const 2.2250738585072024e-308
+  f64.const 5e-324
+  f64.const 5e-324
   f64.const 0
-  i32.const 1
+  i32.const 9
   call $std/math/test_sin
   i32.eqz
   if
@@ -46734,10 +46706,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4501477170144003e-308
-  f64.const 4.4501477170144003e-308
+  f64.const -5e-324
+  f64.const -5e-324
   f64.const 0
-  i32.const 1
+  i32.const 9
   call $std/math/test_sin
   i32.eqz
   if
@@ -46748,10 +46720,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.450147717014403e-308
-  f64.const 4.450147717014403e-308
   f64.const 0
-  i32.const 1
+  f64.const 0
+  f64.const 0
+  i32.const 0
   call $std/math/test_sin
   i32.eqz
   if
@@ -46762,6 +46734,76 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3094
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.225073858507202e-308
+  f64.const 2.225073858507202e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3095
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.2250738585072024e-308
+  f64.const 2.2250738585072024e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3096
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.4501477170144003e-308
+  f64.const 4.4501477170144003e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3097
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.450147717014403e-308
+  f64.const 4.450147717014403e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3098
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 4.450147717014406e-308
   f64.const 4.450147717014406e-308
   f64.const 0
@@ -46771,7 +46813,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3094
+   i32.const 3099
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46785,7 +46827,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3095
+   i32.const 3100
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46799,7 +46841,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3096
+   i32.const 3101
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46813,83 +46855,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3097
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.225073858507202e-308
-  f64.const -2.225073858507202e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3098
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.2250738585072024e-308
-  f64.const -2.2250738585072024e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3099
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.4501477170144003e-308
-  f64.const -4.4501477170144003e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3100
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.450147717014403e-308
-  f64.const -4.450147717014403e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3101
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.450147717014406e-308
-  f64.const -4.450147717014406e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3102
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8.900295434028806e-308
-  f64.const -8.900295434028806e-308
+  f64.const -2.225073858507202e-308
+  f64.const -2.225073858507202e-308
   f64.const 0
   i32.const 1
   call $std/math/test_sin
@@ -46898,6 +46870,76 @@
    i32.const 0
    i32.const 24
    i32.const 3103
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072024e-308
+  f64.const -2.2250738585072024e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3104
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.4501477170144003e-308
+  f64.const -4.4501477170144003e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3105
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.450147717014403e-308
+  f64.const -4.450147717014403e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3106
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.450147717014406e-308
+  f64.const -4.450147717014406e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3107
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -8.900295434028806e-308
+  f64.const -8.900295434028806e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3108
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46911,85 +46953,15 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3104
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.4901161193847656e-08
-  f64.const -1.4901161193847656e-08
-  f64.const -0.1666666716337204
-  i32.const 1
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3105
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.4901161193847656e-08
-  f64.const -1.4901161193847656e-08
-  f64.const -0.1666666716337204
-  i32.const 1
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3106
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1e-323
-  f64.const 1e-323
-  f64.const 0
-  i32.const 9
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3107
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.4e-323
-  f64.const 4.4e-323
-  f64.const 0
-  i32.const 9
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3108
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 5.562684646268003e-309
-  f64.const 5.562684646268003e-309
-  f64.const 0
-  i32.const 9
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3109
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.1125369292536007e-308
-  f64.const 1.1125369292536007e-308
-  f64.const 0
-  i32.const 9
+  f64.const -1.4901161193847656e-08
+  f64.const -1.4901161193847656e-08
+  f64.const -0.1666666716337204
+  i32.const 1
   call $std/math/test_sin
   i32.eqz
   if
@@ -47000,10 +46972,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.2250738585072004e-308
-  f64.const 2.2250738585072004e-308
-  f64.const 0
-  i32.const 9
+  f64.const -1.4901161193847656e-08
+  f64.const -1.4901161193847656e-08
+  f64.const -0.1666666716337204
+  i32.const 1
   call $std/math/test_sin
   i32.eqz
   if
@@ -47014,8 +46986,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507201e-308
-  f64.const 2.225073858507201e-308
+  f64.const 1e-323
+  f64.const 1e-323
   f64.const 0
   i32.const 9
   call $std/math/test_sin
@@ -47028,8 +47000,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1e-323
-  f64.const -1e-323
+  f64.const 4.4e-323
+  f64.const 4.4e-323
   f64.const 0
   i32.const 9
   call $std/math/test_sin
@@ -47042,8 +47014,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4e-323
-  f64.const -4.4e-323
+  f64.const 5.562684646268003e-309
+  f64.const 5.562684646268003e-309
   f64.const 0
   i32.const 9
   call $std/math/test_sin
@@ -47056,8 +47028,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5.562684646268003e-309
-  f64.const -5.562684646268003e-309
+  f64.const 1.1125369292536007e-308
+  f64.const 1.1125369292536007e-308
   f64.const 0
   i32.const 9
   call $std/math/test_sin
@@ -47070,8 +47042,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.1125369292536007e-308
-  f64.const -1.1125369292536007e-308
+  f64.const 2.2250738585072004e-308
+  f64.const 2.2250738585072004e-308
   f64.const 0
   i32.const 9
   call $std/math/test_sin
@@ -47084,8 +47056,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072004e-308
-  f64.const -2.2250738585072004e-308
+  f64.const 2.225073858507201e-308
+  f64.const 2.225073858507201e-308
   f64.const 0
   i32.const 9
   call $std/math/test_sin
@@ -47098,8 +47070,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.225073858507201e-308
-  f64.const -2.225073858507201e-308
+  f64.const -1e-323
+  f64.const -1e-323
   f64.const 0
   i32.const 9
   call $std/math/test_sin
@@ -47112,6 +47084,76 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -4.4e-323
+  f64.const -4.4e-323
+  f64.const 0
+  i32.const 9
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3119
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -5.562684646268003e-309
+  f64.const -5.562684646268003e-309
+  f64.const 0
+  i32.const 9
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3120
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.1125369292536007e-308
+  f64.const -1.1125369292536007e-308
+  f64.const 0
+  i32.const 9
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3121
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072004e-308
+  f64.const -2.2250738585072004e-308
+  f64.const 0
+  i32.const 9
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3122
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.225073858507201e-308
+  f64.const -2.225073858507201e-308
+  f64.const 0
+  i32.const 9
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3123
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0
   f64.const 0
   f64.const 0
@@ -47121,7 +47163,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3121
+   i32.const 3126
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47135,7 +47177,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3122
+   i32.const 3127
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47149,7 +47191,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3123
+   i32.const 3128
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47163,7 +47205,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3124
+   i32.const 3129
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47177,7 +47219,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3125
+   i32.const 3130
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47186,52 +47228,52 @@
   call $~lib/math/NativeMath.sin
   f64.const 1.5707963267948966
   call $~lib/bindings/Math/sin
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3128
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 3.141592653589793
-  call $~lib/math/NativeMath.sin
-  f64.const 3.141592653589793
-  call $~lib/bindings/Math/sin
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3129
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.3283064365386963e-10
-  f64.const 2.3283064365386963e-10
-  call $~lib/math/NativeMath.sin
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3132
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.3283064365386963e-10
-  f64.const -2.3283064365386963e-10
-  call $~lib/math/NativeMath.sin
   f64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 3133
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 3.141592653589793
+  call $~lib/math/NativeMath.sin
+  f64.const 3.141592653589793
+  call $~lib/bindings/Math/sin
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3134
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.3283064365386963e-10
+  f64.const 2.3283064365386963e-10
+  call $~lib/math/NativeMath.sin
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3137
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.3283064365386963e-10
+  f64.const -2.3283064365386963e-10
+  call $~lib/math/NativeMath.sin
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3138
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47244,7 +47286,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3135
+   i32.const 3140
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47257,7 +47299,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3136
+   i32.const 3141
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47270,7 +47312,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3139
+   i32.const 3144
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47283,7 +47325,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3140
+   i32.const 3145
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47296,7 +47338,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3141
+   i32.const 3146
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47309,7 +47351,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3142
+   i32.const 3147
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47322,7 +47364,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3144
+   i32.const 3149
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47335,7 +47377,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3145
+   i32.const 3150
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47348,7 +47390,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3147
+   i32.const 3152
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47361,7 +47403,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3148
+   i32.const 3153
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47374,7 +47416,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3149
+   i32.const 3154
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47387,7 +47429,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3150
+   i32.const 3155
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47400,7 +47442,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3151
+   i32.const 3156
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47413,7 +47455,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3154
+   i32.const 3159
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47426,7 +47468,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3155
+   i32.const 3160
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47440,7 +47482,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3164
+   i32.const 3169
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47454,7 +47496,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3165
+   i32.const 3170
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47468,7 +47510,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3166
+   i32.const 3171
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47482,7 +47524,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3167
+   i32.const 3172
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47496,7 +47538,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3168
+   i32.const 3173
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47510,7 +47552,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3169
+   i32.const 3174
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47524,7 +47566,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3170
+   i32.const 3175
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47538,7 +47580,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3171
+   i32.const 3176
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47552,7 +47594,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3172
+   i32.const 3177
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47566,7 +47608,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3173
+   i32.const 3178
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47580,7 +47622,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3176
+   i32.const 3181
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47594,7 +47636,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3177
+   i32.const 3182
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47608,7 +47650,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3178
+   i32.const 3183
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47622,7 +47664,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3179
+   i32.const 3184
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47636,7 +47678,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3180
+   i32.const 3185
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47650,7 +47692,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3183
+   i32.const 3188
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47664,83 +47706,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3184
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754943508222875e-38
-  f32.const 1.1754943508222875e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3185
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754943508222875e-38
-  f32.const -1.1754943508222875e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3186
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.401298464324817e-45
-  f32.const 1.401298464324817e-45
-  f32.const 0
-  i32.const 9
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3187
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.401298464324817e-45
-  f32.const -1.401298464324817e-45
-  f32.const 0
-  i32.const 9
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3188
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.175494490952134e-38
-  f32.const 1.175494490952134e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3189
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754946310819804e-38
-  f32.const 1.1754946310819804e-38
+  f32.const 1.1754943508222875e-38
+  f32.const 1.1754943508222875e-38
   f32.const 0
   i32.const 1
   call $std/math/test_sinf
@@ -47753,8 +47725,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509880009953429e-38
-  f32.const 2.3509880009953429e-38
+  f32.const -1.1754943508222875e-38
+  f32.const -1.1754943508222875e-38
   f32.const 0
   i32.const 1
   call $std/math/test_sinf
@@ -47767,10 +47739,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.350988701644575e-38
-  f32.const 2.350988701644575e-38
+  f32.const 1.401298464324817e-45
+  f32.const 1.401298464324817e-45
   f32.const 0
-  i32.const 1
+  i32.const 9
   call $std/math/test_sinf
   i32.eqz
   if
@@ -47781,6 +47753,76 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1.401298464324817e-45
+  f32.const -1.401298464324817e-45
+  f32.const 0
+  i32.const 9
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3193
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.175494490952134e-38
+  f32.const 1.175494490952134e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3194
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.1754946310819804e-38
+  f32.const 1.1754946310819804e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3195
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.3509880009953429e-38
+  f32.const 2.3509880009953429e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3196
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.350988701644575e-38
+  f32.const 2.350988701644575e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3197
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 2.3509895424236536e-38
   f32.const 2.3509895424236536e-38
   f32.const 0
@@ -47790,7 +47832,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3193
+   i32.const 3198
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47804,7 +47846,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3194
+   i32.const 3199
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47818,7 +47860,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3195
+   i32.const 3200
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47832,7 +47874,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3196
+   i32.const 3201
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47846,7 +47888,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3197
+   i32.const 3202
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47860,83 +47902,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3198
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.175494490952134e-38
-  f32.const -1.175494490952134e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3199
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754946310819804e-38
-  f32.const -1.1754946310819804e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3200
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.3509880009953429e-38
-  f32.const -2.3509880009953429e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3201
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.350988701644575e-38
-  f32.const -2.350988701644575e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3202
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.3509895424236536e-38
-  f32.const -2.3509895424236536e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3203
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -4.70197740328915e-38
-  f32.const -4.70197740328915e-38
+  f32.const -1.175494490952134e-38
+  f32.const -1.175494490952134e-38
   f32.const 0
   i32.const 1
   call $std/math/test_sinf
@@ -47945,6 +47917,76 @@
    i32.const 0
    i32.const 24
    i32.const 3204
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754946310819804e-38
+  f32.const -1.1754946310819804e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3205
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.3509880009953429e-38
+  f32.const -2.3509880009953429e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3206
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.350988701644575e-38
+  f32.const -2.350988701644575e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3207
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.3509895424236536e-38
+  f32.const -2.3509895424236536e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3208
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -4.70197740328915e-38
+  f32.const -4.70197740328915e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3209
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47958,7 +48000,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3205
+   i32.const 3210
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47972,7 +48014,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3206
+   i32.const 3211
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47986,7 +48028,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3207
+   i32.const 3212
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48000,83 +48042,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3208
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.802596928649634e-45
-  f32.const 2.802596928649634e-45
-  f32.const 0
-  i32.const 9
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3209
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.2611686178923354e-44
-  f32.const 1.2611686178923354e-44
-  f32.const 0
-  i32.const 9
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3210
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.938735877055719e-39
-  f32.const 2.938735877055719e-39
-  f32.const 0
-  i32.const 9
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3211
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 5.877471754111438e-39
-  f32.const 5.877471754111438e-39
-  f32.const 0
-  i32.const 9
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3212
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754940705625946e-38
-  f32.const 1.1754940705625946e-38
-  f32.const 0
-  i32.const 9
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3213
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754942106924411e-38
-  f32.const 1.1754942106924411e-38
+  f32.const 2.802596928649634e-45
+  f32.const 2.802596928649634e-45
   f32.const 0
   i32.const 9
   call $std/math/test_sinf
@@ -48089,8 +48061,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.802596928649634e-45
-  f32.const -2.802596928649634e-45
+  f32.const 1.2611686178923354e-44
+  f32.const 1.2611686178923354e-44
   f32.const 0
   i32.const 9
   call $std/math/test_sinf
@@ -48103,8 +48075,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.2611686178923354e-44
-  f32.const -1.2611686178923354e-44
+  f32.const 2.938735877055719e-39
+  f32.const 2.938735877055719e-39
   f32.const 0
   i32.const 9
   call $std/math/test_sinf
@@ -48117,8 +48089,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.938735877055719e-39
-  f32.const -2.938735877055719e-39
+  f32.const 5.877471754111438e-39
+  f32.const 5.877471754111438e-39
   f32.const 0
   i32.const 9
   call $std/math/test_sinf
@@ -48131,8 +48103,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -5.877471754111438e-39
-  f32.const -5.877471754111438e-39
+  f32.const 1.1754940705625946e-38
+  f32.const 1.1754940705625946e-38
   f32.const 0
   i32.const 9
   call $std/math/test_sinf
@@ -48145,6 +48117,76 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1.1754942106924411e-38
+  f32.const 1.1754942106924411e-38
+  f32.const 0
+  i32.const 9
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3219
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.802596928649634e-45
+  f32.const -2.802596928649634e-45
+  f32.const 0
+  i32.const 9
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3220
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.2611686178923354e-44
+  f32.const -1.2611686178923354e-44
+  f32.const 0
+  i32.const 9
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3221
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.938735877055719e-39
+  f32.const -2.938735877055719e-39
+  f32.const 0
+  i32.const 9
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3222
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -5.877471754111438e-39
+  f32.const -5.877471754111438e-39
+  f32.const 0
+  i32.const 9
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3223
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -1.1754940705625946e-38
   f32.const -1.1754940705625946e-38
   f32.const 0
@@ -48154,7 +48196,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3219
+   i32.const 3224
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48168,7 +48210,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3220
+   i32.const 3225
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48182,7 +48224,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3223
+   i32.const 3228
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48196,7 +48238,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3224
+   i32.const 3229
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48210,7 +48252,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3225
+   i32.const 3230
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48224,7 +48266,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3226
+   i32.const 3231
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48238,7 +48280,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3227
+   i32.const 3232
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48252,7 +48294,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3228
+   i32.const 3233
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48266,7 +48308,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3229
+   i32.const 3234
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48280,7 +48322,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3230
+   i32.const 3235
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48294,7 +48336,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3231
+   i32.const 3236
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48308,7 +48350,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3232
+   i32.const 3237
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48322,7 +48364,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3233
+   i32.const 3238
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48336,7 +48378,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3234
+   i32.const 3239
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48350,7 +48392,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3235
+   i32.const 3240
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48364,7 +48406,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3236
+   i32.const 3241
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48378,7 +48420,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3248
+   i32.const 3253
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48392,7 +48434,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3249
+   i32.const 3254
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48406,7 +48448,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3250
+   i32.const 3255
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48420,7 +48462,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3251
+   i32.const 3256
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48434,7 +48476,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3252
+   i32.const 3257
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48448,7 +48490,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3253
+   i32.const 3258
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48462,7 +48504,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3254
+   i32.const 3259
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48476,7 +48518,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3255
+   i32.const 3260
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48490,7 +48532,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3256
+   i32.const 3261
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48504,53 +48546,53 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3257
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_sinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3260
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_sinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3261
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_sinh
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3262
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_sinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3265
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_sinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3266
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_sinh
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3267
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -inf
   f64.const -inf
   f64.const 0
@@ -48560,7 +48602,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3263
+   i32.const 3268
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48574,7 +48616,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3264
+   i32.const 3269
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48588,7 +48630,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3273
+   i32.const 3278
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48602,7 +48644,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3274
+   i32.const 3279
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48616,7 +48658,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3275
+   i32.const 3280
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48630,7 +48672,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3276
+   i32.const 3281
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48644,7 +48686,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3277
+   i32.const 3282
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48658,7 +48700,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3278
+   i32.const 3283
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48672,7 +48714,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3279
+   i32.const 3284
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48686,7 +48728,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3280
+   i32.const 3285
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48700,7 +48742,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3281
+   i32.const 3286
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48714,53 +48756,53 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3282
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_sinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3285
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_sinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3286
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_sinhf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3287
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_sinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3290
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_sinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3291
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_sinhf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3292
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -inf
   f32.const -inf
   f32.const 0
@@ -48770,7 +48812,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3288
+   i32.const 3293
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48784,7 +48826,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3289
+   i32.const 3294
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48798,7 +48840,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3301
+   i32.const 3306
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48812,7 +48854,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3302
+   i32.const 3307
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48826,7 +48868,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3303
+   i32.const 3308
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48840,7 +48882,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3304
+   i32.const 3309
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48854,7 +48896,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3305
+   i32.const 3310
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48868,7 +48910,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3306
+   i32.const 3311
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48882,7 +48924,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3307
+   i32.const 3312
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48896,7 +48938,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3308
+   i32.const 3313
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48910,7 +48952,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3309
+   i32.const 3314
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48924,7 +48966,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3310
+   i32.const 3315
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48938,7 +48980,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3313
+   i32.const 3318
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48952,7 +48994,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3314
+   i32.const 3319
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48966,7 +49008,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3315
+   i32.const 3320
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48980,7 +49022,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3316
+   i32.const 3321
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48994,7 +49036,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3317
+   i32.const 3322
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49008,7 +49050,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3318
+   i32.const 3323
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49022,7 +49064,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3319
+   i32.const 3324
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49036,7 +49078,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3320
+   i32.const 3325
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49050,7 +49092,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3321
+   i32.const 3326
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49064,7 +49106,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3322
+   i32.const 3327
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49078,7 +49120,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3323
+   i32.const 3328
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49087,76 +49129,6 @@
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
-  call $std/math/test_sqrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3324
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.9999999999999999
-  f64.const 0.9999999999999999
-  f64.const -0.5
-  i32.const 1
-  call $std/math/test_sqrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3325
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.9999999999999998
-  f64.const 1.414213562373095
-  f64.const -0.21107041835784912
-  i32.const 1
-  call $std/math/test_sqrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3326
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.0000000000000002
-  f64.const 1
-  f64.const -0.5
-  i32.const 1
-  call $std/math/test_sqrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3327
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.0000000000000004
-  f64.const 1.4142135623730951
-  f64.const -0.27173060178756714
-  i32.const 1
-  call $std/math/test_sqrt
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3328
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.0000000000000002
-  f64.const 1
-  f64.const -0.5
-  i32.const 1
   call $std/math/test_sqrt
   i32.eqz
   if
@@ -49181,6 +49153,76 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1.9999999999999998
+  f64.const 1.414213562373095
+  f64.const -0.21107041835784912
+  i32.const 1
+  call $std/math/test_sqrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3331
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.0000000000000002
+  f64.const 1
+  f64.const -0.5
+  i32.const 1
+  call $std/math/test_sqrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3332
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.0000000000000004
+  f64.const 1.4142135623730951
+  f64.const -0.27173060178756714
+  i32.const 1
+  call $std/math/test_sqrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3333
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.0000000000000002
+  f64.const 1
+  f64.const -0.5
+  i32.const 1
+  call $std/math/test_sqrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3334
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.9999999999999999
+  f64.const 0.9999999999999999
+  f64.const -0.5
+  i32.const 1
+  call $std/math/test_sqrt
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3335
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -1797693134862315708145274e284
   f64.const nan:0x8000000000000
   f64.const 0
@@ -49190,7 +49232,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3331
+   i32.const 3336
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49204,7 +49246,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3332
+   i32.const 3337
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49218,7 +49260,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3333
+   i32.const 3338
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49232,7 +49274,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3334
+   i32.const 3339
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49246,7 +49288,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3335
+   i32.const 3340
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49260,7 +49302,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3336
+   i32.const 3341
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49274,7 +49316,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3337
+   i32.const 3342
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49288,7 +49330,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3338
+   i32.const 3343
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49302,7 +49344,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3339
+   i32.const 3344
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49316,7 +49358,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3340
+   i32.const 3345
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49330,7 +49372,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3341
+   i32.const 3346
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49344,7 +49386,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3342
+   i32.const 3347
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49358,7 +49400,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3343
+   i32.const 3348
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49372,7 +49414,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3344
+   i32.const 3349
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49386,7 +49428,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3345
+   i32.const 3350
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49400,7 +49442,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3346
+   i32.const 3351
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49414,7 +49456,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3347
+   i32.const 3352
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49428,7 +49470,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3348
+   i32.const 3353
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49442,7 +49484,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3349
+   i32.const 3354
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49456,7 +49498,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3350
+   i32.const 3355
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49470,7 +49512,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3351
+   i32.const 3356
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49484,7 +49526,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3352
+   i32.const 3357
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49498,7 +49540,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3353
+   i32.const 3358
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49512,7 +49554,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3354
+   i32.const 3359
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49526,7 +49568,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3355
+   i32.const 3360
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49540,7 +49582,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3356
+   i32.const 3361
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49554,7 +49596,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3357
+   i32.const 3362
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49568,7 +49610,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3358
+   i32.const 3363
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49582,7 +49624,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3359
+   i32.const 3364
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49596,7 +49638,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3360
+   i32.const 3365
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49610,7 +49652,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3361
+   i32.const 3366
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49624,7 +49666,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3362
+   i32.const 3367
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49638,7 +49680,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3363
+   i32.const 3368
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49652,7 +49694,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3364
+   i32.const 3369
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49666,7 +49708,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3365
+   i32.const 3370
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49680,7 +49722,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3366
+   i32.const 3371
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49694,7 +49736,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3367
+   i32.const 3372
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49708,7 +49750,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3368
+   i32.const 3373
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49722,7 +49764,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3369
+   i32.const 3374
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49736,7 +49778,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3370
+   i32.const 3375
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49750,7 +49792,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3371
+   i32.const 3376
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49764,7 +49806,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3372
+   i32.const 3377
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49778,7 +49820,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3373
+   i32.const 3378
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49792,7 +49834,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3374
+   i32.const 3379
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49806,7 +49848,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3375
+   i32.const 3380
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49820,7 +49862,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3376
+   i32.const 3381
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49834,7 +49876,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3377
+   i32.const 3382
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49848,7 +49890,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3378
+   i32.const 3383
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49862,7 +49904,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3379
+   i32.const 3384
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49876,7 +49918,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3380
+   i32.const 3385
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49890,7 +49932,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3381
+   i32.const 3386
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49904,7 +49946,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3382
+   i32.const 3387
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49918,7 +49960,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3383
+   i32.const 3388
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49932,7 +49974,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3384
+   i32.const 3389
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49946,7 +49988,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3385
+   i32.const 3390
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49960,7 +50002,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3386
+   i32.const 3391
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49974,7 +50016,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3395
+   i32.const 3400
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49988,7 +50030,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3396
+   i32.const 3401
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50002,7 +50044,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3397
+   i32.const 3402
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50016,7 +50058,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3398
+   i32.const 3403
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50030,7 +50072,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3399
+   i32.const 3404
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50044,7 +50086,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3400
+   i32.const 3405
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50058,7 +50100,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3401
+   i32.const 3406
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50072,7 +50114,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3402
+   i32.const 3407
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50086,54 +50128,12 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3403
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.6787636876106262
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_sqrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3404
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_sqrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3407
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_sqrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3408
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const -0.6787636876106262
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -50147,36 +50147,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_sqrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3410
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_sqrtf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3411
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_sqrtf
@@ -50189,10 +50161,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const inf
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_sqrtf
   i32.eqz
   if
@@ -50203,10 +50175,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4
-  f32.const 2
+  f32.const -inf
+  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_sqrtf
   i32.eqz
   if
@@ -50217,8 +50189,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.802596928649634e-45
-  f32.const 5.293955920339377e-23
+  f32.const 0
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_sqrtf
@@ -50231,10 +50203,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.203895392974451e-45
-  f32.const 6.483745598763743e-23
-  f32.const 0.37388554215431213
-  i32.const 1
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  i32.const 0
   call $std/math/test_sqrtf
   i32.eqz
   if
@@ -50245,10 +50217,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.401298464324817e-45
-  f32.const 3.743392066509216e-23
-  f32.const -0.20303145051002502
-  i32.const 1
+  f32.const 1
+  f32.const 1
+  f32.const 0
+  i32.const 0
   call $std/math/test_sqrtf
   i32.eqz
   if
@@ -50259,7 +50231,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.401298464324817e-45
+  f32.const -1
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -50273,6 +50245,76 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 4
+  f32.const 2
+  f32.const 0
+  i32.const 0
+  call $std/math/test_sqrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3419
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.802596928649634e-45
+  f32.const 5.293955920339377e-23
+  f32.const 0
+  i32.const 0
+  call $std/math/test_sqrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3420
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4.203895392974451e-45
+  f32.const 6.483745598763743e-23
+  f32.const 0.37388554215431213
+  i32.const 1
+  call $std/math/test_sqrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3421
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.401298464324817e-45
+  f32.const 3.743392066509216e-23
+  f32.const -0.20303145051002502
+  i32.const 1
+  call $std/math/test_sqrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3422
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.401298464324817e-45
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 2
+  call $std/math/test_sqrtf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3423
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 3402823466385288598117041e14
   f32.const 18446742974197923840
   f32.const -0.5
@@ -50282,7 +50324,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3419
+   i32.const 3424
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50296,7 +50338,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3420
+   i32.const 3425
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50310,7 +50352,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3421
+   i32.const 3426
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50324,7 +50366,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3422
+   i32.const 3427
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50338,7 +50380,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3423
+   i32.const 3428
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50352,7 +50394,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3424
+   i32.const 3429
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50366,7 +50408,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3425
+   i32.const 3430
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50380,7 +50422,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3426
+   i32.const 3431
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50394,7 +50436,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3427
+   i32.const 3432
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50408,7 +50450,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3428
+   i32.const 3433
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50422,7 +50464,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3440
+   i32.const 3445
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50436,7 +50478,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3441
+   i32.const 3446
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50450,7 +50492,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3442
+   i32.const 3447
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50464,7 +50506,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3443
+   i32.const 3448
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50478,7 +50520,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3444
+   i32.const 3449
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50492,7 +50534,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3445
+   i32.const 3450
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50506,7 +50548,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3446
+   i32.const 3451
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50520,7 +50562,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3447
+   i32.const 3452
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50534,7 +50576,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3448
+   i32.const 3453
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50548,7 +50590,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3449
+   i32.const 3454
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50562,7 +50604,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3452
+   i32.const 3457
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50576,91 +50618,91 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3453
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072014e-308
-  f64.const 2.2250738585072014e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3454
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3455
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 5e-324
-  f64.const 5e-324
-  f64.const 0
-  i32.const 9
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3456
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -5e-324
-  f64.const -5e-324
-  f64.const 0
-  i32.const 9
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3457
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3458
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
-  f64.const -0
+  f64.const 2.2250738585072014e-308
+  f64.const 2.2250738585072014e-308
   f64.const 0
-  i32.const 0
+  i32.const 1
   call $std/math/test_tan
   i32.eqz
   if
    i32.const 0
    i32.const 24
    i32.const 3459
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3460
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 5e-324
+  f64.const 5e-324
+  f64.const 0
+  i32.const 9
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3461
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -5e-324
+  f64.const -5e-324
+  f64.const 0
+  i32.const 9
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3462
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3463
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3464
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50674,7 +50716,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3460
+   i32.const 3465
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50688,83 +50730,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3461
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507202e-308
-  f64.const 2.225073858507202e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3462
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072024e-308
-  f64.const 2.2250738585072024e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3463
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.4501477170144003e-308
-  f64.const 4.4501477170144003e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3464
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.450147717014403e-308
-  f64.const 4.450147717014403e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3465
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.450147717014406e-308
-  f64.const 4.450147717014406e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3466
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 8.900295434028806e-308
-  f64.const 8.900295434028806e-308
+  f64.const 2.225073858507202e-308
+  f64.const 2.225073858507202e-308
   f64.const 0
   i32.const 1
   call $std/math/test_tan
@@ -50773,6 +50745,76 @@
    i32.const 0
    i32.const 24
    i32.const 3467
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.2250738585072024e-308
+  f64.const 2.2250738585072024e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3468
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.4501477170144003e-308
+  f64.const 4.4501477170144003e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3469
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.450147717014403e-308
+  f64.const 4.450147717014403e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3470
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.450147717014406e-308
+  f64.const 4.450147717014406e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3471
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 8.900295434028806e-308
+  f64.const 8.900295434028806e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3472
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50786,7 +50828,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3468
+   i32.const 3473
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50800,83 +50842,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3469
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.225073858507202e-308
-  f64.const -2.225073858507202e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3470
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.2250738585072024e-308
-  f64.const -2.2250738585072024e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3471
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.4501477170144003e-308
-  f64.const -4.4501477170144003e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3472
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.450147717014403e-308
-  f64.const -4.450147717014403e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3473
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.450147717014406e-308
-  f64.const -4.450147717014406e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3474
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -8.900295434028806e-308
-  f64.const -8.900295434028806e-308
+  f64.const -2.225073858507202e-308
+  f64.const -2.225073858507202e-308
   f64.const 0
   i32.const 1
   call $std/math/test_tan
@@ -50885,6 +50857,76 @@
    i32.const 0
    i32.const 24
    i32.const 3475
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072024e-308
+  f64.const -2.2250738585072024e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3476
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.4501477170144003e-308
+  f64.const -4.4501477170144003e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3477
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.450147717014403e-308
+  f64.const -4.450147717014403e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3478
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.450147717014406e-308
+  f64.const -4.450147717014406e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3479
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -8.900295434028806e-308
+  f64.const -8.900295434028806e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3480
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50898,7 +50940,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3476
+   i32.const 3481
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50912,83 +50954,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3477
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1e-323
-  f64.const 1e-323
-  f64.const 0
-  i32.const 9
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3478
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.4e-323
-  f64.const 4.4e-323
-  f64.const 0
-  i32.const 9
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3479
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 5.562684646268003e-309
-  f64.const 5.562684646268003e-309
-  f64.const 0
-  i32.const 9
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3480
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.1125369292536007e-308
-  f64.const 1.1125369292536007e-308
-  f64.const 0
-  i32.const 9
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3481
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072004e-308
-  f64.const 2.2250738585072004e-308
-  f64.const 0
-  i32.const 9
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3482
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.225073858507201e-308
-  f64.const 2.225073858507201e-308
+  f64.const 1e-323
+  f64.const 1e-323
   f64.const 0
   i32.const 9
   call $std/math/test_tan
@@ -51001,8 +50973,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1e-323
-  f64.const -1e-323
+  f64.const 4.4e-323
+  f64.const 4.4e-323
   f64.const 0
   i32.const 9
   call $std/math/test_tan
@@ -51015,8 +50987,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4e-323
-  f64.const -4.4e-323
+  f64.const 5.562684646268003e-309
+  f64.const 5.562684646268003e-309
   f64.const 0
   i32.const 9
   call $std/math/test_tan
@@ -51029,8 +51001,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5.562684646268003e-309
-  f64.const -5.562684646268003e-309
+  f64.const 1.1125369292536007e-308
+  f64.const 1.1125369292536007e-308
   f64.const 0
   i32.const 9
   call $std/math/test_tan
@@ -51043,8 +51015,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.1125369292536007e-308
-  f64.const -1.1125369292536007e-308
+  f64.const 2.2250738585072004e-308
+  f64.const 2.2250738585072004e-308
   f64.const 0
   i32.const 9
   call $std/math/test_tan
@@ -51057,8 +51029,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072004e-308
-  f64.const -2.2250738585072004e-308
+  f64.const 2.225073858507201e-308
+  f64.const 2.225073858507201e-308
   f64.const 0
   i32.const 9
   call $std/math/test_tan
@@ -51071,8 +51043,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.225073858507201e-308
-  f64.const -2.225073858507201e-308
+  f64.const -1e-323
+  f64.const -1e-323
   f64.const 0
   i32.const 9
   call $std/math/test_tan
@@ -51085,11 +51057,39 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.3283064365386963e-10
-  call $~lib/math/NativeMath.tan
-  f64.const 2.3283064365386963e-10
-  call $~lib/bindings/Math/tan
-  f64.eq
+  f64.const -4.4e-323
+  f64.const -4.4e-323
+  f64.const 0
+  i32.const 9
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3490
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -5.562684646268003e-309
+  f64.const -5.562684646268003e-309
+  f64.const 0
+  i32.const 9
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3491
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.1125369292536007e-308
+  f64.const -1.1125369292536007e-308
+  f64.const 0
+  i32.const 9
+  call $std/math/test_tan
   i32.eqz
   if
    i32.const 0
@@ -51099,11 +51099,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.3283064365386963e-10
-  call $~lib/math/NativeMath.tan
-  f64.const -2.3283064365386963e-10
-  call $~lib/bindings/Math/tan
-  f64.eq
+  f64.const -2.2250738585072004e-308
+  f64.const -2.2250738585072004e-308
+  f64.const 0
+  i32.const 9
+  call $std/math/test_tan
   i32.eqz
   if
    i32.const 0
@@ -51113,11 +51113,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.6875
-  call $~lib/math/NativeMath.tan
-  f64.const 0.6875
-  call $~lib/bindings/Math/tan
-  f64.eq
+  f64.const -2.225073858507201e-308
+  f64.const -2.225073858507201e-308
+  f64.const 0
+  i32.const 9
+  call $std/math/test_tan
   i32.eqz
   if
    i32.const 0
@@ -51127,37 +51127,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.6875
+  f64.const 2.3283064365386963e-10
   call $~lib/math/NativeMath.tan
-  f64.const -0.6875
-  call $~lib/bindings/Math/tan
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3495
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.39269908169872414
-  call $~lib/math/NativeMath.tan
-  f64.const 0.39269908169872414
-  call $~lib/bindings/Math/tan
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3496
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.6743358
-  call $~lib/math/NativeMath.tan
-  f64.const 0.6743358
+  f64.const 2.3283064365386963e-10
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -51169,9 +51141,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 3.725290298461914e-09
+  f64.const -2.3283064365386963e-10
   call $~lib/math/NativeMath.tan
-  f64.const 3.725290298461914e-09
+  f64.const -2.3283064365386963e-10
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -51183,9 +51155,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5707963267948966
+  f64.const 0.6875
   call $~lib/math/NativeMath.tan
-  f64.const 1.5707963267948966
+  f64.const 0.6875
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -51197,9 +51169,23 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -0.6875
   call $~lib/math/NativeMath.tan
-  f64.const 0.5
+  f64.const -0.6875
+  call $~lib/bindings/Math/tan
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3500
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.39269908169872414
+  call $~lib/math/NativeMath.tan
+  f64.const 0.39269908169872414
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -51211,9 +51197,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.107148717794091
+  f64.const 0.6743358
   call $~lib/math/NativeMath.tan
-  f64.const 1.107148717794091
+  f64.const 0.6743358
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -51225,9 +51211,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5.497787143782138
+  f64.const 3.725290298461914e-09
   call $~lib/math/NativeMath.tan
-  f64.const 5.497787143782138
+  f64.const 3.725290298461914e-09
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -51239,9 +51225,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 7.0685834705770345
+  f64.const 1.5707963267948966
   call $~lib/math/NativeMath.tan
-  f64.const 7.0685834705770345
+  f64.const 1.5707963267948966
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -51253,23 +51239,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1647099.3291652855
+  f64.const 0.5
   call $~lib/math/NativeMath.tan
-  f64.const 1647099.3291652855
-  call $~lib/bindings/Math/tan
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3505
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1647097.7583689587
-  call $~lib/math/NativeMath.tan
-  f64.const 1647097.7583689587
+  f64.const 0.5
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -51281,9 +51253,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1329227995784915872903807e12
+  f64.const 1.107148717794091
   call $~lib/math/NativeMath.tan
-  f64.const 1329227995784915872903807e12
+  f64.const 1.107148717794091
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -51295,9 +51267,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1329227995784915872903807e12
+  f64.const 5.497787143782138
   call $~lib/math/NativeMath.tan
-  f64.const -1329227995784915872903807e12
+  f64.const 5.497787143782138
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -51309,6 +51281,76 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 7.0685834705770345
+  call $~lib/math/NativeMath.tan
+  f64.const 7.0685834705770345
+  call $~lib/bindings/Math/tan
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3509
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1647099.3291652855
+  call $~lib/math/NativeMath.tan
+  f64.const 1647099.3291652855
+  call $~lib/bindings/Math/tan
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3510
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1647097.7583689587
+  call $~lib/math/NativeMath.tan
+  f64.const 1647097.7583689587
+  call $~lib/bindings/Math/tan
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3511
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1329227995784915872903807e12
+  call $~lib/math/NativeMath.tan
+  f64.const 1329227995784915872903807e12
+  call $~lib/bindings/Math/tan
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3512
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1329227995784915872903807e12
+  call $~lib/math/NativeMath.tan
+  f64.const -1329227995784915872903807e12
+  call $~lib/bindings/Math/tan
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3513
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0
   f64.const 0
   f64.const 0
@@ -51318,7 +51360,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3511
+   i32.const 3516
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51332,7 +51374,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3512
+   i32.const 3517
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51346,7 +51388,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3513
+   i32.const 3518
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51360,7 +51402,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3514
+   i32.const 3519
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51374,7 +51416,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3515
+   i32.const 3520
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51388,7 +51430,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3524
+   i32.const 3529
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51402,7 +51444,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3525
+   i32.const 3530
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51416,7 +51458,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3526
+   i32.const 3531
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51430,7 +51472,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3527
+   i32.const 3532
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51444,7 +51486,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3528
+   i32.const 3533
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51458,7 +51500,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3529
+   i32.const 3534
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51472,7 +51514,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3530
+   i32.const 3535
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51486,7 +51528,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3531
+   i32.const 3536
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51500,7 +51542,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3532
+   i32.const 3537
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51514,7 +51556,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3533
+   i32.const 3538
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51528,7 +51570,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3536
+   i32.const 3541
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51542,7 +51584,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3537
+   i32.const 3542
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51556,7 +51598,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3538
+   i32.const 3543
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51570,7 +51612,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3539
+   i32.const 3544
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51584,7 +51626,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3540
+   i32.const 3545
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51598,7 +51640,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3543
+   i32.const 3548
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51612,83 +51654,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3544
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754943508222875e-38
-  f32.const 1.1754943508222875e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3545
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754943508222875e-38
-  f32.const -1.1754943508222875e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3546
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.401298464324817e-45
-  f32.const 1.401298464324817e-45
-  f32.const 0
-  i32.const 9
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3547
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.401298464324817e-45
-  f32.const -1.401298464324817e-45
-  f32.const 0
-  i32.const 9
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3548
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.175494490952134e-38
-  f32.const 1.175494490952134e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3549
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754946310819804e-38
-  f32.const 1.1754946310819804e-38
+  f32.const 1.1754943508222875e-38
+  f32.const 1.1754943508222875e-38
   f32.const 0
   i32.const 1
   call $std/math/test_tanf
@@ -51701,8 +51673,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509880009953429e-38
-  f32.const 2.3509880009953429e-38
+  f32.const -1.1754943508222875e-38
+  f32.const -1.1754943508222875e-38
   f32.const 0
   i32.const 1
   call $std/math/test_tanf
@@ -51715,10 +51687,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.350988701644575e-38
-  f32.const 2.350988701644575e-38
+  f32.const 1.401298464324817e-45
+  f32.const 1.401298464324817e-45
   f32.const 0
-  i32.const 1
+  i32.const 9
   call $std/math/test_tanf
   i32.eqz
   if
@@ -51729,6 +51701,76 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1.401298464324817e-45
+  f32.const -1.401298464324817e-45
+  f32.const 0
+  i32.const 9
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3553
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.175494490952134e-38
+  f32.const 1.175494490952134e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3554
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.1754946310819804e-38
+  f32.const 1.1754946310819804e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3555
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.3509880009953429e-38
+  f32.const 2.3509880009953429e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3556
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.350988701644575e-38
+  f32.const 2.350988701644575e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3557
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 2.3509895424236536e-38
   f32.const 2.3509895424236536e-38
   f32.const 0
@@ -51738,7 +51780,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3553
+   i32.const 3558
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51752,7 +51794,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3554
+   i32.const 3559
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51766,7 +51808,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3555
+   i32.const 3560
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51780,7 +51822,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3556
+   i32.const 3561
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51794,83 +51836,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3557
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.175494490952134e-38
-  f32.const -1.175494490952134e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3558
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754946310819804e-38
-  f32.const -1.1754946310819804e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3559
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.3509880009953429e-38
-  f32.const -2.3509880009953429e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3560
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.350988701644575e-38
-  f32.const 2.350988701644575e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3561
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.3509895424236536e-38
-  f32.const -2.3509895424236536e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3562
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -4.70197740328915e-38
-  f32.const -4.70197740328915e-38
+  f32.const -1.175494490952134e-38
+  f32.const -1.175494490952134e-38
   f32.const 0
   i32.const 1
   call $std/math/test_tanf
@@ -51879,6 +51851,76 @@
    i32.const 0
    i32.const 24
    i32.const 3563
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754946310819804e-38
+  f32.const -1.1754946310819804e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3564
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.3509880009953429e-38
+  f32.const -2.3509880009953429e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3565
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.350988701644575e-38
+  f32.const 2.350988701644575e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3566
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.3509895424236536e-38
+  f32.const -2.3509895424236536e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3567
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -4.70197740328915e-38
+  f32.const -4.70197740328915e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3568
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51892,7 +51934,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3564
+   i32.const 3569
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51906,7 +51948,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3565
+   i32.const 3570
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51920,83 +51962,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3566
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.802596928649634e-45
-  f32.const 2.802596928649634e-45
-  f32.const 0
-  i32.const 9
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3567
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.2611686178923354e-44
-  f32.const 1.2611686178923354e-44
-  f32.const 0
-  i32.const 9
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3568
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.938735877055719e-39
-  f32.const 2.938735877055719e-39
-  f32.const 0
-  i32.const 9
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3569
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 5.877471754111438e-39
-  f32.const 5.877471754111438e-39
-  f32.const 0
-  i32.const 9
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3570
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754940705625946e-38
-  f32.const 1.1754940705625946e-38
-  f32.const 0
-  i32.const 9
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3571
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754942106924411e-38
-  f32.const 1.1754942106924411e-38
+  f32.const 2.802596928649634e-45
+  f32.const 2.802596928649634e-45
   f32.const 0
   i32.const 9
   call $std/math/test_tanf
@@ -52009,8 +51981,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.802596928649634e-45
-  f32.const -2.802596928649634e-45
+  f32.const 1.2611686178923354e-44
+  f32.const 1.2611686178923354e-44
   f32.const 0
   i32.const 9
   call $std/math/test_tanf
@@ -52023,8 +51995,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.2611686178923354e-44
-  f32.const -1.2611686178923354e-44
+  f32.const 2.938735877055719e-39
+  f32.const 2.938735877055719e-39
   f32.const 0
   i32.const 9
   call $std/math/test_tanf
@@ -52037,8 +52009,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2.938735877055719e-39
-  f32.const -2.938735877055719e-39
+  f32.const 5.877471754111438e-39
+  f32.const 5.877471754111438e-39
   f32.const 0
   i32.const 9
   call $std/math/test_tanf
@@ -52051,8 +52023,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -5.877471754111438e-39
-  f32.const -5.877471754111438e-39
+  f32.const 1.1754940705625946e-38
+  f32.const 1.1754940705625946e-38
   f32.const 0
   i32.const 9
   call $std/math/test_tanf
@@ -52065,6 +52037,76 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1.1754942106924411e-38
+  f32.const 1.1754942106924411e-38
+  f32.const 0
+  i32.const 9
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3577
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.802596928649634e-45
+  f32.const -2.802596928649634e-45
+  f32.const 0
+  i32.const 9
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3578
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.2611686178923354e-44
+  f32.const -1.2611686178923354e-44
+  f32.const 0
+  i32.const 9
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3579
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.938735877055719e-39
+  f32.const -2.938735877055719e-39
+  f32.const 0
+  i32.const 9
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3580
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -5.877471754111438e-39
+  f32.const -5.877471754111438e-39
+  f32.const 0
+  i32.const 9
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3581
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -1.1754940705625946e-38
   f32.const -1.1754940705625946e-38
   f32.const 0
@@ -52074,7 +52116,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3577
+   i32.const 3582
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52088,7 +52130,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3578
+   i32.const 3583
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52102,7 +52144,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3590
+   i32.const 3595
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52116,7 +52158,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3591
+   i32.const 3596
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52130,7 +52172,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3592
+   i32.const 3597
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52144,7 +52186,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3593
+   i32.const 3598
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52158,7 +52200,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3594
+   i32.const 3599
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52172,7 +52214,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3595
+   i32.const 3600
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52186,7 +52228,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3596
+   i32.const 3601
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52200,7 +52242,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3597
+   i32.const 3602
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52214,7 +52256,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3598
+   i32.const 3603
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52228,7 +52270,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3599
+   i32.const 3604
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52242,7 +52284,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3602
+   i32.const 3607
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52256,7 +52298,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3603
+   i32.const 3608
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52270,7 +52312,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3604
+   i32.const 3609
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52284,7 +52326,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3605
+   i32.const 3610
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52298,7 +52340,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3606
+   i32.const 3611
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52312,7 +52354,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3615
+   i32.const 3620
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52326,7 +52368,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3616
+   i32.const 3621
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52340,7 +52382,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3617
+   i32.const 3622
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52354,7 +52396,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3618
+   i32.const 3623
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52368,7 +52410,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3619
+   i32.const 3624
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52382,7 +52424,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3620
+   i32.const 3625
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52396,7 +52438,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3621
+   i32.const 3626
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52410,7 +52452,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3622
+   i32.const 3627
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52424,7 +52466,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3623
+   i32.const 3628
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52438,7 +52480,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3624
+   i32.const 3629
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52452,7 +52494,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3627
+   i32.const 3632
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52466,7 +52508,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3628
+   i32.const 3633
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52480,7 +52522,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3629
+   i32.const 3634
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52494,7 +52536,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3630
+   i32.const 3635
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52508,7 +52550,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3631
+   i32.const 3636
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52522,7 +52564,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3643
+   i32.const 3648
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52536,7 +52578,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3644
+   i32.const 3649
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52550,7 +52592,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3645
+   i32.const 3650
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52564,7 +52606,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3646
+   i32.const 3651
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52578,7 +52620,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3647
+   i32.const 3652
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52592,7 +52634,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3648
+   i32.const 3653
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52606,7 +52648,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3649
+   i32.const 3654
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52620,7 +52662,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3650
+   i32.const 3655
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52634,7 +52676,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3651
+   i32.const 3656
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52648,83 +52690,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3652
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3655
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3656
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3657
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3658
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3659
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_trunc
@@ -52737,6 +52709,76 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3661
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3662
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3663
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3664
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3665
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const -1
   f64.const -1
   f64.const 0
@@ -52746,7 +52788,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3661
+   i32.const 3666
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52760,7 +52802,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3662
+   i32.const 3667
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52774,7 +52816,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3663
+   i32.const 3668
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52788,7 +52830,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3664
+   i32.const 3669
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52802,7 +52844,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3665
+   i32.const 3670
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52816,7 +52858,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3666
+   i32.const 3671
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52830,7 +52872,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3667
+   i32.const 3672
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52844,7 +52886,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3668
+   i32.const 3673
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52858,7 +52900,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3669
+   i32.const 3674
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52872,7 +52914,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3678
+   i32.const 3683
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52886,7 +52928,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3679
+   i32.const 3684
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52900,7 +52942,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3680
+   i32.const 3685
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52914,7 +52956,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3681
+   i32.const 3686
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52928,7 +52970,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3682
+   i32.const 3687
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52942,7 +52984,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3683
+   i32.const 3688
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52956,7 +52998,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3684
+   i32.const 3689
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52970,7 +53012,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3685
+   i32.const 3690
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52984,7 +53026,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3686
+   i32.const 3691
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52998,83 +53040,13 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3687
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3690
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3691
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3692
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3693
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3694
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_truncf
@@ -53087,6 +53059,76 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3696
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3697
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3698
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3699
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3700
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const -1
   f32.const -1
   f32.const 0
@@ -53096,7 +53138,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3696
+   i32.const 3701
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53110,7 +53152,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3697
+   i32.const 3702
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53124,7 +53166,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3698
+   i32.const 3703
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53138,7 +53180,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3699
+   i32.const 3704
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53152,7 +53194,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3700
+   i32.const 3705
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53166,7 +53208,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3701
+   i32.const 3706
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53180,7 +53222,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3702
+   i32.const 3707
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53194,7 +53236,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3703
+   i32.const 3708
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53208,7 +53250,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3704
+   i32.const 3709
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53302,7 +53344,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3745
+   i32.const 3750
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53316,7 +53358,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3746
+   i32.const 3751
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53330,7 +53372,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3747
+   i32.const 3752
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53344,7 +53386,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3748
+   i32.const 3753
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53358,7 +53400,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3749
+   i32.const 3754
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53372,7 +53414,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3750
+   i32.const 3755
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53386,7 +53428,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3751
+   i32.const 3756
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53400,7 +53442,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3752
+   i32.const 3757
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53414,7 +53456,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3753
+   i32.const 3758
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53428,7 +53470,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3754
+   i32.const 3759
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53442,7 +53484,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3755
+   i32.const 3760
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53456,7 +53498,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3756
+   i32.const 3761
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53469,7 +53511,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3760
+   i32.const 3765
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53482,7 +53524,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3761
+   i32.const 3766
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53495,7 +53537,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3762
+   i32.const 3767
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53508,7 +53550,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3763
+   i32.const 3768
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53521,7 +53563,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3764
+   i32.const 3769
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53534,7 +53576,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3765
+   i32.const 3770
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53547,7 +53589,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3766
+   i32.const 3771
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53560,7 +53602,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3767
+   i32.const 3772
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53573,7 +53615,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3768
+   i32.const 3773
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53586,7 +53628,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3769
+   i32.const 3774
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53599,7 +53641,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3770
+   i32.const 3775
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53612,7 +53654,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3771
+   i32.const 3776
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53625,7 +53667,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3772
+   i32.const 3777
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53638,7 +53680,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3773
+   i32.const 3778
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53651,7 +53693,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3774
+   i32.const 3779
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53664,68 +53706,12 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3775
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 0
-  i32.const 0
-  call $~lib/math/ipow64
-  i64.const 1
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3779
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 0
-  i32.const 1
-  call $~lib/math/ipow64
-  i64.const 0
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3780
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   i64.const 0
-  i32.const 2
-  call $~lib/math/ipow64
-  i64.const 0
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3781
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 0
-  i32.const 3
-  call $~lib/math/ipow64
-  i64.const 0
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3782
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 1
   i32.const 0
   call $~lib/math/ipow64
   i64.const 1
@@ -53739,10 +53725,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 1
+  i64.const 0
   i32.const 1
   call $~lib/math/ipow64
-  i64.const 1
+  i64.const 0
   i64.eq
   i32.eqz
   if
@@ -53753,10 +53739,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 1
+  i64.const 0
   i32.const 2
   call $~lib/math/ipow64
-  i64.const 1
+  i64.const 0
   i64.eq
   i32.eqz
   if
@@ -53767,10 +53753,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 1
+  i64.const 0
   i32.const 3
   call $~lib/math/ipow64
-  i64.const 1
+  i64.const 0
   i64.eq
   i32.eqz
   if
@@ -53781,7 +53767,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 2
+  i64.const 1
   i32.const 0
   call $~lib/math/ipow64
   i64.const 1
@@ -53795,10 +53781,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 2
+  i64.const 1
   i32.const 1
   call $~lib/math/ipow64
-  i64.const 2
+  i64.const 1
   i64.eq
   i32.eqz
   if
@@ -53809,10 +53795,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 2
+  i64.const 1
   i32.const 2
   call $~lib/math/ipow64
-  i64.const 4
+  i64.const 1
   i64.eq
   i32.eqz
   if
@@ -53823,10 +53809,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 2
+  i64.const 1
   i32.const 3
   call $~lib/math/ipow64
-  i64.const 8
+  i64.const 1
   i64.eq
   i32.eqz
   if
@@ -53837,7 +53823,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const -1
+  i64.const 2
   i32.const 0
   call $~lib/math/ipow64
   i64.const 1
@@ -53851,10 +53837,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const -1
+  i64.const 2
   i32.const 1
   call $~lib/math/ipow64
-  i64.const -1
+  i64.const 2
   i64.eq
   i32.eqz
   if
@@ -53865,10 +53851,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const -1
+  i64.const 2
   i32.const 2
   call $~lib/math/ipow64
-  i64.const 1
+  i64.const 4
   i64.eq
   i32.eqz
   if
@@ -53879,10 +53865,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const -1
+  i64.const 2
   i32.const 3
   call $~lib/math/ipow64
-  i64.const -1
+  i64.const 8
   i64.eq
   i32.eqz
   if
@@ -53893,7 +53879,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const -2
+  i64.const -1
   i32.const 0
   call $~lib/math/ipow64
   i64.const 1
@@ -53907,6 +53893,62 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i64.const -1
+  i32.const 1
+  call $~lib/math/ipow64
+  i64.const -1
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3800
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const -1
+  i32.const 2
+  call $~lib/math/ipow64
+  i64.const 1
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3801
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const -1
+  i32.const 3
+  call $~lib/math/ipow64
+  i64.const -1
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3802
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const -2
+  i32.const 0
+  call $~lib/math/ipow64
+  i64.const 1
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3804
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   i64.const -2
   i32.const 1
   call $~lib/math/ipow64
@@ -53916,7 +53958,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3800
+   i32.const 3805
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53930,7 +53972,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3801
+   i32.const 3806
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53944,7 +53986,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3802
+   i32.const 3807
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53958,7 +54000,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3804
+   i32.const 3809
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53972,7 +54014,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3805
+   i32.const 3810
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53986,7 +54028,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3806
+   i32.const 3811
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54000,7 +54042,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3807
+   i32.const 3812
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54014,7 +54056,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3808
+   i32.const 3813
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54028,7 +54070,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3809
+   i32.const 3814
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54042,7 +54084,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3810
+   i32.const 3815
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54060,79 +54102,12 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3812
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  i32.const 0
-  call $~lib/math/ipow32f
-  f32.const 1
-  f32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3816
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  i32.const 0
-  call $~lib/math/ipow32f
-  f32.const 1
-  f32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3817
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  i32.const 1
-  call $~lib/math/ipow32f
-  call $~lib/number/isNaN<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3818
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  i32.const -1
-  call $~lib/math/ipow32f
-  call $~lib/number/isNaN<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3819
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  i32.const 2
-  call $~lib/math/ipow32f
-  call $~lib/number/isNaN<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3820
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
+  f32.const 0
   i32.const 0
   call $~lib/math/ipow32f
   f32.const 1
@@ -54146,10 +54121,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  i32.const 1
+  f32.const nan:0x400000
+  i32.const 0
   call $~lib/math/ipow32f
-  f32.const inf
+  f32.const 1
   f32.eq
   i32.eqz
   if
@@ -54160,11 +54135,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  i32.const 0
+  f32.const nan:0x400000
+  i32.const 1
   call $~lib/math/ipow32f
-  f32.const 1
-  f32.eq
+  call $~lib/number/isNaN<f32>
   i32.eqz
   if
    i32.const 0
@@ -54174,11 +54148,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  i32.const 1
+  f32.const nan:0x400000
+  i32.const -1
   call $~lib/math/ipow32f
-  f32.const -inf
-  f32.eq
+  call $~lib/number/isNaN<f32>
   i32.eqz
   if
    i32.const 0
@@ -54188,11 +54161,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const nan:0x400000
   i32.const 2
   call $~lib/math/ipow32f
-  f32.const inf
-  f32.eq
+  call $~lib/number/isNaN<f32>
   i32.eqz
   if
    i32.const 0
@@ -54202,7 +54174,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
+  f32.const inf
   i32.const 0
   call $~lib/math/ipow32f
   f32.const 1
@@ -54216,6 +54188,76 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
+  i32.const 1
+  call $~lib/math/ipow32f
+  f32.const inf
+  f32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3827
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  i32.const 0
+  call $~lib/math/ipow32f
+  f32.const 1
+  f32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3828
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  i32.const 1
+  call $~lib/math/ipow32f
+  f32.const -inf
+  f32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3829
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  i32.const 2
+  call $~lib/math/ipow32f
+  f32.const inf
+  f32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3830
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  i32.const 0
+  call $~lib/math/ipow32f
+  f32.const 1
+  f32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3831
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 3402823466385288598117041e14
   i32.const 2
   call $~lib/math/ipow32f
@@ -54225,7 +54267,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3827
+   i32.const 3832
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54239,7 +54281,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3828
+   i32.const 3833
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54253,7 +54295,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3829
+   i32.const 3834
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54267,7 +54309,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3830
+   i32.const 3835
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54281,79 +54323,12 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3831
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  i32.const 0
-  call $~lib/math/ipow64f
-  f64.const 1
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3835
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  i32.const 0
-  call $~lib/math/ipow64f
-  f64.const 1
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
    i32.const 3836
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  i32.const 1
-  call $~lib/math/ipow64f
-  call $~lib/number/isNaN<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3837
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  i32.const -1
-  call $~lib/math/ipow64f
-  call $~lib/number/isNaN<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3838
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  i32.const 2
-  call $~lib/math/ipow64f
-  call $~lib/number/isNaN<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 24
-   i32.const 3839
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
+  f64.const 0
   i32.const 0
   call $~lib/math/ipow64f
   f64.const 1
@@ -54367,10 +54342,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  i32.const 1
+  f64.const nan:0x8000000000000
+  i32.const 0
   call $~lib/math/ipow64f
-  f64.const inf
+  f64.const 1
   f64.eq
   i32.eqz
   if
@@ -54381,11 +54356,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  i32.const 0
+  f64.const nan:0x8000000000000
+  i32.const 1
   call $~lib/math/ipow64f
-  f64.const 1
-  f64.eq
+  call $~lib/number/isNaN<f64>
   i32.eqz
   if
    i32.const 0
@@ -54395,11 +54369,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  i32.const 1
+  f64.const nan:0x8000000000000
+  i32.const -1
   call $~lib/math/ipow64f
-  f64.const -inf
-  f64.eq
+  call $~lib/number/isNaN<f64>
   i32.eqz
   if
    i32.const 0
@@ -54409,11 +54382,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const nan:0x8000000000000
   i32.const 2
   call $~lib/math/ipow64f
-  f64.const inf
-  f64.eq
+  call $~lib/number/isNaN<f64>
   i32.eqz
   if
    i32.const 0
@@ -54423,7 +54395,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
+  f64.const inf
   i32.const 0
   call $~lib/math/ipow64f
   f64.const 1
@@ -54437,6 +54409,76 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
+  i32.const 1
+  call $~lib/math/ipow64f
+  f64.const inf
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3846
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  i32.const 0
+  call $~lib/math/ipow64f
+  f64.const 1
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3847
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  i32.const 1
+  call $~lib/math/ipow64f
+  f64.const -inf
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3848
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  i32.const 2
+  call $~lib/math/ipow64f
+  f64.const inf
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3849
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  i32.const 0
+  call $~lib/math/ipow64f
+  f64.const 1
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 3850
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 1797693134862315708145274e284
   i32.const 2
   call $~lib/math/ipow64f
@@ -54446,7 +54488,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3846
+   i32.const 3851
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54460,7 +54502,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3847
+   i32.const 3852
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54474,7 +54516,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3848
+   i32.const 3853
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54488,7 +54530,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3849
+   i32.const 3854
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54502,7 +54544,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 3850
+   i32.const 3855
    i32.const 0
    call $~lib/builtins/abort
    unreachable


### PR DESCRIPTION
Due to a [regression in Math.hypot](https://bugs.chromium.org/p/v8/issues/detail?id=9546) in v8 7.7 (node 12.11.0), [some of the std/math tests](https://github.com/AssemblyScript/assemblyscript/pull/871/commits/cb69181782f4905cd72dc039ac4d96b0ebfdd7cf#diff-d0b06574e5eed6802cbc0a204227084dR1644-R1652), that also run against node, are currently failing. This PR temporarily disables the JS testing for the edge cases in question. The bug is fixed in v8 7.8, so once latest node uses that, the tests can be enabled again.