### PR TITLE
Use integer fractions for FILL_FACTOR & FREE_FACTOR in Map/Set

### DIFF
--- a/std/assembly/map.ts
+++ b/std/assembly/map.ts
@@ -11,11 +11,19 @@ const INITIAL_CAPACITY = 4;
 
 // @ts-ignore: decorator
 @inline
-const FILL_FACTOR: f64 = 8 / 3;
+const FILL_FACTOR_N = 8;
 
 // @ts-ignore: decorator
 @inline
-const FREE_FACTOR: f64 = 3 / 4;
+const FILL_FACTOR_D = 3;
+
+// @ts-ignore: decorator
+@inline
+const FREE_FACTOR_N = 3;
+
+// @ts-ignore: decorator
+@inline
+const FREE_FACTOR_D = 4;
 
 /** Structure of a map entry. */
 @unmanaged class MapEntry<K,V> {
@@ -122,7 +130,7 @@ export class Map<K,V> {
       // check if rehashing is necessary
       if (this.entriesOffset == this.entriesCapacity) {
         this.rehash(
-          this.entriesCount < <i32>(this.entriesCapacity * FREE_FACTOR)
+          this.entriesCount < this.entriesCapacity * FREE_FACTOR_N / FREE_FACTOR_D
             ?  this.bucketsMask           // just rehash if 1/4+ entries are empty
             : (this.bucketsMask << 1) | 1 // grow capacity to next 2^N
         );
@@ -156,7 +164,7 @@ export class Map<K,V> {
     var halfBucketsMask = this.bucketsMask >> 1;
     if (
       halfBucketsMask + 1 >= max<u32>(INITIAL_CAPACITY, this.entriesCount) &&
-      this.entriesCount < <i32>(this.entriesCapacity * FREE_FACTOR)
+      this.entriesCount < this.entriesCapacity * FREE_FACTOR_N / FREE_FACTOR_D
     ) this.rehash(halfBucketsMask);
     return true;
   }
@@ -164,7 +172,7 @@ export class Map<K,V> {
   private rehash(newBucketsMask: u32): void {
     var newBucketsCapacity = <i32>(newBucketsMask + 1);
     var newBuckets = new ArrayBuffer(newBucketsCapacity * <i32>BUCKET_SIZE);
-    var newEntriesCapacity = <i32>(newBucketsCapacity * FILL_FACTOR);
+    var newEntriesCapacity = newBucketsCapacity * FILL_FACTOR_N / FILL_FACTOR_D;
     var newEntries = new ArrayBuffer(newEntriesCapacity * <i32>ENTRY_SIZE<K,V>());
 
     // copy old entries to new entries

--- a/std/assembly/set.ts
+++ b/std/assembly/set.ts
@@ -10,11 +10,19 @@ const INITIAL_CAPACITY = 4;
 
 // @ts-ignore: decorator
 @inline
-const FILL_FACTOR: f64 = 8 / 3;
+const FILL_FACTOR_N = 8;
 
 // @ts-ignore: decorator
 @inline
-const FREE_FACTOR: f64 = 3 / 4;
+const FILL_FACTOR_D = 3;
+
+// @ts-ignore: decorator
+@inline
+const FREE_FACTOR_N = 3;
+
+// @ts-ignore: decorator
+@inline
+const FREE_FACTOR_D = 4;
 
 /** Structure of a set entry. */
 @unmanaged class SetEntry<K> {
@@ -100,7 +108,7 @@ export class Set<T> {
       // check if rehashing is necessary
       if (this.entriesOffset == this.entriesCapacity) {
         this.rehash(
-          this.entriesCount < <i32>(this.entriesCapacity * FREE_FACTOR)
+          this.entriesCount < this.entriesCapacity * FREE_FACTOR_N / FREE_FACTOR_D
             ?  this.bucketsMask           // just rehash if 1/4+ entries are empty
             : (this.bucketsMask << 1) | 1 // grow capacity to next 2^N
         );
@@ -134,7 +142,7 @@ export class Set<T> {
     var halfBucketsMask = this.bucketsMask >> 1;
     if (
       halfBucketsMask + 1 >= max<u32>(INITIAL_CAPACITY, this.entriesCount) &&
-      this.entriesCount < <i32>(this.entriesCapacity * FREE_FACTOR)
+      this.entriesCount < this.entriesCapacity * FREE_FACTOR_N / FREE_FACTOR_D
     ) this.rehash(halfBucketsMask);
     return true;
   }
@@ -142,7 +150,7 @@ export class Set<T> {
   private rehash(newBucketsMask: u32): void {
     var newBucketsCapacity = <i32>(newBucketsMask + 1);
     var newBuckets = new ArrayBuffer(newBucketsCapacity * <i32>BUCKET_SIZE);
-    var newEntriesCapacity = <i32>(newBucketsCapacity * FILL_FACTOR);
+    var newEntriesCapacity = newBucketsCapacity * FILL_FACTOR_N / FILL_FACTOR_D;
     var newEntries = new ArrayBuffer(newEntriesCapacity * <i32>ENTRY_SIZE<T>());
 
     // copy old entries to new entries

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -2163,10 +2163,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $5
   local.get $3
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
   local.tee $6
   i32.const 12
   i32.mul
@@ -2307,10 +2307,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -2388,7 +2388,7 @@
   if
    i32.const 416
    i32.const 472
-   i32.const 103
+   i32.const 111
    i32.const 16
    call $~lib/builtins/abort
    unreachable
@@ -2445,10 +2445,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -2861,10 +2861,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $5
   local.get $3
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
   local.tee $6
   i32.const 12
   i32.mul
@@ -3003,10 +3003,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -3082,7 +3082,7 @@
   if
    i32.const 416
    i32.const 472
-   i32.const 103
+   i32.const 111
    i32.const 16
    call $~lib/builtins/abort
    unreachable
@@ -3137,10 +3137,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -3601,10 +3601,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $5
   local.get $3
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
   local.tee $6
   i32.const 12
   i32.mul
@@ -3745,10 +3745,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -3826,7 +3826,7 @@
   if
    i32.const 416
    i32.const 472
-   i32.const 103
+   i32.const 111
    i32.const 16
    call $~lib/builtins/abort
    unreachable
@@ -3883,10 +3883,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -4299,10 +4299,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $5
   local.get $3
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
   local.tee $6
   i32.const 12
   i32.mul
@@ -4441,10 +4441,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -4520,7 +4520,7 @@
   if
    i32.const 416
    i32.const 472
-   i32.const 103
+   i32.const 111
    i32.const 16
    call $~lib/builtins/abort
    unreachable
@@ -4575,10 +4575,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -5049,10 +5049,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $5
   local.get $3
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
   local.tee $6
   i32.const 12
   i32.mul
@@ -5189,10 +5189,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -5266,7 +5266,7 @@
   if
    i32.const 416
    i32.const 472
-   i32.const 103
+   i32.const 111
    i32.const 16
    call $~lib/builtins/abort
    unreachable
@@ -5319,10 +5319,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -6193,10 +6193,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $5
   local.get $3
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
   local.tee $6
   i32.const 4
   i32.shl
@@ -6333,10 +6333,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -6410,7 +6410,7 @@
   if
    i32.const 416
    i32.const 472
-   i32.const 103
+   i32.const 111
    i32.const 16
    call $~lib/builtins/abort
    unreachable
@@ -6464,10 +6464,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -7254,10 +7254,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $5
   local.get $3
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
   local.tee $6
   i32.const 12
   i32.mul
@@ -7396,10 +7396,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -7474,7 +7474,7 @@
   if
    i32.const 416
    i32.const 472
-   i32.const 103
+   i32.const 111
    i32.const 16
    call $~lib/builtins/abort
    unreachable
@@ -7529,10 +7529,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -7966,10 +7966,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $5
   local.get $3
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
   local.tee $6
   i32.const 4
   i32.shl
@@ -8108,10 +8108,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -8186,7 +8186,7 @@
   if
    i32.const 416
    i32.const 472
-   i32.const 103
+   i32.const 111
    i32.const 16
    call $~lib/builtins/abort
    unreachable
@@ -8241,10 +8241,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -3739,10 +3739,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
   local.set $4
   i32.const 0
   local.get $4
@@ -3912,10 +3912,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -4003,7 +4003,7 @@
   if
    i32.const 416
    i32.const 472
-   i32.const 103
+   i32.const 111
    i32.const 16
    call $~lib/builtins/abort
    unreachable
@@ -4076,10 +4076,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -4627,10 +4627,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
   local.set $4
   i32.const 0
   local.get $4
@@ -4798,10 +4798,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -4887,7 +4887,7 @@
   if
    i32.const 416
    i32.const 472
-   i32.const 103
+   i32.const 111
    i32.const 16
    call $~lib/builtins/abort
    unreachable
@@ -4958,10 +4958,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -5521,10 +5521,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
   local.set $4
   i32.const 0
   local.get $4
@@ -5694,10 +5694,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -5785,7 +5785,7 @@
   if
    i32.const 416
    i32.const 472
-   i32.const 103
+   i32.const 111
    i32.const 16
    call $~lib/builtins/abort
    unreachable
@@ -5858,10 +5858,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -6409,10 +6409,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
   local.set $4
   i32.const 0
   local.get $4
@@ -6580,10 +6580,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -6669,7 +6669,7 @@
   if
    i32.const 416
    i32.const 472
-   i32.const 103
+   i32.const 111
    i32.const 16
    call $~lib/builtins/abort
    unreachable
@@ -6740,10 +6740,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -7315,10 +7315,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
   local.set $4
   i32.const 0
   local.get $4
@@ -7484,10 +7484,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -7571,7 +7571,7 @@
   if
    i32.const 416
    i32.const 472
-   i32.const 103
+   i32.const 111
    i32.const 16
    call $~lib/builtins/abort
    unreachable
@@ -7640,10 +7640,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -8159,10 +8159,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
   local.set $4
   i32.const 0
   local.get $4
@@ -8328,10 +8328,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -8415,7 +8415,7 @@
   if
    i32.const 416
    i32.const 472
-   i32.const 103
+   i32.const 111
    i32.const 16
    call $~lib/builtins/abort
    unreachable
@@ -8484,10 +8484,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -9092,10 +9092,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
   local.set $4
   i32.const 0
   local.get $4
@@ -9262,10 +9262,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -9349,7 +9349,7 @@
   if
    i32.const 416
    i32.const 472
-   i32.const 103
+   i32.const 111
    i32.const 16
    call $~lib/builtins/abort
    unreachable
@@ -9419,10 +9419,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -9946,10 +9946,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
   local.set $4
   i32.const 0
   local.get $4
@@ -10116,10 +10116,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -10203,7 +10203,7 @@
   if
    i32.const 416
    i32.const 472
-   i32.const 103
+   i32.const 111
    i32.const 16
    call $~lib/builtins/abort
    unreachable
@@ -10273,10 +10273,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -10801,10 +10801,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
   local.set $4
   i32.const 0
   local.get $4
@@ -10973,10 +10973,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -11061,7 +11061,7 @@
   if
    i32.const 416
    i32.const 472
-   i32.const 103
+   i32.const 111
    i32.const 16
    call $~lib/builtins/abort
    unreachable
@@ -11132,10 +11132,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -11660,10 +11660,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
   local.set $4
   i32.const 0
   local.get $4
@@ -11832,10 +11832,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -11920,7 +11920,7 @@
   if
    i32.const 416
    i32.const 472
-   i32.const 103
+   i32.const 111
    i32.const 16
    call $~lib/builtins/abort
    unreachable
@@ -11991,10 +11991,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -2158,10 +2158,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $5
   local.get $3
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
   local.tee $6
   i32.const 3
   i32.shl
@@ -2294,10 +2294,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -2403,10 +2403,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -2720,10 +2720,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $5
   local.get $3
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
   local.tee $6
   i32.const 3
   i32.shl
@@ -2854,10 +2854,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -2961,10 +2961,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -3340,10 +3340,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $5
   local.get $3
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
   local.tee $6
   i32.const 3
   i32.shl
@@ -3476,10 +3476,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -3585,10 +3585,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -3902,10 +3902,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $5
   local.get $3
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
   local.tee $6
   i32.const 3
   i32.shl
@@ -4036,10 +4036,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -4143,10 +4143,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -4532,10 +4532,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $5
   local.get $3
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
   local.tee $6
   i32.const 3
   i32.shl
@@ -4664,10 +4664,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -4769,10 +4769,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -5501,10 +5501,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $5
   local.get $3
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
   local.tee $6
   i32.const 4
   i32.shl
@@ -5633,10 +5633,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -5739,10 +5739,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -6373,10 +6373,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $5
   local.get $3
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
   local.tee $6
   i32.const 3
   i32.shl
@@ -6507,10 +6507,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -6614,10 +6614,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -6973,10 +6973,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $5
   local.get $3
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
   local.tee $6
   i32.const 4
   i32.shl
@@ -7107,10 +7107,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -7214,10 +7214,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -3737,10 +3737,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
   local.set $4
   i32.const 0
   local.get $4
@@ -3902,10 +3902,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -4027,10 +4027,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -4477,10 +4477,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
   local.set $4
   i32.const 0
   local.get $4
@@ -4640,10 +4640,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -4763,10 +4763,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -5239,10 +5239,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
   local.set $4
   i32.const 0
   local.get $4
@@ -5404,10 +5404,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -5529,10 +5529,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -5979,10 +5979,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
   local.set $4
   i32.const 0
   local.get $4
@@ -6142,10 +6142,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -6265,10 +6265,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -6753,10 +6753,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
   local.set $4
   i32.const 0
   local.get $4
@@ -6914,10 +6914,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -7035,10 +7035,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -7481,10 +7481,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
   local.set $4
   i32.const 0
   local.get $4
@@ -7642,10 +7642,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -7763,10 +7763,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -8298,10 +8298,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
   local.set $4
   i32.const 0
   local.get $4
@@ -8460,10 +8460,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -8582,10 +8582,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -9029,10 +9029,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
   local.set $4
   i32.const 0
   local.get $4
@@ -9191,10 +9191,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -9313,10 +9313,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -9761,10 +9761,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
   local.set $4
   i32.const 0
   local.get $4
@@ -9925,10 +9925,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -10048,10 +10048,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0
@@ -10496,10 +10496,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
   local.set $4
   i32.const 0
   local.get $4
@@ -10660,10 +10660,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -10783,10 +10783,10 @@
    i32.load offset=20
    local.get $0
    i32.load offset=12
-   f64.convert_i32_s
-   f64.const 0.75
-   f64.mul
-   i32.trunc_f64_s
+   i32.const 3
+   i32.mul
+   i32.const 4
+   i32.div_s
    i32.lt_s
   else
    i32.const 0

--- a/tests/compiler/std/symbol.optimized.wat
+++ b/tests/compiler/std/symbol.optimized.wat
@@ -681,7 +681,7 @@
   if
    i32.const 200
    i32.const 256
-   i32.const 103
+   i32.const 111
    i32.const 16
    call $~lib/builtins/abort
    unreachable
@@ -706,10 +706,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $2
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
   local.tee $6
   i32.const 12
   i32.mul
@@ -822,10 +822,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -976,10 +976,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $4
   local.get $2
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
   local.tee $6
   i32.const 12
   i32.mul
@@ -1099,10 +1099,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -1219,7 +1219,7 @@
   if
    i32.const 200
    i32.const 256
-   i32.const 103
+   i32.const 111
    i32.const 16
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/symbol.untouched.wat
+++ b/tests/compiler/std/symbol.untouched.wat
@@ -997,7 +997,7 @@
    call $~lib/rt/stub/__release
    i32.const 200
    i32.const 256
-   i32.const 103
+   i32.const 111
    i32.const 16
    call $~lib/builtins/abort
    unreachable
@@ -1032,10 +1032,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
   local.set $4
   i32.const 0
   local.get $4
@@ -1214,10 +1214,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -1398,10 +1398,10 @@
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $3
   local.get $2
-  f64.convert_i32_s
-  f64.const 2.6666666666666665
-  f64.mul
-  i32.trunc_f64_s
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
   local.set $4
   i32.const 0
   local.get $4
@@ -1581,10 +1581,10 @@
     i32.load offset=20
     local.get $0
     i32.load offset=12
-    f64.convert_i32_s
-    f64.const 0.75
-    f64.mul
-    i32.trunc_f64_s
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
     i32.lt_s
     if (result i32)
      local.get $0
@@ -1750,7 +1750,7 @@
   if
    i32.const 200
    i32.const 256
-   i32.const 103
+   i32.const 111
    i32.const 16
    call $~lib/builtins/abort
    unreachable


### PR DESCRIPTION
I expect this shouldn't decrease performance because division by constant usually transform to [wide multiplication + shift](https://en.wikipedia.org/wiki/Division_algorithm#Division_by_a_constant).

Close #902 