### PR TITLE
Emit related ranges for duplicate identifiers

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -7,7 +7,8 @@ import {
   CommonFlags,
   CommonSymbols,
   PATH_DELIMITER,
-  LIBRARY_PREFIX
+  LIBRARY_PREFIX,
+  LIBRARY_SUBST
 } from "./common";
 
 import {
@@ -1648,6 +1649,12 @@ export class Source extends Node {
     this.text = text;
   }
 
+  /** Checks if this source represents native code. */
+  get isNative(): bool {
+    return this.internalPath == LIBRARY_SUBST;
+  }
+
+  /** Checks if this source is part of the (standard) library. */
   get isLibrary(): bool {
     var kind = this.sourceKind;
     return kind == SourceKind.LIBRARY || kind == SourceKind.LIBRARY_ENTRY;

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -212,11 +212,11 @@ export function formatDiagnosticMessage(
       }
       sb.push("\n");
       sb.push(" in ");
-      sb.push(range.source.normalizedPath);
+      sb.push(relatedRange.source.normalizedPath);
       sb.push("(");
-      sb.push(range.line.toString(10));
+      sb.push(relatedRange.line.toString(10));
       sb.push(",");
-      sb.push(range.column.toString(10));
+      sb.push(relatedRange.column.toString(10));
       sb.push(")");
     }
   }

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -416,10 +416,19 @@ export class Flow {
       let existingLocal = this.scopedLocals.get(name);
       if (existingLocal) {
         if (reportNode) {
-          this.parentFunction.program.error(
-            DiagnosticCode.Duplicate_identifier_0,
-            reportNode.range
-          );
+          if (!existingLocal.declaration.range.source.isNative) {
+            this.parentFunction.program.errorRelated(
+              DiagnosticCode.Duplicate_identifier_0,
+              reportNode.range,
+              existingLocal.declaration.name.range,
+              name
+            );
+          } else {
+            this.parentFunction.program.error(
+              DiagnosticCode.Duplicate_identifier_0,
+              reportNode.range, name
+            );
+          }
         }
         return existingLocal;
       }

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -2738,9 +2738,11 @@ export class Resolver extends DiagnosticEmitter {
             let instanceMembers = instance.members;
             if (!instanceMembers) instance.members = instanceMembers = new Map();
             else if (instanceMembers.has(member.name)) {
-              this.error(
+              let existing = instanceMembers.get(member.name)!;
+              this.errorRelated(
                 DiagnosticCode.Duplicate_identifier_0,
                 (<FieldPrototype>member).identifierNode.range,
+                existing.declaration.name.range,
                 member.name
               );
               break;

--- a/tests/compiler/duplicate-identifier.json
+++ b/tests/compiler/duplicate-identifier.json
@@ -1,0 +1,14 @@
+{
+  "asc_flags": [
+    "--runtime none"
+  ],
+  "stderr": [
+    "TS2300: Duplicate identifier 'a'", "var a: f32", "var a: i32",
+    "TS2300: Duplicate identifier 'b'", "b: f32", "b: i32",
+    "TS2300: Duplicate identifier 'c'", "static c: f32", " static c: i32",
+    "TS2300: Duplicate identifier 'd'", "const d: f32", "const d: i32",
+    "TS2300: Duplicate identifier 'e'", "var e: f32", "var e: i32",
+    "TS2300: Duplicate identifier 'f'", "let f: f32",
+    "EOF"
+  ]
+}

--- a/tests/compiler/duplicate-identifier.ts
+++ b/tests/compiler/duplicate-identifier.ts
@@ -1,0 +1,27 @@
+var a: i32;
+var a: f32;
+
+class Foo {
+  b: i32;
+  b: f32;
+  static c: i32;
+  static c: f32;
+}
+
+namespace Bar {
+  const d: i32 = 0;
+  const d: f32 = 1;
+}
+
+function baz(): void {
+  var e: i32;
+  var e: f32;
+  {
+    let f: i32;
+    let f: f32;
+  }
+}
+
+baz();
+
+ERROR("EOF"); // mark end and ensure fail


### PR DESCRIPTION
Related: https://github.com/AssemblyScript/assemblyscript/pull/797

This PR extends "Duplicate identifier: X" errors by also printing the range of the already existing identifier. This isn't currently possible for scoped locals (`let`, `const` in a block) that use a shared declaration (multiple names share the same local), but works for any `var`, class member, namespace member etc. Also fixes the assertions triggered previously.