### PR TITLE
Fix join objects. Unify join arrays & objects

### DIFF
--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -462,7 +462,7 @@ export class Array<T> extends ArrayBufferView {
   join(separator: string = ","): string {
     var dataStart = this.dataStart;
     var length = this.length_;
-    if (isString<T>())    return joinStringArray<T>(dataStart, length, separator);
+    if (isString<T>())    return joinStringArray(dataStart, length, separator);
     if (isBoolean<T>())   return joinBooleanArray(dataStart, length, separator);
     if (isInteger<T>())   return joinIntegerArray<T>(dataStart, length, separator);
     if (isFloat<T>())     return joinFloatArray<T>(dataStart, length, separator);

--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -462,7 +462,7 @@ export class Array<T> extends ArrayBufferView {
   join(separator: string = ","): string {
     var dataStart = this.dataStart;
     var length = this.length_;
-    if (isString<T>())    return joinStringArray(dataStart, length, separator);
+    if (isString<T>())    return joinStringArray<T>(dataStart, length, separator);
     if (isBoolean<T>())   return joinBooleanArray(dataStart, length, separator);
     if (isInteger<T>())   return joinIntegerArray<T>(dataStart, length, separator);
     if (isFloat<T>())     return joinFloatArray<T>(dataStart, length, separator);

--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -462,10 +462,13 @@ export class Array<T> extends ArrayBufferView {
   join(separator: string = ","): string {
     var dataStart = this.dataStart;
     var length = this.length_;
-    if (isString<T>())    return joinStringArray(dataStart, length, separator);
     if (isBoolean<T>())   return joinBooleanArray(dataStart, length, separator);
     if (isInteger<T>())   return joinIntegerArray<T>(dataStart, length, separator);
     if (isFloat<T>())     return joinFloatArray<T>(dataStart, length, separator);
+
+    if (ASC_SHRINK_LEVEL < 1) {
+      if (isString<T>())  return joinStringArray(dataStart, length, separator);
+    }
     // For rest objects and arrays use general join routine
     if (isReference<T>()) return joinReferenceArray<T>(dataStart, length, separator);
     ERROR("unspported element type");

--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -466,7 +466,7 @@ export class Array<T> extends ArrayBufferView {
     if (isBoolean<T>())   return joinBooleanArray(dataStart, length, separator);
     if (isInteger<T>())   return joinIntegerArray<T>(dataStart, length, separator);
     if (isFloat<T>())     return joinFloatArray<T>(dataStart, length, separator);
-    if (isArray<T>())     return joinReferenceArray<T>(dataStart, length, separator);
+    // For rest objects and arrays use general join routine
     if (isReference<T>()) return joinReferenceArray<T>(dataStart, length, separator);
     ERROR("unspported element type");
     return <string>unreachable();

--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -3,7 +3,7 @@
 import { BLOCK_MAXSIZE } from "./rt/common";
 import { COMPARATOR, SORT } from "./util/sort";
 import { ArrayBufferView } from "./arraybuffer";
-import { joinBooleanArray, joinIntegerArray, joinFloatArray, joinStringArray, joinArrays, joinObjectArray } from "./util/string";
+import { joinBooleanArray, joinIntegerArray, joinFloatArray, joinStringArray, joinReferenceArray } from "./util/string";
 import { idof, isArray as builtin_isArray } from "./builtins";
 import { E_INDEXOUTOFRANGE, E_INVALIDLENGTH, E_EMPTYARRAY, E_HOLEYARRAY } from "./util/error";
 
@@ -466,8 +466,8 @@ export class Array<T> extends ArrayBufferView {
     if (isBoolean<T>())   return joinBooleanArray(dataStart, length, separator);
     if (isInteger<T>())   return joinIntegerArray<T>(dataStart, length, separator);
     if (isFloat<T>())     return joinFloatArray<T>(dataStart, length, separator);
-    if (isArray<T>())     return joinArrays<T>(dataStart, length, separator);
-    if (isReference<T>()) return joinObjectArray<T>(dataStart, length, separator);
+    if (isArray<T>())     return joinReferenceArray<T>(dataStart, length, separator);
+    if (isReference<T>()) return joinReferenceArray<T>(dataStart, length, separator);
     ERROR("unspported element type");
     return <string>unreachable();
   }

--- a/std/assembly/util/string.ts
+++ b/std/assembly/util/string.ts
@@ -418,14 +418,19 @@ export function joinReferenceArray<T>(dataStart: usize, length: i32, separator: 
   var lastIndex = length - 1;
   if (lastIndex < 0) return "";
 
-  var result = "";
-  var sepLen = separator.length;
   var value: T;
   if (!lastIndex) {
     value = load<T>(dataStart);
-    // @ts-ignore: type
-    return value !== null ? value.toString() : "";
+    if (isNullable<T>()) {
+      // @ts-ignore: type
+      return value !== null ? value.toString() : "";
+    } else {
+      // @ts-ignore: type
+      return value.toString();
+    }
   }
+  var result = "";
+  var sepLen = separator.length;
   for (let i = 0; i < lastIndex; ++i) {
     value = load<T>(dataStart + (<usize>i << alignof<T>()));
     if (isNullable<T>()) {

--- a/std/assembly/util/string.ts
+++ b/std/assembly/util/string.ts
@@ -372,19 +372,19 @@ export function joinFloatArray<T>(dataStart: usize, length: i32, separator: stri
 export function joinStringArray(dataStart: usize, length: i32, separator: string): string {
   var lastIndex = length - 1;
   if (lastIndex < 0) return "";
-  var value: string;
   if (!lastIndex) {
     // @ts-ignore: type
     return load<string>(dataStart) || "";
   }
-  var sepLen = separator.length;
   var estLen = 0;
+  var value: string;
   for (let i = 0; i < length; ++i) {
     value = load<string>(dataStart + (<usize>i << alignof<string>()));
     // @ts-ignore: type
     if (value !== null) estLen += value.length;
   }
   var offset = 0;
+  var sepLen = separator.length;
   var result = changetype<string>(__alloc((estLen + sepLen * lastIndex) << 1, idof<string>())); // retains
   for (let i = 0; i < lastIndex; ++i) {
     value = load<string>(dataStart + (<usize>i << alignof<string>()));

--- a/std/assembly/util/string.ts
+++ b/std/assembly/util/string.ts
@@ -369,46 +369,26 @@ export function joinFloatArray<T>(dataStart: usize, length: i32, separator: stri
   return result;
 }
 
-export function joinStringArray<T>(dataStart: usize, length: i32, separator: string): string {
+export function joinStringArray(dataStart: usize, length: i32, separator: string): string {
   var lastIndex = length - 1;
   if (lastIndex < 0) return "";
-  var value: T;
+  var value: string;
   if (!lastIndex) {
-    if (isNullable<T>()) {
-      // @ts-ignore: type
-      return load<T>(dataStart)! || "";
-    } else {
-      // @ts-ignore: type
-      return load<string>(dataStart);
-    }
+    // @ts-ignore: type
+    return load<string>(dataStart) || "";
   }
   var sepLen = separator.length;
   var estLen = 0;
   for (let i = 0; i < length; ++i) {
-    value = load<T>(dataStart + (<usize>i << alignof<string>()));
-    if (isNullable<T>()) {
-      // @ts-ignore: type
-      if (value !== null) estLen += value.length;
-    } else {
-      // @ts-ignore: type
-      estLen += value.length;
-    }
+    value = load<string>(dataStart + (<usize>i << alignof<string>()));
+    // @ts-ignore: type
+    if (value !== null) estLen += value.length;
   }
   var offset = 0;
   var result = changetype<string>(__alloc((estLen + sepLen * lastIndex) << 1, idof<string>())); // retains
   for (let i = 0; i < lastIndex; ++i) {
-    value = load<T>(dataStart + (<usize>i << alignof<string>()));
-    if (isNullable<T>()) {
-      if (value !== null) {
-        let valueLen = changetype<string>(value).length;
-        memory.copy(
-          changetype<usize>(result) + (<usize>offset << 1),
-          changetype<usize>(value),
-          <usize>valueLen << 1
-        );
-        offset += valueLen;
-      }
-    } else {
+    value = load<string>(dataStart + (<usize>i << alignof<string>()));
+    if (value !== null) {
       let valueLen = changetype<string>(value).length;
       memory.copy(
         changetype<usize>(result) + (<usize>offset << 1),
@@ -426,16 +406,8 @@ export function joinStringArray<T>(dataStart: usize, length: i32, separator: str
       offset += sepLen;
     }
   }
-  value = load<T>(dataStart + (<usize>lastIndex << alignof<string>()));
-  if (isNullable<T>()) {
-    if (value !== null) {
-      memory.copy(
-        changetype<usize>(result) + (<usize>offset << 1),
-        changetype<usize>(value),
-        <usize>changetype<string>(value).length << 1
-      );
-    }
-  } else {
+  value = load<string>(dataStart + (<usize>lastIndex << alignof<string>()));
+  if (value !== null) {
     memory.copy(
       changetype<usize>(result) + (<usize>offset << 1),
       changetype<usize>(value),

--- a/std/assembly/util/string.ts
+++ b/std/assembly/util/string.ts
@@ -420,39 +420,23 @@ export function joinStringArray(dataStart: usize, length: i32, separator: string
 export function joinReferenceArray<T>(dataStart: usize, length: i32, separator: string): string {
   var lastIndex = length - 1;
   if (lastIndex < 0) return "";
-
   var value: T;
   if (!lastIndex) {
     value = load<T>(dataStart);
-    if (isNullable<T>()) {
-      // @ts-ignore: type
-      return value !== null ? value.toString() : "";
-    } else {
-      // @ts-ignore: type
-      return value.toString();
-    }
+    // @ts-ignore: type
+    return value !== null ? value.toString() : "";
   }
   var result = "";
   var sepLen = separator.length;
   for (let i = 0; i < lastIndex; ++i) {
     value = load<T>(dataStart + (<usize>i << alignof<T>()));
-    if (isNullable<T>()) {
-      // @ts-ignore: type
-      if (value !== null) result += value.toString();
-    } else {
-      // @ts-ignore: type
-      result += value.toString();
-    }
+    // @ts-ignore: type
+    if (value !== null) result += value.toString();
     if (sepLen) result += separator;
   }
   value = load<T>(dataStart + (<usize>lastIndex << alignof<T>()));
-  if (isNullable<T>()) {
-    // @ts-ignore: type
-    if (value !== null) result += value.toString();
-  } else {
-    // @ts-ignore: type
-    result += value.toString();
-  }
+  // @ts-ignore: type
+  if (value !== null) result += value.toString();
   return result;
 }
 

--- a/std/assembly/util/string.ts
+++ b/std/assembly/util/string.ts
@@ -385,13 +385,13 @@ export function joinStringArray(dataStart: usize, length: i32, separator: string
   }
   var offset = 0;
   var sepLen = separator.length;
-  var result = changetype<string>(__alloc((estLen + sepLen * lastIndex) << 1, idof<string>())); // retains
+  var result = __alloc((estLen + sepLen * lastIndex) << 1, idof<string>());
   for (let i = 0; i < lastIndex; ++i) {
     value = load<string>(dataStart + (<usize>i << alignof<string>()));
     if (value !== null) {
-      let valueLen = changetype<string>(value).length;
+      let valueLen = value.length;
       memory.copy(
-        changetype<usize>(result) + (<usize>offset << 1),
+        result + (<usize>offset << 1),
         changetype<usize>(value),
         <usize>valueLen << 1
       );
@@ -399,7 +399,7 @@ export function joinStringArray(dataStart: usize, length: i32, separator: string
     }
     if (sepLen) {
       memory.copy(
-        changetype<usize>(result) + (<usize>offset << 1),
+        result + (<usize>offset << 1),
         changetype<usize>(separator),
         <usize>sepLen << 1
       );
@@ -409,12 +409,12 @@ export function joinStringArray(dataStart: usize, length: i32, separator: string
   value = load<string>(dataStart + (<usize>lastIndex << alignof<string>()));
   if (value !== null) {
     memory.copy(
-      changetype<usize>(result) + (<usize>offset << 1),
+      result + (<usize>offset << 1),
       changetype<usize>(value),
-      <usize>changetype<string>(value).length << 1
+      <usize>value.length << 1
     );
   }
-  return result;
+  return changetype<string>(result); // retains
 }
 
 export function joinReferenceArray<T>(dataStart: usize, length: i32, separator: string): string {

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -9481,170 +9481,17 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/util/string/joinReferenceArray<std/array/Ref> (; 177 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
+ (func $~lib/array/Array<std/array/Ref | null>#join (; 177 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 4464
   call $~lib/rt/pure/__retain
   drop
-  local.get $1
-  i32.const 1
-  i32.sub
-  local.tee $4
-  i32.const 0
-  i32.lt_s
-  if
-   i32.const 4248
-   call $~lib/rt/pure/__retain
-   i32.const 4464
-   call $~lib/rt/pure/__release
-   return
-  end
-  local.get $4
-  i32.eqz
-  if
-   local.get $0
-   i32.load
-   local.tee $0
-   if
-    local.get $0
-    call $~lib/rt/pure/__retain
-    drop
-    i32.const 0
-    call $~lib/rt/pure/__release
-   end
-   i32.const 6200
-   call $~lib/rt/pure/__retain
-   i32.const 4464
-   call $~lib/rt/pure/__release
-   local.get $0
-   call $~lib/rt/pure/__release
-   return
-  end
-  i32.const 4248
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 4464
-  call $~lib/string/String#get:length
-  local.set $7
-  loop $loop|0
-   local.get $5
-   local.get $4
-   i32.lt_s
-   if
-    local.get $3
-    local.set $2
-    local.get $2
-    local.get $5
-    i32.const 2
-    i32.shl
-    local.get $0
-    i32.add
-    i32.load
-    local.tee $3
-    i32.ne
-    if
-     local.get $3
-     call $~lib/rt/pure/__retain
-     drop
-     local.get $2
-     call $~lib/rt/pure/__release
-    end
-    local.get $1
-    local.set $2
-    i32.const 6200
-    call $~lib/rt/pure/__retain
-    local.tee $1
-    local.get $2
-    local.get $2
-    local.get $1
-    call $~lib/string/String.__concat
-    local.tee $8
-    local.tee $1
-    i32.ne
-    if
-     local.get $1
-     call $~lib/rt/pure/__retain
-     drop
-     local.get $2
-     call $~lib/rt/pure/__release
-    end
-    call $~lib/rt/pure/__release
-    local.get $8
-    call $~lib/rt/pure/__release
-    local.get $7
-    if
-     local.get $1
-     local.tee $2
-     i32.const 4464
-     call $~lib/string/String.__concat
-     local.tee $6
-     local.tee $1
-     local.get $2
-     i32.ne
-     if
-      local.get $1
-      call $~lib/rt/pure/__retain
-      drop
-      local.get $2
-      call $~lib/rt/pure/__release
-     end
-     local.get $6
-     call $~lib/rt/pure/__release
-    end
-    local.get $5
-    i32.const 1
-    i32.add
-    local.set $5
-    br $loop|0
-   end
-  end
-  local.get $4
-  i32.const 2
-  i32.shl
   local.get $0
-  i32.add
-  i32.load
-  local.tee $0
-  local.get $3
-  i32.ne
-  if
-   local.get $0
-   call $~lib/rt/pure/__retain
-   drop
-   local.get $3
-   call $~lib/rt/pure/__release
-  end
-  i32.const 6200
-  call $~lib/rt/pure/__retain
-  local.tee $3
-  local.get $1
-  local.get $3
-  call $~lib/string/String.__concat
-  local.tee $4
-  local.tee $3
-  local.get $1
-  i32.ne
-  if
-   local.get $3
-   call $~lib/rt/pure/__retain
-   drop
-   local.get $1
-   call $~lib/rt/pure/__release
-  end
-  call $~lib/rt/pure/__release
-  local.get $4
-  call $~lib/rt/pure/__release
+  i32.load offset=4
+  local.get $0
+  i32.load offset=12
+  call $~lib/util/string/joinReferenceArray<std/array/Ref | null>
   i32.const 4464
   call $~lib/rt/pure/__release
-  local.get $0
-  call $~lib/rt/pure/__release
-  local.get $3
  )
  (func $~lib/array/Array<i32>#toString (; 178 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
@@ -10560,7 +10407,13 @@
     call $~lib/rt/pure/__release
    end
    local.get $0
-   call $~lib/array/Array<i32>#toString
+   if (result i32)
+    local.get $0
+    call $~lib/array/Array<i32>#toString
+   else
+    i32.const 4248
+    call $~lib/rt/pure/__retain
+   end
    i32.const 4464
    call $~lib/rt/pure/__release
    local.get $0
@@ -10596,27 +10449,30 @@
      local.get $2
      call $~lib/rt/pure/__release
     end
-    local.get $1
-    local.tee $2
     local.get $3
-    call $~lib/array/Array<i32>#toString
-    local.tee $6
-    call $~lib/string/String.__concat
-    local.tee $8
-    local.tee $1
-    local.get $2
-    i32.ne
     if
      local.get $1
-     call $~lib/rt/pure/__retain
-     drop
+     local.tee $2
+     local.get $3
+     call $~lib/array/Array<i32>#toString
+     local.tee $6
+     call $~lib/string/String.__concat
+     local.tee $8
+     local.tee $1
      local.get $2
+     i32.ne
+     if
+      local.get $1
+      call $~lib/rt/pure/__retain
+      drop
+      local.get $2
+      call $~lib/rt/pure/__release
+     end
+     local.get $6
+     call $~lib/rt/pure/__release
+     local.get $8
      call $~lib/rt/pure/__release
     end
-    local.get $6
-    call $~lib/rt/pure/__release
-    local.get $8
-    call $~lib/rt/pure/__release
     local.get $7
     if
      local.get $1
@@ -10650,41 +10506,45 @@
   local.get $0
   i32.add
   i32.load
-  local.tee $0
+  local.tee $2
   local.get $3
   i32.ne
   if
-   local.get $0
+   local.get $2
    call $~lib/rt/pure/__retain
    drop
    local.get $3
-   call $~lib/rt/pure/__release
-  end
-  local.get $1
-  local.get $0
-  call $~lib/array/Array<i32>#toString
-  local.tee $2
-  call $~lib/string/String.__concat
-  local.tee $4
-  local.tee $3
-  local.get $1
-  i32.ne
-  if
-   local.get $3
-   call $~lib/rt/pure/__retain
-   drop
-   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $2
-  call $~lib/rt/pure/__release
-  local.get $4
-  call $~lib/rt/pure/__release
+  if
+   local.get $1
+   local.tee $0
+   local.get $2
+   call $~lib/array/Array<i32>#toString
+   local.tee $3
+   call $~lib/string/String.__concat
+   local.tee $4
+   local.tee $1
+   local.get $0
+   i32.ne
+   if
+    local.get $1
+    call $~lib/rt/pure/__retain
+    drop
+    local.get $0
+    call $~lib/rt/pure/__release
+   end
+   local.get $3
+   call $~lib/rt/pure/__release
+   local.get $4
+   call $~lib/rt/pure/__release
+  end
   i32.const 4464
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $2
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $1
  )
  (func $~lib/util/number/itoa_stream<u8> (; 193 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
@@ -10885,7 +10745,13 @@
     call $~lib/rt/pure/__release
    end
    local.get $0
-   call $~lib/array/Array<u8>#toString
+   if (result i32)
+    local.get $0
+    call $~lib/array/Array<u8>#toString
+   else
+    i32.const 4248
+    call $~lib/rt/pure/__retain
+   end
    i32.const 4464
    call $~lib/rt/pure/__release
    local.get $0
@@ -10921,27 +10787,30 @@
      local.get $2
      call $~lib/rt/pure/__release
     end
-    local.get $1
-    local.tee $2
     local.get $3
-    call $~lib/array/Array<u8>#toString
-    local.tee $6
-    call $~lib/string/String.__concat
-    local.tee $8
-    local.tee $1
-    local.get $2
-    i32.ne
     if
      local.get $1
-     call $~lib/rt/pure/__retain
-     drop
+     local.tee $2
+     local.get $3
+     call $~lib/array/Array<u8>#toString
+     local.tee $6
+     call $~lib/string/String.__concat
+     local.tee $8
+     local.tee $1
      local.get $2
+     i32.ne
+     if
+      local.get $1
+      call $~lib/rt/pure/__retain
+      drop
+      local.get $2
+      call $~lib/rt/pure/__release
+     end
+     local.get $6
+     call $~lib/rt/pure/__release
+     local.get $8
      call $~lib/rt/pure/__release
     end
-    local.get $6
-    call $~lib/rt/pure/__release
-    local.get $8
-    call $~lib/rt/pure/__release
     local.get $7
     if
      local.get $1
@@ -10975,41 +10844,45 @@
   local.get $0
   i32.add
   i32.load
-  local.tee $0
+  local.tee $2
   local.get $3
   i32.ne
   if
-   local.get $0
+   local.get $2
    call $~lib/rt/pure/__retain
    drop
    local.get $3
-   call $~lib/rt/pure/__release
-  end
-  local.get $1
-  local.get $0
-  call $~lib/array/Array<u8>#toString
-  local.tee $2
-  call $~lib/string/String.__concat
-  local.tee $4
-  local.tee $3
-  local.get $1
-  i32.ne
-  if
-   local.get $3
-   call $~lib/rt/pure/__retain
-   drop
-   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $2
-  call $~lib/rt/pure/__release
-  local.get $4
-  call $~lib/rt/pure/__release
+  if
+   local.get $1
+   local.tee $0
+   local.get $2
+   call $~lib/array/Array<u8>#toString
+   local.tee $3
+   call $~lib/string/String.__concat
+   local.tee $4
+   local.tee $1
+   local.get $0
+   i32.ne
+   if
+    local.get $1
+    call $~lib/rt/pure/__retain
+    drop
+    local.get $0
+    call $~lib/rt/pure/__release
+   end
+   local.get $3
+   call $~lib/rt/pure/__release
+   local.get $4
+   call $~lib/rt/pure/__release
+  end
   i32.const 4464
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $2
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $1
  )
  (func $~lib/array/Array<u32>#toString (; 197 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
@@ -11054,7 +10927,13 @@
     call $~lib/rt/pure/__release
    end
    local.get $0
-   call $~lib/array/Array<u32>#toString
+   if (result i32)
+    local.get $0
+    call $~lib/array/Array<u32>#toString
+   else
+    i32.const 4248
+    call $~lib/rt/pure/__retain
+   end
    i32.const 4464
    call $~lib/rt/pure/__release
    local.get $0
@@ -11090,27 +10969,30 @@
      local.get $2
      call $~lib/rt/pure/__release
     end
-    local.get $1
-    local.tee $2
     local.get $3
-    call $~lib/array/Array<u32>#toString
-    local.tee $6
-    call $~lib/string/String.__concat
-    local.tee $8
-    local.tee $1
-    local.get $2
-    i32.ne
     if
      local.get $1
-     call $~lib/rt/pure/__retain
-     drop
+     local.tee $2
+     local.get $3
+     call $~lib/array/Array<u32>#toString
+     local.tee $6
+     call $~lib/string/String.__concat
+     local.tee $8
+     local.tee $1
      local.get $2
+     i32.ne
+     if
+      local.get $1
+      call $~lib/rt/pure/__retain
+      drop
+      local.get $2
+      call $~lib/rt/pure/__release
+     end
+     local.get $6
+     call $~lib/rt/pure/__release
+     local.get $8
      call $~lib/rt/pure/__release
     end
-    local.get $6
-    call $~lib/rt/pure/__release
-    local.get $8
-    call $~lib/rt/pure/__release
     local.get $7
     if
      local.get $1
@@ -11144,41 +11026,45 @@
   local.get $0
   i32.add
   i32.load
-  local.tee $0
+  local.tee $2
   local.get $3
   i32.ne
   if
-   local.get $0
+   local.get $2
    call $~lib/rt/pure/__retain
    drop
    local.get $3
-   call $~lib/rt/pure/__release
-  end
-  local.get $1
-  local.get $0
-  call $~lib/array/Array<u32>#toString
-  local.tee $2
-  call $~lib/string/String.__concat
-  local.tee $4
-  local.tee $3
-  local.get $1
-  i32.ne
-  if
-   local.get $3
-   call $~lib/rt/pure/__retain
-   drop
-   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $2
-  call $~lib/rt/pure/__release
-  local.get $4
-  call $~lib/rt/pure/__release
+  if
+   local.get $1
+   local.tee $0
+   local.get $2
+   call $~lib/array/Array<u32>#toString
+   local.tee $3
+   call $~lib/string/String.__concat
+   local.tee $4
+   local.tee $1
+   local.get $0
+   i32.ne
+   if
+    local.get $1
+    call $~lib/rt/pure/__retain
+    drop
+    local.get $0
+    call $~lib/rt/pure/__release
+   end
+   local.get $3
+   call $~lib/rt/pure/__release
+   local.get $4
+   call $~lib/rt/pure/__release
+  end
   i32.const 4464
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $2
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $1
  )
  (func $~lib/array/Array<~lib/array/Array<u32>>#toString (; 199 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 4464
@@ -11230,7 +11116,13 @@
     call $~lib/rt/pure/__release
    end
    local.get $0
-   call $~lib/array/Array<~lib/array/Array<u32>>#toString
+   if (result i32)
+    local.get $0
+    call $~lib/array/Array<~lib/array/Array<u32>>#toString
+   else
+    i32.const 4248
+    call $~lib/rt/pure/__retain
+   end
    i32.const 4464
    call $~lib/rt/pure/__release
    local.get $0
@@ -11266,27 +11158,30 @@
      local.get $2
      call $~lib/rt/pure/__release
     end
-    local.get $1
-    local.tee $2
     local.get $3
-    call $~lib/array/Array<~lib/array/Array<u32>>#toString
-    local.tee $6
-    call $~lib/string/String.__concat
-    local.tee $8
-    local.tee $1
-    local.get $2
-    i32.ne
     if
      local.get $1
-     call $~lib/rt/pure/__retain
-     drop
+     local.tee $2
+     local.get $3
+     call $~lib/array/Array<~lib/array/Array<u32>>#toString
+     local.tee $6
+     call $~lib/string/String.__concat
+     local.tee $8
+     local.tee $1
      local.get $2
+     i32.ne
+     if
+      local.get $1
+      call $~lib/rt/pure/__retain
+      drop
+      local.get $2
+      call $~lib/rt/pure/__release
+     end
+     local.get $6
+     call $~lib/rt/pure/__release
+     local.get $8
      call $~lib/rt/pure/__release
     end
-    local.get $6
-    call $~lib/rt/pure/__release
-    local.get $8
-    call $~lib/rt/pure/__release
     local.get $7
     if
      local.get $1
@@ -11320,41 +11215,45 @@
   local.get $0
   i32.add
   i32.load
-  local.tee $0
+  local.tee $2
   local.get $3
   i32.ne
   if
-   local.get $0
+   local.get $2
    call $~lib/rt/pure/__retain
    drop
    local.get $3
-   call $~lib/rt/pure/__release
-  end
-  local.get $1
-  local.get $0
-  call $~lib/array/Array<~lib/array/Array<u32>>#toString
-  local.tee $2
-  call $~lib/string/String.__concat
-  local.tee $4
-  local.tee $3
-  local.get $1
-  i32.ne
-  if
-   local.get $3
-   call $~lib/rt/pure/__retain
-   drop
-   local.get $1
    call $~lib/rt/pure/__release
   end
   local.get $2
-  call $~lib/rt/pure/__release
-  local.get $4
-  call $~lib/rt/pure/__release
+  if
+   local.get $1
+   local.tee $0
+   local.get $2
+   call $~lib/array/Array<~lib/array/Array<u32>>#toString
+   local.tee $3
+   call $~lib/string/String.__concat
+   local.tee $4
+   local.tee $1
+   local.get $0
+   i32.ne
+   if
+    local.get $1
+    call $~lib/rt/pure/__retain
+    drop
+    local.get $0
+    call $~lib/rt/pure/__release
+   end
+   local.get $3
+   call $~lib/rt/pure/__release
+   local.get $4
+   call $~lib/rt/pure/__release
+  end
   i32.const 4464
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $2
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $1
  )
  (func $start:std/array (; 201 ;) (type $FUNCSIG$v)
   (local $0 i32)
@@ -12421,7 +12320,7 @@
   i32.const 1152
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $14
+  local.tee $13
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12441,7 +12340,7 @@
   i32.const 1192
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $17
+  local.tee $15
   local.tee $0
   i32.ne
   if
@@ -12456,14 +12355,14 @@
   i32.const 2
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $18
+  local.tee $16
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 1232
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $19
+  local.tee $17
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12483,7 +12382,7 @@
   i32.const 1272
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $20
+  local.tee $18
   local.tee $0
   i32.ne
   if
@@ -12498,14 +12397,14 @@
   i32.const 3
   i32.const 4
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $21
+  local.tee $19
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 1312
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $22
+  local.tee $20
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12525,7 +12424,7 @@
   i32.const 1352
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $23
+  local.tee $21
   local.tee $0
   i32.ne
   if
@@ -12567,7 +12466,7 @@
   i32.const 1432
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $10
+  local.tee $11
   local.tee $0
   i32.ne
   if
@@ -12589,7 +12488,7 @@
   i32.const 1472
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $13
+  local.tee $14
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12609,7 +12508,7 @@
   i32.const 1512
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $15
+  local.tee $22
   local.tee $0
   i32.ne
   if
@@ -12624,7 +12523,7 @@
   i32.const -2
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $16
+  local.tee $23
   i32.const 5
   i32.const 2
   i32.const 3
@@ -12693,7 +12592,7 @@
   i32.const 1672
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $11
+  local.tee $10
   local.tee $0
   i32.ne
   if
@@ -12829,7 +12728,11 @@
   call $~lib/rt/pure/__release
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $14
+  local.get $13
+  call $~lib/rt/pure/__release
+  local.get $15
+  call $~lib/rt/pure/__release
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $17
   call $~lib/rt/pure/__release
@@ -12841,23 +12744,19 @@
   call $~lib/rt/pure/__release
   local.get $21
   call $~lib/rt/pure/__release
-  local.get $22
-  call $~lib/rt/pure/__release
-  local.get $23
-  call $~lib/rt/pure/__release
   local.get $8
   call $~lib/rt/pure/__release
   local.get $9
   call $~lib/rt/pure/__release
-  local.get $10
+  local.get $11
   call $~lib/rt/pure/__release
   local.get $12
   call $~lib/rt/pure/__release
-  local.get $13
+  local.get $14
   call $~lib/rt/pure/__release
-  local.get $15
+  local.get $22
   call $~lib/rt/pure/__release
-  local.get $16
+  local.get $23
   call $~lib/rt/pure/__release
   local.get $24
   call $~lib/rt/pure/__release
@@ -12867,7 +12766,7 @@
   call $~lib/rt/pure/__release
   local.get $27
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $10
   call $~lib/rt/pure/__release
   local.get $28
   call $~lib/rt/pure/__release
@@ -14001,7 +13900,7 @@
   i32.const 2488
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $14
+  local.tee $13
   local.tee $0
   i32.ne
   if
@@ -14015,14 +13914,14 @@
   i32.const -2
   i32.const 1
   call $~lib/array/Array<i32>#splice
-  local.tee $17
+  local.tee $15
   i32.const 1
   i32.const 2
   i32.const 3
   i32.const 2528
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $18
+  local.tee $16
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -14041,7 +13940,7 @@
   i32.const 2552
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $19
+  local.tee $17
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -14061,7 +13960,7 @@
   i32.const 2584
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $20
+  local.tee $18
   local.tee $0
   i32.ne
   if
@@ -14075,14 +13974,14 @@
   i32.const -7
   i32.const 1
   call $~lib/array/Array<i32>#splice
-  local.tee $21
+  local.tee $19
   i32.const 1
   i32.const 2
   i32.const 3
   i32.const 2624
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $22
+  local.tee $20
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -14101,7 +14000,7 @@
   i32.const 2648
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $23
+  local.tee $21
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -14142,7 +14041,7 @@
   i32.const 2720
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $10
+  local.tee $11
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -14181,7 +14080,7 @@
   i32.const 2776
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $13
+  local.tee $14
   local.tee $0
   i32.ne
   if
@@ -14195,14 +14094,14 @@
   i32.const 1
   i32.const -2
   call $~lib/array/Array<i32>#splice
-  local.tee $15
+  local.tee $22
   i32.const 0
   i32.const 2
   i32.const 3
   i32.const 2816
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $16
+  local.tee $23
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -14281,7 +14180,7 @@
   i32.const 2928
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $11
+  local.tee $10
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -14463,7 +14362,11 @@
   call $~lib/rt/pure/__release
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $14
+  local.get $13
+  call $~lib/rt/pure/__release
+  local.get $15
+  call $~lib/rt/pure/__release
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $17
   call $~lib/rt/pure/__release
@@ -14475,23 +14378,19 @@
   call $~lib/rt/pure/__release
   local.get $21
   call $~lib/rt/pure/__release
-  local.get $22
-  call $~lib/rt/pure/__release
-  local.get $23
-  call $~lib/rt/pure/__release
   local.get $8
   call $~lib/rt/pure/__release
   local.get $9
   call $~lib/rt/pure/__release
-  local.get $10
+  local.get $11
   call $~lib/rt/pure/__release
   local.get $12
   call $~lib/rt/pure/__release
-  local.get $13
+  local.get $14
   call $~lib/rt/pure/__release
-  local.get $15
+  local.get $22
   call $~lib/rt/pure/__release
-  local.get $16
+  local.get $23
   call $~lib/rt/pure/__release
   local.get $24
   call $~lib/rt/pure/__release
@@ -14501,7 +14400,7 @@
   call $~lib/rt/pure/__release
   local.get $27
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $10
   call $~lib/rt/pure/__release
   local.get $28
   call $~lib/rt/pure/__release
@@ -15567,23 +15466,23 @@
   i32.const 3392
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $15
+  local.tee $22
   call $~lib/rt/pure/__retain
-  local.set $14
+  local.set $13
   i32.const 0
   global.set $~lib/argc
-  local.get $14
+  local.get $13
   i32.const 44
   call $~lib/array/Array<f32>#sort
   call $~lib/rt/pure/__release
-  local.get $14
+  local.get $13
   i32.const 8
   i32.const 2
   i32.const 8
   i32.const 3440
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $16
+  local.tee $23
   call $std/array/isArraysEqual<f32>
   i32.eqz
   if
@@ -15602,14 +15501,14 @@
   call $~lib/rt/pure/__retain
   local.tee $24
   call $~lib/rt/pure/__retain
-  local.set $17
+  local.set $15
   i32.const 0
   global.set $~lib/argc
-  local.get $17
+  local.get $15
   i32.const 45
   call $~lib/array/Array<f64>#sort
   call $~lib/rt/pure/__release
-  local.get $17
+  local.get $15
   i32.const 8
   i32.const 3
   i32.const 9
@@ -15635,14 +15534,14 @@
   call $~lib/rt/pure/__retain
   local.tee $26
   call $~lib/rt/pure/__retain
-  local.set $18
+  local.set $16
   i32.const 0
   global.set $~lib/argc
-  local.get $18
+  local.get $16
   i32.const 46
   call $~lib/array/Array<i32>#sort
   call $~lib/rt/pure/__release
-  local.get $18
+  local.get $16
   i32.const 5
   i32.const 2
   i32.const 3
@@ -15667,16 +15566,16 @@
   i32.const 3728
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $11
+  local.tee $10
   call $~lib/rt/pure/__retain
-  local.set $19
+  local.set $17
   i32.const 0
   global.set $~lib/argc
-  local.get $19
+  local.get $17
   i32.const 47
   call $~lib/array/Array<i32>#sort
   call $~lib/rt/pure/__release
-  local.get $19
+  local.get $17
   i32.const 5
   i32.const 2
   i32.const 7
@@ -15712,7 +15611,7 @@
   call $~lib/rt/pure/__retain
   local.tee $5
   call $~lib/rt/pure/__retain
-  local.set $20
+  local.set $18
   i32.const 2
   i32.const 2
   i32.const 3
@@ -15721,7 +15620,7 @@
   call $~lib/rt/pure/__retain
   local.tee $4
   call $~lib/rt/pure/__retain
-  local.set $21
+  local.set $19
   i32.const 4
   i32.const 2
   i32.const 3
@@ -15730,7 +15629,7 @@
   call $~lib/rt/pure/__retain
   local.tee $6
   call $~lib/rt/pure/__retain
-  local.set $22
+  local.set $20
   i32.const 4
   i32.const 2
   i32.const 3
@@ -15742,7 +15641,7 @@
   local.set $7
   i32.const 64
   call $std/array/createReverseOrderedArray
-  local.set $23
+  local.set $21
   i32.const 128
   call $std/array/createReverseOrderedArray
   local.set $8
@@ -15751,15 +15650,15 @@
   local.set $9
   i32.const 10000
   call $std/array/createReverseOrderedArray
-  local.set $10
+  local.set $11
   i32.const 512
   call $std/array/createRandomOrderedArray
-  local.set $13
+  local.set $14
   local.get $12
   call $std/array/assertSortedDefault<i32>
-  local.get $20
+  local.get $18
   call $std/array/assertSortedDefault<i32>
-  local.get $20
+  local.get $18
   i32.const 1
   i32.const 2
   i32.const 3
@@ -15778,9 +15677,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $21
+  local.get $19
   call $std/array/assertSortedDefault<i32>
-  local.get $21
+  local.get $19
   i32.const 2
   i32.const 2
   i32.const 3
@@ -15799,9 +15698,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $22
+  local.get $20
   call $std/array/assertSortedDefault<i32>
-  local.get $22
+  local.get $20
   local.get $7
   i32.const 0
   call $std/array/isArraysEqual<u32>
@@ -15814,9 +15713,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $23
+  local.get $21
   call $std/array/assertSortedDefault<i32>
-  local.get $23
+  local.get $21
   local.get $7
   i32.const 4
   call $std/array/isArraysEqual<u32>
@@ -15859,9 +15758,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $10
+  local.get $11
   call $std/array/assertSortedDefault<i32>
-  local.get $10
+  local.get $11
   local.get $7
   i32.const 4
   call $std/array/isArraysEqual<u32>
@@ -15874,29 +15773,29 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $13
-  call $std/array/assertSortedDefault<i32>
-  local.get $15
-  call $~lib/rt/pure/__release
   local.get $14
+  call $std/array/assertSortedDefault<i32>
+  local.get $22
   call $~lib/rt/pure/__release
-  local.get $16
+  local.get $13
+  call $~lib/rt/pure/__release
+  local.get $23
   call $~lib/rt/pure/__release
   local.get $24
   call $~lib/rt/pure/__release
-  local.get $17
+  local.get $15
   call $~lib/rt/pure/__release
   local.get $25
   call $~lib/rt/pure/__release
   local.get $26
   call $~lib/rt/pure/__release
-  local.get $18
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $27
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $10
   call $~lib/rt/pure/__release
-  local.get $19
+  local.get $17
   call $~lib/rt/pure/__release
   local.get $28
   call $~lib/rt/pure/__release
@@ -15906,29 +15805,29 @@
   call $~lib/rt/pure/__release
   local.get $5
   call $~lib/rt/pure/__release
-  local.get $20
+  local.get $18
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
-  local.get $21
+  local.get $19
   call $~lib/rt/pure/__release
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $22
+  local.get $20
   call $~lib/rt/pure/__release
   local.get $3
   call $~lib/rt/pure/__release
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $23
+  local.get $21
   call $~lib/rt/pure/__release
   local.get $8
   call $~lib/rt/pure/__release
   local.get $9
   call $~lib/rt/pure/__release
-  local.get $10
+  local.get $11
   call $~lib/rt/pure/__release
-  local.get $13
+  local.get $14
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -16035,10 +15934,10 @@
   local.get $8
   i32.load offset=12
   call $~lib/util/string/joinBooleanArray
-  local.set $13
+  local.set $11
   i32.const 4464
   call $~lib/rt/pure/__release
-  local.get $13
+  local.get $11
   i32.const 4488
   call $~lib/string/String.__eq
   i32.eqz
@@ -16056,10 +15955,10 @@
   i32.const 4528
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $24
+  local.tee $14
   i32.const 4248
   call $~lib/array/Array<i32>#join
-  local.tee $25
+  local.tee $22
   i32.const 4584
   call $~lib/string/String.__eq
   i32.eqz
@@ -16077,10 +15976,10 @@
   i32.const 4616
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $26
+  local.tee $23
   i32.const 4648
   call $~lib/array/Array<u32>#join
-  local.tee $27
+  local.tee $24
   i32.const 4584
   call $~lib/string/String.__eq
   i32.eqz
@@ -16098,10 +15997,10 @@
   i32.const 4672
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $11
+  local.tee $25
   i32.const 4696
   call $~lib/array/Array<i32>#join
-  local.tee $28
+  local.tee $26
   i32.const 4720
   call $~lib/string/String.__eq
   i32.eqz
@@ -16128,10 +16027,10 @@
   local.get $9
   i32.load offset=12
   call $~lib/util/string/joinFloatArray<f64>
-  local.set $15
+  local.set $12
   i32.const 4848
   call $~lib/rt/pure/__release
-  local.get $15
+  local.get $12
   i32.const 6048
   call $~lib/string/String.__eq
   i32.eqz
@@ -16149,10 +16048,10 @@
   i32.const 6168
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $2
+  local.tee $27
   i32.const 4248
   call $~lib/array/Array<~lib/string/String | null>#join
-  local.tee $5
+  local.tee $10
   i32.const 6144
   call $~lib/string/String.__eq
   i32.eqz
@@ -16173,7 +16072,7 @@
   i32.load offset=4
   local.tee $0
   call $std/array/Ref#constructor
-  local.tee $4
+  local.tee $28
   call $~lib/rt/pure/__retain
   i32.store
   local.get $0
@@ -16182,24 +16081,14 @@
   i32.store offset=4
   local.get $0
   call $std/array/Ref#constructor
-  local.tee $6
+  local.tee $2
   call $~lib/rt/pure/__retain
   i32.store offset=8
   local.get $1
   call $~lib/rt/pure/__retain
-  local.set $10
-  i32.const 4464
-  call $~lib/rt/pure/__retain
-  drop
-  local.get $10
-  i32.load offset=4
-  local.get $10
-  i32.load offset=12
-  call $~lib/util/string/joinReferenceArray<std/array/Ref | null>
-  local.set $16
-  i32.const 4464
-  call $~lib/rt/pure/__release
-  local.get $16
+  local.tee $5
+  call $~lib/array/Array<std/array/Ref | null>#join
+  local.tee $4
   i32.const 6248
   call $~lib/string/String.__eq
   i32.eqz
@@ -16216,33 +16105,23 @@
   i32.const 20
   i32.const 0
   call $~lib/rt/__allocArray
-  local.tee $3
+  local.tee $0
   i32.load offset=4
   local.tee $1
   call $std/array/Ref#constructor
-  local.tee $0
+  local.tee $6
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
   call $std/array/Ref#constructor
-  local.tee $1
+  local.tee $3
   call $~lib/rt/pure/__retain
   i32.store offset=4
-  local.get $3
+  local.get $0
   call $~lib/rt/pure/__retain
-  local.set $12
-  i32.const 4464
-  call $~lib/rt/pure/__retain
-  drop
-  local.get $12
-  i32.load offset=4
-  local.get $12
-  i32.load offset=12
-  call $~lib/util/string/joinReferenceArray<std/array/Ref>
-  local.set $3
-  i32.const 4464
-  call $~lib/rt/pure/__release
-  local.get $3
+  local.tee $0
+  call $~lib/array/Array<std/array/Ref | null>#join
+  local.tee $1
   i32.const 6328
   call $~lib/string/String.__eq
   i32.eqz
@@ -16256,7 +16135,13 @@
   end
   local.get $8
   call $~lib/rt/pure/__release
-  local.get $13
+  local.get $11
+  call $~lib/rt/pure/__release
+  local.get $14
+  call $~lib/rt/pure/__release
+  local.get $22
+  call $~lib/rt/pure/__release
+  local.get $23
   call $~lib/rt/pure/__release
   local.get $24
   call $~lib/rt/pure/__release
@@ -16264,15 +16149,15 @@
   call $~lib/rt/pure/__release
   local.get $26
   call $~lib/rt/pure/__release
-  local.get $27
-  call $~lib/rt/pure/__release
-  local.get $11
-  call $~lib/rt/pure/__release
-  local.get $28
-  call $~lib/rt/pure/__release
   local.get $9
   call $~lib/rt/pure/__release
-  local.get $15
+  local.get $12
+  call $~lib/rt/pure/__release
+  local.get $27
+  call $~lib/rt/pure/__release
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $28
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
@@ -16282,17 +16167,11 @@
   call $~lib/rt/pure/__release
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $10
-  call $~lib/rt/pure/__release
-  local.get $16
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
   local.get $1
-  call $~lib/rt/pure/__release
-  local.get $12
-  call $~lib/rt/pure/__release
-  local.get $3
   call $~lib/rt/pure/__release
   i32.const 0
   i32.const 2
@@ -16300,7 +16179,7 @@
   i32.const 6408
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $17
+  local.tee $15
   call $~lib/rt/pure/__retain
   local.set $35
   i32.const 1
@@ -16309,7 +16188,7 @@
   i32.const 6424
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $18
+  local.tee $16
   call $~lib/rt/pure/__retain
   local.set $36
   i32.const 2
@@ -16318,7 +16197,7 @@
   i32.const 6448
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $19
+  local.tee $17
   call $~lib/rt/pure/__retain
   local.set $7
   i32.const 4
@@ -16327,12 +16206,12 @@
   i32.const 6472
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $20
+  local.tee $18
   call $~lib/rt/pure/__retain
-  local.set $14
+  local.set $13
   local.get $35
   call $~lib/array/Array<i32>#toString
-  local.tee $21
+  local.tee $19
   i32.const 4248
   call $~lib/string/String.__eq
   i32.eqz
@@ -16346,7 +16225,7 @@
   end
   local.get $36
   call $~lib/array/Array<i32>#toString
-  local.tee $22
+  local.tee $20
   i32.const 6144
   call $~lib/string/String.__eq
   i32.eqz
@@ -16360,7 +16239,7 @@
   end
   local.get $7
   call $~lib/array/Array<i32>#toString
-  local.tee $23
+  local.tee $21
   i32.const 6504
   call $~lib/string/String.__eq
   i32.eqz
@@ -16372,7 +16251,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $14
+  local.get $13
   call $~lib/array/Array<i32>#toString
   local.tee $8
   i32.const 6528
@@ -16514,7 +16393,7 @@
   call $~lib/rt/pure/__retain
   local.tee $9
   call $~lib/rt/pure/__retain
-  local.tee $10
+  local.tee $11
   call $~lib/array/Array<~lib/string/String | null>#toString
   local.tee $12
   i32.const 6984
@@ -16534,9 +16413,9 @@
   i32.const 7080
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $13
+  local.tee $14
   call $~lib/array/Array<~lib/string/String | null>#toString
-  local.tee $15
+  local.tee $22
   i32.const 7112
   call $~lib/string/String.__eq
   i32.eqz
@@ -16562,7 +16441,7 @@
   i32.const 7144
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $16
+  local.tee $23
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
@@ -16682,13 +16561,13 @@
   i32.store
   local.get $27
   call $~lib/rt/pure/__retain
-  local.set $11
+  local.set $10
   i32.const 4464
   call $~lib/rt/pure/__retain
   drop
-  local.get $11
+  local.get $10
   i32.load offset=4
-  local.get $11
+  local.get $10
   i32.load offset=12
   call $~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>>
   local.set $1
@@ -16706,27 +16585,27 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $17
+  local.get $15
   call $~lib/rt/pure/__release
   local.get $35
   call $~lib/rt/pure/__release
-  local.get $18
+  local.get $16
   call $~lib/rt/pure/__release
   local.get $36
   call $~lib/rt/pure/__release
-  local.get $19
+  local.get $17
   call $~lib/rt/pure/__release
   local.get $7
   call $~lib/rt/pure/__release
+  local.get $18
+  call $~lib/rt/pure/__release
+  local.get $13
+  call $~lib/rt/pure/__release
+  local.get $19
+  call $~lib/rt/pure/__release
   local.get $20
   call $~lib/rt/pure/__release
-  local.get $14
-  call $~lib/rt/pure/__release
   local.get $21
-  call $~lib/rt/pure/__release
-  local.get $22
-  call $~lib/rt/pure/__release
-  local.get $23
   call $~lib/rt/pure/__release
   local.get $8
   call $~lib/rt/pure/__release
@@ -16748,15 +16627,15 @@
   call $~lib/rt/pure/__release
   local.get $9
   call $~lib/rt/pure/__release
-  local.get $10
+  local.get $11
   call $~lib/rt/pure/__release
   local.get $12
   call $~lib/rt/pure/__release
-  local.get $13
+  local.get $14
   call $~lib/rt/pure/__release
-  local.get $15
+  local.get $22
   call $~lib/rt/pure/__release
-  local.get $16
+  local.get $23
   call $~lib/rt/pure/__release
   local.get $24
   call $~lib/rt/pure/__release
@@ -16778,7 +16657,7 @@
   call $~lib/rt/pure/__release
   local.get $34
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $10
   call $~lib/rt/pure/__release
  )
  (func $start (; 202 ;) (type $FUNCSIG$v)

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -182,34 +182,35 @@
  (data (i32.const 6152) "\0c\00\00\00\01\00\00\00\00\00\00\00\0c\00\00\00\98\10\00\00\00\18")
  (data (i32.const 6184) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00[\00o\00b\00j\00e\00c\00t\00 \00O\00b\00j\00e\00c\00t\00]")
  (data (i32.const 6232) "@\00\00\00\01\00\00\00\01\00\00\00@\00\00\00[\00o\00b\00j\00e\00c\00t\00 \00O\00b\00j\00e\00c\00t\00]\00,\00,\00[\00o\00b\00j\00e\00c\00t\00 \00O\00b\00j\00e\00c\00t\00]")
- (data (i32.const 6316) "\01")
- (data (i32.const 6328) "\04\00\00\00\01\00\00\00\00\00\00\00\04\00\00\00\01")
- (data (i32.const 6352) "\08\00\00\00\01\00\00\00\00\00\00\00\08\00\00\00\01\00\00\00\02")
- (data (i32.const 6376) "\10\00\00\00\01\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00\03")
- (data (i32.const 6408) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\001\00,\002")
- (data (i32.const 6432) "\0e\00\00\00\01\00\00\00\01\00\00\00\0e\00\00\000\00,\001\00,\002\00,\003")
- (data (i32.const 6464) "\03\00\00\00\01\00\00\00\00\00\00\00\03\00\00\00\01\ff")
- (data (i32.const 6488) "\0c\00\00\00\01\00\00\00\01\00\00\00\0c\00\00\001\00,\00-\001\00,\000")
- (data (i32.const 6520) "\06\00\00\00\01\00\00\00\00\00\00\00\06\00\00\00\01\00\ff\ff")
- (data (i32.const 6544) "\12\00\00\00\01\00\00\00\01\00\00\00\12\00\00\001\00,\006\005\005\003\005\00,\000")
- (data (i32.const 6584) "\18\00\00\00\01\00\00\00\00\00\00\00\18\00\00\00\01\00\00\00\00\00\00\00\ff\ff\ff\ff\ff\ff\ff\ff")
- (data (i32.const 6624) "0\00\00\00\01\00\00\00\01\00\00\000\00\00\001\00,\001\008\004\004\006\007\004\004\000\007\003\007\000\009\005\005\001\006\001\005\00,\000")
- (data (i32.const 6688) " \00\00\00\01\00\00\00\00\00\00\00 \00\00\00\ff\ff\ff\ff\ff\ff\ff\ff@Eu\c3*\9d\fb\ff")
- (data (i32.const 6728) "\ff\ff\ff\ff\ff\ff\ff\7f")
- (data (i32.const 6736) "T\00\00\00\01\00\00\00\01\00\00\00T\00\00\00-\001\00,\00-\001\002\003\004\005\006\007\008\009\000\001\002\003\004\005\006\00,\000\00,\009\002\002\003\003\007\002\000\003\006\008\005\004\007\007\005\008\000\007")
- (data (i32.const 6840) "\1c\00\00\00\01\00\00\00\00\00\00\00\1c\00\00\00\98\10\00\008\10\00\008\10\00\00h\10\00\00P\10\00\00\80\10")
- (data (i32.const 6888) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00,\00a\00,\00a\00,\00a\00b\00,\00b\00,\00b\00a\00,")
- (data (i32.const 6936) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\002")
- (data (i32.const 6960) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\004")
- (data (i32.const 6984) "\10\00\00\00\01\00\00\00\00\00\00\00\10\00\00\00\00\18\00\00(\1b\00\00\00\00\00\00@\1b")
- (data (i32.const 7016) "\0c\00\00\00\01\00\00\00\01\00\00\00\0c\00\00\001\00,\002\00,\00,\004")
- (data (i32.const 7048) "\08\00\00\00\01\00\00\00\00\00\00\00\08\00\00\00\01\00\00\00\02")
- (data (i32.const 7072) "\08\00\00\00\01\00\00\00\00\00\00\00\08\00\00\00\03\00\00\00\04")
- (data (i32.const 7096) "\0e\00\00\00\01\00\00\00\01\00\00\00\0e\00\00\001\00,\002\00,\003\00,\004")
- (data (i32.const 7128) "\02\00\00\00\01\00\00\00\00\00\00\00\02\00\00\00\01\02")
- (data (i32.const 7152) "\02\00\00\00\01\00\00\00\00\00\00\00\02\00\00\00\03\04")
- (data (i32.const 7176) "\04\00\00\00\01\00\00\00\00\00\00\00\04\00\00\00\01")
- (data (i32.const 7200) "\1a\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\93\04\00\00\02\00\00\00\10\00\00\00\00\00\00\001\00\00\00\02\00\00\003\00\00\00\02\00\00\00\93\00\00\00\02\00\00\00\93\0c\00\00\02\00\00\00\13\0d\00\00\02\00\00\00\93 \00\00\02\00\00\00\10\00\00\00\00\00\00\00\93 \00\00\02\00\00\00\930\00\00\02\00\00\00\93 \00\00\02\00\00\003\00\00\00\02\00\00\00\13\01\00\00\02\00\00\00S\04\00\00\02\00\00\00\10\00\00\00\00\00\00\00\930\00\00\02\00\00\003\04\00\00\02\00\00\00S\00\00\00\02\00\00\00\13\05\00\00\02\00\00\00\93 \00\00\02\00\00\00\93 \00\00\02\00\00\00\93 \00\00\02")
+ (data (i32.const 6312) ">\00\00\00\01\00\00\00\01\00\00\00>\00\00\00[\00o\00b\00j\00e\00c\00t\00 \00O\00b\00j\00e\00c\00t\00]\00,\00[\00o\00b\00j\00e\00c\00t\00 \00O\00b\00j\00e\00c\00t\00]")
+ (data (i32.const 6396) "\01")
+ (data (i32.const 6408) "\04\00\00\00\01\00\00\00\00\00\00\00\04\00\00\00\01")
+ (data (i32.const 6432) "\08\00\00\00\01\00\00\00\00\00\00\00\08\00\00\00\01\00\00\00\02")
+ (data (i32.const 6456) "\10\00\00\00\01\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00\03")
+ (data (i32.const 6488) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\001\00,\002")
+ (data (i32.const 6512) "\0e\00\00\00\01\00\00\00\01\00\00\00\0e\00\00\000\00,\001\00,\002\00,\003")
+ (data (i32.const 6544) "\03\00\00\00\01\00\00\00\00\00\00\00\03\00\00\00\01\ff")
+ (data (i32.const 6568) "\0c\00\00\00\01\00\00\00\01\00\00\00\0c\00\00\001\00,\00-\001\00,\000")
+ (data (i32.const 6600) "\06\00\00\00\01\00\00\00\00\00\00\00\06\00\00\00\01\00\ff\ff")
+ (data (i32.const 6624) "\12\00\00\00\01\00\00\00\01\00\00\00\12\00\00\001\00,\006\005\005\003\005\00,\000")
+ (data (i32.const 6664) "\18\00\00\00\01\00\00\00\00\00\00\00\18\00\00\00\01\00\00\00\00\00\00\00\ff\ff\ff\ff\ff\ff\ff\ff")
+ (data (i32.const 6704) "0\00\00\00\01\00\00\00\01\00\00\000\00\00\001\00,\001\008\004\004\006\007\004\004\000\007\003\007\000\009\005\005\001\006\001\005\00,\000")
+ (data (i32.const 6768) " \00\00\00\01\00\00\00\00\00\00\00 \00\00\00\ff\ff\ff\ff\ff\ff\ff\ff@Eu\c3*\9d\fb\ff")
+ (data (i32.const 6808) "\ff\ff\ff\ff\ff\ff\ff\7f")
+ (data (i32.const 6816) "T\00\00\00\01\00\00\00\01\00\00\00T\00\00\00-\001\00,\00-\001\002\003\004\005\006\007\008\009\000\001\002\003\004\005\006\00,\000\00,\009\002\002\003\003\007\002\000\003\006\008\005\004\007\007\005\008\000\007")
+ (data (i32.const 6920) "\1c\00\00\00\01\00\00\00\00\00\00\00\1c\00\00\00\98\10\00\008\10\00\008\10\00\00h\10\00\00P\10\00\00\80\10")
+ (data (i32.const 6968) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00,\00a\00,\00a\00,\00a\00b\00,\00b\00,\00b\00a\00,")
+ (data (i32.const 7016) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\002")
+ (data (i32.const 7040) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\004")
+ (data (i32.const 7064) "\10\00\00\00\01\00\00\00\00\00\00\00\10\00\00\00\00\18\00\00x\1b\00\00\00\00\00\00\90\1b")
+ (data (i32.const 7096) "\0c\00\00\00\01\00\00\00\01\00\00\00\0c\00\00\001\00,\002\00,\00,\004")
+ (data (i32.const 7128) "\08\00\00\00\01\00\00\00\00\00\00\00\08\00\00\00\01\00\00\00\02")
+ (data (i32.const 7152) "\08\00\00\00\01\00\00\00\00\00\00\00\08\00\00\00\03\00\00\00\04")
+ (data (i32.const 7176) "\0e\00\00\00\01\00\00\00\01\00\00\00\0e\00\00\001\00,\002\00,\003\00,\004")
+ (data (i32.const 7208) "\02\00\00\00\01\00\00\00\00\00\00\00\02\00\00\00\01\02")
+ (data (i32.const 7232) "\02\00\00\00\01\00\00\00\00\00\00\00\02\00\00\00\03\04")
+ (data (i32.const 7256) "\04\00\00\00\01\00\00\00\00\00\00\00\04\00\00\00\01")
+ (data (i32.const 7280) "\1b\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\93\04\00\00\02\00\00\00\10\00\00\00\00\00\00\001\00\00\00\02\00\00\003\00\00\00\02\00\00\00\93\00\00\00\02\00\00\00\93\0c\00\00\02\00\00\00\13\0d\00\00\02\00\00\00\93 \00\00\02\00\00\00\10\00\00\00\00\00\00\00\93 \00\00\02\00\00\00\930\00\00\02\00\00\00\93 \00\00\02\00\00\003\00\00\00\02\00\00\00\13\01\00\00\02\00\00\00S\04\00\00\02\00\00\00\10\00\00\00\00\00\00\00\930\00\00\02\00\00\00\93 \00\00\02\00\00\003\04\00\00\02\00\00\00S\00\00\00\02\00\00\00\13\05\00\00\02\00\00\00\93 \00\00\02\00\00\00\93 \00\00\02\00\00\00\93 \00\00\02")
  (table $0 57 funcref)
  (elem (i32.const 0) $null $start:std/array~anonymous|0 $start:std/array~anonymous|1 $start:std/array~anonymous|2 $start:std/array~anonymous|3 $start:std/array~anonymous|2 $start:std/array~anonymous|5 $start:std/array~anonymous|6 $start:std/array~anonymous|7 $start:std/array~anonymous|8 $start:std/array~anonymous|9 $start:std/array~anonymous|10 $start:std/array~anonymous|11 $start:std/array~anonymous|12 $start:std/array~anonymous|13 $start:std/array~anonymous|14 $start:std/array~anonymous|15 $start:std/array~anonymous|16 $start:std/array~anonymous|17 $start:std/array~anonymous|16 $start:std/array~anonymous|19 $start:std/array~anonymous|20 $start:std/array~anonymous|21 $start:std/array~anonymous|22 $start:std/array~anonymous|23 $start:std/array~anonymous|24 $start:std/array~anonymous|25 $start:std/array~anonymous|26 $start:std/array~anonymous|27 $start:std/array~anonymous|28 $start:std/array~anonymous|29 $start:std/array~anonymous|29 $start:std/array~anonymous|31 $start:std/array~anonymous|32 $start:std/array~anonymous|33 $start:std/array~anonymous|29 $start:std/array~anonymous|35 $start:std/array~anonymous|29 $start:std/array~anonymous|29 $start:std/array~anonymous|31 $start:std/array~anonymous|32 $start:std/array~anonymous|33 $start:std/array~anonymous|29 $start:std/array~anonymous|35 $~lib/util/sort/COMPARATOR<f32>~anonymous|0 $~lib/util/sort/COMPARATOR<f64>~anonymous|0 $~lib/util/sort/COMPARATOR<i32>~anonymous|0 $~lib/util/sort/COMPARATOR<u32>~anonymous|0 $~lib/util/sort/COMPARATOR<i32>~anonymous|0 $~lib/util/sort/COMPARATOR<i32>~anonymous|0 $start:std/array~anonymous|44 $~lib/util/sort/COMPARATOR<i32>~anonymous|0 $start:std/array~anonymous|44 $start:std/array~anonymous|47 $start:std/array~anonymous|48 $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0 $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0)
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
@@ -819,10 +820,10 @@
   if
    unreachable
   end
-  i32.const 7424
+  i32.const 7504
   i32.const 0
   i32.store
-  i32.const 8992
+  i32.const 9072
   i32.const 0
   i32.store
   i32.const 0
@@ -836,7 +837,7 @@
     local.get $0
     i32.const 2
     i32.shl
-    i32.const 7424
+    i32.const 7504
     i32.add
     i32.const 0
     i32.store offset=4
@@ -855,7 +856,7 @@
       i32.add
       i32.const 2
       i32.shl
-      i32.const 7424
+      i32.const 7504
       i32.add
       i32.const 0
       i32.store offset=96
@@ -873,13 +874,13 @@
     br $loop|0
    end
   end
-  i32.const 7424
-  i32.const 9008
+  i32.const 7504
+  i32.const 9088
   memory.size
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
-  i32.const 7424
+  i32.const 7504
   global.set $~lib/rt/tlsf/ROOT
  )
  (func $~lib/rt/tlsf/prepareSize (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
@@ -1795,7 +1796,7 @@
  )
  (func $~lib/rt/pure/__retain (; 24 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
-  i32.const 7412
+  i32.const 7500
   i32.gt_u
   if
    local.get $0
@@ -1807,7 +1808,7 @@
  )
  (func $~lib/rt/__typeinfo (; 25 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
-  i32.const 7200
+  i32.const 7280
   i32.load
   i32.gt_u
   if
@@ -1821,7 +1822,7 @@
   local.get $0
   i32.const 3
   i32.shl
-  i32.const 7204
+  i32.const 7284
   i32.add
   i32.load
  )
@@ -2193,7 +2194,7 @@
  )
  (func $~lib/rt/pure/__release (; 31 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
-  i32.const 7412
+  i32.const 7500
   i32.gt_u
   if
    local.get $0
@@ -9301,7 +9302,7 @@
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/string/joinObjectArray<std/array/Ref | null> (; 176 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<std/array/Ref | null> (; 176 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9328,89 +9329,108 @@
   local.get $4
   i32.eqz
   if
-   i32.const 6200
-   call $~lib/rt/pure/__retain
+   local.get $0
+   i32.load
+   local.tee $0
+   if
+    local.get $0
+    call $~lib/rt/pure/__retain
+    drop
+    i32.const 0
+    call $~lib/rt/pure/__release
+   end
+   local.get $0
+   if (result i32)
+    i32.const 6200
+    call $~lib/rt/pure/__retain
+   else
+    i32.const 4248
+    call $~lib/rt/pure/__retain
+   end
    i32.const 4464
+   call $~lib/rt/pure/__release
+   local.get $0
    call $~lib/rt/pure/__release
    return
   end
+  i32.const 4248
+  call $~lib/rt/pure/__retain
+  local.set $1
   i32.const 4464
   call $~lib/string/String#get:length
-  local.tee $5
-  i32.const 15
-  i32.add
-  local.get $4
-  i32.mul
-  i32.const 15
-  i32.add
-  local.tee $8
-  i32.const 1
-  i32.shl
-  i32.const 1
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.set $3
-  i32.const 0
-  local.set $1
+  local.set $7
   loop $loop|0
-   local.get $6
+   local.get $5
    local.get $4
    i32.lt_s
    if
-    local.get $1
-    local.set $7
-    local.get $7
-    local.get $6
+    local.get $3
+    local.set $2
+    local.get $2
+    local.get $5
     i32.const 2
     i32.shl
     local.get $0
     i32.add
     i32.load
-    local.tee $1
+    local.tee $3
     i32.ne
     if
-     local.get $1
+     local.get $3
      call $~lib/rt/pure/__retain
      drop
-     local.get $7
+     local.get $2
      call $~lib/rt/pure/__release
     end
-    local.get $1
+    local.get $3
     if
-     local.get $2
-     i32.const 1
-     i32.shl
-     local.get $3
-     i32.add
-     i32.const 6200
-     i32.const 30
-     call $~lib/memory/memory.copy
-     local.get $2
-     i32.const 15
-     i32.add
+     local.get $1
      local.set $2
+     i32.const 6200
+     call $~lib/rt/pure/__retain
+     local.tee $1
+     local.get $2
+     local.get $2
+     local.get $1
+     call $~lib/string/String.__concat
+     local.tee $8
+     local.tee $1
+     i32.ne
+     if
+      local.get $1
+      call $~lib/rt/pure/__retain
+      drop
+      local.get $2
+      call $~lib/rt/pure/__release
+     end
+     call $~lib/rt/pure/__release
+     local.get $8
+     call $~lib/rt/pure/__release
+    end
+    local.get $7
+    if
+     local.get $1
+     local.tee $2
+     i32.const 4464
+     call $~lib/string/String.__concat
+     local.tee $6
+     local.tee $1
+     local.get $2
+     i32.ne
+     if
+      local.get $1
+      call $~lib/rt/pure/__retain
+      drop
+      local.get $2
+      call $~lib/rt/pure/__release
+     end
+     local.get $6
+     call $~lib/rt/pure/__release
     end
     local.get $5
-    if
-     local.get $2
-     i32.const 1
-     i32.shl
-     local.get $3
-     i32.add
-     i32.const 4464
-     local.get $5
-     i32.const 1
-     i32.shl
-     call $~lib/memory/memory.copy
-     local.get $2
-     local.get $5
-     i32.add
-     local.set $2
-    end
-    local.get $6
     i32.const 1
     i32.add
-    local.set $6
+    local.set $5
     br $loop|0
    end
   end
@@ -9420,47 +9440,218 @@
   local.get $0
   i32.add
   i32.load
+  local.tee $2
+  local.get $3
+  i32.ne
   if
    local.get $2
-   i32.const 1
-   i32.shl
+   call $~lib/rt/pure/__retain
+   drop
    local.get $3
-   i32.add
-   i32.const 6200
-   i32.const 30
-   call $~lib/memory/memory.copy
-   local.get $2
-   i32.const 15
-   i32.add
-   local.set $2
+   call $~lib/rt/pure/__release
   end
-  local.get $8
   local.get $2
-  i32.gt_s
   if
-   local.get $3
-   local.get $2
-   call $~lib/string/String#substring
-   i32.const 4464
-   call $~lib/rt/pure/__release
-   local.get $3
-   call $~lib/rt/pure/__release
    local.get $1
+   local.set $0
+   i32.const 6200
+   call $~lib/rt/pure/__retain
+   local.tee $1
+   local.get $0
+   local.get $0
+   local.get $1
+   call $~lib/string/String.__concat
+   local.tee $4
+   local.tee $1
+   i32.ne
+   if
+    local.get $1
+    call $~lib/rt/pure/__retain
+    drop
+    local.get $0
+    call $~lib/rt/pure/__release
+   end
    call $~lib/rt/pure/__release
-   return
+   local.get $4
+   call $~lib/rt/pure/__release
   end
   i32.const 4464
   call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $1
+ )
+ (func $~lib/util/string/joinReferenceArray<std/array/Ref> (; 177 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  i32.const 4464
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $1
+  i32.const 1
+  i32.sub
+  local.tee $4
+  i32.const 0
+  i32.lt_s
+  if
+   i32.const 4248
+   call $~lib/rt/pure/__retain
+   i32.const 4464
+   call $~lib/rt/pure/__release
+   return
+  end
+  local.get $4
+  i32.eqz
+  if
+   local.get $0
+   i32.load
+   local.tee $0
+   if
+    local.get $0
+    call $~lib/rt/pure/__retain
+    drop
+    i32.const 0
+    call $~lib/rt/pure/__release
+   end
+   i32.const 6200
+   call $~lib/rt/pure/__retain
+   i32.const 4464
+   call $~lib/rt/pure/__release
+   local.get $0
+   call $~lib/rt/pure/__release
+   return
+  end
+  i32.const 4248
+  call $~lib/rt/pure/__retain
+  local.set $1
+  i32.const 4464
+  call $~lib/string/String#get:length
+  local.set $7
+  loop $loop|0
+   local.get $5
+   local.get $4
+   i32.lt_s
+   if
+    local.get $3
+    local.set $2
+    local.get $2
+    local.get $5
+    i32.const 2
+    i32.shl
+    local.get $0
+    i32.add
+    i32.load
+    local.tee $3
+    i32.ne
+    if
+     local.get $3
+     call $~lib/rt/pure/__retain
+     drop
+     local.get $2
+     call $~lib/rt/pure/__release
+    end
+    local.get $1
+    local.set $2
+    i32.const 6200
+    call $~lib/rt/pure/__retain
+    local.tee $1
+    local.get $2
+    local.get $2
+    local.get $1
+    call $~lib/string/String.__concat
+    local.tee $8
+    local.tee $1
+    i32.ne
+    if
+     local.get $1
+     call $~lib/rt/pure/__retain
+     drop
+     local.get $2
+     call $~lib/rt/pure/__release
+    end
+    call $~lib/rt/pure/__release
+    local.get $8
+    call $~lib/rt/pure/__release
+    local.get $7
+    if
+     local.get $1
+     local.tee $2
+     i32.const 4464
+     call $~lib/string/String.__concat
+     local.tee $6
+     local.tee $1
+     local.get $2
+     i32.ne
+     if
+      local.get $1
+      call $~lib/rt/pure/__retain
+      drop
+      local.get $2
+      call $~lib/rt/pure/__release
+     end
+     local.get $6
+     call $~lib/rt/pure/__release
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+  end
+  local.get $4
+  i32.const 2
+  i32.shl
+  local.get $0
+  i32.add
+  i32.load
+  local.tee $0
+  local.get $3
+  i32.ne
+  if
+   local.get $0
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+  i32.const 6200
+  call $~lib/rt/pure/__retain
+  local.tee $3
+  local.get $1
+  local.get $3
+  call $~lib/string/String.__concat
+  local.tee $4
+  local.tee $3
+  local.get $1
+  i32.ne
+  if
+   local.get $3
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $1
+   call $~lib/rt/pure/__release
+  end
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+  i32.const 4464
+  call $~lib/rt/pure/__release
+  local.get $0
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<i32>#toString (; 177 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#toString (; 178 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4464
   call $~lib/array/Array<i32>#join
  )
- (func $~lib/util/number/itoa_stream<i8> (; 178 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i8> (; 179 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 1
@@ -9515,7 +9706,7 @@
   end
   local.get $2
  )
- (func $~lib/util/string/joinIntegerArray<i8> (; 179 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i8> (; 180 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9634,7 +9825,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/number/itoa_stream<u16> (; 180 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u16> (; 181 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   i32.const 1
   i32.shl
@@ -9664,7 +9855,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u16> (; 181 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u16> (; 182 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9787,7 +9978,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/number/decimalCount64 (; 182 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64 (; 183 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   i32.const 10
   i32.const 11
   i32.const 12
@@ -9840,7 +10031,7 @@
   i64.lt_u
   select
  )
- (func $~lib/util/number/utoa_simple<u64> (; 183 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u64> (; 184 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   loop $continue|0
    local.get $1
@@ -9870,7 +10061,7 @@
    br_if $continue|0
   end
  )
- (func $~lib/util/number/utoa64 (; 184 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/utoa64 (; 185 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9914,7 +10105,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<u64> (; 185 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<u64> (; 186 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 1
@@ -9954,7 +10145,7 @@
   end
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u64> (; 186 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u64> (; 187 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10077,7 +10268,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/number/itoa64 (; 187 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa64 (; 188 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -10142,7 +10333,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<i64> (; 188 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<i64> (; 189 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -10203,7 +10394,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<i64> (; 189 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i64> (; 190 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10326,12 +10517,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/array/Array<~lib/string/String | null>#toString (; 190 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#toString (; 191 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4464
   call $~lib/array/Array<~lib/string/String | null>#join
  )
- (func $~lib/util/string/joinArrays<~lib/array/Array<i32>> (; 191 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>> (; 192 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10355,12 +10546,6 @@
    call $~lib/rt/pure/__release
    return
   end
-  i32.const 4248
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 4464
-  call $~lib/string/String#get:length
-  local.set $7
   local.get $4
   i32.eqz
   if
@@ -10375,22 +10560,19 @@
     call $~lib/rt/pure/__release
    end
    local.get $0
-   if (result i32)
-    local.get $0
-    i32.const 4464
-    call $~lib/array/Array<i32>#join
-   else
-    i32.const 4248
-    call $~lib/rt/pure/__retain
-   end
+   call $~lib/array/Array<i32>#toString
    i32.const 4464
-   call $~lib/rt/pure/__release
-   local.get $1
    call $~lib/rt/pure/__release
    local.get $0
    call $~lib/rt/pure/__release
    return
   end
+  i32.const 4248
+  call $~lib/rt/pure/__retain
+  local.set $1
+  i32.const 4464
+  call $~lib/string/String#get:length
+  local.set $7
   loop $loop|0
    local.get $5
    local.get $4
@@ -10414,31 +10596,27 @@
      local.get $2
      call $~lib/rt/pure/__release
     end
+    local.get $1
+    local.tee $2
     local.get $3
+    call $~lib/array/Array<i32>#toString
+    local.tee $6
+    call $~lib/string/String.__concat
+    local.tee $8
+    local.tee $1
+    local.get $2
+    i32.ne
     if
      local.get $1
-     local.tee $2
-     local.get $3
-     i32.const 4464
-     call $~lib/array/Array<i32>#join
-     local.tee $6
-     call $~lib/string/String.__concat
-     local.tee $8
-     local.tee $1
+     call $~lib/rt/pure/__retain
+     drop
      local.get $2
-     i32.ne
-     if
-      local.get $1
-      call $~lib/rt/pure/__retain
-      drop
-      local.get $2
-      call $~lib/rt/pure/__release
-     end
-     local.get $6
-     call $~lib/rt/pure/__release
-     local.get $8
      call $~lib/rt/pure/__release
     end
+    local.get $6
+    call $~lib/rt/pure/__release
+    local.get $8
+    call $~lib/rt/pure/__release
     local.get $7
     if
      local.get $1
@@ -10472,48 +10650,43 @@
   local.get $0
   i32.add
   i32.load
-  local.tee $2
+  local.tee $0
   local.get $3
   i32.ne
   if
-   local.get $2
+   local.get $0
    call $~lib/rt/pure/__retain
    drop
    local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $1
+  local.get $0
+  call $~lib/array/Array<i32>#toString
+  local.tee $2
+  call $~lib/string/String.__concat
+  local.tee $4
+  local.tee $3
+  local.get $1
+  i32.ne
   if
-   local.get $1
-   local.tee $0
-   local.get $2
-   i32.const 4464
-   call $~lib/array/Array<i32>#join
-   local.tee $3
-   call $~lib/string/String.__concat
-   local.tee $4
-   local.tee $1
-   local.get $0
-   i32.ne
-   if
-    local.get $1
-    call $~lib/rt/pure/__retain
-    drop
-    local.get $0
-    call $~lib/rt/pure/__release
-   end
    local.get $3
-   call $~lib/rt/pure/__release
-   local.get $4
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $1
    call $~lib/rt/pure/__release
   end
-  i32.const 4464
-  call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $4
+  call $~lib/rt/pure/__release
+  i32.const 4464
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $3
  )
- (func $~lib/util/number/itoa_stream<u8> (; 192 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u8> (; 193 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   i32.const 1
   i32.shl
@@ -10543,7 +10716,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u8> (; 193 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u8> (; 194 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10662,7 +10835,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/array/Array<u8>#join (; 194 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u8>#toString (; 195 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 4464
   call $~lib/rt/pure/__retain
   drop
@@ -10674,7 +10847,7 @@
   i32.const 4464
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/string/joinArrays<~lib/array/Array<u8>> (; 195 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u8>> (; 196 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10698,12 +10871,6 @@
    call $~lib/rt/pure/__release
    return
   end
-  i32.const 4248
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 4464
-  call $~lib/string/String#get:length
-  local.set $7
   local.get $4
   i32.eqz
   if
@@ -10718,21 +10885,19 @@
     call $~lib/rt/pure/__release
    end
    local.get $0
-   if (result i32)
-    local.get $0
-    call $~lib/array/Array<u8>#join
-   else
-    i32.const 4248
-    call $~lib/rt/pure/__retain
-   end
+   call $~lib/array/Array<u8>#toString
    i32.const 4464
-   call $~lib/rt/pure/__release
-   local.get $1
    call $~lib/rt/pure/__release
    local.get $0
    call $~lib/rt/pure/__release
    return
   end
+  i32.const 4248
+  call $~lib/rt/pure/__retain
+  local.set $1
+  i32.const 4464
+  call $~lib/string/String#get:length
+  local.set $7
   loop $loop|0
    local.get $5
    local.get $4
@@ -10756,30 +10921,27 @@
      local.get $2
      call $~lib/rt/pure/__release
     end
+    local.get $1
+    local.tee $2
     local.get $3
+    call $~lib/array/Array<u8>#toString
+    local.tee $6
+    call $~lib/string/String.__concat
+    local.tee $8
+    local.tee $1
+    local.get $2
+    i32.ne
     if
      local.get $1
-     local.tee $2
-     local.get $3
-     call $~lib/array/Array<u8>#join
-     local.tee $6
-     call $~lib/string/String.__concat
-     local.tee $8
-     local.tee $1
+     call $~lib/rt/pure/__retain
+     drop
      local.get $2
-     i32.ne
-     if
-      local.get $1
-      call $~lib/rt/pure/__retain
-      drop
-      local.get $2
-      call $~lib/rt/pure/__release
-     end
-     local.get $6
-     call $~lib/rt/pure/__release
-     local.get $8
      call $~lib/rt/pure/__release
     end
+    local.get $6
+    call $~lib/rt/pure/__release
+    local.get $8
+    call $~lib/rt/pure/__release
     local.get $7
     if
      local.get $1
@@ -10813,47 +10975,48 @@
   local.get $0
   i32.add
   i32.load
-  local.tee $2
+  local.tee $0
   local.get $3
   i32.ne
   if
-   local.get $2
+   local.get $0
    call $~lib/rt/pure/__retain
    drop
    local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $1
+  local.get $0
+  call $~lib/array/Array<u8>#toString
+  local.tee $2
+  call $~lib/string/String.__concat
+  local.tee $4
+  local.tee $3
+  local.get $1
+  i32.ne
   if
-   local.get $1
-   local.tee $0
-   local.get $2
-   call $~lib/array/Array<u8>#join
-   local.tee $3
-   call $~lib/string/String.__concat
-   local.tee $4
-   local.tee $1
-   local.get $0
-   i32.ne
-   if
-    local.get $1
-    call $~lib/rt/pure/__retain
-    drop
-    local.get $0
-    call $~lib/rt/pure/__release
-   end
    local.get $3
-   call $~lib/rt/pure/__release
-   local.get $4
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $1
    call $~lib/rt/pure/__release
   end
-  i32.const 4464
-  call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $4
+  call $~lib/rt/pure/__release
+  i32.const 4464
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $3
  )
- (func $~lib/util/string/joinArrays<~lib/array/Array<u32>> (; 196 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#toString (; 197 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.const 4464
+  call $~lib/array/Array<u32>#join
+ )
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>> (; 198 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10877,12 +11040,6 @@
    call $~lib/rt/pure/__release
    return
   end
-  i32.const 4248
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 4464
-  call $~lib/string/String#get:length
-  local.set $7
   local.get $4
   i32.eqz
   if
@@ -10897,22 +11054,19 @@
     call $~lib/rt/pure/__release
    end
    local.get $0
-   if (result i32)
-    local.get $0
-    i32.const 4464
-    call $~lib/array/Array<u32>#join
-   else
-    i32.const 4248
-    call $~lib/rt/pure/__retain
-   end
+   call $~lib/array/Array<u32>#toString
    i32.const 4464
-   call $~lib/rt/pure/__release
-   local.get $1
    call $~lib/rt/pure/__release
    local.get $0
    call $~lib/rt/pure/__release
    return
   end
+  i32.const 4248
+  call $~lib/rt/pure/__retain
+  local.set $1
+  i32.const 4464
+  call $~lib/string/String#get:length
+  local.set $7
   loop $loop|0
    local.get $5
    local.get $4
@@ -10936,31 +11090,27 @@
      local.get $2
      call $~lib/rt/pure/__release
     end
+    local.get $1
+    local.tee $2
     local.get $3
+    call $~lib/array/Array<u32>#toString
+    local.tee $6
+    call $~lib/string/String.__concat
+    local.tee $8
+    local.tee $1
+    local.get $2
+    i32.ne
     if
      local.get $1
-     local.tee $2
-     local.get $3
-     i32.const 4464
-     call $~lib/array/Array<u32>#join
-     local.tee $6
-     call $~lib/string/String.__concat
-     local.tee $8
-     local.tee $1
+     call $~lib/rt/pure/__retain
+     drop
      local.get $2
-     i32.ne
-     if
-      local.get $1
-      call $~lib/rt/pure/__retain
-      drop
-      local.get $2
-      call $~lib/rt/pure/__release
-     end
-     local.get $6
-     call $~lib/rt/pure/__release
-     local.get $8
      call $~lib/rt/pure/__release
     end
+    local.get $6
+    call $~lib/rt/pure/__release
+    local.get $8
+    call $~lib/rt/pure/__release
     local.get $7
     if
      local.get $1
@@ -10994,48 +11144,43 @@
   local.get $0
   i32.add
   i32.load
-  local.tee $2
+  local.tee $0
   local.get $3
   i32.ne
   if
-   local.get $2
+   local.get $0
    call $~lib/rt/pure/__retain
    drop
    local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $1
+  local.get $0
+  call $~lib/array/Array<u32>#toString
+  local.tee $2
+  call $~lib/string/String.__concat
+  local.tee $4
+  local.tee $3
+  local.get $1
+  i32.ne
   if
-   local.get $1
-   local.tee $0
-   local.get $2
-   i32.const 4464
-   call $~lib/array/Array<u32>#join
-   local.tee $3
-   call $~lib/string/String.__concat
-   local.tee $4
-   local.tee $1
-   local.get $0
-   i32.ne
-   if
-    local.get $1
-    call $~lib/rt/pure/__retain
-    drop
-    local.get $0
-    call $~lib/rt/pure/__release
-   end
    local.get $3
-   call $~lib/rt/pure/__release
-   local.get $4
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $1
    call $~lib/rt/pure/__release
   end
-  i32.const 4464
-  call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $4
+  call $~lib/rt/pure/__release
+  i32.const 4464
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $3
  )
- (func $~lib/array/Array<~lib/array/Array<u32>>#join (; 197 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u32>>#toString (; 199 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 4464
   call $~lib/rt/pure/__retain
   drop
@@ -11043,11 +11188,11 @@
   i32.load offset=4
   local.get $0
   i32.load offset=12
-  call $~lib/util/string/joinArrays<~lib/array/Array<u32>>
+  call $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>>
   i32.const 4464
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/string/joinArrays<~lib/array/Array<~lib/array/Array<u32>>> (; 198 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>> (; 200 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11071,12 +11216,6 @@
    call $~lib/rt/pure/__release
    return
   end
-  i32.const 4248
-  call $~lib/rt/pure/__retain
-  local.set $1
-  i32.const 4464
-  call $~lib/string/String#get:length
-  local.set $7
   local.get $4
   i32.eqz
   if
@@ -11091,21 +11230,19 @@
     call $~lib/rt/pure/__release
    end
    local.get $0
-   if (result i32)
-    local.get $0
-    call $~lib/array/Array<~lib/array/Array<u32>>#join
-   else
-    i32.const 4248
-    call $~lib/rt/pure/__retain
-   end
+   call $~lib/array/Array<~lib/array/Array<u32>>#toString
    i32.const 4464
-   call $~lib/rt/pure/__release
-   local.get $1
    call $~lib/rt/pure/__release
    local.get $0
    call $~lib/rt/pure/__release
    return
   end
+  i32.const 4248
+  call $~lib/rt/pure/__retain
+  local.set $1
+  i32.const 4464
+  call $~lib/string/String#get:length
+  local.set $7
   loop $loop|0
    local.get $5
    local.get $4
@@ -11129,30 +11266,27 @@
      local.get $2
      call $~lib/rt/pure/__release
     end
+    local.get $1
+    local.tee $2
     local.get $3
+    call $~lib/array/Array<~lib/array/Array<u32>>#toString
+    local.tee $6
+    call $~lib/string/String.__concat
+    local.tee $8
+    local.tee $1
+    local.get $2
+    i32.ne
     if
      local.get $1
-     local.tee $2
-     local.get $3
-     call $~lib/array/Array<~lib/array/Array<u32>>#join
-     local.tee $6
-     call $~lib/string/String.__concat
-     local.tee $8
-     local.tee $1
+     call $~lib/rt/pure/__retain
+     drop
      local.get $2
-     i32.ne
-     if
-      local.get $1
-      call $~lib/rt/pure/__retain
-      drop
-      local.get $2
-      call $~lib/rt/pure/__release
-     end
-     local.get $6
-     call $~lib/rt/pure/__release
-     local.get $8
      call $~lib/rt/pure/__release
     end
+    local.get $6
+    call $~lib/rt/pure/__release
+    local.get $8
+    call $~lib/rt/pure/__release
     local.get $7
     if
      local.get $1
@@ -11186,47 +11320,43 @@
   local.get $0
   i32.add
   i32.load
-  local.tee $2
+  local.tee $0
   local.get $3
   i32.ne
   if
-   local.get $2
+   local.get $0
    call $~lib/rt/pure/__retain
    drop
    local.get $3
    call $~lib/rt/pure/__release
   end
-  local.get $2
+  local.get $1
+  local.get $0
+  call $~lib/array/Array<~lib/array/Array<u32>>#toString
+  local.tee $2
+  call $~lib/string/String.__concat
+  local.tee $4
+  local.tee $3
+  local.get $1
+  i32.ne
   if
-   local.get $1
-   local.tee $0
-   local.get $2
-   call $~lib/array/Array<~lib/array/Array<u32>>#join
-   local.tee $3
-   call $~lib/string/String.__concat
-   local.tee $4
-   local.tee $1
-   local.get $0
-   i32.ne
-   if
-    local.get $1
-    call $~lib/rt/pure/__retain
-    drop
-    local.get $0
-    call $~lib/rt/pure/__release
-   end
    local.get $3
-   call $~lib/rt/pure/__release
-   local.get $4
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $1
    call $~lib/rt/pure/__release
   end
-  i32.const 4464
-  call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $1
+  local.get $4
+  call $~lib/rt/pure/__release
+  i32.const 4464
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $3
  )
- (func $start:std/array (; 199 ;) (type $FUNCSIG$v)
+ (func $start:std/array (; 201 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -12291,7 +12421,7 @@
   i32.const 1152
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $12
+  local.tee $14
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12311,7 +12441,7 @@
   i32.const 1192
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $15
+  local.tee $17
   local.tee $0
   i32.ne
   if
@@ -12326,14 +12456,14 @@
   i32.const 2
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $16
+  local.tee $18
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 1232
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $17
+  local.tee $19
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12353,7 +12483,7 @@
   i32.const 1272
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $18
+  local.tee $20
   local.tee $0
   i32.ne
   if
@@ -12368,14 +12498,14 @@
   i32.const 3
   i32.const 4
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $19
+  local.tee $21
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 1312
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $20
+  local.tee $22
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12395,7 +12525,7 @@
   i32.const 1352
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $21
+  local.tee $23
   local.tee $0
   i32.ne
   if
@@ -12410,14 +12540,14 @@
   i32.const 3
   i32.const 4
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $22
+  local.tee $8
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 1392
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $23
+  local.tee $9
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12437,7 +12567,7 @@
   i32.const 1432
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $24
+  local.tee $10
   local.tee $0
   i32.ne
   if
@@ -12452,14 +12582,14 @@
   i32.const 2
   i32.const 4
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $29
+  local.tee $12
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 1472
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $13
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12479,7 +12609,7 @@
   i32.const 1512
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $10
+  local.tee $15
   local.tee $0
   i32.ne
   if
@@ -12494,14 +12624,14 @@
   i32.const -2
   i32.const 2147483647
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $11
+  local.tee $16
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 1552
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $13
+  local.tee $24
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12521,7 +12651,7 @@
   i32.const 1592
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $14
+  local.tee $25
   local.tee $0
   i32.ne
   if
@@ -12536,14 +12666,14 @@
   i32.const -2
   i32.const -1
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $25
+  local.tee $26
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 1632
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $26
+  local.tee $27
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -12563,7 +12693,7 @@
   i32.const 1672
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $11
   local.tee $0
   i32.ne
   if
@@ -12578,7 +12708,7 @@
   i32.const -3
   i32.const -2
   call $~lib/array/Array<i32>#copyWithin
-  local.tee $27
+  local.tee $28
   i32.const 5
   i32.const 2
   i32.const 3
@@ -12648,16 +12778,16 @@
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   local.tee $3
-  local.tee $28
+  local.tee $29
   i32.ne
   if
-   local.get $28
+   local.get $29
    call $~lib/rt/pure/__retain
    drop
    local.get $1
    call $~lib/rt/pure/__release
   end
-  local.get $28
+  local.get $29
   i32.const -4
   i32.const -3
   i32.const 2147483647
@@ -12681,7 +12811,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $28
+  local.get $29
   call $~lib/rt/pure/__release
   local.get $30
   call $~lib/rt/pure/__release
@@ -12699,11 +12829,7 @@
   call $~lib/rt/pure/__release
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $12
-  call $~lib/rt/pure/__release
-  local.get $15
-  call $~lib/rt/pure/__release
-  local.get $16
+  local.get $14
   call $~lib/rt/pure/__release
   local.get $17
   call $~lib/rt/pure/__release
@@ -12719,27 +12845,31 @@
   call $~lib/rt/pure/__release
   local.get $23
   call $~lib/rt/pure/__release
-  local.get $24
-  call $~lib/rt/pure/__release
-  local.get $29
+  local.get $8
   call $~lib/rt/pure/__release
   local.get $9
   call $~lib/rt/pure/__release
   local.get $10
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $12
   call $~lib/rt/pure/__release
   local.get $13
   call $~lib/rt/pure/__release
-  local.get $14
+  local.get $15
+  call $~lib/rt/pure/__release
+  local.get $16
+  call $~lib/rt/pure/__release
+  local.get $24
   call $~lib/rt/pure/__release
   local.get $25
   call $~lib/rt/pure/__release
   local.get $26
   call $~lib/rt/pure/__release
-  local.get $8
-  call $~lib/rt/pure/__release
   local.get $27
+  call $~lib/rt/pure/__release
+  local.get $11
+  call $~lib/rt/pure/__release
+  local.get $28
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
@@ -13731,7 +13861,7 @@
   i32.const 2264
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $28
+  local.tee $29
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -13871,7 +14001,7 @@
   i32.const 2488
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $12
+  local.tee $14
   local.tee $0
   i32.ne
   if
@@ -13885,14 +14015,14 @@
   i32.const -2
   i32.const 1
   call $~lib/array/Array<i32>#splice
-  local.tee $15
+  local.tee $17
   i32.const 1
   i32.const 2
   i32.const 3
   i32.const 2528
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $16
+  local.tee $18
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -13911,7 +14041,7 @@
   i32.const 2552
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $17
+  local.tee $19
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -13931,7 +14061,7 @@
   i32.const 2584
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $18
+  local.tee $20
   local.tee $0
   i32.ne
   if
@@ -13945,14 +14075,14 @@
   i32.const -7
   i32.const 1
   call $~lib/array/Array<i32>#splice
-  local.tee $19
+  local.tee $21
   i32.const 1
   i32.const 2
   i32.const 3
   i32.const 2624
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $20
+  local.tee $22
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -13971,7 +14101,7 @@
   i32.const 2648
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $21
+  local.tee $23
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -13991,7 +14121,7 @@
   i32.const 2680
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $22
+  local.tee $8
   local.tee $0
   i32.ne
   if
@@ -14005,14 +14135,14 @@
   i32.const -2
   i32.const -1
   call $~lib/array/Array<i32>#splice
-  local.tee $23
+  local.tee $9
   i32.const 0
   i32.const 2
   i32.const 3
   i32.const 2720
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $24
+  local.tee $10
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -14031,7 +14161,7 @@
   i32.const 2736
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $29
+  local.tee $12
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -14051,7 +14181,7 @@
   i32.const 2776
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $13
   local.tee $0
   i32.ne
   if
@@ -14065,14 +14195,14 @@
   i32.const 1
   i32.const -2
   call $~lib/array/Array<i32>#splice
-  local.tee $10
+  local.tee $15
   i32.const 0
   i32.const 2
   i32.const 3
   i32.const 2816
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $11
+  local.tee $16
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -14091,7 +14221,7 @@
   i32.const 2832
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $13
+  local.tee $24
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -14111,7 +14241,7 @@
   i32.const 2872
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $14
+  local.tee $25
   local.tee $0
   i32.ne
   if
@@ -14125,14 +14255,14 @@
   i32.const 4
   i32.const 0
   call $~lib/array/Array<i32>#splice
-  local.tee $25
+  local.tee $26
   i32.const 0
   i32.const 2
   i32.const 3
   i32.const 2912
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $26
+  local.tee $27
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -14151,7 +14281,7 @@
   i32.const 2928
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $11
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -14171,7 +14301,7 @@
   i32.const 2968
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $27
+  local.tee $28
   local.tee $0
   i32.ne
   if
@@ -14315,7 +14445,7 @@
   call $~lib/rt/pure/__release
   local.get $52
   call $~lib/rt/pure/__release
-  local.get $28
+  local.get $29
   call $~lib/rt/pure/__release
   local.get $30
   call $~lib/rt/pure/__release
@@ -14333,11 +14463,7 @@
   call $~lib/rt/pure/__release
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $12
-  call $~lib/rt/pure/__release
-  local.get $15
-  call $~lib/rt/pure/__release
-  local.get $16
+  local.get $14
   call $~lib/rt/pure/__release
   local.get $17
   call $~lib/rt/pure/__release
@@ -14353,27 +14479,31 @@
   call $~lib/rt/pure/__release
   local.get $23
   call $~lib/rt/pure/__release
-  local.get $24
-  call $~lib/rt/pure/__release
-  local.get $29
+  local.get $8
   call $~lib/rt/pure/__release
   local.get $9
   call $~lib/rt/pure/__release
   local.get $10
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $12
   call $~lib/rt/pure/__release
   local.get $13
   call $~lib/rt/pure/__release
-  local.get $14
+  local.get $15
+  call $~lib/rt/pure/__release
+  local.get $16
+  call $~lib/rt/pure/__release
+  local.get $24
   call $~lib/rt/pure/__release
   local.get $25
   call $~lib/rt/pure/__release
   local.get $26
   call $~lib/rt/pure/__release
-  local.get $8
-  call $~lib/rt/pure/__release
   local.get $27
+  call $~lib/rt/pure/__release
+  local.get $11
+  call $~lib/rt/pure/__release
+  local.get $28
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
@@ -15437,23 +15567,23 @@
   i32.const 3392
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $10
+  local.tee $15
   call $~lib/rt/pure/__retain
-  local.set $12
+  local.set $14
   i32.const 0
   global.set $~lib/argc
-  local.get $12
+  local.get $14
   i32.const 44
   call $~lib/array/Array<f32>#sort
   call $~lib/rt/pure/__release
-  local.get $12
+  local.get $14
   i32.const 8
   i32.const 2
   i32.const 8
   i32.const 3440
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $11
+  local.tee $16
   call $std/array/isArraysEqual<f32>
   i32.eqz
   if
@@ -15470,23 +15600,23 @@
   i32.const 3488
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $13
+  local.tee $24
   call $~lib/rt/pure/__retain
-  local.set $15
+  local.set $17
   i32.const 0
   global.set $~lib/argc
-  local.get $15
+  local.get $17
   i32.const 45
   call $~lib/array/Array<f64>#sort
   call $~lib/rt/pure/__release
-  local.get $15
+  local.get $17
   i32.const 8
   i32.const 3
   i32.const 9
   i32.const 3568
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $14
+  local.tee $25
   call $std/array/isArraysEqual<f64>
   i32.eqz
   if
@@ -15503,23 +15633,23 @@
   i32.const 3648
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $25
+  local.tee $26
   call $~lib/rt/pure/__retain
-  local.set $16
+  local.set $18
   i32.const 0
   global.set $~lib/argc
-  local.get $16
+  local.get $18
   i32.const 46
   call $~lib/array/Array<i32>#sort
   call $~lib/rt/pure/__release
-  local.get $16
+  local.get $18
   i32.const 5
   i32.const 2
   i32.const 3
   i32.const 3688
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $26
+  local.tee $27
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -15537,23 +15667,23 @@
   i32.const 3728
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $11
   call $~lib/rt/pure/__retain
-  local.set $17
+  local.set $19
   i32.const 0
   global.set $~lib/argc
-  local.get $17
+  local.get $19
   i32.const 47
   call $~lib/array/Array<i32>#sort
   call $~lib/rt/pure/__release
-  local.get $17
+  local.get $19
   i32.const 5
   i32.const 2
   i32.const 7
   i32.const 3768
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $27
+  local.tee $28
   i32.const 0
   call $std/array/isArraysEqual<u32>
   i32.eqz
@@ -15573,7 +15703,7 @@
   call $~lib/rt/pure/__retain
   local.tee $2
   call $~lib/rt/pure/__retain
-  local.set $29
+  local.set $12
   i32.const 1
   i32.const 2
   i32.const 3
@@ -15582,7 +15712,7 @@
   call $~lib/rt/pure/__retain
   local.tee $5
   call $~lib/rt/pure/__retain
-  local.set $18
+  local.set $20
   i32.const 2
   i32.const 2
   i32.const 3
@@ -15591,7 +15721,7 @@
   call $~lib/rt/pure/__retain
   local.tee $4
   call $~lib/rt/pure/__retain
-  local.set $19
+  local.set $21
   i32.const 4
   i32.const 2
   i32.const 3
@@ -15600,7 +15730,7 @@
   call $~lib/rt/pure/__retain
   local.tee $6
   call $~lib/rt/pure/__retain
-  local.set $20
+  local.set $22
   i32.const 4
   i32.const 2
   i32.const 3
@@ -15612,24 +15742,24 @@
   local.set $7
   i32.const 64
   call $std/array/createReverseOrderedArray
-  local.set $21
+  local.set $23
   i32.const 128
   call $std/array/createReverseOrderedArray
-  local.set $22
+  local.set $8
   i32.const 1024
   call $std/array/createReverseOrderedArray
-  local.set $23
+  local.set $9
   i32.const 10000
   call $std/array/createReverseOrderedArray
-  local.set $24
+  local.set $10
   i32.const 512
   call $std/array/createRandomOrderedArray
-  local.set $9
-  local.get $29
+  local.set $13
+  local.get $12
   call $std/array/assertSortedDefault<i32>
-  local.get $18
+  local.get $20
   call $std/array/assertSortedDefault<i32>
-  local.get $18
+  local.get $20
   i32.const 1
   i32.const 2
   i32.const 3
@@ -15648,9 +15778,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $19
+  local.get $21
   call $std/array/assertSortedDefault<i32>
-  local.get $19
+  local.get $21
   i32.const 2
   i32.const 2
   i32.const 3
@@ -15669,9 +15799,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $20
+  local.get $22
   call $std/array/assertSortedDefault<i32>
-  local.get $20
+  local.get $22
   local.get $7
   i32.const 0
   call $std/array/isArraysEqual<u32>
@@ -15684,9 +15814,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $21
+  local.get $23
   call $std/array/assertSortedDefault<i32>
-  local.get $21
+  local.get $23
   local.get $7
   i32.const 4
   call $std/array/isArraysEqual<u32>
@@ -15699,9 +15829,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $22
+  local.get $8
   call $std/array/assertSortedDefault<i32>
-  local.get $22
+  local.get $8
   local.get $7
   i32.const 4
   call $std/array/isArraysEqual<u32>
@@ -15714,9 +15844,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $23
+  local.get $9
   call $std/array/assertSortedDefault<i32>
-  local.get $23
+  local.get $9
   local.get $7
   i32.const 4
   call $std/array/isArraysEqual<u32>
@@ -15729,9 +15859,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $24
+  local.get $10
   call $std/array/assertSortedDefault<i32>
-  local.get $24
+  local.get $10
   local.get $7
   i32.const 4
   call $std/array/isArraysEqual<u32>
@@ -15744,61 +15874,61 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
-  call $std/array/assertSortedDefault<i32>
-  local.get $10
-  call $~lib/rt/pure/__release
-  local.get $12
-  call $~lib/rt/pure/__release
-  local.get $11
-  call $~lib/rt/pure/__release
   local.get $13
-  call $~lib/rt/pure/__release
+  call $std/array/assertSortedDefault<i32>
   local.get $15
   call $~lib/rt/pure/__release
   local.get $14
   call $~lib/rt/pure/__release
-  local.get $25
-  call $~lib/rt/pure/__release
   local.get $16
   call $~lib/rt/pure/__release
-  local.get $26
-  call $~lib/rt/pure/__release
-  local.get $8
+  local.get $24
   call $~lib/rt/pure/__release
   local.get $17
   call $~lib/rt/pure/__release
-  local.get $27
+  local.get $25
   call $~lib/rt/pure/__release
-  local.get $2
-  call $~lib/rt/pure/__release
-  local.get $29
-  call $~lib/rt/pure/__release
-  local.get $5
+  local.get $26
   call $~lib/rt/pure/__release
   local.get $18
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $27
+  call $~lib/rt/pure/__release
+  local.get $11
   call $~lib/rt/pure/__release
   local.get $19
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $28
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $12
+  call $~lib/rt/pure/__release
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $20
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $21
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
+  local.get $22
   call $~lib/rt/pure/__release
   local.get $3
   call $~lib/rt/pure/__release
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $21
-  call $~lib/rt/pure/__release
-  local.get $22
-  call $~lib/rt/pure/__release
   local.get $23
   call $~lib/rt/pure/__release
-  local.get $24
+  local.get $8
   call $~lib/rt/pure/__release
   local.get $9
+  call $~lib/rt/pure/__release
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $13
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
@@ -15896,13 +16026,13 @@
   i32.const 4384
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.set $9
+  local.set $8
   i32.const 4464
   call $~lib/rt/pure/__retain
   drop
-  local.get $9
+  local.get $8
   i32.load offset=4
-  local.get $9
+  local.get $8
   i32.load offset=12
   call $~lib/util/string/joinBooleanArray
   local.set $13
@@ -15915,7 +16045,7 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 940
+   i32.const 945
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15926,17 +16056,17 @@
   i32.const 4528
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $25
+  local.tee $24
   i32.const 4248
   call $~lib/array/Array<i32>#join
-  local.tee $26
+  local.tee $25
   i32.const 4584
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 941
+   i32.const 946
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -15947,130 +16077,11 @@
   i32.const 4616
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $8
+  local.tee $26
   i32.const 4648
   call $~lib/array/Array<u32>#join
   local.tee $27
   i32.const 4584
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 376
-   i32.const 942
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 2
-  i32.const 2
-  i32.const 3
-  i32.const 4672
-  call $~lib/rt/__allocArray
-  call $~lib/rt/pure/__retain
-  local.tee $2
-  i32.const 4696
-  call $~lib/array/Array<i32>#join
-  local.tee $5
-  i32.const 4720
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 376
-   i32.const 943
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 6
-  i32.const 3
-  i32.const 9
-  i32.const 4784
-  call $~lib/rt/__allocArray
-  call $~lib/rt/pure/__retain
-  local.set $10
-  i32.const 4848
-  call $~lib/rt/pure/__retain
-  drop
-  local.get $10
-  i32.load offset=4
-  local.get $10
-  i32.load offset=12
-  call $~lib/util/string/joinFloatArray<f64>
-  local.set $14
-  i32.const 4848
-  call $~lib/rt/pure/__release
-  local.get $14
-  i32.const 6048
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 376
-   i32.const 944
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 3
-  i32.const 2
-  i32.const 13
-  i32.const 6168
-  call $~lib/rt/__allocArray
-  call $~lib/rt/pure/__retain
-  local.tee $4
-  i32.const 4248
-  call $~lib/array/Array<~lib/string/String | null>#join
-  local.tee $6
-  i32.const 6144
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 376
-   i32.const 945
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 3
-  i32.const 2
-  i32.const 19
-  i32.const 0
-  call $~lib/rt/__allocArray
-  local.tee $3
-  i32.load offset=4
-  local.tee $1
-  call $std/array/Ref#constructor
-  local.tee $0
-  call $~lib/rt/pure/__retain
-  i32.store
-  local.get $1
-  i32.const 0
-  call $~lib/rt/pure/__retain
-  i32.store offset=4
-  local.get $1
-  call $std/array/Ref#constructor
-  local.tee $1
-  call $~lib/rt/pure/__retain
-  i32.store offset=8
-  local.get $3
-  call $~lib/rt/pure/__retain
-  local.set $11
-  i32.const 4464
-  call $~lib/rt/pure/__retain
-  drop
-  local.get $11
-  i32.load offset=4
-  local.get $11
-  i32.load offset=12
-  call $~lib/util/string/joinObjectArray<std/array/Ref | null>
-  local.set $3
-  i32.const 4464
-  call $~lib/rt/pure/__release
-  local.get $3
-  i32.const 6248
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -16081,164 +16092,334 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $9
-  call $~lib/rt/pure/__release
-  local.get $13
-  call $~lib/rt/pure/__release
-  local.get $25
-  call $~lib/rt/pure/__release
-  local.get $26
-  call $~lib/rt/pure/__release
-  local.get $8
-  call $~lib/rt/pure/__release
-  local.get $27
-  call $~lib/rt/pure/__release
-  local.get $2
-  call $~lib/rt/pure/__release
-  local.get $5
-  call $~lib/rt/pure/__release
-  local.get $10
-  call $~lib/rt/pure/__release
-  local.get $14
-  call $~lib/rt/pure/__release
-  local.get $4
-  call $~lib/rt/pure/__release
-  local.get $6
-  call $~lib/rt/pure/__release
-  local.get $0
-  call $~lib/rt/pure/__release
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $11
-  call $~lib/rt/pure/__release
-  local.get $3
-  call $~lib/rt/pure/__release
-  i32.const 0
-  i32.const 2
-  i32.const 3
-  i32.const 6328
-  call $~lib/rt/__allocArray
-  call $~lib/rt/pure/__retain
-  local.tee $15
-  call $~lib/rt/pure/__retain
-  local.set $35
-  i32.const 1
-  i32.const 2
-  i32.const 3
-  i32.const 6344
-  call $~lib/rt/__allocArray
-  call $~lib/rt/pure/__retain
-  local.tee $16
-  call $~lib/rt/pure/__retain
-  local.set $36
   i32.const 2
   i32.const 2
   i32.const 3
-  i32.const 6368
+  i32.const 4672
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $17
-  call $~lib/rt/pure/__retain
-  local.set $7
-  i32.const 4
-  i32.const 2
-  i32.const 3
-  i32.const 6392
-  call $~lib/rt/__allocArray
-  call $~lib/rt/pure/__retain
-  local.tee $18
-  call $~lib/rt/pure/__retain
-  local.set $12
-  local.get $35
-  call $~lib/array/Array<i32>#toString
-  local.tee $19
-  i32.const 4248
+  local.tee $11
+  i32.const 4696
+  call $~lib/array/Array<i32>#join
+  local.tee $28
+  i32.const 4720
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 957
+   i32.const 948
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $36
-  call $~lib/array/Array<i32>#toString
-  local.tee $20
+  i32.const 6
+  i32.const 3
+  i32.const 9
+  i32.const 4784
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.set $9
+  i32.const 4848
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $9
+  i32.load offset=4
+  local.get $9
+  i32.load offset=12
+  call $~lib/util/string/joinFloatArray<f64>
+  local.set $15
+  i32.const 4848
+  call $~lib/rt/pure/__release
+  local.get $15
+  i32.const 6048
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 949
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 3
+  i32.const 2
+  i32.const 13
+  i32.const 6168
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  i32.const 4248
+  call $~lib/array/Array<~lib/string/String | null>#join
+  local.tee $5
   i32.const 6144
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 958
+   i32.const 950
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 3
+  i32.const 2
+  i32.const 19
+  i32.const 0
+  call $~lib/rt/__allocArray
+  local.tee $1
+  i32.load offset=4
+  local.tee $0
+  call $std/array/Ref#constructor
+  local.tee $4
+  call $~lib/rt/pure/__retain
+  i32.store
+  local.get $0
+  i32.const 0
+  call $~lib/rt/pure/__retain
+  i32.store offset=4
+  local.get $0
+  call $std/array/Ref#constructor
+  local.tee $6
+  call $~lib/rt/pure/__retain
+  i32.store offset=8
+  local.get $1
+  call $~lib/rt/pure/__retain
+  local.set $10
+  i32.const 4464
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $10
+  i32.load offset=4
+  local.get $10
+  i32.load offset=12
+  call $~lib/util/string/joinReferenceArray<std/array/Ref | null>
+  local.set $16
+  i32.const 4464
+  call $~lib/rt/pure/__release
+  local.get $16
+  i32.const 6248
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 952
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 2
+  i32.const 2
+  i32.const 20
+  i32.const 0
+  call $~lib/rt/__allocArray
+  local.tee $3
+  i32.load offset=4
+  local.tee $1
+  call $std/array/Ref#constructor
+  local.tee $0
+  call $~lib/rt/pure/__retain
+  i32.store
+  local.get $1
+  call $std/array/Ref#constructor
+  local.tee $1
+  call $~lib/rt/pure/__retain
+  i32.store offset=4
+  local.get $3
+  call $~lib/rt/pure/__retain
+  local.set $12
+  i32.const 4464
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $12
+  i32.load offset=4
+  local.get $12
+  i32.load offset=12
+  call $~lib/util/string/joinReferenceArray<std/array/Ref>
+  local.set $3
+  i32.const 4464
+  call $~lib/rt/pure/__release
+  local.get $3
+  i32.const 6328
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 955
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $8
+  call $~lib/rt/pure/__release
+  local.get $13
+  call $~lib/rt/pure/__release
+  local.get $24
+  call $~lib/rt/pure/__release
+  local.get $25
+  call $~lib/rt/pure/__release
+  local.get $26
+  call $~lib/rt/pure/__release
+  local.get $27
+  call $~lib/rt/pure/__release
+  local.get $11
+  call $~lib/rt/pure/__release
+  local.get $28
+  call $~lib/rt/pure/__release
+  local.get $9
+  call $~lib/rt/pure/__release
+  local.get $15
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $16
+  call $~lib/rt/pure/__release
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $12
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  i32.const 0
+  i32.const 2
+  i32.const 3
+  i32.const 6408
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $17
+  call $~lib/rt/pure/__retain
+  local.set $35
+  i32.const 1
+  i32.const 2
+  i32.const 3
+  i32.const 6424
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $18
+  call $~lib/rt/pure/__retain
+  local.set $36
+  i32.const 2
+  i32.const 2
+  i32.const 3
+  i32.const 6448
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $19
+  call $~lib/rt/pure/__retain
+  local.set $7
+  i32.const 4
+  i32.const 2
+  i32.const 3
+  i32.const 6472
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $20
+  call $~lib/rt/pure/__retain
+  local.set $14
+  local.get $35
+  call $~lib/array/Array<i32>#toString
+  local.tee $21
+  i32.const 4248
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 965
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $36
+  call $~lib/array/Array<i32>#toString
+  local.tee $22
+  i32.const 6144
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 966
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
   local.get $7
   call $~lib/array/Array<i32>#toString
-  local.tee $21
-  i32.const 6424
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 376
-   i32.const 959
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $12
-  call $~lib/array/Array<i32>#toString
-  local.tee $22
-  i32.const 6448
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 376
-   i32.const 960
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 3
-  i32.const 0
-  i32.const 20
-  i32.const 6480
-  call $~lib/rt/__allocArray
-  call $~lib/rt/pure/__retain
-  local.set $28
-  i32.const 4464
-  call $~lib/rt/pure/__retain
-  drop
-  local.get $28
-  i32.load offset=4
-  local.get $28
-  i32.load offset=12
-  call $~lib/util/string/joinIntegerArray<i8>
-  local.set $2
-  i32.const 4464
-  call $~lib/rt/pure/__release
-  local.get $2
+  local.tee $23
   i32.const 6504
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 962
+   i32.const 967
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $14
+  call $~lib/array/Array<i32>#toString
+  local.tee $8
+  i32.const 6528
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 968
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 3
+  i32.const 0
+  i32.const 21
+  i32.const 6560
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.set $29
+  i32.const 4464
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $29
+  i32.load offset=4
+  local.get $29
+  i32.load offset=12
+  call $~lib/util/string/joinIntegerArray<i8>
+  local.set $2
+  i32.const 4464
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.const 6584
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 970
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
   i32.const 3
   i32.const 1
-  i32.const 21
-  i32.const 6536
+  i32.const 22
+  i32.const 6616
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   local.set $30
@@ -16254,13 +16435,13 @@
   i32.const 4464
   call $~lib/rt/pure/__release
   local.get $5
-  i32.const 6560
+  i32.const 6640
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 963
+   i32.const 971
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -16268,7 +16449,7 @@
   i32.const 3
   i32.const 3
   i32.const 16
-  i32.const 6600
+  i32.const 6680
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   local.set $31
@@ -16284,21 +16465,21 @@
   i32.const 4464
   call $~lib/rt/pure/__release
   local.get $4
-  i32.const 6640
+  i32.const 6720
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 964
+   i32.const 972
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
   i32.const 4
   i32.const 3
-  i32.const 22
-  i32.const 6704
+  i32.const 23
+  i32.const 6784
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   local.set $32
@@ -16314,13 +16495,13 @@
   i32.const 4464
   call $~lib/rt/pure/__release
   local.get $6
-  i32.const 6752
+  i32.const 6832
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 965
+   i32.const 973
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -16328,21 +16509,21 @@
   i32.const 7
   i32.const 2
   i32.const 13
-  i32.const 6856
+  i32.const 6936
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $23
+  local.tee $9
   call $~lib/rt/pure/__retain
-  local.tee $24
+  local.tee $10
   call $~lib/array/Array<~lib/string/String | null>#toString
-  local.tee $29
-  i32.const 6904
+  local.tee $12
+  i32.const 6984
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 969
+   i32.const 977
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -16350,19 +16531,19 @@
   i32.const 4
   i32.const 2
   i32.const 13
-  i32.const 7000
+  i32.const 7080
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $9
+  local.tee $13
   call $~lib/array/Array<~lib/string/String | null>#toString
-  local.tee $10
-  i32.const 7032
+  local.tee $15
+  i32.const 7112
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 970
+   i32.const 978
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -16378,20 +16559,20 @@
   i32.const 2
   i32.const 2
   i32.const 3
-  i32.const 7064
+  i32.const 7144
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $11
+  local.tee $16
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
   i32.const 2
   i32.const 2
   i32.const 3
-  i32.const 7088
+  i32.const 7168
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $13
+  local.tee $24
   call $~lib/rt/pure/__retain
   i32.store offset=4
   local.get $0
@@ -16404,25 +16585,25 @@
   i32.load offset=4
   local.get $33
   i32.load offset=12
-  call $~lib/util/string/joinArrays<~lib/array/Array<i32>>
+  call $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>>
   local.set $3
   i32.const 4464
   call $~lib/rt/pure/__release
   local.get $3
-  i32.const 7112
+  i32.const 7192
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 973
+   i32.const 981
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
   i32.const 2
   i32.const 2
-  i32.const 23
+  i32.const 24
   i32.const 0
   call $~lib/rt/__allocArray
   local.tee $0
@@ -16431,20 +16612,20 @@
   i32.const 2
   i32.const 0
   i32.const 6
-  i32.const 7144
+  i32.const 7224
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $14
+  local.tee $25
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
   i32.const 2
   i32.const 0
   i32.const 6
-  i32.const 7168
+  i32.const 7248
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $25
+  local.tee $26
   call $~lib/rt/pure/__retain
   i32.store offset=4
   local.get $0
@@ -16457,32 +16638,32 @@
   i32.load offset=4
   local.get $34
   i32.load offset=12
-  call $~lib/util/string/joinArrays<~lib/array/Array<u8>>
+  call $~lib/util/string/joinReferenceArray<~lib/array/Array<u8>>
   local.set $0
   i32.const 4464
   call $~lib/rt/pure/__release
   local.get $0
-  i32.const 7112
+  i32.const 7192
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 976
+   i32.const 984
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
   i32.const 1
   i32.const 2
-  i32.const 25
+  i32.const 26
   i32.const 0
   call $~lib/rt/__allocArray
-  local.tee $26
+  local.tee $27
   i32.load offset=4
   i32.const 1
   i32.const 2
-  i32.const 24
+  i32.const 25
   i32.const 0
   call $~lib/rt/__allocArray
   local.tee $1
@@ -16490,26 +16671,26 @@
   i32.const 1
   i32.const 2
   i32.const 7
-  i32.const 7192
+  i32.const 7272
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $27
+  local.tee $28
   call $~lib/rt/pure/__retain
   i32.store
   local.get $1
   call $~lib/rt/pure/__retain
   i32.store
-  local.get $26
+  local.get $27
   call $~lib/rt/pure/__retain
-  local.set $8
+  local.set $11
   i32.const 4464
   call $~lib/rt/pure/__retain
   drop
-  local.get $8
+  local.get $11
   i32.load offset=4
-  local.get $8
+  local.get $11
   i32.load offset=12
-  call $~lib/util/string/joinArrays<~lib/array/Array<~lib/array/Array<u32>>>
+  call $~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>>
   local.set $1
   i32.const 4464
   call $~lib/rt/pure/__release
@@ -16520,36 +16701,36 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 979
+   i32.const 987
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $15
+  local.get $17
   call $~lib/rt/pure/__release
   local.get $35
   call $~lib/rt/pure/__release
-  local.get $16
+  local.get $18
   call $~lib/rt/pure/__release
   local.get $36
   call $~lib/rt/pure/__release
-  local.get $17
+  local.get $19
   call $~lib/rt/pure/__release
   local.get $7
   call $~lib/rt/pure/__release
-  local.get $18
-  call $~lib/rt/pure/__release
-  local.get $12
-  call $~lib/rt/pure/__release
-  local.get $19
-  call $~lib/rt/pure/__release
   local.get $20
+  call $~lib/rt/pure/__release
+  local.get $14
   call $~lib/rt/pure/__release
   local.get $21
   call $~lib/rt/pure/__release
   local.get $22
   call $~lib/rt/pure/__release
-  local.get $28
+  local.get $23
+  call $~lib/rt/pure/__release
+  local.get $8
+  call $~lib/rt/pure/__release
+  local.get $29
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
@@ -16565,29 +16746,29 @@
   call $~lib/rt/pure/__release
   local.get $6
   call $~lib/rt/pure/__release
-  local.get $23
-  call $~lib/rt/pure/__release
-  local.get $24
-  call $~lib/rt/pure/__release
-  local.get $29
-  call $~lib/rt/pure/__release
   local.get $9
   call $~lib/rt/pure/__release
   local.get $10
   call $~lib/rt/pure/__release
-  local.get $11
+  local.get $12
   call $~lib/rt/pure/__release
   local.get $13
   call $~lib/rt/pure/__release
-  local.get $3
+  local.get $15
   call $~lib/rt/pure/__release
-  local.get $14
+  local.get $16
+  call $~lib/rt/pure/__release
+  local.get $24
+  call $~lib/rt/pure/__release
+  local.get $3
   call $~lib/rt/pure/__release
   local.get $25
   call $~lib/rt/pure/__release
+  local.get $26
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $27
+  local.get $28
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
@@ -16597,10 +16778,10 @@
   call $~lib/rt/pure/__release
   local.get $34
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $11
   call $~lib/rt/pure/__release
  )
- (func $start (; 200 ;) (type $FUNCSIG$v)
+ (func $start (; 202 ;) (type $FUNCSIG$v)
   global.get $~lib/started
   if
    return
@@ -16610,9 +16791,9 @@
   end
   call $start:std/array
  )
- (func $~lib/rt/pure/__visit (; 201 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 203 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
-  i32.const 7412
+  i32.const 7500
   i32.lt_u
   if
    return
@@ -16720,7 +16901,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__visit_impl (; 202 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__visit_impl (; 204 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -16753,25 +16934,31 @@
    end
   end
  )
- (func $~lib/rt/__visit_members (; 203 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (; 205 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   block $block$4$break
    block $switch$1$default
-    block $switch$1$case$27
-     block $switch$1$case$26
-      block $switch$1$case$25
-       block $switch$1$case$21
-        block $switch$1$case$16
-         block $switch$1$case$15
-          block $switch$1$case$14
-           block $switch$1$case$12
-            block $switch$1$case$2
-             local.get $0
-             i32.const 8
-             i32.sub
-             i32.load
-             br_table $switch$1$case$2 $switch$1$case$2 $block$4$break $block$4$break $switch$1$case$2 $block$4$break $block$4$break $block$4$break $block$4$break $block$4$break $switch$1$case$12 $switch$1$case$2 $switch$1$case$14 $switch$1$case$15 $switch$1$case$16 $block$4$break $block$4$break $block$4$break $switch$1$case$2 $switch$1$case$21 $block$4$break $block$4$break $block$4$break $switch$1$case$25 $switch$1$case$26 $switch$1$case$27 $switch$1$default
+    block $switch$1$case$28
+     block $switch$1$case$27
+      block $switch$1$case$26
+       block $switch$1$case$22
+        block $switch$1$case$21
+         block $switch$1$case$16
+          block $switch$1$case$15
+           block $switch$1$case$14
+            block $switch$1$case$12
+             block $switch$1$case$2
+              local.get $0
+              i32.const 8
+              i32.sub
+              i32.load
+              br_table $switch$1$case$2 $switch$1$case$2 $block$4$break $block$4$break $switch$1$case$2 $block$4$break $block$4$break $block$4$break $block$4$break $block$4$break $switch$1$case$12 $switch$1$case$2 $switch$1$case$14 $switch$1$case$15 $switch$1$case$16 $block$4$break $block$4$break $block$4$break $switch$1$case$2 $switch$1$case$21 $switch$1$case$22 $block$4$break $block$4$break $block$4$break $switch$1$case$26 $switch$1$case$27 $switch$1$case$28 $switch$1$default
+             end
+             return
             end
-            return
+            local.get $0
+            local.get $1
+            call $~lib/array/Array<~lib/array/Array<i32>>#__visit_impl
+            br $block$4$break
            end
            local.get $0
            local.get $1
@@ -16824,7 +17011,7 @@
    call $~lib/rt/pure/__visit
   end
  )
- (func $null (; 204 ;) (type $FUNCSIG$v)
+ (func $null (; 206 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -9086,20 +9086,21 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/string/joinStringArray (; 173 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/string/String | null> (; 173 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $7
+  local.tee $5
   i32.const 0
   i32.lt_s
   if
@@ -9109,53 +9110,106 @@
    call $~lib/rt/pure/__release
    return
   end
-  local.get $7
+  local.get $5
   i32.eqz
   if
    local.get $0
    i32.load
    local.tee $0
-   i32.eqz
    if
-    i32.const 4248
-    local.set $0
+    local.get $0
+    call $~lib/rt/pure/__retain
+    drop
+    i32.const 0
+    call $~lib/rt/pure/__release
    end
    local.get $0
-   call $~lib/rt/pure/__retain
+   if (result i32)
+    local.get $0
+    call $~lib/rt/pure/__retain
+   else
+    i32.const 4248
+    call $~lib/rt/pure/__retain
+   end
    local.get $2
+   call $~lib/rt/pure/__release
+   local.get $0
    call $~lib/rt/pure/__release
    return
   end
+  i32.const 4248
+  call $~lib/rt/pure/__retain
+  local.set $1
+  local.get $2
+  call $~lib/string/String#get:length
+  local.set $8
   loop $loop|0
-   block $break|0
-    local.get $6
-    local.get $1
-    i32.ge_s
-    br_if $break|0
+   local.get $6
+   local.get $5
+   i32.lt_s
+   if
+    local.get $4
+    local.set $3
     local.get $3
-    local.tee $4
     local.get $6
     i32.const 2
     i32.shl
     local.get $0
     i32.add
     i32.load
-    local.tee $3
+    local.tee $4
     i32.ne
     if
-     local.get $3
+     local.get $4
      call $~lib/rt/pure/__retain
      drop
-     local.get $4
+     local.get $3
      call $~lib/rt/pure/__release
     end
-    local.get $3
+    local.get $4
     if
+     local.get $1
+     local.set $3
+     local.get $4
+     call $~lib/rt/pure/__retain
+     local.tee $1
      local.get $3
-     call $~lib/string/String#get:length
-     local.get $5
-     i32.add
-     local.set $5
+     local.get $3
+     local.get $1
+     call $~lib/string/String.__concat
+     local.tee $9
+     local.tee $1
+     i32.ne
+     if
+      local.get $1
+      call $~lib/rt/pure/__retain
+      drop
+      local.get $3
+      call $~lib/rt/pure/__release
+     end
+     call $~lib/rt/pure/__release
+     local.get $9
+     call $~lib/rt/pure/__release
+    end
+    local.get $8
+    if
+     local.get $1
+     local.tee $3
+     local.get $2
+     call $~lib/string/String.__concat
+     local.tee $7
+     local.tee $1
+     local.get $3
+     i32.ne
+     if
+      local.get $1
+      call $~lib/rt/pure/__retain
+      drop
+      local.get $3
+      call $~lib/rt/pure/__release
+     end
+     local.get $7
+     call $~lib/rt/pure/__release
     end
     local.get $6
     i32.const 1
@@ -9164,124 +9218,52 @@
     br $loop|0
    end
   end
-  i32.const 0
-  local.set $4
-  local.get $2
-  call $~lib/string/String#get:length
-  local.tee $8
-  local.get $7
-  i32.mul
   local.get $5
-  i32.add
-  i32.const 1
-  i32.shl
-  i32.const 1
-  call $~lib/rt/tlsf/__alloc
-  local.set $5
-  i32.const 0
-  local.set $6
-  loop $loop|1
-   block $break|1
-    local.get $6
-    local.get $7
-    i32.ge_s
-    br_if $break|1
-    local.get $3
-    local.tee $1
-    local.get $6
-    i32.const 2
-    i32.shl
-    local.get $0
-    i32.add
-    i32.load
-    local.tee $3
-    i32.ne
-    if
-     local.get $3
-     call $~lib/rt/pure/__retain
-     drop
-     local.get $1
-     call $~lib/rt/pure/__release
-    end
-    local.get $3
-    if
-     local.get $4
-     i32.const 1
-     i32.shl
-     local.get $5
-     i32.add
-     local.get $3
-     local.get $3
-     call $~lib/string/String#get:length
-     local.tee $1
-     i32.const 1
-     i32.shl
-     call $~lib/memory/memory.copy
-     local.get $1
-     local.get $4
-     i32.add
-     local.set $4
-    end
-    local.get $8
-    if
-     local.get $4
-     i32.const 1
-     i32.shl
-     local.get $5
-     i32.add
-     local.get $2
-     local.get $8
-     i32.const 1
-     i32.shl
-     call $~lib/memory/memory.copy
-     local.get $4
-     local.get $8
-     i32.add
-     local.set $4
-    end
-    local.get $6
-    i32.const 1
-    i32.add
-    local.set $6
-    br $loop|1
-   end
-  end
-  local.get $7
   i32.const 2
   i32.shl
   local.get $0
   i32.add
   i32.load
-  local.tee $0
-  local.get $3
+  local.tee $3
+  local.get $4
   i32.ne
   if
-   local.get $0
+   local.get $3
    call $~lib/rt/pure/__retain
    drop
-   local.get $3
+   local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $0
+  local.get $3
   if
-   local.get $4
-   i32.const 1
-   i32.shl
+   local.get $1
+   local.set $0
+   local.get $3
+   call $~lib/rt/pure/__retain
+   local.tee $1
+   local.get $0
+   local.get $0
+   local.get $1
+   call $~lib/string/String.__concat
+   local.tee $5
+   local.tee $1
+   i32.ne
+   if
+    local.get $1
+    call $~lib/rt/pure/__retain
+    drop
+    local.get $0
+    call $~lib/rt/pure/__release
+   end
+   call $~lib/rt/pure/__release
    local.get $5
-   i32.add
-   local.get $0
-   local.get $0
-   call $~lib/string/String#get:length
-   i32.const 1
-   i32.shl
-   call $~lib/memory/memory.copy
+   call $~lib/rt/pure/__release
   end
-  local.get $5
-  call $~lib/rt/pure/__retain
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $0
+  local.get $3
   call $~lib/rt/pure/__release
+  local.get $1
  )
  (func $~lib/array/Array<~lib/string/String | null>#join (; 174 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
@@ -9292,7 +9274,7 @@
   local.get $0
   i32.load offset=12
   local.get $1
-  call $~lib/util/string/joinStringArray
+  call $~lib/util/string/joinReferenceArray<~lib/string/String | null>
   local.get $1
   call $~lib/rt/pure/__release
  )

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -9086,7 +9086,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/string/joinStringArray (; 173 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinStringArray<~lib/string/String | null> (; 173 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9099,7 +9099,7 @@
   local.get $1
   i32.const 1
   i32.sub
-  local.tee $6
+  local.tee $7
   i32.const 0
   i32.lt_s
   if
@@ -9109,166 +9109,174 @@
    call $~lib/rt/pure/__release
    return
   end
-  local.get $6
+  local.get $7
   i32.eqz
   if
    local.get $0
    i32.load
+   local.tee $0
+   i32.eqz
+   if
+    unreachable
+   end
+   local.get $0
+   i32.eqz
+   if
+    i32.const 4248
+    local.set $0
+   end
+   local.get $0
    call $~lib/rt/pure/__retain
    local.get $2
+   call $~lib/rt/pure/__release
+   i32.const 0
    call $~lib/rt/pure/__release
    return
   end
   local.get $2
   call $~lib/string/String#get:length
   local.set $8
-  i32.const 0
-  local.set $1
-  local.get $6
-  i32.const 1
-  i32.add
-  local.set $5
   loop $loop|0
    block $break|0
-    local.get $3
-    local.get $5
+    local.get $6
+    local.get $1
     i32.ge_s
     br_if $break|0
-    local.get $1
-    local.tee $7
     local.get $3
+    local.tee $4
+    local.get $6
     i32.const 2
     i32.shl
     local.get $0
     i32.add
     i32.load
-    local.tee $1
+    local.tee $3
     i32.ne
     if
-     local.get $1
+     local.get $3
      call $~lib/rt/pure/__retain
      drop
-     local.get $7
+     local.get $4
      call $~lib/rt/pure/__release
     end
-    local.get $1
-    if
-     local.get $1
-     call $~lib/string/String#get:length
-     local.get $4
-     i32.add
-     local.set $4
-    end
     local.get $3
+    if
+     local.get $3
+     call $~lib/string/String#get:length
+     local.get $5
+     i32.add
+     local.set $5
+    end
+    local.get $6
     i32.const 1
     i32.add
-    local.set $3
+    local.set $6
     br $loop|0
    end
   end
   i32.const 0
-  local.set $3
-  local.get $6
+  local.set $4
+  local.get $7
   local.get $8
   i32.mul
-  local.get $4
+  local.get $5
   i32.add
   i32.const 1
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $4
-  i32.const 0
   local.set $5
+  i32.const 0
+  local.set $6
   loop $loop|1
    block $break|1
-    local.get $5
     local.get $6
+    local.get $7
     i32.ge_s
     br_if $break|1
-    local.get $1
-    local.tee $7
-    local.get $5
+    local.get $3
+    local.tee $1
+    local.get $6
     i32.const 2
     i32.shl
     local.get $0
     i32.add
     i32.load
-    local.tee $1
+    local.tee $3
     i32.ne
     if
-     local.get $1
+     local.get $3
      call $~lib/rt/pure/__retain
      drop
-     local.get $7
+     local.get $1
      call $~lib/rt/pure/__release
     end
-    local.get $1
+    local.get $3
     if
-     local.get $3
+     local.get $4
      i32.const 1
      i32.shl
-     local.get $4
+     local.get $5
      i32.add
-     local.get $1
-     local.get $1
+     local.get $3
+     local.get $3
      call $~lib/string/String#get:length
-     local.tee $7
+     local.tee $1
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $3
-     local.get $7
+     local.get $1
+     local.get $4
      i32.add
-     local.set $3
+     local.set $4
     end
     local.get $8
     if
-     local.get $3
+     local.get $4
      i32.const 1
      i32.shl
-     local.get $4
+     local.get $5
      i32.add
      local.get $2
      local.get $8
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $3
+     local.get $4
      local.get $8
      i32.add
-     local.set $3
+     local.set $4
     end
-    local.get $5
+    local.get $6
     i32.const 1
     i32.add
-    local.set $5
+    local.set $6
     br $loop|1
    end
   end
-  local.get $6
+  local.get $7
   i32.const 2
   i32.shl
   local.get $0
   i32.add
   i32.load
   local.tee $0
-  local.get $1
+  local.get $3
   i32.ne
   if
    local.get $0
    call $~lib/rt/pure/__retain
    drop
-   local.get $1
+   local.get $3
    call $~lib/rt/pure/__release
   end
   local.get $0
   if
-   local.get $3
+   local.get $4
    i32.const 1
    i32.shl
-   local.get $4
+   local.get $5
    i32.add
    local.get $0
    local.get $0
@@ -9281,7 +9289,7 @@
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $5
  )
  (func $~lib/array/Array<~lib/string/String | null>#join (; 174 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
@@ -9292,7 +9300,7 @@
   local.get $0
   i32.load offset=12
   local.get $1
-  call $~lib/util/string/joinStringArray
+  call $~lib/util/string/joinStringArray<~lib/string/String | null>
   local.get $1
   call $~lib/rt/pure/__release
  )

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -9086,7 +9086,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/string/joinStringArray<~lib/string/String | null> (; 173 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinStringArray (; 173 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9115,11 +9115,6 @@
    local.get $0
    i32.load
    local.tee $0
-   i32.eqz
-   if
-    unreachable
-   end
-   local.get $0
    i32.eqz
    if
     i32.const 4248
@@ -9300,7 +9295,7 @@
   local.get $0
   i32.load offset=12
   local.get $1
-  call $~lib/util/string/joinStringArray<~lib/string/String | null>
+  call $~lib/util/string/joinStringArray
   local.get $1
   call $~lib/rt/pure/__release
  )

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -9124,13 +9124,8 @@
    call $~lib/rt/pure/__retain
    local.get $2
    call $~lib/rt/pure/__release
-   i32.const 0
-   call $~lib/rt/pure/__release
    return
   end
-  local.get $2
-  call $~lib/string/String#get:length
-  local.set $8
   loop $loop|0
    block $break|0
     local.get $6
@@ -9171,8 +9166,10 @@
   end
   i32.const 0
   local.set $4
+  local.get $2
+  call $~lib/string/String#get:length
+  local.tee $8
   local.get $7
-  local.get $8
   i32.mul
   local.get $5
   i32.add

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -9177,7 +9177,6 @@
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
   local.set $5
   i32.const 0
   local.set $6
@@ -9277,11 +9276,12 @@
    i32.shl
    call $~lib/memory/memory.copy
   end
+  local.get $5
+  call $~lib/rt/pure/__retain
   local.get $2
   call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
-  local.get $5
  )
  (func $~lib/array/Array<~lib/string/String | null>#join (; 174 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1

--- a/tests/compiler/std/array.ts
+++ b/tests/compiler/std/array.ts
@@ -934,7 +934,12 @@ function assertSortedDefault<T>(arr: Array<T>): void {
 
 // Array#join //////////////////////////////////////////////////////////////////////////////////////
 
-class Ref { constructor() {} }
+class Ref {
+  constructor() {}
+  toString(): string {
+    return "[object Object]";
+  }
+}
 
 {
   assert((<bool[]>[true, false]).join() == "true,false");
@@ -945,6 +950,9 @@ class Ref { constructor() {} }
   assert((<Array<string | null>>["", "1", null]).join("") == "1");
   let refArr: (Ref | null)[] = [new Ref(), null, new Ref()];
   assert(refArr.join() == "[object Object],,[object Object]");
+
+  let refArr2: Ref[] = [new Ref(), new Ref()];
+  assert(refArr2.join() == "[object Object],[object Object]");
 }
 
 // Array#toString //////////////////////////////////////////////////////////////////////////////////
@@ -964,7 +972,7 @@ class Ref { constructor() {} }
   assert((<u64[]>[1, 0xFFFFFFFFFFFFFFFF, 0]).toString() == "1,18446744073709551615,0");
   assert((<i64[]>[-1, -1234567890123456, 0, i64.MAX_VALUE]).toString() == "-1,-1234567890123456,0,9223372036854775807");
 
-  let arrStr: (string | null)[] = ["", "a", "a", "ab", "b", "ba", null]
+  let arrStr: (string | null)[] = ["", "a", "a", "ab", "b", "ba", null];
 
   assert(arrStr.toString() == ",a,a,ab,b,ba,");
   assert((<Array<string | null>>["1", "2", null, "4"]).toString() == "1,2,,4");

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -14387,8 +14387,6 @@
    local.get $4
    return
   end
-  i32.const 0
-  local.set $5
   local.get $3
   i32.eqz
   if
@@ -14404,16 +14402,13 @@
    local.set $4
    local.get $2
    call $~lib/rt/pure/__release
-   local.get $5
-   call $~lib/rt/pure/__release
    local.get $4
    return
   end
-  local.get $2
-  call $~lib/string/String#get:length
-  local.set $6
   i32.const 0
-  local.set $7
+  local.set $5
+  i32.const 0
+  local.set $6
   block $break|0
    i32.const 0
    local.set $4
@@ -14429,28 +14424,28 @@
     i32.shl
     i32.add
     i32.load
+    local.tee $7
+    local.get $6
     local.tee $8
-    local.get $5
-    local.tee $9
-    i32.ne
-    if
-     local.get $8
-     call $~lib/rt/pure/__retain
-     drop
-     local.get $9
-     call $~lib/rt/pure/__release
-    end
-    local.get $8
-    local.set $5
-    local.get $5
-    i32.const 0
     i32.ne
     if
      local.get $7
+     call $~lib/rt/pure/__retain
+     drop
+     local.get $8
+     call $~lib/rt/pure/__release
+    end
+    local.get $7
+    local.set $6
+    local.get $6
+    i32.const 0
+    i32.ne
+    if
      local.get $5
+     local.get $6
      call $~lib/string/String#get:length
      i32.add
-     local.set $7
+     local.set $5
     end
     local.get $4
     i32.const 1
@@ -14461,9 +14456,12 @@
    unreachable
   end
   i32.const 0
+  local.set $9
+  local.get $2
+  call $~lib/string/String#get:length
   local.set $10
-  local.get $7
-  local.get $6
+  local.get $5
+  local.get $10
   local.get $3
   i32.mul
   i32.add
@@ -14488,57 +14486,57 @@
     i32.shl
     i32.add
     i32.load
-    local.tee $9
-    local.get $5
     local.tee $8
+    local.get $6
+    local.tee $7
     i32.ne
     if
-     local.get $9
+     local.get $8
      call $~lib/rt/pure/__retain
      drop
-     local.get $8
+     local.get $7
      call $~lib/rt/pure/__release
     end
-    local.get $9
-    local.set $5
-    local.get $5
+    local.get $8
+    local.set $6
+    local.get $6
     i32.const 0
     i32.ne
     if
-     local.get $5
+     local.get $6
      call $~lib/string/String#get:length
-     local.set $9
+     local.set $8
      local.get $11
-     local.get $10
+     local.get $9
      i32.const 1
      i32.shl
      i32.add
-     local.get $5
-     local.get $9
+     local.get $6
+     local.get $8
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $10
      local.get $9
+     local.get $8
      i32.add
-     local.set $10
+     local.set $9
     end
-    local.get $6
+    local.get $10
     if
      local.get $11
-     local.get $10
+     local.get $9
      i32.const 1
      i32.shl
      i32.add
      local.get $2
-     local.get $6
+     local.get $10
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
+     local.get $9
      local.get $10
-     local.get $6
      i32.add
-     local.set $10
+     local.set $9
     end
     local.get $4
     i32.const 1
@@ -14554,42 +14552,42 @@
   i32.shl
   i32.add
   i32.load
-  local.tee $8
-  local.get $5
+  local.tee $7
+  local.get $6
   local.tee $4
   i32.ne
   if
-   local.get $8
+   local.get $7
    call $~lib/rt/pure/__retain
    drop
    local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $8
-  local.set $5
-  local.get $5
+  local.get $7
+  local.set $6
+  local.get $6
   i32.const 0
   i32.ne
   if
    local.get $11
-   local.get $10
+   local.get $9
    i32.const 1
    i32.shl
    i32.add
-   local.get $5
-   local.get $5
+   local.get $6
+   local.get $6
    call $~lib/string/String#get:length
    i32.const 1
    i32.shl
    call $~lib/memory/memory.copy
   end
   local.get $11
-  local.set $8
+  local.set $7
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $5
+  local.get $6
   call $~lib/rt/pure/__release
-  local.get $8
+  local.get $7
  )
  (func $~lib/array/Array<~lib/string/String | null>#join (; 255 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -14915,7 +14915,15 @@
    local.get $4
    local.set $5
    local.get $5
-   call $std/array/Ref#toString
+   i32.const 0
+   i32.ne
+   if (result i32)
+    local.get $5
+    call $std/array/Ref#toString
+   else
+    i32.const 4248
+    call $~lib/rt/pure/__retain
+   end
    local.set $4
    local.get $2
    call $~lib/rt/pure/__release
@@ -14958,29 +14966,34 @@
     end
     local.get $6
     local.set $5
-    local.get $7
     local.get $5
-    call $std/array/Ref#toString
-    local.tee $6
-    call $~lib/string/String.__concat
-    local.tee $9
-    local.tee $10
-    local.get $7
-    local.tee $11
+    i32.const 0
     i32.ne
     if
+     local.get $7
+     local.get $5
+     call $std/array/Ref#toString
+     local.tee $6
+     call $~lib/string/String.__concat
+     local.tee $9
+     local.tee $10
+     local.get $7
+     local.tee $11
+     i32.ne
+     if
+      local.get $10
+      call $~lib/rt/pure/__retain
+      drop
+      local.get $11
+      call $~lib/rt/pure/__release
+     end
      local.get $10
-     call $~lib/rt/pure/__retain
-     drop
-     local.get $11
+     local.set $7
+     local.get $6
+     call $~lib/rt/pure/__release
+     local.get $9
      call $~lib/rt/pure/__release
     end
-    local.get $10
-    local.set $7
-    local.get $6
-    call $~lib/rt/pure/__release
-    local.get $9
-    call $~lib/rt/pure/__release
     local.get $8
     if
      local.get $7
@@ -15030,29 +15043,34 @@
   end
   local.get $10
   local.set $5
-  local.get $7
   local.get $5
-  call $std/array/Ref#toString
-  local.tee $10
-  call $~lib/string/String.__concat
-  local.tee $4
-  local.tee $6
-  local.get $7
-  local.tee $9
+  i32.const 0
   i32.ne
   if
+   local.get $7
+   local.get $5
+   call $std/array/Ref#toString
+   local.tee $10
+   call $~lib/string/String.__concat
+   local.tee $4
+   local.tee $6
+   local.get $7
+   local.tee $9
+   i32.ne
+   if
+    local.get $6
+    call $~lib/rt/pure/__retain
+    drop
+    local.get $9
+    call $~lib/rt/pure/__release
+   end
    local.get $6
-   call $~lib/rt/pure/__retain
-   drop
-   local.get $9
+   local.set $7
+   local.get $10
+   call $~lib/rt/pure/__release
+   local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $6
-  local.set $7
-  local.get $10
-  call $~lib/rt/pure/__release
-  local.get $4
-  call $~lib/rt/pure/__release
   local.get $7
   local.set $4
   local.get $2
@@ -16486,7 +16504,15 @@
    local.get $4
    local.set $5
    local.get $5
-   call $~lib/array/Array<i32>#toString
+   i32.const 0
+   i32.ne
+   if (result i32)
+    local.get $5
+    call $~lib/array/Array<i32>#toString
+   else
+    i32.const 4248
+    call $~lib/rt/pure/__retain
+   end
    local.set $4
    local.get $2
    call $~lib/rt/pure/__release
@@ -16529,29 +16555,34 @@
     end
     local.get $6
     local.set $5
-    local.get $7
     local.get $5
-    call $~lib/array/Array<i32>#toString
-    local.tee $6
-    call $~lib/string/String.__concat
-    local.tee $9
-    local.tee $10
-    local.get $7
-    local.tee $11
+    i32.const 0
     i32.ne
     if
+     local.get $7
+     local.get $5
+     call $~lib/array/Array<i32>#toString
+     local.tee $6
+     call $~lib/string/String.__concat
+     local.tee $9
+     local.tee $10
+     local.get $7
+     local.tee $11
+     i32.ne
+     if
+      local.get $10
+      call $~lib/rt/pure/__retain
+      drop
+      local.get $11
+      call $~lib/rt/pure/__release
+     end
      local.get $10
-     call $~lib/rt/pure/__retain
-     drop
-     local.get $11
+     local.set $7
+     local.get $6
+     call $~lib/rt/pure/__release
+     local.get $9
      call $~lib/rt/pure/__release
     end
-    local.get $10
-    local.set $7
-    local.get $6
-    call $~lib/rt/pure/__release
-    local.get $9
-    call $~lib/rt/pure/__release
     local.get $8
     if
      local.get $7
@@ -16601,29 +16632,34 @@
   end
   local.get $10
   local.set $5
-  local.get $7
   local.get $5
-  call $~lib/array/Array<i32>#toString
-  local.tee $10
-  call $~lib/string/String.__concat
-  local.tee $4
-  local.tee $6
-  local.get $7
-  local.tee $9
+  i32.const 0
   i32.ne
   if
+   local.get $7
+   local.get $5
+   call $~lib/array/Array<i32>#toString
+   local.tee $10
+   call $~lib/string/String.__concat
+   local.tee $4
+   local.tee $6
+   local.get $7
+   local.tee $9
+   i32.ne
+   if
+    local.get $6
+    call $~lib/rt/pure/__retain
+    drop
+    local.get $9
+    call $~lib/rt/pure/__release
+   end
    local.get $6
-   call $~lib/rt/pure/__retain
-   drop
-   local.get $9
+   local.set $7
+   local.get $10
+   call $~lib/rt/pure/__release
+   local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $6
-  local.set $7
-  local.get $10
-  call $~lib/rt/pure/__release
-  local.get $4
-  call $~lib/rt/pure/__release
   local.get $7
   local.set $4
   local.get $2
@@ -16936,7 +16972,15 @@
    local.get $4
    local.set $5
    local.get $5
-   call $~lib/array/Array<u8>#toString
+   i32.const 0
+   i32.ne
+   if (result i32)
+    local.get $5
+    call $~lib/array/Array<u8>#toString
+   else
+    i32.const 4248
+    call $~lib/rt/pure/__retain
+   end
    local.set $4
    local.get $2
    call $~lib/rt/pure/__release
@@ -16979,29 +17023,34 @@
     end
     local.get $6
     local.set $5
-    local.get $7
     local.get $5
-    call $~lib/array/Array<u8>#toString
-    local.tee $6
-    call $~lib/string/String.__concat
-    local.tee $9
-    local.tee $10
-    local.get $7
-    local.tee $11
+    i32.const 0
     i32.ne
     if
+     local.get $7
+     local.get $5
+     call $~lib/array/Array<u8>#toString
+     local.tee $6
+     call $~lib/string/String.__concat
+     local.tee $9
+     local.tee $10
+     local.get $7
+     local.tee $11
+     i32.ne
+     if
+      local.get $10
+      call $~lib/rt/pure/__retain
+      drop
+      local.get $11
+      call $~lib/rt/pure/__release
+     end
      local.get $10
-     call $~lib/rt/pure/__retain
-     drop
-     local.get $11
+     local.set $7
+     local.get $6
+     call $~lib/rt/pure/__release
+     local.get $9
      call $~lib/rt/pure/__release
     end
-    local.get $10
-    local.set $7
-    local.get $6
-    call $~lib/rt/pure/__release
-    local.get $9
-    call $~lib/rt/pure/__release
     local.get $8
     if
      local.get $7
@@ -17051,29 +17100,34 @@
   end
   local.get $10
   local.set $5
-  local.get $7
   local.get $5
-  call $~lib/array/Array<u8>#toString
-  local.tee $10
-  call $~lib/string/String.__concat
-  local.tee $4
-  local.tee $6
-  local.get $7
-  local.tee $9
+  i32.const 0
   i32.ne
   if
+   local.get $7
+   local.get $5
+   call $~lib/array/Array<u8>#toString
+   local.tee $10
+   call $~lib/string/String.__concat
+   local.tee $4
+   local.tee $6
+   local.get $7
+   local.tee $9
+   i32.ne
+   if
+    local.get $6
+    call $~lib/rt/pure/__retain
+    drop
+    local.get $9
+    call $~lib/rt/pure/__release
+   end
    local.get $6
-   call $~lib/rt/pure/__retain
-   drop
-   local.get $9
+   local.set $7
+   local.get $10
+   call $~lib/rt/pure/__release
+   local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $6
-  local.set $7
-  local.get $10
-  call $~lib/rt/pure/__release
-  local.get $4
-  call $~lib/rt/pure/__release
   local.get $7
   local.set $4
   local.get $2
@@ -17165,7 +17219,15 @@
    local.get $4
    local.set $5
    local.get $5
-   call $~lib/array/Array<u32>#toString
+   i32.const 0
+   i32.ne
+   if (result i32)
+    local.get $5
+    call $~lib/array/Array<u32>#toString
+   else
+    i32.const 4248
+    call $~lib/rt/pure/__retain
+   end
    local.set $4
    local.get $2
    call $~lib/rt/pure/__release
@@ -17208,29 +17270,34 @@
     end
     local.get $6
     local.set $5
-    local.get $7
     local.get $5
-    call $~lib/array/Array<u32>#toString
-    local.tee $6
-    call $~lib/string/String.__concat
-    local.tee $9
-    local.tee $10
-    local.get $7
-    local.tee $11
+    i32.const 0
     i32.ne
     if
+     local.get $7
+     local.get $5
+     call $~lib/array/Array<u32>#toString
+     local.tee $6
+     call $~lib/string/String.__concat
+     local.tee $9
+     local.tee $10
+     local.get $7
+     local.tee $11
+     i32.ne
+     if
+      local.get $10
+      call $~lib/rt/pure/__retain
+      drop
+      local.get $11
+      call $~lib/rt/pure/__release
+     end
      local.get $10
-     call $~lib/rt/pure/__retain
-     drop
-     local.get $11
+     local.set $7
+     local.get $6
+     call $~lib/rt/pure/__release
+     local.get $9
      call $~lib/rt/pure/__release
     end
-    local.get $10
-    local.set $7
-    local.get $6
-    call $~lib/rt/pure/__release
-    local.get $9
-    call $~lib/rt/pure/__release
     local.get $8
     if
      local.get $7
@@ -17280,29 +17347,34 @@
   end
   local.get $10
   local.set $5
-  local.get $7
   local.get $5
-  call $~lib/array/Array<u32>#toString
-  local.tee $10
-  call $~lib/string/String.__concat
-  local.tee $4
-  local.tee $6
-  local.get $7
-  local.tee $9
+  i32.const 0
   i32.ne
   if
+   local.get $7
+   local.get $5
+   call $~lib/array/Array<u32>#toString
+   local.tee $10
+   call $~lib/string/String.__concat
+   local.tee $4
+   local.tee $6
+   local.get $7
+   local.tee $9
+   i32.ne
+   if
+    local.get $6
+    call $~lib/rt/pure/__retain
+    drop
+    local.get $9
+    call $~lib/rt/pure/__release
+   end
    local.get $6
-   call $~lib/rt/pure/__retain
-   drop
-   local.get $9
+   local.set $7
+   local.get $10
+   call $~lib/rt/pure/__release
+   local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $6
-  local.set $7
-  local.get $10
-  call $~lib/rt/pure/__release
-  local.get $4
-  call $~lib/rt/pure/__release
   local.get $7
   local.set $4
   local.get $2
@@ -17389,7 +17461,15 @@
    local.get $4
    local.set $5
    local.get $5
-   call $~lib/array/Array<~lib/array/Array<u32>>#toString
+   i32.const 0
+   i32.ne
+   if (result i32)
+    local.get $5
+    call $~lib/array/Array<~lib/array/Array<u32>>#toString
+   else
+    i32.const 4248
+    call $~lib/rt/pure/__retain
+   end
    local.set $4
    local.get $2
    call $~lib/rt/pure/__release
@@ -17432,29 +17512,34 @@
     end
     local.get $6
     local.set $5
-    local.get $7
     local.get $5
-    call $~lib/array/Array<~lib/array/Array<u32>>#toString
-    local.tee $6
-    call $~lib/string/String.__concat
-    local.tee $9
-    local.tee $10
-    local.get $7
-    local.tee $11
+    i32.const 0
     i32.ne
     if
+     local.get $7
+     local.get $5
+     call $~lib/array/Array<~lib/array/Array<u32>>#toString
+     local.tee $6
+     call $~lib/string/String.__concat
+     local.tee $9
+     local.tee $10
+     local.get $7
+     local.tee $11
+     i32.ne
+     if
+      local.get $10
+      call $~lib/rt/pure/__retain
+      drop
+      local.get $11
+      call $~lib/rt/pure/__release
+     end
      local.get $10
-     call $~lib/rt/pure/__retain
-     drop
-     local.get $11
+     local.set $7
+     local.get $6
+     call $~lib/rt/pure/__release
+     local.get $9
      call $~lib/rt/pure/__release
     end
-    local.get $10
-    local.set $7
-    local.get $6
-    call $~lib/rt/pure/__release
-    local.get $9
-    call $~lib/rt/pure/__release
     local.get $8
     if
      local.get $7
@@ -17504,29 +17589,34 @@
   end
   local.get $10
   local.set $5
-  local.get $7
   local.get $5
-  call $~lib/array/Array<~lib/array/Array<u32>>#toString
-  local.tee $10
-  call $~lib/string/String.__concat
-  local.tee $4
-  local.tee $6
-  local.get $7
-  local.tee $9
+  i32.const 0
   i32.ne
   if
+   local.get $7
+   local.get $5
+   call $~lib/array/Array<~lib/array/Array<u32>>#toString
+   local.tee $10
+   call $~lib/string/String.__concat
+   local.tee $4
+   local.tee $6
+   local.get $7
+   local.tee $9
+   i32.ne
+   if
+    local.get $6
+    call $~lib/rt/pure/__retain
+    drop
+    local.get $9
+    call $~lib/rt/pure/__release
+   end
    local.get $6
-   call $~lib/rt/pure/__retain
-   drop
-   local.get $9
+   local.set $7
+   local.get $10
+   call $~lib/rt/pure/__release
+   local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $6
-  local.set $7
-  local.get $10
-  call $~lib/rt/pure/__release
-  local.get $4
-  call $~lib/rt/pure/__release
   local.get $7
   local.set $4
   local.get $2

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -14469,7 +14469,6 @@
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
   local.set $11
   block $break|1
    i32.const 0
@@ -14582,6 +14581,7 @@
    call $~lib/memory/memory.copy
   end
   local.get $11
+  call $~lib/rt/pure/__retain
   local.set $7
   local.get $2
   call $~lib/rt/pure/__release

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -180,33 +180,34 @@
  (data (i32.const 6600) "\0c\00\00\00\01\00\00\00\00\00\00\00\0c\00\00\00\98\10\00\00\c0\19\00\00\00\00\00\00")
  (data (i32.const 6632) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00[\00o\00b\00j\00e\00c\00t\00 \00O\00b\00j\00e\00c\00t\00]\00")
  (data (i32.const 6680) "@\00\00\00\01\00\00\00\01\00\00\00@\00\00\00[\00o\00b\00j\00e\00c\00t\00 \00O\00b\00j\00e\00c\00t\00]\00,\00,\00[\00o\00b\00j\00e\00c\00t\00 \00O\00b\00j\00e\00c\00t\00]\00")
- (data (i32.const 6760) "\00\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00")
- (data (i32.const 6776) "\04\00\00\00\01\00\00\00\00\00\00\00\04\00\00\00\01\00\00\00")
- (data (i32.const 6800) "\08\00\00\00\01\00\00\00\00\00\00\00\08\00\00\00\01\00\00\00\02\00\00\00")
- (data (i32.const 6824) "\10\00\00\00\01\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00\03\00\00\00")
- (data (i32.const 6856) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\001\00,\002\00")
- (data (i32.const 6880) "\0e\00\00\00\01\00\00\00\01\00\00\00\0e\00\00\000\00,\001\00,\002\00,\003\00")
- (data (i32.const 6912) "\03\00\00\00\01\00\00\00\00\00\00\00\03\00\00\00\01\ff\00")
- (data (i32.const 6936) "\0c\00\00\00\01\00\00\00\01\00\00\00\0c\00\00\001\00,\00-\001\00,\000\00")
- (data (i32.const 6968) "\06\00\00\00\01\00\00\00\00\00\00\00\06\00\00\00\01\00\ff\ff\00\00")
- (data (i32.const 6992) "\12\00\00\00\01\00\00\00\01\00\00\00\12\00\00\001\00,\006\005\005\003\005\00,\000\00")
- (data (i32.const 7032) "\18\00\00\00\01\00\00\00\00\00\00\00\18\00\00\00\01\00\00\00\00\00\00\00\ff\ff\ff\ff\ff\ff\ff\ff\00\00\00\00\00\00\00\00")
- (data (i32.const 7072) "0\00\00\00\01\00\00\00\01\00\00\000\00\00\001\00,\001\008\004\004\006\007\004\004\000\007\003\007\000\009\005\005\001\006\001\005\00,\000\00")
- (data (i32.const 7136) " \00\00\00\01\00\00\00\00\00\00\00 \00\00\00\ff\ff\ff\ff\ff\ff\ff\ff@Eu\c3*\9d\fb\ff\00\00\00\00\00\00\00\00\ff\ff\ff\ff\ff\ff\ff\7f")
- (data (i32.const 7184) "T\00\00\00\01\00\00\00\01\00\00\00T\00\00\00-\001\00,\00-\001\002\003\004\005\006\007\008\009\000\001\002\003\004\005\006\00,\000\00,\009\002\002\003\003\007\002\000\003\006\008\005\004\007\007\005\008\000\007\00")
- (data (i32.const 7288) "\1c\00\00\00\01\00\00\00\00\00\00\00\1c\00\00\00\98\10\00\008\10\00\008\10\00\00h\10\00\00P\10\00\00\80\10\00\00\00\00\00\00")
- (data (i32.const 7336) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00,\00a\00,\00a\00,\00a\00b\00,\00b\00,\00b\00a\00,\00")
- (data (i32.const 7384) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\002\00")
- (data (i32.const 7408) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\004\00")
- (data (i32.const 7432) "\10\00\00\00\01\00\00\00\00\00\00\00\10\00\00\00\c0\19\00\00\e8\1c\00\00\00\00\00\00\00\1d\00\00")
- (data (i32.const 7464) "\0c\00\00\00\01\00\00\00\01\00\00\00\0c\00\00\001\00,\002\00,\00,\004\00")
- (data (i32.const 7496) "\08\00\00\00\01\00\00\00\00\00\00\00\08\00\00\00\01\00\00\00\02\00\00\00")
- (data (i32.const 7520) "\08\00\00\00\01\00\00\00\00\00\00\00\08\00\00\00\03\00\00\00\04\00\00\00")
- (data (i32.const 7544) "\0e\00\00\00\01\00\00\00\01\00\00\00\0e\00\00\001\00,\002\00,\003\00,\004\00")
- (data (i32.const 7576) "\02\00\00\00\01\00\00\00\00\00\00\00\02\00\00\00\01\02")
- (data (i32.const 7600) "\02\00\00\00\01\00\00\00\00\00\00\00\02\00\00\00\03\04")
- (data (i32.const 7624) "\04\00\00\00\01\00\00\00\00\00\00\00\04\00\00\00\01\00\00\00")
- (data (i32.const 7648) "\1a\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\93\04\00\00\02\00\00\00\10\00\00\00\00\00\00\001\00\00\00\02\00\00\003\00\00\00\02\00\00\00\93\00\00\00\02\00\00\00\93\0c\00\00\02\00\00\00\13\0d\00\00\02\00\00\00\93 \00\00\02\00\00\00\10\00\00\00\00\00\00\00\93 \00\00\02\00\00\00\930\00\00\02\00\00\00\93 \00\00\02\00\00\003\00\00\00\02\00\00\00\13\01\00\00\02\00\00\00S\04\00\00\02\00\00\00\10\00\00\00\00\00\00\00\930\00\00\02\00\00\003\04\00\00\02\00\00\00S\00\00\00\02\00\00\00\13\05\00\00\02\00\00\00\93 \00\00\02\00\00\00\93 \00\00\02\00\00\00\93 \00\00\02\00\00\00")
+ (data (i32.const 6760) ">\00\00\00\01\00\00\00\01\00\00\00>\00\00\00[\00o\00b\00j\00e\00c\00t\00 \00O\00b\00j\00e\00c\00t\00]\00,\00[\00o\00b\00j\00e\00c\00t\00 \00O\00b\00j\00e\00c\00t\00]\00")
+ (data (i32.const 6840) "\00\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 6856) "\04\00\00\00\01\00\00\00\00\00\00\00\04\00\00\00\01\00\00\00")
+ (data (i32.const 6880) "\08\00\00\00\01\00\00\00\00\00\00\00\08\00\00\00\01\00\00\00\02\00\00\00")
+ (data (i32.const 6904) "\10\00\00\00\01\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00\03\00\00\00")
+ (data (i32.const 6936) "\06\00\00\00\01\00\00\00\01\00\00\00\06\00\00\001\00,\002\00")
+ (data (i32.const 6960) "\0e\00\00\00\01\00\00\00\01\00\00\00\0e\00\00\000\00,\001\00,\002\00,\003\00")
+ (data (i32.const 6992) "\03\00\00\00\01\00\00\00\00\00\00\00\03\00\00\00\01\ff\00")
+ (data (i32.const 7016) "\0c\00\00\00\01\00\00\00\01\00\00\00\0c\00\00\001\00,\00-\001\00,\000\00")
+ (data (i32.const 7048) "\06\00\00\00\01\00\00\00\00\00\00\00\06\00\00\00\01\00\ff\ff\00\00")
+ (data (i32.const 7072) "\12\00\00\00\01\00\00\00\01\00\00\00\12\00\00\001\00,\006\005\005\003\005\00,\000\00")
+ (data (i32.const 7112) "\18\00\00\00\01\00\00\00\00\00\00\00\18\00\00\00\01\00\00\00\00\00\00\00\ff\ff\ff\ff\ff\ff\ff\ff\00\00\00\00\00\00\00\00")
+ (data (i32.const 7152) "0\00\00\00\01\00\00\00\01\00\00\000\00\00\001\00,\001\008\004\004\006\007\004\004\000\007\003\007\000\009\005\005\001\006\001\005\00,\000\00")
+ (data (i32.const 7216) " \00\00\00\01\00\00\00\00\00\00\00 \00\00\00\ff\ff\ff\ff\ff\ff\ff\ff@Eu\c3*\9d\fb\ff\00\00\00\00\00\00\00\00\ff\ff\ff\ff\ff\ff\ff\7f")
+ (data (i32.const 7264) "T\00\00\00\01\00\00\00\01\00\00\00T\00\00\00-\001\00,\00-\001\002\003\004\005\006\007\008\009\000\001\002\003\004\005\006\00,\000\00,\009\002\002\003\003\007\002\000\003\006\008\005\004\007\007\005\008\000\007\00")
+ (data (i32.const 7368) "\1c\00\00\00\01\00\00\00\00\00\00\00\1c\00\00\00\98\10\00\008\10\00\008\10\00\00h\10\00\00P\10\00\00\80\10\00\00\00\00\00\00")
+ (data (i32.const 7416) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00,\00a\00,\00a\00,\00a\00b\00,\00b\00,\00b\00a\00,\00")
+ (data (i32.const 7464) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\002\00")
+ (data (i32.const 7488) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\004\00")
+ (data (i32.const 7512) "\10\00\00\00\01\00\00\00\00\00\00\00\10\00\00\00\c0\19\00\008\1d\00\00\00\00\00\00P\1d\00\00")
+ (data (i32.const 7544) "\0c\00\00\00\01\00\00\00\01\00\00\00\0c\00\00\001\00,\002\00,\00,\004\00")
+ (data (i32.const 7576) "\08\00\00\00\01\00\00\00\00\00\00\00\08\00\00\00\01\00\00\00\02\00\00\00")
+ (data (i32.const 7600) "\08\00\00\00\01\00\00\00\00\00\00\00\08\00\00\00\03\00\00\00\04\00\00\00")
+ (data (i32.const 7624) "\0e\00\00\00\01\00\00\00\01\00\00\00\0e\00\00\001\00,\002\00,\003\00,\004\00")
+ (data (i32.const 7656) "\02\00\00\00\01\00\00\00\00\00\00\00\02\00\00\00\01\02")
+ (data (i32.const 7680) "\02\00\00\00\01\00\00\00\00\00\00\00\02\00\00\00\03\04")
+ (data (i32.const 7704) "\04\00\00\00\01\00\00\00\00\00\00\00\04\00\00\00\01\00\00\00")
+ (data (i32.const 7728) "\1b\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\93\04\00\00\02\00\00\00\10\00\00\00\00\00\00\001\00\00\00\02\00\00\003\00\00\00\02\00\00\00\93\00\00\00\02\00\00\00\93\0c\00\00\02\00\00\00\13\0d\00\00\02\00\00\00\93 \00\00\02\00\00\00\10\00\00\00\00\00\00\00\93 \00\00\02\00\00\00\930\00\00\02\00\00\00\93 \00\00\02\00\00\003\00\00\00\02\00\00\00\13\01\00\00\02\00\00\00S\04\00\00\02\00\00\00\10\00\00\00\00\00\00\00\930\00\00\02\00\00\00\93 \00\00\02\00\00\003\04\00\00\02\00\00\00S\00\00\00\02\00\00\00\13\05\00\00\02\00\00\00\93 \00\00\02\00\00\00\93 \00\00\02\00\00\00\93 \00\00\02\00\00\00")
  (table $0 57 funcref)
  (elem (i32.const 0) $null $start:std/array~anonymous|0 $start:std/array~anonymous|1 $start:std/array~anonymous|2 $start:std/array~anonymous|3 $start:std/array~anonymous|4 $start:std/array~anonymous|5 $start:std/array~anonymous|6 $start:std/array~anonymous|7 $start:std/array~anonymous|8 $start:std/array~anonymous|9 $start:std/array~anonymous|10 $start:std/array~anonymous|11 $start:std/array~anonymous|12 $start:std/array~anonymous|13 $start:std/array~anonymous|14 $start:std/array~anonymous|15 $start:std/array~anonymous|16 $start:std/array~anonymous|17 $start:std/array~anonymous|18 $start:std/array~anonymous|19 $start:std/array~anonymous|20 $start:std/array~anonymous|21 $start:std/array~anonymous|22 $start:std/array~anonymous|23 $start:std/array~anonymous|24 $start:std/array~anonymous|25 $start:std/array~anonymous|26 $start:std/array~anonymous|27 $start:std/array~anonymous|28 $start:std/array~anonymous|29 $start:std/array~anonymous|30 $start:std/array~anonymous|31 $start:std/array~anonymous|32 $start:std/array~anonymous|33 $start:std/array~anonymous|34 $start:std/array~anonymous|35 $start:std/array~anonymous|36 $start:std/array~anonymous|37 $start:std/array~anonymous|38 $start:std/array~anonymous|39 $start:std/array~anonymous|40 $start:std/array~anonymous|41 $start:std/array~anonymous|42 $~lib/util/sort/COMPARATOR<f32>~anonymous|0 $~lib/util/sort/COMPARATOR<f64>~anonymous|0 $~lib/util/sort/COMPARATOR<i32>~anonymous|0 $~lib/util/sort/COMPARATOR<u32>~anonymous|0 $~lib/util/sort/COMPARATOR<i32>~anonymous|1 $start:std/array~anonymous|43 $start:std/array~anonymous|44 $start:std/array~anonymous|45 $start:std/array~anonymous|46 $start:std/array~anonymous|47 $start:std/array~anonymous|48 $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0 $~lib/util/sort/COMPARATOR<~lib/string/String>~anonymous|0)
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
@@ -236,8 +237,8 @@
  (global $~lib/builtins/u32.MAX_VALUE i32 (i32.const -1))
  (global $~lib/builtins/i64.MAX_VALUE i64 (i64.const 9223372036854775807))
  (global $~lib/started (mut i32) (i32.const 0))
- (global $~lib/rt/__rtti_base i32 (i32.const 7648))
- (global $~lib/heap/__heap_base i32 (i32.const 7860))
+ (global $~lib/rt/__rtti_base i32 (i32.const 7728))
+ (global $~lib/heap/__heap_base i32 (i32.const 7948))
  (export "__start" (func $start))
  (export "memory" (memory $0))
  (func $~lib/rt/tlsf/removeBlock (; 6 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
@@ -14622,7 +14623,11 @@
   end
   local.get $0
  )
- (func $~lib/util/string/joinObjectArray<std/array/Ref | null> (; 257 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/Ref#toString (; 257 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  i32.const 6648
+  call $~lib/rt/pure/__retain
+ )
+ (func $~lib/util/string/joinReferenceArray<std/array/Ref | null> (; 258 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -14651,39 +14656,50 @@
    local.get $4
    return
   end
+  i32.const 0
+  local.set $5
   local.get $3
   i32.eqz
   if
-   i32.const 6648
-   call $~lib/rt/pure/__retain
+   local.get $0
+   i32.load
+   local.tee $4
+   local.get $5
+   local.tee $6
+   i32.ne
+   if
+    local.get $4
+    call $~lib/rt/pure/__retain
+    drop
+    local.get $6
+    call $~lib/rt/pure/__release
+   end
+   local.get $4
+   local.set $5
+   local.get $5
+   i32.const 0
+   i32.ne
+   if (result i32)
+    local.get $5
+    call $std/array/Ref#toString
+   else
+    i32.const 4248
+    call $~lib/rt/pure/__retain
+   end
    local.set $4
    local.get $2
+   call $~lib/rt/pure/__release
+   local.get $5
    call $~lib/rt/pure/__release
    local.get $4
    return
   end
-  local.get $2
-  call $~lib/string/String#get:length
-  local.set $5
-  i32.const 15
-  local.get $5
-  i32.add
-  local.get $3
-  i32.mul
-  i32.const 15
-  i32.add
-  local.set $6
-  local.get $6
-  i32.const 1
-  i32.shl
-  i32.const 1
-  call $~lib/rt/tlsf/__alloc
+  i32.const 4248
   call $~lib/rt/pure/__retain
   local.set $7
-  i32.const 0
+  local.get $2
+  call $~lib/string/String#get:length
   local.set $8
-  i32.const 0
-  local.set $9
   block $break|0
    i32.const 0
    local.set $4
@@ -14699,52 +14715,68 @@
     i32.shl
     i32.add
     i32.load
-    local.tee $10
-    local.get $9
-    local.tee $11
+    local.tee $6
+    local.get $5
+    local.tee $9
     i32.ne
     if
-     local.get $10
+     local.get $6
      call $~lib/rt/pure/__retain
      drop
-     local.get $11
+     local.get $9
      call $~lib/rt/pure/__release
     end
-    local.get $10
-    local.set $9
-    local.get $9
-    if
-     local.get $7
-     local.get $8
-     i32.const 1
-     i32.shl
-     i32.add
-     i32.const 6648
-     i32.const 15
-     i32.const 1
-     i32.shl
-     call $~lib/memory/memory.copy
-     local.get $8
-     i32.const 15
-     i32.add
-     local.set $8
-    end
+    local.get $6
+    local.set $5
     local.get $5
+    i32.const 0
+    i32.ne
     if
      local.get $7
-     local.get $8
-     i32.const 1
-     i32.shl
-     i32.add
+     local.get $5
+     call $std/array/Ref#toString
+     local.tee $6
+     call $~lib/string/String.__concat
+     local.tee $9
+     local.tee $10
+     local.get $7
+     local.tee $11
+     i32.ne
+     if
+      local.get $10
+      call $~lib/rt/pure/__retain
+      drop
+      local.get $11
+      call $~lib/rt/pure/__release
+     end
+     local.get $10
+     local.set $7
+     local.get $6
+     call $~lib/rt/pure/__release
+     local.get $9
+     call $~lib/rt/pure/__release
+    end
+    local.get $8
+    if
+     local.get $7
      local.get $2
-     local.get $5
-     i32.const 1
-     i32.shl
-     call $~lib/memory/memory.copy
-     local.get $8
-     local.get $5
-     i32.add
-     local.set $8
+     call $~lib/string/String.__concat
+     local.tee $9
+     local.tee $11
+     local.get $7
+     local.tee $6
+     i32.ne
+     if
+      local.get $11
+      call $~lib/rt/pure/__retain
+      drop
+      local.get $6
+      call $~lib/rt/pure/__release
+     end
+     local.get $11
+     local.set $7
+     local.get $9
+     call $~lib/rt/pure/__release
     end
     local.get $4
     i32.const 1
@@ -14760,49 +14792,56 @@
   i32.shl
   i32.add
   i32.load
+  local.tee $10
+  local.get $5
+  local.tee $4
+  i32.ne
   if
-   local.get $7
-   local.get $8
-   i32.const 1
-   i32.shl
-   i32.add
-   i32.const 6648
-   i32.const 15
-   i32.const 1
-   i32.shl
-   call $~lib/memory/memory.copy
-   local.get $8
-   i32.const 15
-   i32.add
-   local.set $8
+   local.get $10
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   call $~lib/rt/pure/__release
   end
-  local.get $6
-  local.get $8
-  i32.gt_s
+  local.get $10
+  local.set $5
+  local.get $5
+  i32.const 0
+  i32.ne
   if
    local.get $7
-   i32.const 0
-   local.get $8
-   call $~lib/string/String#substring
-   local.set $4
-   local.get $2
-   call $~lib/rt/pure/__release
+   local.get $5
+   call $std/array/Ref#toString
+   local.tee $10
+   call $~lib/string/String.__concat
+   local.tee $4
+   local.tee $6
    local.get $7
-   call $~lib/rt/pure/__release
-   local.get $9
+   local.tee $9
+   i32.ne
+   if
+    local.get $6
+    call $~lib/rt/pure/__retain
+    drop
+    local.get $9
+    call $~lib/rt/pure/__release
+   end
+   local.get $6
+   local.set $7
+   local.get $10
    call $~lib/rt/pure/__release
    local.get $4
-   return
+   call $~lib/rt/pure/__release
   end
   local.get $7
   local.set $4
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<std/array/Ref | null>#join (; 258 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#join (; 259 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14818,19 +14857,238 @@
   local.get $2
   local.get $3
   local.get $1
-  call $~lib/util/string/joinObjectArray<std/array/Ref | null>
+  call $~lib/util/string/joinReferenceArray<std/array/Ref | null>
   local.set $4
   local.get $1
   call $~lib/rt/pure/__release
   local.get $4
   return
  )
- (func $~lib/array/Array<i32>#toString (; 259 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<std/array/Ref> (; 260 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  local.get $2
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $1
+  i32.const 1
+  i32.sub
+  local.set $3
+  local.get $3
+  i32.const 0
+  i32.lt_s
+  if
+   i32.const 4248
+   call $~lib/rt/pure/__retain
+   local.set $4
+   local.get $2
+   call $~lib/rt/pure/__release
+   local.get $4
+   return
+  end
+  i32.const 0
+  local.set $5
+  local.get $3
+  i32.eqz
+  if
+   local.get $0
+   i32.load
+   local.tee $4
+   local.get $5
+   local.tee $6
+   i32.ne
+   if
+    local.get $4
+    call $~lib/rt/pure/__retain
+    drop
+    local.get $6
+    call $~lib/rt/pure/__release
+   end
+   local.get $4
+   local.set $5
+   local.get $5
+   call $std/array/Ref#toString
+   local.set $4
+   local.get $2
+   call $~lib/rt/pure/__release
+   local.get $5
+   call $~lib/rt/pure/__release
+   local.get $4
+   return
+  end
+  i32.const 4248
+  call $~lib/rt/pure/__retain
+  local.set $7
+  local.get $2
+  call $~lib/string/String#get:length
+  local.set $8
+  block $break|0
+   i32.const 0
+   local.set $4
+   loop $loop|0
+    local.get $4
+    local.get $3
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $0
+    local.get $4
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load
+    local.tee $6
+    local.get $5
+    local.tee $9
+    i32.ne
+    if
+     local.get $6
+     call $~lib/rt/pure/__retain
+     drop
+     local.get $9
+     call $~lib/rt/pure/__release
+    end
+    local.get $6
+    local.set $5
+    local.get $7
+    local.get $5
+    call $std/array/Ref#toString
+    local.tee $6
+    call $~lib/string/String.__concat
+    local.tee $9
+    local.tee $10
+    local.get $7
+    local.tee $11
+    i32.ne
+    if
+     local.get $10
+     call $~lib/rt/pure/__retain
+     drop
+     local.get $11
+     call $~lib/rt/pure/__release
+    end
+    local.get $10
+    local.set $7
+    local.get $6
+    call $~lib/rt/pure/__release
+    local.get $9
+    call $~lib/rt/pure/__release
+    local.get $8
+    if
+     local.get $7
+     local.get $2
+     call $~lib/string/String.__concat
+     local.tee $9
+     local.tee $11
+     local.get $7
+     local.tee $6
+     i32.ne
+     if
+      local.get $11
+      call $~lib/rt/pure/__retain
+      drop
+      local.get $6
+      call $~lib/rt/pure/__release
+     end
+     local.get $11
+     local.set $7
+     local.get $9
+     call $~lib/rt/pure/__release
+    end
+    local.get $4
+    i32.const 1
+    i32.add
+    local.set $4
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $0
+  local.get $3
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
+  local.tee $10
+  local.get $5
+  local.tee $4
+  i32.ne
+  if
+   local.get $10
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $4
+   call $~lib/rt/pure/__release
+  end
+  local.get $10
+  local.set $5
+  local.get $7
+  local.get $5
+  call $std/array/Ref#toString
+  local.tee $10
+  call $~lib/string/String.__concat
+  local.tee $4
+  local.tee $6
+  local.get $7
+  local.tee $9
+  i32.ne
+  if
+   local.get $6
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $9
+   call $~lib/rt/pure/__release
+  end
+  local.get $6
+  local.set $7
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $7
+  local.set $4
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $4
+ )
+ (func $~lib/array/Array<std/array/Ref>#join (; 261 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  local.get $1
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $0
+  i32.load offset=4
+  local.set $2
+  local.get $0
+  i32.load offset=12
+  local.set $3
+  local.get $2
+  local.get $3
+  local.get $1
+  call $~lib/util/string/joinReferenceArray<std/array/Ref>
+  local.set $4
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $4
+  return
+ )
+ (func $~lib/array/Array<i32>#toString (; 262 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4464
   call $~lib/array/Array<i32>#join
  )
- (func $~lib/util/number/itoa<i8> (; 260 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<i8> (; 263 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -14839,7 +15097,7 @@
   call $~lib/util/number/itoa32
   return
  )
- (func $~lib/util/number/itoa_stream<i8> (; 261 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i8> (; 264 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -14912,7 +15170,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<i8> (; 262 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i8> (; 265 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15060,7 +15318,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i8>#join (; 263 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#join (; 266 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15083,19 +15341,19 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<i8>#toString (; 264 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i8>#toString (; 267 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4464
   call $~lib/array/Array<i8>#join
  )
- (func $~lib/util/number/itoa<u16> (; 265 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<u16> (; 268 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/util/number/itoa_stream<u16> (; 266 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u16> (; 269 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15138,7 +15396,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<u16> (; 267 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u16> (; 270 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15286,7 +15544,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<u16>#join (; 268 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#join (; 271 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15309,12 +15567,12 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<u16>#toString (; 269 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u16>#toString (; 272 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4464
   call $~lib/array/Array<u16>#join
  )
- (func $~lib/util/number/decimalCount64 (; 270 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64 (; 273 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   local.get $0
   i64.const 1000000000000000
@@ -15387,7 +15645,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/utoa64_lut (; 271 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/util/number/utoa64_lut (; 274 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -15514,7 +15772,7 @@
   local.get $2
   call $~lib/util/number/utoa32_lut
  )
- (func $~lib/util/number/utoa64 (; 272 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/utoa64 (; 275 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -15579,12 +15837,12 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<u64> (; 273 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa<u64> (; 276 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   local.get $0
   call $~lib/util/number/utoa64
   return
  )
- (func $~lib/util/number/itoa_stream<u64> (; 274 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<u64> (; 277 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15645,7 +15903,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<u64> (; 275 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u64> (; 278 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15793,7 +16051,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<u64>#join (; 276 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u64>#join (; 279 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15816,12 +16074,12 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<u64>#toString (; 277 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u64>#toString (; 280 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4464
   call $~lib/array/Array<u64>#join
  )
- (func $~lib/util/number/itoa64 (; 278 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa64 (; 281 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -15908,12 +16166,12 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<i64> (; 279 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa<i64> (; 282 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   local.get $0
   call $~lib/util/number/itoa64
   return
  )
- (func $~lib/util/number/itoa_stream<i64> (; 280 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<i64> (; 283 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15996,7 +16254,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<i64> (; 281 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i64> (; 284 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16144,7 +16402,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i64>#join (; 282 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i64>#join (; 285 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16167,17 +16425,17 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<i64>#toString (; 283 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i64>#toString (; 286 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4464
   call $~lib/array/Array<i64>#join
  )
- (func $~lib/array/Array<~lib/string/String | null>#toString (; 284 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#toString (; 287 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4464
   call $~lib/array/Array<~lib/string/String | null>#join
  )
- (func $~lib/util/string/joinArrays<~lib/array/Array<i32>> (; 285 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>> (; 288 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16206,51 +16464,42 @@
    local.get $4
    return
   end
-  i32.const 4248
-  call $~lib/rt/pure/__retain
-  local.set $5
-  local.get $2
-  call $~lib/string/String#get:length
-  local.set $6
   i32.const 0
-  local.set $7
+  local.set $5
   local.get $3
   i32.eqz
   if
    local.get $0
    i32.load
    local.tee $4
-   local.get $7
-   local.tee $8
+   local.get $5
+   local.tee $6
    i32.ne
    if
     local.get $4
     call $~lib/rt/pure/__retain
     drop
-    local.get $8
+    local.get $6
     call $~lib/rt/pure/__release
    end
    local.get $4
-   local.set $7
-   local.get $7
-   if (result i32)
-    local.get $7
-    local.get $2
-    call $~lib/array/Array<i32>#join
-   else
-    i32.const 4248
-    call $~lib/rt/pure/__retain
-   end
+   local.set $5
+   local.get $5
+   call $~lib/array/Array<i32>#toString
    local.set $4
    local.get $2
    call $~lib/rt/pure/__release
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $7
-   call $~lib/rt/pure/__release
    local.get $4
    return
   end
+  i32.const 4248
+  call $~lib/rt/pure/__retain
+  local.set $7
+  local.get $2
+  call $~lib/string/String#get:length
+  local.set $8
   block $break|0
    i32.const 0
    local.set $4
@@ -16266,65 +16515,61 @@
     i32.shl
     i32.add
     i32.load
-    local.tee $8
-    local.get $7
+    local.tee $6
+    local.get $5
     local.tee $9
     i32.ne
     if
-     local.get $8
+     local.get $6
      call $~lib/rt/pure/__retain
      drop
      local.get $9
      call $~lib/rt/pure/__release
     end
-    local.get $8
-    local.set $7
+    local.get $6
+    local.set $5
     local.get $7
+    local.get $5
+    call $~lib/array/Array<i32>#toString
+    local.tee $6
+    call $~lib/string/String.__concat
+    local.tee $9
+    local.tee $10
+    local.get $7
+    local.tee $11
+    i32.ne
     if
-     local.get $5
-     local.get $7
-     local.get $2
-     call $~lib/array/Array<i32>#join
-     local.tee $8
-     call $~lib/string/String.__concat
-     local.tee $9
-     local.tee $10
-     local.get $5
-     local.tee $11
-     i32.ne
-     if
-      local.get $10
-      call $~lib/rt/pure/__retain
-      drop
-      local.get $11
-      call $~lib/rt/pure/__release
-     end
      local.get $10
-     local.set $5
-     local.get $8
-     call $~lib/rt/pure/__release
-     local.get $9
+     call $~lib/rt/pure/__retain
+     drop
+     local.get $11
      call $~lib/rt/pure/__release
     end
+    local.get $10
+    local.set $7
     local.get $6
+    call $~lib/rt/pure/__release
+    local.get $9
+    call $~lib/rt/pure/__release
+    local.get $8
     if
-     local.get $5
+     local.get $7
      local.get $2
      call $~lib/string/String.__concat
      local.tee $9
      local.tee $11
-     local.get $5
-     local.tee $8
+     local.get $7
+     local.tee $6
      i32.ne
      if
       local.get $11
       call $~lib/rt/pure/__retain
       drop
-      local.get $8
+      local.get $6
       call $~lib/rt/pure/__release
      end
      local.get $11
-     local.set $5
+     local.set $7
      local.get $9
      call $~lib/rt/pure/__release
     end
@@ -16343,7 +16588,7 @@
   i32.add
   i32.load
   local.tee $10
-  local.get $7
+  local.get $5
   local.tee $4
   i32.ne
   if
@@ -16354,43 +16599,39 @@
    call $~lib/rt/pure/__release
   end
   local.get $10
-  local.set $7
+  local.set $5
   local.get $7
+  local.get $5
+  call $~lib/array/Array<i32>#toString
+  local.tee $10
+  call $~lib/string/String.__concat
+  local.tee $4
+  local.tee $6
+  local.get $7
+  local.tee $9
+  i32.ne
   if
-   local.get $5
-   local.get $7
-   local.get $2
-   call $~lib/array/Array<i32>#join
-   local.tee $10
-   call $~lib/string/String.__concat
-   local.tee $4
-   local.tee $8
-   local.get $5
-   local.tee $9
-   i32.ne
-   if
-    local.get $8
-    call $~lib/rt/pure/__retain
-    drop
-    local.get $9
-    call $~lib/rt/pure/__release
-   end
-   local.get $8
-   local.set $5
-   local.get $10
-   call $~lib/rt/pure/__release
-   local.get $4
+   local.get $6
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $9
    call $~lib/rt/pure/__release
   end
-  local.get $5
+  local.get $6
+  local.set $7
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $7
   local.set $4
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#join (; 286 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#join (; 289 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16406,26 +16647,26 @@
   local.get $2
   local.get $3
   local.get $1
-  call $~lib/util/string/joinArrays<~lib/array/Array<i32>>
+  call $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>>
   local.set $4
   local.get $1
   call $~lib/rt/pure/__release
   local.get $4
   return
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#toString (; 287 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#toString (; 290 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4464
   call $~lib/array/Array<~lib/array/Array<i32>>#join
  )
- (func $~lib/util/number/itoa<u8> (; 288 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<u8> (; 291 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/util/number/itoa_stream<u8> (; 289 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u8> (; 292 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16468,7 +16709,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<u8> (; 290 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u8> (; 293 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16616,7 +16857,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<u8>#join (; 291 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#join (; 294 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16639,7 +16880,12 @@
   local.get $4
   return
  )
- (func $~lib/util/string/joinArrays<~lib/array/Array<u8>> (; 292 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<u8>#toString (; 295 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.const 4464
+  call $~lib/array/Array<u8>#join
+ )
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u8>> (; 296 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16668,51 +16914,42 @@
    local.get $4
    return
   end
-  i32.const 4248
-  call $~lib/rt/pure/__retain
-  local.set $5
-  local.get $2
-  call $~lib/string/String#get:length
-  local.set $6
   i32.const 0
-  local.set $7
+  local.set $5
   local.get $3
   i32.eqz
   if
    local.get $0
    i32.load
    local.tee $4
-   local.get $7
-   local.tee $8
+   local.get $5
+   local.tee $6
    i32.ne
    if
     local.get $4
     call $~lib/rt/pure/__retain
     drop
-    local.get $8
+    local.get $6
     call $~lib/rt/pure/__release
    end
    local.get $4
-   local.set $7
-   local.get $7
-   if (result i32)
-    local.get $7
-    local.get $2
-    call $~lib/array/Array<u8>#join
-   else
-    i32.const 4248
-    call $~lib/rt/pure/__retain
-   end
+   local.set $5
+   local.get $5
+   call $~lib/array/Array<u8>#toString
    local.set $4
    local.get $2
    call $~lib/rt/pure/__release
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $7
-   call $~lib/rt/pure/__release
    local.get $4
    return
   end
+  i32.const 4248
+  call $~lib/rt/pure/__retain
+  local.set $7
+  local.get $2
+  call $~lib/string/String#get:length
+  local.set $8
   block $break|0
    i32.const 0
    local.set $4
@@ -16728,65 +16965,61 @@
     i32.shl
     i32.add
     i32.load
-    local.tee $8
-    local.get $7
+    local.tee $6
+    local.get $5
     local.tee $9
     i32.ne
     if
-     local.get $8
+     local.get $6
      call $~lib/rt/pure/__retain
      drop
      local.get $9
      call $~lib/rt/pure/__release
     end
-    local.get $8
-    local.set $7
+    local.get $6
+    local.set $5
     local.get $7
+    local.get $5
+    call $~lib/array/Array<u8>#toString
+    local.tee $6
+    call $~lib/string/String.__concat
+    local.tee $9
+    local.tee $10
+    local.get $7
+    local.tee $11
+    i32.ne
     if
-     local.get $5
-     local.get $7
-     local.get $2
-     call $~lib/array/Array<u8>#join
-     local.tee $8
-     call $~lib/string/String.__concat
-     local.tee $9
-     local.tee $10
-     local.get $5
-     local.tee $11
-     i32.ne
-     if
-      local.get $10
-      call $~lib/rt/pure/__retain
-      drop
-      local.get $11
-      call $~lib/rt/pure/__release
-     end
      local.get $10
-     local.set $5
-     local.get $8
-     call $~lib/rt/pure/__release
-     local.get $9
+     call $~lib/rt/pure/__retain
+     drop
+     local.get $11
      call $~lib/rt/pure/__release
     end
+    local.get $10
+    local.set $7
     local.get $6
+    call $~lib/rt/pure/__release
+    local.get $9
+    call $~lib/rt/pure/__release
+    local.get $8
     if
-     local.get $5
+     local.get $7
      local.get $2
      call $~lib/string/String.__concat
      local.tee $9
      local.tee $11
-     local.get $5
-     local.tee $8
+     local.get $7
+     local.tee $6
      i32.ne
      if
       local.get $11
       call $~lib/rt/pure/__retain
       drop
-      local.get $8
+      local.get $6
       call $~lib/rt/pure/__release
      end
      local.get $11
-     local.set $5
+     local.set $7
      local.get $9
      call $~lib/rt/pure/__release
     end
@@ -16805,7 +17038,7 @@
   i32.add
   i32.load
   local.tee $10
-  local.get $7
+  local.get $5
   local.tee $4
   i32.ne
   if
@@ -16816,43 +17049,39 @@
    call $~lib/rt/pure/__release
   end
   local.get $10
-  local.set $7
+  local.set $5
   local.get $7
+  local.get $5
+  call $~lib/array/Array<u8>#toString
+  local.tee $10
+  call $~lib/string/String.__concat
+  local.tee $4
+  local.tee $6
+  local.get $7
+  local.tee $9
+  i32.ne
   if
-   local.get $5
-   local.get $7
-   local.get $2
-   call $~lib/array/Array<u8>#join
-   local.tee $10
-   call $~lib/string/String.__concat
-   local.tee $4
-   local.tee $8
-   local.get $5
-   local.tee $9
-   i32.ne
-   if
-    local.get $8
-    call $~lib/rt/pure/__retain
-    drop
-    local.get $9
-    call $~lib/rt/pure/__release
-   end
-   local.get $8
-   local.set $5
-   local.get $10
-   call $~lib/rt/pure/__release
-   local.get $4
+   local.get $6
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $9
    call $~lib/rt/pure/__release
   end
-  local.get $5
+  local.get $6
+  local.set $7
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $7
   local.set $4
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<~lib/array/Array<u8>>#join (; 293 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u8>>#join (; 297 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16868,19 +17097,24 @@
   local.get $2
   local.get $3
   local.get $1
-  call $~lib/util/string/joinArrays<~lib/array/Array<u8>>
+  call $~lib/util/string/joinReferenceArray<~lib/array/Array<u8>>
   local.set $4
   local.get $1
   call $~lib/rt/pure/__release
   local.get $4
   return
  )
- (func $~lib/array/Array<~lib/array/Array<u8>>#toString (; 294 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u8>>#toString (; 298 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4464
   call $~lib/array/Array<~lib/array/Array<u8>>#join
  )
- (func $~lib/util/string/joinArrays<~lib/array/Array<u32>> (; 295 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<u32>#toString (; 299 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.const 4464
+  call $~lib/array/Array<u32>#join
+ )
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>> (; 300 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16909,51 +17143,42 @@
    local.get $4
    return
   end
-  i32.const 4248
-  call $~lib/rt/pure/__retain
-  local.set $5
-  local.get $2
-  call $~lib/string/String#get:length
-  local.set $6
   i32.const 0
-  local.set $7
+  local.set $5
   local.get $3
   i32.eqz
   if
    local.get $0
    i32.load
    local.tee $4
-   local.get $7
-   local.tee $8
+   local.get $5
+   local.tee $6
    i32.ne
    if
     local.get $4
     call $~lib/rt/pure/__retain
     drop
-    local.get $8
+    local.get $6
     call $~lib/rt/pure/__release
    end
    local.get $4
-   local.set $7
-   local.get $7
-   if (result i32)
-    local.get $7
-    local.get $2
-    call $~lib/array/Array<u32>#join
-   else
-    i32.const 4248
-    call $~lib/rt/pure/__retain
-   end
+   local.set $5
+   local.get $5
+   call $~lib/array/Array<u32>#toString
    local.set $4
    local.get $2
    call $~lib/rt/pure/__release
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $7
-   call $~lib/rt/pure/__release
    local.get $4
    return
   end
+  i32.const 4248
+  call $~lib/rt/pure/__retain
+  local.set $7
+  local.get $2
+  call $~lib/string/String#get:length
+  local.set $8
   block $break|0
    i32.const 0
    local.set $4
@@ -16969,65 +17194,61 @@
     i32.shl
     i32.add
     i32.load
-    local.tee $8
-    local.get $7
+    local.tee $6
+    local.get $5
     local.tee $9
     i32.ne
     if
-     local.get $8
+     local.get $6
      call $~lib/rt/pure/__retain
      drop
      local.get $9
      call $~lib/rt/pure/__release
     end
-    local.get $8
-    local.set $7
+    local.get $6
+    local.set $5
     local.get $7
+    local.get $5
+    call $~lib/array/Array<u32>#toString
+    local.tee $6
+    call $~lib/string/String.__concat
+    local.tee $9
+    local.tee $10
+    local.get $7
+    local.tee $11
+    i32.ne
     if
-     local.get $5
-     local.get $7
-     local.get $2
-     call $~lib/array/Array<u32>#join
-     local.tee $8
-     call $~lib/string/String.__concat
-     local.tee $9
-     local.tee $10
-     local.get $5
-     local.tee $11
-     i32.ne
-     if
-      local.get $10
-      call $~lib/rt/pure/__retain
-      drop
-      local.get $11
-      call $~lib/rt/pure/__release
-     end
      local.get $10
-     local.set $5
-     local.get $8
-     call $~lib/rt/pure/__release
-     local.get $9
+     call $~lib/rt/pure/__retain
+     drop
+     local.get $11
      call $~lib/rt/pure/__release
     end
+    local.get $10
+    local.set $7
     local.get $6
+    call $~lib/rt/pure/__release
+    local.get $9
+    call $~lib/rt/pure/__release
+    local.get $8
     if
-     local.get $5
+     local.get $7
      local.get $2
      call $~lib/string/String.__concat
      local.tee $9
      local.tee $11
-     local.get $5
-     local.tee $8
+     local.get $7
+     local.tee $6
      i32.ne
      if
       local.get $11
       call $~lib/rt/pure/__retain
       drop
-      local.get $8
+      local.get $6
       call $~lib/rt/pure/__release
      end
      local.get $11
-     local.set $5
+     local.set $7
      local.get $9
      call $~lib/rt/pure/__release
     end
@@ -17046,7 +17267,7 @@
   i32.add
   i32.load
   local.tee $10
-  local.get $7
+  local.get $5
   local.tee $4
   i32.ne
   if
@@ -17057,43 +17278,39 @@
    call $~lib/rt/pure/__release
   end
   local.get $10
-  local.set $7
+  local.set $5
   local.get $7
+  local.get $5
+  call $~lib/array/Array<u32>#toString
+  local.tee $10
+  call $~lib/string/String.__concat
+  local.tee $4
+  local.tee $6
+  local.get $7
+  local.tee $9
+  i32.ne
   if
-   local.get $5
-   local.get $7
-   local.get $2
-   call $~lib/array/Array<u32>#join
-   local.tee $10
-   call $~lib/string/String.__concat
-   local.tee $4
-   local.tee $8
-   local.get $5
-   local.tee $9
-   i32.ne
-   if
-    local.get $8
-    call $~lib/rt/pure/__retain
-    drop
-    local.get $9
-    call $~lib/rt/pure/__release
-   end
-   local.get $8
-   local.set $5
-   local.get $10
-   call $~lib/rt/pure/__release
-   local.get $4
+   local.get $6
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $9
    call $~lib/rt/pure/__release
   end
-  local.get $5
+  local.get $6
+  local.set $7
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $7
   local.set $4
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<~lib/array/Array<u32>>#join (; 296 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u32>>#join (; 301 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17109,14 +17326,19 @@
   local.get $2
   local.get $3
   local.get $1
-  call $~lib/util/string/joinArrays<~lib/array/Array<u32>>
+  call $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>>
   local.set $4
   local.get $1
   call $~lib/rt/pure/__release
   local.get $4
   return
  )
- (func $~lib/util/string/joinArrays<~lib/array/Array<~lib/array/Array<u32>>> (; 297 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u32>>#toString (; 302 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.const 4464
+  call $~lib/array/Array<~lib/array/Array<u32>>#join
+ )
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>> (; 303 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -17145,51 +17367,42 @@
    local.get $4
    return
   end
-  i32.const 4248
-  call $~lib/rt/pure/__retain
-  local.set $5
-  local.get $2
-  call $~lib/string/String#get:length
-  local.set $6
   i32.const 0
-  local.set $7
+  local.set $5
   local.get $3
   i32.eqz
   if
    local.get $0
    i32.load
    local.tee $4
-   local.get $7
-   local.tee $8
+   local.get $5
+   local.tee $6
    i32.ne
    if
     local.get $4
     call $~lib/rt/pure/__retain
     drop
-    local.get $8
+    local.get $6
     call $~lib/rt/pure/__release
    end
    local.get $4
-   local.set $7
-   local.get $7
-   if (result i32)
-    local.get $7
-    local.get $2
-    call $~lib/array/Array<~lib/array/Array<u32>>#join
-   else
-    i32.const 4248
-    call $~lib/rt/pure/__retain
-   end
+   local.set $5
+   local.get $5
+   call $~lib/array/Array<~lib/array/Array<u32>>#toString
    local.set $4
    local.get $2
    call $~lib/rt/pure/__release
    local.get $5
    call $~lib/rt/pure/__release
-   local.get $7
-   call $~lib/rt/pure/__release
    local.get $4
    return
   end
+  i32.const 4248
+  call $~lib/rt/pure/__retain
+  local.set $7
+  local.get $2
+  call $~lib/string/String#get:length
+  local.set $8
   block $break|0
    i32.const 0
    local.set $4
@@ -17205,65 +17418,61 @@
     i32.shl
     i32.add
     i32.load
-    local.tee $8
-    local.get $7
+    local.tee $6
+    local.get $5
     local.tee $9
     i32.ne
     if
-     local.get $8
+     local.get $6
      call $~lib/rt/pure/__retain
      drop
      local.get $9
      call $~lib/rt/pure/__release
     end
-    local.get $8
-    local.set $7
+    local.get $6
+    local.set $5
     local.get $7
+    local.get $5
+    call $~lib/array/Array<~lib/array/Array<u32>>#toString
+    local.tee $6
+    call $~lib/string/String.__concat
+    local.tee $9
+    local.tee $10
+    local.get $7
+    local.tee $11
+    i32.ne
     if
-     local.get $5
-     local.get $7
-     local.get $2
-     call $~lib/array/Array<~lib/array/Array<u32>>#join
-     local.tee $8
-     call $~lib/string/String.__concat
-     local.tee $9
-     local.tee $10
-     local.get $5
-     local.tee $11
-     i32.ne
-     if
-      local.get $10
-      call $~lib/rt/pure/__retain
-      drop
-      local.get $11
-      call $~lib/rt/pure/__release
-     end
      local.get $10
-     local.set $5
-     local.get $8
-     call $~lib/rt/pure/__release
-     local.get $9
+     call $~lib/rt/pure/__retain
+     drop
+     local.get $11
      call $~lib/rt/pure/__release
     end
+    local.get $10
+    local.set $7
     local.get $6
+    call $~lib/rt/pure/__release
+    local.get $9
+    call $~lib/rt/pure/__release
+    local.get $8
     if
-     local.get $5
+     local.get $7
      local.get $2
      call $~lib/string/String.__concat
      local.tee $9
      local.tee $11
-     local.get $5
-     local.tee $8
+     local.get $7
+     local.tee $6
      i32.ne
      if
       local.get $11
       call $~lib/rt/pure/__retain
       drop
-      local.get $8
+      local.get $6
       call $~lib/rt/pure/__release
      end
      local.get $11
-     local.set $5
+     local.set $7
      local.get $9
      call $~lib/rt/pure/__release
     end
@@ -17282,7 +17491,7 @@
   i32.add
   i32.load
   local.tee $10
-  local.get $7
+  local.get $5
   local.tee $4
   i32.ne
   if
@@ -17293,43 +17502,39 @@
    call $~lib/rt/pure/__release
   end
   local.get $10
-  local.set $7
+  local.set $5
   local.get $7
+  local.get $5
+  call $~lib/array/Array<~lib/array/Array<u32>>#toString
+  local.tee $10
+  call $~lib/string/String.__concat
+  local.tee $4
+  local.tee $6
+  local.get $7
+  local.tee $9
+  i32.ne
   if
-   local.get $5
-   local.get $7
-   local.get $2
-   call $~lib/array/Array<~lib/array/Array<u32>>#join
-   local.tee $10
-   call $~lib/string/String.__concat
-   local.tee $4
-   local.tee $8
-   local.get $5
-   local.tee $9
-   i32.ne
-   if
-    local.get $8
-    call $~lib/rt/pure/__retain
-    drop
-    local.get $9
-    call $~lib/rt/pure/__release
-   end
-   local.get $8
-   local.set $5
-   local.get $10
-   call $~lib/rt/pure/__release
-   local.get $4
+   local.get $6
+   call $~lib/rt/pure/__retain
+   drop
+   local.get $9
    call $~lib/rt/pure/__release
   end
-  local.get $5
+  local.get $6
+  local.set $7
+  local.get $10
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $7
   local.set $4
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#join (; 298 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#join (; 304 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17345,19 +17550,19 @@
   local.get $2
   local.get $3
   local.get $1
-  call $~lib/util/string/joinArrays<~lib/array/Array<~lib/array/Array<u32>>>
+  call $~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>>
   local.set $4
   local.get $1
   call $~lib/rt/pure/__release
   local.get $4
   return
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#toString (; 299 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#toString (; 305 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4464
   call $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#join
  )
- (func $start:std/array (; 300 ;) (type $FUNCSIG$v)
+ (func $start:std/array (; 306 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -22418,7 +22623,7 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 940
+   i32.const 945
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22439,7 +22644,7 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 941
+   i32.const 946
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22460,7 +22665,7 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 942
+   i32.const 947
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22481,7 +22686,7 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 943
+   i32.const 948
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22502,7 +22707,7 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 944
+   i32.const 949
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22523,7 +22728,7 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 945
+   i32.const 950
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22566,7 +22771,46 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 947
+   i32.const 952
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 2
+  i32.const 2
+  i32.const 20
+  i32.const 0
+  call $~lib/rt/__allocArray
+  local.set $40
+  local.get $40
+  i32.load offset=4
+  local.set $41
+  local.get $41
+  i32.const 0
+  call $std/array/Ref#constructor
+  local.tee $45
+  call $~lib/rt/pure/__retain
+  i32.store
+  local.get $41
+  i32.const 0
+  call $std/array/Ref#constructor
+  local.tee $39
+  call $~lib/rt/pure/__retain
+  i32.store offset=4
+  local.get $40
+  call $~lib/rt/pure/__retain
+  local.set $41
+  local.get $41
+  i32.const 4464
+  call $~lib/array/Array<std/array/Ref>#join
+  local.tee $40
+  i32.const 6776
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 955
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22603,168 +22847,54 @@
   call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
+  local.get $45
+  call $~lib/rt/pure/__release
+  local.get $39
+  call $~lib/rt/pure/__release
+  local.get $41
+  call $~lib/rt/pure/__release
+  local.get $40
+  call $~lib/rt/pure/__release
   i32.const 0
   i32.const 2
   i32.const 3
-  i32.const 6776
+  i32.const 6856
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $41
+  call $~lib/rt/pure/__retain
+  local.set $40
+  i32.const 1
+  i32.const 2
+  i32.const 3
+  i32.const 6872
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $45
+  call $~lib/rt/pure/__retain
+  local.set $39
+  i32.const 2
+  i32.const 2
+  i32.const 3
+  i32.const 6896
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   local.tee $34
   call $~lib/rt/pure/__retain
   local.set $1
-  i32.const 1
+  i32.const 4
   i32.const 2
   i32.const 3
-  i32.const 6792
+  i32.const 6920
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   local.tee $38
   call $~lib/rt/pure/__retain
   local.set $42
-  i32.const 2
-  i32.const 2
-  i32.const 3
-  i32.const 6816
-  call $~lib/rt/__allocArray
-  call $~lib/rt/pure/__retain
-  local.tee $8
-  call $~lib/rt/pure/__retain
-  local.set $10
-  i32.const 4
-  i32.const 2
-  i32.const 3
-  i32.const 6840
-  call $~lib/rt/__allocArray
-  call $~lib/rt/pure/__retain
-  local.tee $6
-  call $~lib/rt/pure/__retain
-  local.set $9
-  local.get $1
+  local.get $40
   call $~lib/array/Array<i32>#toString
-  local.tee $4
+  local.tee $10
   i32.const 4248
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 376
-   i32.const 957
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $42
-  call $~lib/array/Array<i32>#toString
-  local.tee $11
-  i32.const 6592
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 376
-   i32.const 958
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $10
-  call $~lib/array/Array<i32>#toString
-  local.tee $15
-  i32.const 6872
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 376
-   i32.const 959
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $9
-  call $~lib/array/Array<i32>#toString
-  local.tee $13
-  i32.const 6896
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 376
-   i32.const 960
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 3
-  i32.const 0
-  i32.const 20
-  i32.const 6928
-  call $~lib/rt/__allocArray
-  call $~lib/rt/pure/__retain
-  local.tee $17
-  call $~lib/array/Array<i8>#toString
-  local.tee $12
-  i32.const 6952
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 376
-   i32.const 962
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 3
-  i32.const 1
-  i32.const 21
-  i32.const 6984
-  call $~lib/rt/__allocArray
-  call $~lib/rt/pure/__retain
-  local.tee $2
-  call $~lib/array/Array<u16>#toString
-  local.tee $14
-  i32.const 7008
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 376
-   i32.const 963
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 3
-  i32.const 3
-  i32.const 16
-  i32.const 7048
-  call $~lib/rt/__allocArray
-  call $~lib/rt/pure/__retain
-  local.tee $41
-  call $~lib/array/Array<u64>#toString
-  local.tee $40
-  i32.const 7088
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 376
-   i32.const 964
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 4
-  i32.const 3
-  i32.const 22
-  i32.const 7152
-  call $~lib/rt/__allocArray
-  call $~lib/rt/pure/__retain
-  local.tee $39
-  call $~lib/array/Array<i64>#toString
-  local.tee $45
-  i32.const 7200
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -22775,10 +22905,132 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $39
+  call $~lib/array/Array<i32>#toString
+  local.tee $8
+  i32.const 6592
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 966
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  call $~lib/array/Array<i32>#toString
+  local.tee $9
+  i32.const 6952
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 967
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $42
+  call $~lib/array/Array<i32>#toString
+  local.tee $6
+  i32.const 6976
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 968
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 3
+  i32.const 0
+  i32.const 21
+  i32.const 7008
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $11
+  call $~lib/array/Array<i8>#toString
+  local.tee $4
+  i32.const 7032
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 970
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 3
+  i32.const 1
+  i32.const 22
+  i32.const 7064
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $13
+  call $~lib/array/Array<u16>#toString
+  local.tee $15
+  i32.const 7088
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 971
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 3
+  i32.const 3
+  i32.const 16
+  i32.const 7128
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $17
+  call $~lib/array/Array<u64>#toString
+  local.tee $12
+  i32.const 7168
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 972
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 4
+  i32.const 3
+  i32.const 23
+  i32.const 7232
+  call $~lib/rt/__allocArray
+  call $~lib/rt/pure/__retain
+  local.tee $2
+  call $~lib/array/Array<i64>#toString
+  local.tee $14
+  i32.const 7280
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 973
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
   i32.const 7
   i32.const 2
   i32.const 13
-  i32.const 7304
+  i32.const 7384
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   local.tee $48
@@ -22787,13 +23039,13 @@
   local.get $44
   call $~lib/array/Array<~lib/string/String | null>#toString
   local.tee $46
-  i32.const 7352
+  i32.const 7432
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 969
+   i32.const 977
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22801,19 +23053,19 @@
   i32.const 4
   i32.const 2
   i32.const 13
-  i32.const 7448
+  i32.const 7528
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   local.tee $47
   call $~lib/array/Array<~lib/string/String | null>#toString
   local.tee $43
-  i32.const 7480
+  i32.const 7560
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 970
+   i32.const 978
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -22831,7 +23083,7 @@
   i32.const 2
   i32.const 2
   i32.const 3
-  i32.const 7512
+  i32.const 7592
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   local.tee $52
@@ -22841,7 +23093,7 @@
   i32.const 2
   i32.const 2
   i32.const 3
-  i32.const 7536
+  i32.const 7616
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   local.tee $16
@@ -22853,20 +23105,20 @@
   local.get $54
   call $~lib/array/Array<~lib/array/Array<i32>>#toString
   local.tee $50
-  i32.const 7560
+  i32.const 7640
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 973
+   i32.const 981
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
   i32.const 2
   i32.const 2
-  i32.const 23
+  i32.const 24
   i32.const 0
   call $~lib/rt/__allocArray
   local.set $49
@@ -22877,7 +23129,7 @@
   i32.const 2
   i32.const 0
   i32.const 6
-  i32.const 7592
+  i32.const 7672
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   local.tee $19
@@ -22887,7 +23139,7 @@
   i32.const 2
   i32.const 0
   i32.const 6
-  i32.const 7616
+  i32.const 7696
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   local.tee $20
@@ -22899,20 +23151,20 @@
   local.get $55
   call $~lib/array/Array<~lib/array/Array<u8>>#toString
   local.tee $53
-  i32.const 7560
+  i32.const 7640
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 976
+   i32.const 984
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
   i32.const 1
   i32.const 2
-  i32.const 25
+  i32.const 26
   i32.const 0
   call $~lib/rt/__allocArray
   local.set $49
@@ -22922,7 +23174,7 @@
   local.get $0
   i32.const 1
   i32.const 2
-  i32.const 24
+  i32.const 25
   i32.const 0
   call $~lib/rt/__allocArray
   local.set $18
@@ -22933,7 +23185,7 @@
   i32.const 1
   i32.const 2
   i32.const 7
-  i32.const 7640
+  i32.const 7720
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
   local.tee $23
@@ -22954,11 +23206,19 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 979
+   i32.const 987
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $41
+  call $~lib/rt/pure/__release
+  local.get $40
+  call $~lib/rt/pure/__release
+  local.get $45
+  call $~lib/rt/pure/__release
+  local.get $39
+  call $~lib/rt/pure/__release
   local.get $34
   call $~lib/rt/pure/__release
   local.get $1
@@ -22967,21 +23227,21 @@
   call $~lib/rt/pure/__release
   local.get $42
   call $~lib/rt/pure/__release
-  local.get $8
-  call $~lib/rt/pure/__release
   local.get $10
   call $~lib/rt/pure/__release
-  local.get $6
+  local.get $8
   call $~lib/rt/pure/__release
   local.get $9
   call $~lib/rt/pure/__release
-  local.get $4
+  local.get $6
   call $~lib/rt/pure/__release
   local.get $11
   call $~lib/rt/pure/__release
-  local.get $15
+  local.get $4
   call $~lib/rt/pure/__release
   local.get $13
+  call $~lib/rt/pure/__release
+  local.get $15
   call $~lib/rt/pure/__release
   local.get $17
   call $~lib/rt/pure/__release
@@ -22990,14 +23250,6 @@
   local.get $2
   call $~lib/rt/pure/__release
   local.get $14
-  call $~lib/rt/pure/__release
-  local.get $41
-  call $~lib/rt/pure/__release
-  local.get $40
-  call $~lib/rt/pure/__release
-  local.get $39
-  call $~lib/rt/pure/__release
-  local.get $45
   call $~lib/rt/pure/__release
   local.get $48
   call $~lib/rt/pure/__release
@@ -23034,7 +23286,7 @@
   local.get $56
   call $~lib/rt/pure/__release
  )
- (func $start (; 301 ;) (type $FUNCSIG$v)
+ (func $start (; 307 ;) (type $FUNCSIG$v)
   global.get $~lib/started
   if
    return
@@ -23044,22 +23296,22 @@
   end
   call $start:std/array
  )
- (func $~lib/array/Array<i32>#__visit_impl (; 302 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#__visit_impl (; 308 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u8>#__visit_impl (; 303 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u8>#__visit_impl (; 309 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u32>#__visit_impl (; 304 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u32>#__visit_impl (; 310 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<f32>#__visit_impl (; 305 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f32>#__visit_impl (; 311 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<f64>#__visit_impl (; 306 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f64>#__visit_impl (; 312 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/rt/pure/__visit (; 307 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 313 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -23189,7 +23441,7 @@
    end
   end
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__visit_impl (; 308 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__visit_impl (; 314 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23228,7 +23480,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#__visit_impl (; 309 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#__visit_impl (; 315 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23267,7 +23519,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/string/String | null>#__visit_impl (; 310 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/string/String | null>#__visit_impl (; 316 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23306,7 +23558,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/string/String>#__visit_impl (; 311 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/string/String>#__visit_impl (; 317 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23345,16 +23597,16 @@
    unreachable
   end
  )
- (func $~lib/array/Array<bool>#__visit_impl (; 312 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<bool>#__visit_impl (; 318 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u64>#__visit_impl (; 313 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u64>#__visit_impl (; 319 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<i16>#__visit_impl (; 314 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i16>#__visit_impl (; 320 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<std/array/Ref | null>#__visit_impl (; 315 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<std/array/Ref | null>#__visit_impl (; 321 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23393,16 +23645,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<i8>#__visit_impl (; 316 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
-  nop
- )
- (func $~lib/array/Array<u16>#__visit_impl (; 317 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
-  nop
- )
- (func $~lib/array/Array<i64>#__visit_impl (; 318 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
-  nop
- )
- (func $~lib/array/Array<~lib/array/Array<u8>>#__visit_impl (; 319 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<std/array/Ref>#__visit_impl (; 322 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23441,7 +23684,16 @@
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/array/Array<u32>>#__visit_impl (; 320 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i8>#__visit_impl (; 323 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  nop
+ )
+ (func $~lib/array/Array<u16>#__visit_impl (; 324 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  nop
+ )
+ (func $~lib/array/Array<i64>#__visit_impl (; 325 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  nop
+ )
+ (func $~lib/array/Array<~lib/array/Array<u8>>#__visit_impl (; 326 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23480,7 +23732,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#__visit_impl (; 321 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/array/Array<u32>>#__visit_impl (; 327 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23519,104 +23771,149 @@
    unreachable
   end
  )
- (func $~lib/rt/__visit_members (; 322 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#__visit_impl (; 328 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  local.get $0
+  i32.load offset=4
+  local.set $2
+  local.get $2
+  local.get $0
+  i32.load offset=12
+  i32.const 2
+  i32.shl
+  i32.add
+  local.set $3
+  block $break|0
+   loop $continue|0
+    local.get $2
+    local.get $3
+    i32.lt_u
+    i32.eqz
+    br_if $break|0
+    local.get $2
+    i32.load
+    local.set $4
+    local.get $4
+    if
+     local.get $4
+     local.get $1
+     call $~lib/rt/pure/__visit
+    end
+    local.get $2
+    i32.const 4
+    i32.add
+    local.set $2
+    br $continue|0
+   end
+   unreachable
+  end
+ )
+ (func $~lib/rt/__visit_members (; 329 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $block$4$break
    block $switch$1$default
-    block $switch$1$case$27
-     block $switch$1$case$26
-      block $switch$1$case$25
-       block $switch$1$case$24
-        block $switch$1$case$23
-         block $switch$1$case$22
-          block $switch$1$case$21
-           block $switch$1$case$19
-            block $switch$1$case$18
-             block $switch$1$case$17
-              block $switch$1$case$16
-               block $switch$1$case$15
-                block $switch$1$case$14
-                 block $switch$1$case$12
-                  block $switch$1$case$11
-                   block $switch$1$case$10
-                    block $switch$1$case$9
-                     block $switch$1$case$8
-                      block $switch$1$case$5
-                       block $switch$1$case$4
-                        block $switch$1$case$2
-                         local.get $0
-                         i32.const 8
-                         i32.sub
-                         i32.load
-                         br_table $switch$1$case$2 $switch$1$case$2 $switch$1$case$4 $switch$1$case$5 $switch$1$case$2 $switch$1$case$4 $switch$1$case$8 $switch$1$case$9 $switch$1$case$10 $switch$1$case$11 $switch$1$case$12 $switch$1$case$2 $switch$1$case$14 $switch$1$case$15 $switch$1$case$16 $switch$1$case$17 $switch$1$case$18 $switch$1$case$19 $switch$1$case$2 $switch$1$case$21 $switch$1$case$22 $switch$1$case$23 $switch$1$case$24 $switch$1$case$25 $switch$1$case$26 $switch$1$case$27 $switch$1$default
+    block $switch$1$case$28
+     block $switch$1$case$27
+      block $switch$1$case$26
+       block $switch$1$case$25
+        block $switch$1$case$24
+         block $switch$1$case$23
+          block $switch$1$case$22
+           block $switch$1$case$21
+            block $switch$1$case$19
+             block $switch$1$case$18
+              block $switch$1$case$17
+               block $switch$1$case$16
+                block $switch$1$case$15
+                 block $switch$1$case$14
+                  block $switch$1$case$12
+                   block $switch$1$case$11
+                    block $switch$1$case$10
+                     block $switch$1$case$9
+                      block $switch$1$case$8
+                       block $switch$1$case$5
+                        block $switch$1$case$4
+                         block $switch$1$case$2
+                          local.get $0
+                          i32.const 8
+                          i32.sub
+                          i32.load
+                          br_table $switch$1$case$2 $switch$1$case$2 $switch$1$case$4 $switch$1$case$5 $switch$1$case$2 $switch$1$case$4 $switch$1$case$8 $switch$1$case$9 $switch$1$case$10 $switch$1$case$11 $switch$1$case$12 $switch$1$case$2 $switch$1$case$14 $switch$1$case$15 $switch$1$case$16 $switch$1$case$17 $switch$1$case$18 $switch$1$case$19 $switch$1$case$2 $switch$1$case$21 $switch$1$case$22 $switch$1$case$23 $switch$1$case$24 $switch$1$case$25 $switch$1$case$26 $switch$1$case$27 $switch$1$case$28 $switch$1$default
+                         end
+                         return
                         end
-                        return
+                        br $block$4$break
                        end
+                       local.get $0
+                       local.get $1
+                       call $~lib/array/Array<i32>#__visit_impl
                        br $block$4$break
                       end
                       local.get $0
                       local.get $1
-                      call $~lib/array/Array<i32>#__visit_impl
+                      call $~lib/array/Array<u8>#__visit_impl
                       br $block$4$break
                      end
                      local.get $0
                      local.get $1
-                     call $~lib/array/Array<u8>#__visit_impl
+                     call $~lib/array/Array<u32>#__visit_impl
                      br $block$4$break
                     end
                     local.get $0
                     local.get $1
-                    call $~lib/array/Array<u32>#__visit_impl
+                    call $~lib/array/Array<f32>#__visit_impl
                     br $block$4$break
                    end
                    local.get $0
                    local.get $1
-                   call $~lib/array/Array<f32>#__visit_impl
+                   call $~lib/array/Array<f64>#__visit_impl
                    br $block$4$break
                   end
                   local.get $0
                   local.get $1
-                  call $~lib/array/Array<f64>#__visit_impl
+                  call $~lib/array/Array<~lib/array/Array<i32>>#__visit_impl
                   br $block$4$break
                  end
                  local.get $0
                  local.get $1
-                 call $~lib/array/Array<~lib/array/Array<i32>>#__visit_impl
+                 call $~lib/array/Array<std/array/Proxy<i32>>#__visit_impl
                  br $block$4$break
                 end
                 local.get $0
                 local.get $1
-                call $~lib/array/Array<std/array/Proxy<i32>>#__visit_impl
+                call $~lib/array/Array<~lib/string/String | null>#__visit_impl
                 br $block$4$break
                end
                local.get $0
                local.get $1
-               call $~lib/array/Array<~lib/string/String | null>#__visit_impl
+               call $~lib/array/Array<~lib/string/String>#__visit_impl
                br $block$4$break
               end
               local.get $0
               local.get $1
-              call $~lib/array/Array<~lib/string/String>#__visit_impl
+              call $~lib/array/Array<bool>#__visit_impl
               br $block$4$break
              end
              local.get $0
              local.get $1
-             call $~lib/array/Array<bool>#__visit_impl
+             call $~lib/array/Array<u64>#__visit_impl
              br $block$4$break
             end
             local.get $0
             local.get $1
-            call $~lib/array/Array<u64>#__visit_impl
+            call $~lib/array/Array<i16>#__visit_impl
             br $block$4$break
            end
            local.get $0
            local.get $1
-           call $~lib/array/Array<i16>#__visit_impl
+           call $~lib/array/Array<std/array/Ref | null>#__visit_impl
            br $block$4$break
           end
           local.get $0
           local.get $1
-          call $~lib/array/Array<std/array/Ref | null>#__visit_impl
+          call $~lib/array/Array<std/array/Ref>#__visit_impl
           br $block$4$break
          end
          local.get $0
@@ -23661,6 +23958,6 @@
   end
   return
  )
- (func $null (; 323 ;) (type $FUNCSIG$v)
+ (func $null (; 330 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -14358,7 +14358,7 @@
   local.get $4
   return
  )
- (func $~lib/util/string/joinStringArray (; 254 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinStringArray<~lib/string/String | null> (; 254 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -14368,7 +14368,6 @@
   (local $9 i32)
   (local $10 i32)
   (local $11 i32)
-  (local $12 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -14388,35 +14387,45 @@
    local.get $4
    return
   end
+  i32.const 0
+  local.set $5
   local.get $3
   i32.eqz
   if
    local.get $0
    i32.load
+   local.tee $4
+   if (result i32)
+    local.get $4
+   else
+    unreachable
+   end
+   local.tee $4
+   if (result i32)
+    local.get $4
+   else
+    i32.const 4248
+   end
    call $~lib/rt/pure/__retain
    local.set $4
    local.get $2
+   call $~lib/rt/pure/__release
+   local.get $5
    call $~lib/rt/pure/__release
    local.get $4
    return
   end
   local.get $2
   call $~lib/string/String#get:length
-  local.set $5
-  i32.const 0
   local.set $6
   i32.const 0
   local.set $7
   block $break|0
    i32.const 0
    local.set $4
-   local.get $3
-   i32.const 1
-   i32.add
-   local.set $8
    loop $loop|0
     local.get $4
-    local.get $8
+    local.get $1
     i32.lt_s
     i32.eqz
     br_if $break|0
@@ -14426,28 +14435,28 @@
     i32.shl
     i32.add
     i32.load
+    local.tee $8
+    local.get $5
     local.tee $9
-    local.get $7
-    local.tee $10
     i32.ne
     if
-     local.get $9
+     local.get $8
      call $~lib/rt/pure/__retain
      drop
-     local.get $10
+     local.get $9
      call $~lib/rt/pure/__release
     end
-    local.get $9
-    local.set $7
-    local.get $7
+    local.get $8
+    local.set $5
+    local.get $5
     i32.const 0
     i32.ne
     if
-     local.get $6
      local.get $7
+     local.get $5
      call $~lib/string/String#get:length
      i32.add
-     local.set $6
+     local.set $7
     end
     local.get $4
     i32.const 1
@@ -14458,9 +14467,9 @@
    unreachable
   end
   i32.const 0
-  local.set $11
+  local.set $10
+  local.get $7
   local.get $6
-  local.get $5
   local.get $3
   i32.mul
   i32.add
@@ -14469,78 +14478,78 @@
   i32.const 1
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
-  local.set $12
+  local.set $11
   block $break|1
    i32.const 0
-   local.set $8
+   local.set $4
    loop $loop|1
-    local.get $8
+    local.get $4
     local.get $3
     i32.lt_s
     i32.eqz
     br_if $break|1
     local.get $0
-    local.get $8
+    local.get $4
     i32.const 2
     i32.shl
     i32.add
     i32.load
-    local.tee $10
-    local.get $7
-    local.tee $4
+    local.tee $9
+    local.get $5
+    local.tee $8
     i32.ne
     if
-     local.get $10
+     local.get $9
      call $~lib/rt/pure/__retain
      drop
-     local.get $4
+     local.get $8
      call $~lib/rt/pure/__release
     end
-    local.get $10
-    local.set $7
-    local.get $7
+    local.get $9
+    local.set $5
+    local.get $5
     i32.const 0
     i32.ne
     if
-     local.get $7
+     local.get $5
      call $~lib/string/String#get:length
-     local.set $10
-     local.get $12
+     local.set $9
      local.get $11
+     local.get $10
      i32.const 1
      i32.shl
      i32.add
-     local.get $7
-     local.get $10
+     local.get $5
+     local.get $9
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
+     local.get $10
+     local.get $9
+     i32.add
+     local.set $10
+    end
+    local.get $6
+    if
      local.get $11
      local.get $10
-     i32.add
-     local.set $11
-    end
-    local.get $5
-    if
-     local.get $12
-     local.get $11
      i32.const 1
      i32.shl
      i32.add
      local.get $2
-     local.get $5
+     local.get $6
      i32.const 1
      i32.shl
      call $~lib/memory/memory.copy
-     local.get $11
-     local.get $5
+     local.get $10
+     local.get $6
      i32.add
-     local.set $11
+     local.set $10
     end
-    local.get $8
+    local.get $4
     i32.const 1
     i32.add
-    local.set $8
+    local.set $4
     br $loop|1
    end
    unreachable
@@ -14551,42 +14560,42 @@
   i32.shl
   i32.add
   i32.load
-  local.tee $9
-  local.get $7
   local.tee $8
+  local.get $5
+  local.tee $4
   i32.ne
   if
-   local.get $9
+   local.get $8
    call $~lib/rt/pure/__retain
    drop
-   local.get $8
+   local.get $4
    call $~lib/rt/pure/__release
   end
-  local.get $9
-  local.set $7
-  local.get $7
+  local.get $8
+  local.set $5
+  local.get $5
   i32.const 0
   i32.ne
   if
-   local.get $12
    local.get $11
+   local.get $10
    i32.const 1
    i32.shl
    i32.add
-   local.get $7
-   local.get $7
+   local.get $5
+   local.get $5
    call $~lib/string/String#get:length
    i32.const 1
    i32.shl
    call $~lib/memory/memory.copy
   end
-  local.get $12
-  local.set $9
+  local.get $11
+  local.set $8
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $7
+  local.get $5
   call $~lib/rt/pure/__release
-  local.get $9
+  local.get $8
  )
  (func $~lib/array/Array<~lib/string/String | null>#join (; 255 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -14604,7 +14613,7 @@
   local.get $2
   local.get $3
   local.get $1
-  call $~lib/util/string/joinStringArray
+  call $~lib/util/string/joinStringArray<~lib/string/String | null>
   local.set $4
   local.get $1
   call $~lib/rt/pure/__release

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -14358,7 +14358,7 @@
   local.get $4
   return
  )
- (func $~lib/util/string/joinStringArray<~lib/string/String | null> (; 254 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinStringArray (; 254 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -14394,12 +14394,6 @@
   if
    local.get $0
    i32.load
-   local.tee $4
-   if (result i32)
-    local.get $4
-   else
-    unreachable
-   end
    local.tee $4
    if (result i32)
     local.get $4
@@ -14613,7 +14607,7 @@
   local.get $2
   local.get $3
   local.get $1
-  call $~lib/util/string/joinStringArray<~lib/string/String | null>
+  call $~lib/util/string/joinStringArray
   local.set $4
   local.get $1
   call $~lib/rt/pure/__release


### PR DESCRIPTION
Now during join arrays of objects we always call `toString`. Also slightly improve join array of strings