### PR TITLE
Allow omitting return type in callback arrow functions

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -15,6 +15,7 @@ under the licensing terms detailed in LICENSE:
 * Aaron Turner <aaron@aaronthedev.com>
 * Willem Wyndham <willem@cs.umd.edu>
 * Bowen Wang <bowen@nearprotocol.com>
+* Emil Laine <laine.emil@gmail.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ $> git clone https://github.com/AssemblyScript/assemblyscript.git
 $> cd assemblyscript
 $> npm install
 $> npm link
-$> npm clean
+$> npm run clean
 ```
 
-Note that a fresh clone of the compiler will use the distribution files in `dist/`, but after an `npm clean` it will run [the sources](./src) directly through ts-node, which is useful in development. This condition can also be checked by running `asc -v` (it is running the sources if it states `-dev`). Also please see our [contribution guidelines](./CONTRIBUTING.md) before making your first pull request.
+Note that a fresh clone of the compiler will use the distribution files in `dist/`, but after an `npm run clean` it will run [the sources](./src) directly through ts-node, which is useful in development. This condition can also be checked by running `asc -v` (it is running the sources if it states `-dev`). Also please see our [contribution guidelines](./CONTRIBUTING.md) before making your first pull request.
 
 Building
 --------

--- a/lib/lint/formatters/asFormatter.js
+++ b/lib/lint/formatters/asFormatter.js
@@ -41,10 +41,10 @@ class Formatter extends abstractFormatter_1.AbstractFormatter {
         });
     }
 }
+exports.Formatter = Formatter;
 Formatter.metadata = {
     formatterName: "as",
     description: "AssemblyScript's TSLint formatter.",
     sample: "Similar to ASC's output.",
     consumer: "human",
 };
-exports.Formatter = Formatter;

--- a/lib/lint/rules/asTypesRule.js
+++ b/lib/lint/rules/asTypesRule.js
@@ -7,9 +7,9 @@ class Rule extends Lint.Rules.AbstractRule {
         return this.applyWithWalker(new DiagnosticsWalker(sourceFile, this.getOptions()));
     }
 }
+exports.Rule = Rule;
 Rule.MISSING_TYPE_OR_INITIALIZER = "Missing type or initializer.";
 Rule.MISSING_RETURN_TYPE = "Missing return type.";
-exports.Rule = Rule;
 class DiagnosticsWalker extends Lint.RuleWalker {
     visitVariableDeclaration(node) {
         var list = node.parent;
@@ -39,7 +39,9 @@ class DiagnosticsWalker extends Lint.RuleWalker {
         super.visitFunctionDeclaration(node);
     }
     visitArrowFunction(node) {
-        this.checkFunctionReturnType(node);
+        if (!isArgument(node)) {
+            this.checkFunctionReturnType(node);
+        }
         super.visitArrowFunction(node);
     }
     visitMethodDeclaration(node) {
@@ -55,4 +57,7 @@ class DiagnosticsWalker extends Lint.RuleWalker {
             this.addFailureAtNode(node, Rule.MISSING_RETURN_TYPE);
         }
     }
+}
+function isArgument(node) {
+    return ts.isCallLikeExpression(node.parent);
 }

--- a/lib/lint/rules/asTypesRule.js
+++ b/lib/lint/rules/asTypesRule.js
@@ -40,7 +40,7 @@ class DiagnosticsWalker extends Lint.RuleWalker {
         super.visitFunctionDeclaration(node);
     }
     visitArrowFunction(node) {
-        if (!isArgument(node)) {
+        if (requiresReturnType(node)) {
             this.checkFunctionReturnType(node);
         }
         else if (node.type) {
@@ -62,6 +62,10 @@ class DiagnosticsWalker extends Lint.RuleWalker {
         }
     }
 }
-function isArgument(node) {
-    return ts.isCallLikeExpression(node.parent);
+function requiresReturnType(node) {
+    if (ts.isCallExpression(node.parent) && ts.isIdentifier(node.parent.expression)
+        && ["lengthof", "nameof"].includes(node.parent.expression.text)) {
+        return true;
+    }
+    return !ts.isCallLikeExpression(node.parent);
 }

--- a/lib/lint/rules/asTypesRule.js
+++ b/lib/lint/rules/asTypesRule.js
@@ -10,6 +10,7 @@ class Rule extends Lint.Rules.AbstractRule {
 exports.Rule = Rule;
 Rule.MISSING_TYPE_OR_INITIALIZER = "Missing type or initializer.";
 Rule.MISSING_RETURN_TYPE = "Missing return type.";
+Rule.UNNECESSARY_RETURN_TYPE = "Unnecessary return type.";
 class DiagnosticsWalker extends Lint.RuleWalker {
     visitVariableDeclaration(node) {
         var list = node.parent;
@@ -41,6 +42,9 @@ class DiagnosticsWalker extends Lint.RuleWalker {
     visitArrowFunction(node) {
         if (!isArgument(node)) {
             this.checkFunctionReturnType(node);
+        }
+        else if (node.type) {
+            this.addFailureAtNode(node.type, Rule.UNNECESSARY_RETURN_TYPE);
         }
         super.visitArrowFunction(node);
     }

--- a/lib/lint/rules/asVariablesRule.js
+++ b/lib/lint/rules/asVariablesRule.js
@@ -7,9 +7,9 @@ class Rule extends Lint.Rules.AbstractRule {
         return this.applyWithWalker(new VariablesWalker(sourceFile, this.getOptions()));
     }
 }
+exports.Rule = Rule;
 Rule.TOP_LEVEL_VAR = "Top-level variable should be 'var' (distinct local or global).";
 Rule.BLOCK_LEVEL_LET = "Block-level variable should be 'let' (shared local).";
-exports.Rule = Rule;
 class VariablesWalker extends Lint.RuleWalker {
     visitVariableDeclarationList(node) {
         if (tsutils_1.isVariableStatement(node.parent)) {

--- a/lib/lint/rules/internal/asInternalCaseRule.js
+++ b/lib/lint/rules/internal/asInternalCaseRule.js
@@ -8,8 +8,8 @@ class Rule extends Lint.Rules.AbstractRule {
         return this.applyWithWalker(new CaseWalker(sourceFile, this.getOptions()));
     }
 }
-Rule.NOT_BRACED = "Multi-line case clauses should be braced.";
 exports.Rule = Rule;
+Rule.NOT_BRACED = "Multi-line case clauses should be braced.";
 class CaseWalker extends Lint.RuleWalker {
     visitDefaultClause(node) {
         this.checkDefaultOrCaseClause(node);

--- a/lib/lint/rules/internal/asInternalDiagnosticsRule.js
+++ b/lib/lint/rules/internal/asInternalDiagnosticsRule.js
@@ -8,8 +8,8 @@ class Rule extends Lint.Rules.AbstractRule {
         return this.applyWithWalker(new DiagnosticsWalker(sourceFile, this.getOptions()));
     }
 }
-Rule.NOT_ON_SEPARATE_LINE = "Diagnostic message not on a separate line.";
 exports.Rule = Rule;
+Rule.NOT_ON_SEPARATE_LINE = "Diagnostic message not on a separate line.";
 class DiagnosticsWalker extends Lint.RuleWalker {
     visitPropertyAccessExpression(node) {
         if (node.expression.kind === ts.SyntaxKind.Identifier) {

--- a/lib/lint/src/rules/asTypesRule.ts
+++ b/lib/lint/src/rules/asTypesRule.ts
@@ -46,7 +46,9 @@ class DiagnosticsWalker extends Lint.RuleWalker {
   }
 
   visitArrowFunction(node: ts.ArrowFunction) {
-    this.checkFunctionReturnType(node);
+    if (!isArgument(node)) {
+      this.checkFunctionReturnType(node);
+    }
     super.visitArrowFunction(node);
   }
 
@@ -65,4 +67,8 @@ class DiagnosticsWalker extends Lint.RuleWalker {
       this.addFailureAtNode(node, Rule.MISSING_RETURN_TYPE);
     }
   }
+}
+
+function isArgument(node: ts.Node) {
+  return ts.isCallLikeExpression(node.parent);
 }

--- a/lib/lint/src/rules/asTypesRule.ts
+++ b/lib/lint/src/rules/asTypesRule.ts
@@ -47,7 +47,7 @@ class DiagnosticsWalker extends Lint.RuleWalker {
   }
 
   visitArrowFunction(node: ts.ArrowFunction) {
-    if (!isArgument(node)) {
+    if (requiresReturnType(node)) {
       this.checkFunctionReturnType(node);
     } else if (node.type) {
       this.addFailureAtNode(node.type, Rule.UNNECESSARY_RETURN_TYPE);
@@ -72,6 +72,10 @@ class DiagnosticsWalker extends Lint.RuleWalker {
   }
 }
 
-function isArgument(node: ts.Node) {
-  return ts.isCallLikeExpression(node.parent);
+function requiresReturnType(node: ts.ArrowFunction): boolean {
+  if (ts.isCallExpression(node.parent) && ts.isIdentifier(node.parent.expression)
+    && ["lengthof", "nameof"].includes(node.parent.expression.text)) {
+    return true;
+  }
+  return !ts.isCallLikeExpression(node.parent);
 }

--- a/lib/lint/src/rules/asTypesRule.ts
+++ b/lib/lint/src/rules/asTypesRule.ts
@@ -5,6 +5,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
   static MISSING_TYPE_OR_INITIALIZER = "Missing type or initializer.";
   static MISSING_RETURN_TYPE = "Missing return type.";
+  static UNNECESSARY_RETURN_TYPE = "Unnecessary return type.";
 
   apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
     return this.applyWithWalker(new DiagnosticsWalker(sourceFile, this.getOptions()));
@@ -48,6 +49,8 @@ class DiagnosticsWalker extends Lint.RuleWalker {
   visitArrowFunction(node: ts.ArrowFunction) {
     if (!isArgument(node)) {
       this.checkFunctionReturnType(node);
+    } else if (node.type) {
+      this.addFailureAtNode(node.type, Rule.UNNECESSARY_RETURN_TYPE);
     }
     super.visitArrowFunction(node);
   }

--- a/tests/compiler/builtins.ts
+++ b/tests/compiler/builtins.ts
@@ -453,7 +453,7 @@ f64.trunc(1.0);
   assert(nameof<usize>() == "usize");
   assert(nameof<void>() == "void");
   assert(nameof("some value") == "String");
-  assert(nameof(() => {}) == "Function");
+  assert(nameof((): void => {}) == "Function");
 }
 
 assert(isVoid<void>());
@@ -475,7 +475,7 @@ assert(lengthof<() => void>() == 0);
 assert(lengthof<(a: i32) => void>() == 1);
 assert(lengthof<(a: i32, b: C) => void>() == 2);
 assert(lengthof<(a: i32, b: C, c: string) => void>() == 3);
-assert(lengthof((a: i32, b: i32, c: i32, d: i32) => {}) == 4);
+assert(lengthof((a: i32, b: i32, c: i32, d: i32): void => {}) == 4);
 
 assert(isInteger<ReturnType<() => i32>>());
 assert(isInteger<returnof<() => i32>>());

--- a/tests/compiler/builtins.ts
+++ b/tests/compiler/builtins.ts
@@ -453,7 +453,7 @@ f64.trunc(1.0);
   assert(nameof<usize>() == "usize");
   assert(nameof<void>() == "void");
   assert(nameof("some value") == "String");
-  assert(nameof((): void => {}) == "Function");
+  assert(nameof(() => {}) == "Function");
 }
 
 assert(isVoid<void>());
@@ -475,7 +475,7 @@ assert(lengthof<() => void>() == 0);
 assert(lengthof<(a: i32) => void>() == 1);
 assert(lengthof<(a: i32, b: C) => void>() == 2);
 assert(lengthof<(a: i32, b: C, c: string) => void>() == 3);
-assert(lengthof((a: i32, b: i32, c: i32, d: i32): void => {}) == 4);
+assert(lengthof((a: i32, b: i32, c: i32, d: i32) => {}) == 4);
 
 assert(isInteger<ReturnType<() => i32>>());
 assert(isInteger<returnof<() => i32>>());

--- a/tests/compiler/std/array.ts
+++ b/tests/compiler/std/array.ts
@@ -396,25 +396,25 @@ var i: i32;
   arr[2] = 2;
   arr[3] = 3;
 
-  i = arr.findIndex((value: i32, index: i32, array: Array<i32>): bool => value == 0);
+  i = arr.findIndex((value: i32, index: i32, array: Array<i32>) => value == 0);
 
   assert(i == 0);
 
-  i = arr.findIndex((value: i32, index: i32, array: Array<i32>): bool => value == 1);
+  i = arr.findIndex((value: i32, index: i32, array: Array<i32>) => value == 1);
   assert(i == 1);
 
-  i = arr.findIndex((value: i32, index: i32, array: Array<i32>): bool => value == 100);
+  i = arr.findIndex((value: i32, index: i32, array: Array<i32>) => value == 100);
   assert(i == -1);
 
   // Test side effect push
-  i = arr.findIndex((value: i32, index: i32, array: Array<i32>): bool => {
+  i = arr.findIndex((value: i32, index: i32, array: Array<i32>) => {
     array.push(100); // push side effect should not affect this method by spec
     return value == 100;
   });
   // array should be changed, but this method result should be calculated for old array length
   assert(i == -1);
   assert(arr.length == 8);
-  i = arr.findIndex((value: i32, index: i32, array: Array<i32>): bool => value == 100);
+  i = arr.findIndex((value: i32, index: i32, array: Array<i32>) => value == 100);
   assert(i != -1);
 
   arr.pop();
@@ -423,7 +423,7 @@ var i: i32;
   arr.pop();
 
   // Test side effect pop
-  i = arr.findIndex((value: i32, index: i32, array: Array<i32>): bool => {
+  i = arr.findIndex((value: i32, index: i32, array: Array<i32>) => {
     array.pop(); // popped items shouldn't be looked up, and we shouldn't go out of bounds
     return value == 100;
   });
@@ -438,21 +438,21 @@ var i: i32;
 // Array#every /////////////////////////////////////////////////////////////////////////////////////
 
 {
-  let every = arr.every((value: i32, index: i32, array: Array<i32>): bool => value >= 0);
+  let every = arr.every((value: i32, index: i32, array: Array<i32>) => value >= 0);
   assert(every == true);
 
-  every = arr.every((value: i32, index: i32, array: Array<i32>): bool => value <= 0);
+  every = arr.every((value: i32, index: i32, array: Array<i32>) => value <= 0);
   assert(every == false);
 
   // Test side effect push
-  every = arr.every((value: i32, index: i32, array: Array<i32>): bool => {
+  every = arr.every((value: i32, index: i32, array: Array<i32>) => {
     array.push(100); // push side effect should not affect this method by spec
     return value < 10;
   });
   // array should be changed, but this method result should be calculated for old array length
   assert(every == true);
   assert(arr.length == 8);
-  every = arr.every((value: i32, index: i32, array: Array<i32>): bool => value < 10);
+  every = arr.every((value: i32, index: i32, array: Array<i32>) => value < 10);
   assert(every == false);
 
   arr.pop();
@@ -461,7 +461,7 @@ var i: i32;
   arr.pop();
 
   // Test side effect pop
-  every = arr.every((value: i32, index: i32, array: Array<i32>): bool => {
+  every = arr.every((value: i32, index: i32, array: Array<i32>) => {
     array.pop(); //poped items shouldn't be looked up, and we shouldn't go out of bounds
     return value < 3;
   });
@@ -476,21 +476,21 @@ var i: i32;
 // Array#some //////////////////////////////////////////////////////////////////////////////////////
 
 {
-  let some = arr.some((value: i32, index: i32, array: Array<i32>): bool => value >= 3);
+  let some = arr.some((value: i32, index: i32, array: Array<i32>) => value >= 3);
   assert(some == true);
 
-  some = arr.some((value: i32, index: i32, array: Array<i32>): bool => value <= -1);
+  some = arr.some((value: i32, index: i32, array: Array<i32>) => value <= -1);
   assert(some == false);
 
   // Test side effect push
-  some = arr.some((value: i32, index: i32, array: Array<i32>): bool => {
+  some = arr.some((value: i32, index: i32, array: Array<i32>) => {
     array.push(100); // push side effect should not affect this method by spec
     return value > 10;
   });
   // array should be changed, but this method result should be calculated for old array length
   assert(some == false);
   assert(arr.length == 8);
-  some = arr.some((value: i32, index: i32, array: Array<i32>): bool => value > 10);
+  some = arr.some((value: i32, index: i32, array: Array<i32>) => value > 10);
   assert(some == true);
 
   arr.pop();
@@ -499,7 +499,7 @@ var i: i32;
   arr.pop();
 
   // Test side effect pop
-  some = arr.some((value: i32, index: i32, array: Array<i32>): bool => {
+  some = arr.some((value: i32, index: i32, array: Array<i32>) => {
     array.pop(); // poped items shouldn't be looked up, and we shouldn't go out of bounds
     return value > 3;
   });
@@ -515,12 +515,12 @@ var i: i32;
 
 {
   i = 0;
-  arr.forEach((value: i32, index: i32, array: Array<i32>): void => { i += value; });
+  arr.forEach((value: i32, index: i32, array: Array<i32>) => { i += value; });
   assert(i == 6);
 
   // Test side effect push
   i = 0;
-  arr.forEach((value: i32, index: i32, array: Array<i32>): void => {
+  arr.forEach((value: i32, index: i32, array: Array<i32>) => {
     array.push(100); //push side effect should not affect this method by spec
     i += value;
   });
@@ -528,7 +528,7 @@ var i: i32;
   assert(i == 6);
   assert(arr.length == 8);
   i = 0;
-  arr.forEach((value: i32, index: i32, array: Array<i32>): void => { i += value; });
+  arr.forEach((value: i32, index: i32, array: Array<i32>) => { i += value; });
   assert(i == 406);
 
   arr.pop();
@@ -538,7 +538,7 @@ var i: i32;
 
   // Test side effect pop
   i = 0;
-  arr.forEach((value: i32, index: i32, array: Array<i32>): void => {
+  arr.forEach((value: i32, index: i32, array: Array<i32>) => {
     array.pop(); //poped items shouldn't be looked up, and we shouldn't go out of bounds
     i += value;
   });
@@ -550,7 +550,7 @@ var i: i32;
   arr.push(3);
 
   // Test rehash action effec
-  arr.forEach((value: i32, index: i32, array: Array<i32>): void => {
+  arr.forEach((value: i32, index: i32, array: Array<i32>) => {
     if (index == 0) {
       for (let i = 0; i < 4; i++) {
         array.pop();
@@ -582,13 +582,13 @@ var i: i32;
 // Array#map ///////////////////////////////////////////////////////////////////////////////////////
 
 {
-  let newArr: f32[] = arr.map<f32>((value: i32, index: i32, array: Array<i32>): f32 => <f32>value);
+  let newArr: f32[] = arr.map<f32>((value: i32, index: i32, array: Array<i32>) => <f32>value);
   assert(newArr.length == 4);
   assert(newArr[0] == <f32>arr[0]);
 
   // Test side effect push
   i = 0;
-  arr.map<i32>((value: i32, index: i32, array: Array<i32>): i32 => {
+  arr.map<i32>((value: i32, index: i32, array: Array<i32>) => {
     array.push(100); //push side effect should not affect this method by spec
     i += value;
     return value;
@@ -597,7 +597,7 @@ var i: i32;
   assert(arr.length == 8);
 
   i = 0;
-  arr.map<i32>((value: i32, index: i32, array: Array<i32>): i32 => {
+  arr.map<i32>((value: i32, index: i32, array: Array<i32>) => {
     i += value;
     return value;
   });
@@ -610,7 +610,7 @@ var i: i32;
 
   // Test side effect pop
   i = 0;
-  arr.map<i32>((value: i32, index: i32, array: Array<i32>): i32 => {
+  arr.map<i32>((value: i32, index: i32, array: Array<i32>) => {
     array.pop(); //poped items shouldn't be looked up, and we shouldn't go out of bounds
     i += value;
     return value;
@@ -626,12 +626,12 @@ var i: i32;
 // Array#filter ////////////////////////////////////////////////////////////////////////////////////
 
 {
-  let filteredArr: i32[] = arr.filter((value: i32, index: i32, array: Array<i32>): bool => value >= 2);
+  let filteredArr: i32[] = arr.filter((value: i32, index: i32, array: Array<i32>) => value >= 2);
   assert(filteredArr.length == 2);
 
   // Test side effect push
   i = 0;
-  arr.filter((value: i32, index: i32, array: Array<i32>): bool => {
+  arr.filter((value: i32, index: i32, array: Array<i32>) => {
     array.push(100); //push side effect should not affect this method by spec
     i += value;
     return value >= 2;
@@ -640,7 +640,7 @@ var i: i32;
   assert(arr.length == 8);
 
   i = 0;
-  arr.filter((value: i32, index: i32, array: Array<i32>): bool => {
+  arr.filter((value: i32, index: i32, array: Array<i32>) => {
     i += value;
     return value >= 2;
   });
@@ -653,7 +653,7 @@ var i: i32;
 
   // Test side effect pop
   i = 0;
-  arr.filter((value: i32, index: i32, array: Array<i32>): bool => {
+  arr.filter((value: i32, index: i32, array: Array<i32>) => {
     array.pop(); //poped items shouldn't be looked up, and we shouldn't go out of bounds
     i += value;
     return value >= 2;
@@ -900,23 +900,23 @@ function assertSortedDefault<T>(arr: Array<T>): void {
   let randomized64  = createRandomOrderedArray(64);
   let randomized257 = createRandomOrderedArray(257);
 
-  assertSorted<i32>(randomized64, (a: i32, b: i32): i32 => a - b);
-  assertSorted<i32>(randomized64, (a: i32, b: i32): i32 => b - a);
+  assertSorted<i32>(randomized64, (a: i32, b: i32) => a - b);
+  assertSorted<i32>(randomized64, (a: i32, b: i32) => b - a);
 
-  assertSorted<i32>(randomized257, (a: i32, b: i32): i32 => a - b);
-  assertSorted<i32>(randomized257, (a: i32, b: i32): i32 => b - a);
+  assertSorted<i32>(randomized257, (a: i32, b: i32) => a - b);
+  assertSorted<i32>(randomized257, (a: i32, b: i32) => b - a);
 }
 
 // Test sorting complex objects
 {
   let reversedNested512 = createReverseOrderedNestedArray(2);
-  assertSorted<i32[]>(reversedNested512, (a: i32[], b: i32[]): i32 => a[0] - b[0]);
+  assertSorted<i32[]>(reversedNested512, (a: i32[], b: i32[]) => a[0] - b[0]);
 }
 
 // Test sorting reference elements
 {
   let reversedElements512 = createReverseOrderedElementsArray(512);
-  assertSorted<Proxy<i32>>(reversedElements512, (a: Proxy<i32>, b: Proxy<i32>): i32 => a.x - b.x);
+  assertSorted<Proxy<i32>>(reversedElements512, (a: Proxy<i32>, b: Proxy<i32>) => a.x - b.x);
 }
 
 // Test sorting strings

--- a/tests/compiler/std/typedarray.ts
+++ b/tests/compiler/std/typedarray.ts
@@ -319,7 +319,7 @@ function testReduce<ArrayType extends TypedArray<T>, T extends number>(): void {
   array[0] = <T>1;
   array[1] = <T>2;
   array[2] = <T>3;
-  var result = array.reduce<T>((acc: T, val: T): T => <T>(acc + val), <T>0);
+  var result = array.reduce<T>((acc: T, val: T) => <T>(acc + val), <T>0);
   assert(result == <T>6);
 }
 
@@ -340,7 +340,7 @@ function testReduceRight<ArrayType extends TypedArray<T>, T extends number>(): v
   array[0] = <T>1;
   array[1] = <T>2;
   array[2] = <T>3;
-  var result = array.reduceRight<T>((acc: T, val: T): T => <T>(acc + val), <T>0);
+  var result = array.reduceRight<T>((acc: T, val: T) => <T>(acc + val), <T>0);
   assert(result == <T>6);
 }
 
@@ -361,7 +361,7 @@ function testArrayMap<ArrayType extends TypedArray<T>, T extends number>(): void
   source[0] = <T>1;
   source[1] = <T>2;
   source[2] = <T>3;
-  var result = source.map((value: T): T => <T>(value * value));
+  var result = source.map((value: T) => <T>(value * value));
   assert(result[0] == <T>1);
   assert(result[1] == <T>4);
   assert(result[2] == <T>9);
@@ -386,7 +386,7 @@ function testArrayFilter<ArrayType extends TypedArray<T>, T extends number>(): v
   source[2] = <T>3;
   source[3] = <T>4;
   source[5] = <T>5;
-  var result = source.filter((value: T): bool => value > 2);
+  var result = source.filter((value: T) => value > 2);
   assert(result.byteOffset == 0);
   assert(result.length == 3);
   assert(result[0] == <T>3);
@@ -411,9 +411,9 @@ function testArraySome<ArrayType extends TypedArray<T>, T extends number>(): voi
   source[0] = <T>2;
   source[1] = <T>4;
   source[2] = <T>6;
-  var result: bool = source.some((value: T): bool => value == <T>2);
+  var result: bool = source.some((value: T) => value == <T>2);
   assert(result);
-  var failResult = source.some((value: T): bool => value == <T>0);
+  var failResult = source.some((value: T) => value == <T>0);
   assert(!failResult);
 }
 
@@ -434,9 +434,9 @@ function testArrayFindIndex<ArrayType extends TypedArray<T>, T extends number>()
   source[0] = <T>1;
   source[1] = <T>2;
   source[2] = <T>3;
-  var result = source.findIndex((value: T): bool => value == <T>2);
+  var result = source.findIndex((value: T) => value == <T>2);
   assert(result == 1);
-  var failResult = source.findIndex((value: T): bool => value == <T>4);
+  var failResult = source.findIndex((value: T) => value == <T>4);
   assert(failResult == -1);
 }
 
@@ -457,9 +457,9 @@ function testArrayEvery<ArrayType extends TypedArray<T>, T extends number>(): vo
   source[0] = <T>2;
   source[1] = <T>4;
   source[2] = <T>6;
-  var result = source.every((value: T): bool => value % <T>2 == <T>0);
+  var result = source.every((value: T) => value % <T>2 == <T>0);
   assert(result);
-  var failResult = source.every((value: T): bool => value == <T>2);
+  var failResult = source.every((value: T) => value == <T>2);
   assert(!failResult);
 }
 
@@ -485,7 +485,7 @@ function testArrayForEach<TArray extends TypedArray<T>, T extends number>(): voi
   array[0] = <T>forEachValues[0];
   array[1] = <T>forEachValues[1];
   array[2] = <T>forEachValues[2];
-  array.forEach((value: T, index: i32, self: TArray): void => {
+  array.forEach((value: T, index: i32, self: TArray) => {
     var matchedValue = forEachValues[index];
     assert(value == <T>matchedValue);
     assert(index == forEachCallCount);


### PR DESCRIPTION
Fixes #819.

Also makes the linter detect arrow function return types that are now unnecessary, and fixes those cases.

Also I think `npm clean` should be `npm run clean` in the readme, so fixed that as well.