### PR TITLE
tests\compiler\relocatable test offsets for globals

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -16,6 +16,7 @@ under the licensing terms detailed in LICENSE:
 * Willem Wyndham <willem@cs.umd.edu>
 * Bowen Wang <bowen@nearprotocol.com>
 * Emil Laine <laine.emil@gmail.com>
+* Sam Paioletti <sampaioletti@gmail.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/tests/compiler/relocatable.js
+++ b/tests/compiler/relocatable.js
@@ -3,7 +3,16 @@ exports.preInstantiate = function(imports, exports) {
   // of env.memory_base yet, hence we need to import a suitable memory as well:
   imports["env"] = {
     "memory": new WebAssembly.Memory({ initial: 2 }),
-    "memory_base": 65536,
-    "table_base": 100
+    "memory_base": 2,
+    "table_base": 100,
+    "log":(offset,length)=>{
+      let view=new Uint16Array(imports["env"].memory.buffer,offset,length)
+      let str=String.fromCharCode.apply(null,view)
+      assert(str==="relocatable",`expected relocatable got'${str}' at index ${offset}`)
+    }
   };
 };
+
+exports.postInstantiate=function(instance){
+  instance.exports.main()
+}

--- a/tests/compiler/relocatable.optimized.wat
+++ b/tests/compiler/relocatable.optimized.wat
@@ -1,14 +1,27 @@
 (module
  (type $FUNCSIG$v (func))
+ (type $FUNCSIG$vii (func (param i32 i32)))
  (import "env" "memory" (memory $0 1))
- (data (global.get $__memory_base) "\00\00\00\00\00\00\00\00\04\00\00\00\01\00\00\00\00\00\00\00\04\00\00\00\00\00\00\00\00\00\00\00\10\00\00\00\01\00\00\00\03\00\00\00\10\00\00\00\18\00\00\00\18\00\00\00\04\00\00\00\01\00\00\00")
+ (data (global.get $__memory_base) "\00\00\00\00\00\00\00\00\04\00\00\00\01\00\00\00\00\00\00\00\04\00\00\00\00\00\00\00\00\00\00\00\10\00\00\00\01\00\00\00\03\00\00\00\10\00\00\00\18\00\00\00\18\00\00\00\04\00\00\00\01\00\00\00\16\00\00\00\01\00\00\00\01\00\00\00\16\00\00\00r\00e\00l\00o\00c\00a\00t\00a\00b\00l\00e\00")
  (import "env" "memory_base" (global $__memory_base i32))
- (global $__memory_size i32 (i32.const 64))
+ (import "env" "log" (func $relocatable/log (param i32 i32)))
+ (global $__memory_size i32 (i32.const 112))
  (global $__table_size i32 (i32.const 1))
  (export "memory" (memory $0))
+ (export "main" (func $relocatable/main))
  (export "__memory_size" (global $__memory_size))
  (export "__table_size" (global $__table_size))
- (func $start (; 0 ;) (type $FUNCSIG$v)
+ (func $relocatable/main (; 1 ;) (type $FUNCSIG$v)
+  i32.const 80
+  global.get $__memory_base
+  i32.const -64
+  i32.sub
+  i32.load offset=12
+  i32.const 1
+  i32.shr_u
+  call $relocatable/log
+ )
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/relocatable.ts
+++ b/tests/compiler/relocatable.ts
@@ -1,3 +1,11 @@
 const someStaticStuff: i32[] = [0];
 
 someStaticStuff;
+
+@external("env","log")
+declare function log(s:string,length:i32):void
+
+export function main():void{
+    let s="relocatable"
+    log(s,s.length)
+}

--- a/tests/compiler/relocatable.untouched.wat
+++ b/tests/compiler/relocatable.untouched.wat
@@ -1,27 +1,60 @@
 (module
  (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$vi (func (param i32)))
  (import "env" "memory" (memory $0 1))
- (data (global.get $__memory_base) "\00\00\00\00\00\00\00\00\04\00\00\00\01\00\00\00\00\00\00\00\04\00\00\00\00\00\00\00\00\00\00\00\10\00\00\00\01\00\00\00\03\00\00\00\10\00\00\00\18\00\00\00\18\00\00\00\04\00\00\00\01\00\00\00")
+ (data (global.get $__memory_base) "\00\00\00\00\00\00\00\00\04\00\00\00\01\00\00\00\00\00\00\00\04\00\00\00\00\00\00\00\00\00\00\00\10\00\00\00\01\00\00\00\03\00\00\00\10\00\00\00\18\00\00\00\18\00\00\00\04\00\00\00\01\00\00\00\16\00\00\00\01\00\00\00\01\00\00\00\16\00\00\00r\00e\00l\00o\00c\00a\00t\00a\00b\00l\00e\00")
  (import "env" "memory_base" (global $__memory_base i32))
  (import "env" "table_base" (global $__table_base i32))
+ (import "env" "log" (func $relocatable/log (param i32 i32)))
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (global $relocatable/someStaticStuff i32 (i32.const 48))
- (global $__memory_size i32 (i32.const 64))
+ (global $__memory_size i32 (i32.const 112))
  (global $__table_size i32 (i32.const 1))
  (export "memory" (memory $0))
+ (export "main" (func $relocatable/main))
  (export "__memory_size" (global $__memory_size))
  (export "__table_size" (global $__table_size))
  (start $start)
- (func $start:relocatable (; 0 ;) (type $FUNCSIG$v)
+ (func $start:relocatable (; 1 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   global.get $relocatable/someStaticStuff
   drop
  )
- (func $start (; 1 ;) (type $FUNCSIG$v)
+ (func $~lib/rt/stub/__retain (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+ )
+ (func $~lib/string/String#get:length (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  global.get $__memory_base
+  local.get $0
+  i32.const 16
+  i32.sub
+  i32.add
+  i32.load offset=12
+  i32.const 1
+  i32.shr_u
+ )
+ (func $~lib/rt/stub/__release (; 4 ;) (type $FUNCSIG$vi) (param $0 i32)
+  nop
+ )
+ (func $relocatable/main (; 5 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  i32.const 80
+  call $~lib/rt/stub/__retain
+  local.set $0
+  local.get $0
+  local.get $0
+  call $~lib/string/String#get:length
+  call $relocatable/log
+  local.get $0
+  call $~lib/rt/stub/__release
+ )
+ (func $start (; 6 ;) (type $FUNCSIG$v)
   call $start:relocatable
  )
- (func $null (; 2 ;) (type $FUNCSIG$v)
+ (func $null (; 7 ;) (type $FUNCSIG$v)
  )
 )


### PR DESCRIPTION
Instantiating the data segments to memory is working correctly for what I can tell, but need to add offset logic to the index values

for example from the relocatable.untouched.wat fixture that I updated

```wat
  ;;line 43
 (func $relocatable/main (; 5 ;) (type $FUNCSIG$v)
  (local $0 i32)
  i32.const 80 ;; offset from mem_base
  call $~lib/rt/stub/__retain
```

should be

```wat
  ;;line 43
 (func $relocatable/main (; 5 ;) (type $FUNCSIG$v)
  (local $0 i32)
  global.get $__memory_base
  i32.const 80
  i32.add
  call $~lib/rt/stub/__retain
```

I'll look into it...but may be above my paygrade (: