### PR TITLE
sync AS and portable behaviour for Array#sort with default comparator

### DIFF
--- a/std/portable/index.js
+++ b/std/portable/index.js
@@ -209,7 +209,7 @@ if (!String.prototype.replaceAll) {
 function defaultComparator(a, b) {
   if (a === b) {
     if (a !== 0) return 0;
-    a = String(a), b = String(b);
+    a = 1 / a, b = 1 / b;
   } else {
     var nanA = a != a, nanB = b != b;
     if (nanA | nanB) return nanA - nanB;

--- a/std/portable/index.js
+++ b/std/portable/index.js
@@ -206,6 +206,21 @@ if (!String.prototype.replaceAll) {
   });
 }
 
+function defaultComparator(a, b) {
+  var isNanA = a != a;
+  var isNanB = b != b;
+  if (isNanA | isNanB) return isNanA - isNanB;
+  if (a == null) a = String(a);
+  if (b == null) b = String(b);
+  if (a === 0 && b === 0) { a = 1 / a, b = 1 / b; }
+  return (a > b) - (a < b);
+}
+
+const arraySort = Array.prototype.sort;
+Array.prototype.sort = function sort(comparator) {
+  return arraySort.call(this, comparator || defaultComparator);
+};
+
 globalScope["isInteger"] = Number.isInteger;
 
 globalScope["isFloat"] = function isFloat(arg) {

--- a/std/portable/index.js
+++ b/std/portable/index.js
@@ -209,10 +209,9 @@ if (!String.prototype.replaceAll) {
 function defaultComparator(a, b) {
   if (a === b) {
     if (a !== 0) return 0;
-    a = 1 / a, b = 1 / b;
+    a = String(a), b = String(b);
   } else {
-    var nanA = a != a;
-    var nanB = b != b;
+    var nanA = a != a, nanB = b != b;
     if (nanA | nanB) return nanA - nanB;
     if (a == null) a = String(a);
     if (b == null) b = String(b);

--- a/std/portable/index.js
+++ b/std/portable/index.js
@@ -207,11 +207,16 @@ if (!String.prototype.replaceAll) {
 }
 
 function defaultComparator(a, b) {
-  var isNanA = a != a, isNanB = b != b;
-  if (isNanA | isNanB) return isNanA - isNanB;
-  if (a == null) a = String(a);
-  if (b == null) b = String(b);
-  if (a === 0 && b === 0) { a = 1 / a, b = 1 / b; }
+  if (a === b) {
+    if (a !== 0) return 0;
+    a = 1 / a, b = 1 / b;
+  } else {
+    var nanA = a != a;
+    var nanB = b != b;
+    if (nanA | nanB) return nanA - nanB;
+    if (a == null) a = String(a);
+    if (b == null) b = String(b);
+  }
   return (a > b) - (a < b);
 }
 

--- a/std/portable/index.js
+++ b/std/portable/index.js
@@ -207,8 +207,7 @@ if (!String.prototype.replaceAll) {
 }
 
 function defaultComparator(a, b) {
-  var isNanA = a != a;
-  var isNanB = b != b;
+  var isNanA = a != a, isNanB = b != b;
   if (isNanA | isNanB) return isNanA - isNanB;
   if (a == null) a = String(a);
   if (b == null) b = String(b);

--- a/std/portable/index.js
+++ b/std/portable/index.js
@@ -217,7 +217,7 @@ function defaultComparator(a, b) {
     if (a == null) a = String(a);
     if (b == null) b = String(b);
   }
-  return (a > b) - (a < b);
+  return a > b ? 1 : -1;
 }
 
 const arraySort = Array.prototype.sort;


### PR DESCRIPTION
This normalize `Array#sort()` for portable so now:
```ts
[0, -0, -1, NaN, Infinity, 2, 123].sort()
```
output (which the same as AS):
```ts
[ -1, -0, 0, 2, 123, Infinity, NaN ]
```
instead:
```ts
[ -1, 0, -0, 123, 2, Infinity, NaN ]
```

This also [speed-up](https://esbench.com/bench/5d9251b84cd7e6009ef627ef) array's sort 