### PR TITLE
Improve generic builtin type inference with multiple parameters

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1331,6 +1331,17 @@ export enum LiteralKind {
   OBJECT
 }
 
+/** Checks if the given node represents a numeric (float or integer) literal. */
+export function isNumericLiteral(node: Expression): bool {
+  if (node.kind == NodeKind.LITERAL) {
+    switch ((<LiteralExpression>node).literalKind) {
+      case LiteralKind.FLOAT:
+      case LiteralKind.INTEGER: return true;
+    }
+  }
+  return false;
+}
+
 /** Base class of all literal expressions. */
 export abstract class LiteralExpression extends Expression {
   kind = NodeKind.LITERAL;

--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -21,7 +21,8 @@ import {
   LiteralKind,
   LiteralExpression,
   StringLiteralExpression,
-  CallExpression
+  CallExpression,
+  isNumericLiteral
 } from "./ast";
 
 import {
@@ -1081,7 +1082,7 @@ export function compileCall(
       ) return module.unreachable();
       let arg0 = typeArguments
         ? compiler.compileExpression(operands[0], typeArguments[0], Constraints.CONV_IMPLICIT | Constraints.MUST_WRAP)
-        : compiler.compileExpression(operands[0], Type.f64, Constraints.MUST_WRAP);
+        : compiler.compileExpression(operands[0], Type.auto, Constraints.MUST_WRAP);
       let type = compiler.currentType;
       if (!type.is(TypeFlags.REFERENCE)) {
         switch (type.kind) {
@@ -1179,12 +1180,21 @@ export function compileCall(
         checkTypeOptional(typeArguments, reportNode, compiler, true) |
         checkArgsRequired(operands, 2, reportNode, compiler)
       ) return module.unreachable();
+      let left = operands[0];
       let arg0 = typeArguments
-        ? compiler.compileExpression(operands[0], typeArguments[0], Constraints.CONV_IMPLICIT | Constraints.MUST_WRAP)
-        : compiler.compileExpression(operands[0], Type.f64, Constraints.MUST_WRAP);
+        ? compiler.compileExpression(left, typeArguments[0], Constraints.CONV_IMPLICIT | Constraints.MUST_WRAP)
+        : compiler.compileExpression(operands[0], Type.auto, Constraints.MUST_WRAP);
       let type = compiler.currentType;
       if (!type.is(TypeFlags.REFERENCE)) {
-        let arg1 = compiler.compileExpression(operands[1], type, Constraints.CONV_IMPLICIT | Constraints.MUST_WRAP);
+        let arg1: ExpressionRef;
+        if (!typeArguments && isNumericLiteral(left)) { // prefer right type
+          arg1 = compiler.compileExpression(operands[1], type, Constraints.MUST_WRAP);
+          if (compiler.currentType != type) {
+            arg0 = compiler.compileExpression(left, type = compiler.currentType, Constraints.CONV_IMPLICIT | Constraints.MUST_WRAP);
+          }
+        } else {
+          arg1 = compiler.compileExpression(operands[1], type, Constraints.CONV_IMPLICIT | Constraints.MUST_WRAP);
+        }
         let op: BinaryOp = -1;
         switch (type.kind) {
           case TypeKind.I8:
@@ -1240,12 +1250,21 @@ export function compileCall(
         checkTypeOptional(typeArguments, reportNode, compiler, true) |
         checkArgsRequired(operands, 2, reportNode, compiler)
       ) return module.unreachable();
+      let left = operands[0];
       let arg0 = typeArguments
-        ? compiler.compileExpression(operands[0], typeArguments[0], Constraints.CONV_IMPLICIT | Constraints.MUST_WRAP)
-        : compiler.compileExpression(operands[0], Type.f64, Constraints.MUST_WRAP);
+        ? compiler.compileExpression(left, typeArguments[0], Constraints.CONV_IMPLICIT | Constraints.MUST_WRAP)
+        : compiler.compileExpression(operands[0], Type.auto, Constraints.MUST_WRAP);
       let type = compiler.currentType;
       if (!type.is(TypeFlags.REFERENCE)) {
-        let arg1 = compiler.compileExpression(operands[1], type, Constraints.CONV_IMPLICIT | Constraints.MUST_WRAP);
+        let arg1: ExpressionRef;
+        if (!typeArguments && isNumericLiteral(left)) { // prefer right type
+          arg1 = compiler.compileExpression(operands[1], type, Constraints.MUST_WRAP);
+          if (compiler.currentType != type) {
+            arg0 = compiler.compileExpression(left, type = compiler.currentType, Constraints.CONV_IMPLICIT | Constraints.MUST_WRAP);
+          }
+        } else {
+          arg1 = compiler.compileExpression(operands[1], type, Constraints.CONV_IMPLICIT | Constraints.MUST_WRAP);
+        }
         let op: BinaryOp = -1;
         switch (type.kind) {
           case TypeKind.I8:
@@ -1303,7 +1322,7 @@ export function compileCall(
       ) return module.unreachable();
       let arg0 = typeArguments
         ? compiler.compileExpression(operands[0], typeArguments[0], Constraints.CONV_IMPLICIT)
-        : compiler.compileExpression(operands[0], Type.f64, Constraints.NONE);
+        : compiler.compileExpression(operands[0], Type.auto, Constraints.NONE);
       let type = compiler.currentType;
       if (!type.is(TypeFlags.REFERENCE)) {
         switch (type.kind) {
@@ -1335,7 +1354,7 @@ export function compileCall(
       ) return module.unreachable();
       let arg0 = typeArguments
         ? compiler.compileExpression(operands[0], typeArguments[0], Constraints.CONV_IMPLICIT)
-        : compiler.compileExpression(operands[0], Type.f64, Constraints.NONE);
+        : compiler.compileExpression(operands[0], Type.auto, Constraints.NONE);
       let type = compiler.currentType;
       if (!type.is(TypeFlags.REFERENCE)) {
         switch (type.kind) {
@@ -1390,7 +1409,7 @@ export function compileCall(
       ) return module.unreachable();
       let arg0 = typeArguments
         ? compiler.compileExpression(operands[0], typeArguments[0], Constraints.CONV_IMPLICIT)
-        : compiler.compileExpression(operands[0], Type.f64, Constraints.NONE);
+        : compiler.compileExpression(operands[0], Type.auto, Constraints.NONE);
       let type = compiler.currentType;
       if (!type.is(TypeFlags.REFERENCE)) {
         switch (type.kind) {
@@ -1498,7 +1517,7 @@ export function compileCall(
       ) return module.unreachable();
       let arg0 = typeArguments
         ? compiler.compileExpression(operands[0], typeArguments[0], Constraints.CONV_IMPLICIT)
-        : compiler.compileExpression(operands[0], Type.f64, Constraints.NONE);
+        : compiler.compileExpression(operands[0], Type.auto, Constraints.NONE);
       let type = compiler.currentType;
       if (!type.is(TypeFlags.REFERENCE)) {
         switch (type.kind) {

--- a/tests/compiler/builtins.optimized.wat
+++ b/tests/compiler/builtins.optimized.wat
@@ -428,6 +428,12 @@
   f64.const 1.25
   call $~lib/number/isFinite<f64>
   global.set $builtins/b
+  f64.const 0
+  global.set $builtins/F
+  f32.const 0
+  global.get $builtins/f
+  f32.max
+  global.set $builtins/f
   i32.const 8
   i32.load
   global.set $builtins/i
@@ -627,7 +633,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 294
+   i32.const 299
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -638,7 +644,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 295
+   i32.const 300
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -648,7 +654,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 296
+   i32.const 301
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -658,7 +664,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 297
+   i32.const 302
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -668,7 +674,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 298
+   i32.const 303
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -678,7 +684,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 299
+   i32.const 304
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -689,7 +695,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 300
+   i32.const 305
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -700,7 +706,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 301
+   i32.const 306
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -789,73 +795,13 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 437
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 176
-  i32.const 176
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 438
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 208
-  i32.const 208
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 439
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 232
-  i32.const 232
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 440
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 264
-  i32.const 264
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 441
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 288
-  i32.const 288
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 64
    i32.const 442
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 312
-  i32.const 312
+  i32.const 176
+  i32.const 176
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -866,8 +812,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 336
-  i32.const 336
+  i32.const 208
+  i32.const 208
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -878,8 +824,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 360
-  i32.const 360
+  i32.const 232
+  i32.const 232
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -890,8 +836,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 384
-  i32.const 384
+  i32.const 264
+  i32.const 264
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -902,8 +848,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 408
-  i32.const 408
+  i32.const 288
+  i32.const 288
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -914,8 +860,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 432
-  i32.const 432
+  i32.const 312
+  i32.const 312
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -926,8 +872,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 456
-  i32.const 456
+  i32.const 336
+  i32.const 336
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -938,8 +884,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 480
-  i32.const 480
+  i32.const 360
+  i32.const 360
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -950,8 +896,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 504
-  i32.const 504
+  i32.const 384
+  i32.const 384
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -962,8 +908,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 528
-  i32.const 528
+  i32.const 408
+  i32.const 408
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -974,8 +920,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 560
-  i32.const 560
+  i32.const 432
+  i32.const 432
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -986,8 +932,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 592
-  i32.const 592
+  i32.const 456
+  i32.const 456
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -998,6 +944,66 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 480
+  i32.const 480
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 64
+   i32.const 455
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 504
+  i32.const 504
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 64
+   i32.const 456
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 528
+  i32.const 528
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 64
+   i32.const 457
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 560
+  i32.const 560
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 64
+   i32.const 458
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 592
+  i32.const 592
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 64
+   i32.const 459
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
   i32.const 232
   i32.const 232
   call $~lib/string/String.__eq
@@ -1005,7 +1011,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 455
+   i32.const 460
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1017,7 +1023,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 456
+   i32.const 461
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/builtins.ts
+++ b/tests/compiler/builtins.ts
@@ -158,6 +158,11 @@ F = trunc<f64>(1.25);
 b = isNaN<f64>(1.25);
 b = isFinite<f64>(1.25);
 
+// prefer right type if left is a numeric literal
+
+F = min(0, 1.0);
+f = max(0, f);
+
 // load and store
 
 i = load<i32>(8); store<i32>(8, i);

--- a/tests/compiler/builtins.untouched.wat
+++ b/tests/compiler/builtins.untouched.wat
@@ -871,6 +871,14 @@
   f64.const 1.25
   call $~lib/number/isFinite<f64>
   global.set $builtins/b
+  f64.const 0
+  f64.const 1
+  f64.min
+  global.set $builtins/F
+  f32.const 0
+  global.get $builtins/f
+  f32.max
+  global.set $builtins/f
   i32.const 8
   i32.load
   global.set $builtins/i
@@ -1129,7 +1137,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 294
+   i32.const 299
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -1140,7 +1148,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 295
+   i32.const 300
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -1152,7 +1160,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 296
+   i32.const 301
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -1164,7 +1172,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 297
+   i32.const 302
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -1176,7 +1184,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 298
+   i32.const 303
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -1188,7 +1196,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 299
+   i32.const 304
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -1199,7 +1207,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 300
+   i32.const 305
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -1210,7 +1218,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 301
+   i32.const 306
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -1420,7 +1428,7 @@
   if
    i32.const 144
    i32.const 64
-   i32.const 430
+   i32.const 435
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1432,7 +1440,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 431
+   i32.const 436
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1444,7 +1452,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 432
+   i32.const 437
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1456,73 +1464,13 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 433
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 176
-  i32.const 176
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 437
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 176
-  i32.const 176
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 64
    i32.const 438
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 208
-  i32.const 208
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 439
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 232
-  i32.const 232
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 440
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 264
-  i32.const 264
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 441
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 288
-  i32.const 288
+  i32.const 176
+  i32.const 176
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -1533,8 +1481,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 312
-  i32.const 312
+  i32.const 176
+  i32.const 176
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -1545,8 +1493,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 336
-  i32.const 336
+  i32.const 208
+  i32.const 208
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -1557,8 +1505,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 360
-  i32.const 360
+  i32.const 232
+  i32.const 232
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -1569,8 +1517,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 384
-  i32.const 384
+  i32.const 264
+  i32.const 264
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -1581,8 +1529,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 408
-  i32.const 408
+  i32.const 288
+  i32.const 288
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -1593,8 +1541,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 432
-  i32.const 432
+  i32.const 312
+  i32.const 312
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -1605,8 +1553,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 456
-  i32.const 456
+  i32.const 336
+  i32.const 336
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -1617,8 +1565,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 480
-  i32.const 480
+  i32.const 360
+  i32.const 360
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -1629,8 +1577,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 504
-  i32.const 504
+  i32.const 384
+  i32.const 384
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -1641,8 +1589,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 528
-  i32.const 528
+  i32.const 408
+  i32.const 408
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -1653,8 +1601,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 560
-  i32.const 560
+  i32.const 432
+  i32.const 432
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -1665,8 +1613,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i32.const 592
-  i32.const 592
+  i32.const 456
+  i32.const 456
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -1677,6 +1625,66 @@
    call $~lib/builtins/abort
    unreachable
   end
+  i32.const 480
+  i32.const 480
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 64
+   i32.const 455
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 504
+  i32.const 504
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 64
+   i32.const 456
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 528
+  i32.const 528
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 64
+   i32.const 457
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 560
+  i32.const 560
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 64
+   i32.const 458
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 592
+  i32.const 592
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 64
+   i32.const 459
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
   i32.const 232
   i32.const 232
   call $~lib/string/String.__eq
@@ -1684,7 +1692,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 455
+   i32.const 460
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1696,7 +1704,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 456
+   i32.const 461
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/mandelbrot.optimized.wat
+++ b/tests/compiler/mandelbrot.optimized.wat
@@ -378,7 +378,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 f64)
-  (local $9 f64)
+  (local $9 i32)
   (local $10 f64)
   (local $11 f64)
   (local $12 f64)
@@ -393,42 +393,48 @@
   f64.mul
   f64.sub
   f64.const 10
-  f64.const 3
   local.get $1
-  f64.convert_i32_u
-  f64.mul
-  f64.const 4
-  local.get $2
-  f64.convert_i32_u
-  f64.mul
-  f64.min
-  f64.div
+  i32.const 3
+  i32.mul
   local.tee $9
+  local.get $2
+  i32.const 2
+  i32.shl
+  local.tee $2
+  local.get $9
+  local.get $2
+  i32.lt_s
+  select
+  f64.convert_i32_s
+  f64.div
+  local.tee $10
   f64.mul
-  local.set $10
+  local.set $11
   local.get $1
   f64.convert_i32_u
   f64.const 0.625
   f64.mul
-  local.get $9
+  local.get $10
   f64.mul
-  local.set $12
+  local.set $13
   local.get $0
   local.get $1
   i32.mul
   i32.const 1
   i32.shl
-  local.set $0
+  local.set $2
   f64.const 1
   local.get $3
   f64.convert_i32_u
   f64.div
-  local.set $13
-  f64.const 8
-  local.get $3
-  f64.convert_i32_u
-  f64.min
   local.set $14
+  i32.const 8
+  local.get $3
+  i32.const 8
+  local.get $3
+  i32.lt_u
+  select
+  local.set $0
   loop $loop|0
    block $break|0
     local.get $7
@@ -437,11 +443,11 @@
     br_if $break|0
     local.get $7
     f64.convert_i32_u
-    local.get $9
+    local.get $10
     f64.mul
-    local.get $12
+    local.get $13
     f64.sub
-    local.set $11
+    local.set $12
     f64.const 0
     local.set $4
     f64.const 0
@@ -468,13 +474,13 @@
       f64.mul
       local.get $5
       f64.mul
-      local.get $10
+      local.get $11
       f64.add
       local.set $5
       local.get $15
       local.get $8
       f64.sub
-      local.get $11
+      local.get $12
       f64.add
       local.set $4
       local.get $6
@@ -490,9 +496,9 @@
     end
     loop $continue|2
      local.get $6
-     f64.convert_i32_u
-     local.get $14
-     f64.lt
+     local.get $0
+     i32.ge_u
+     i32.eqz
      if
       local.get $4
       local.get $4
@@ -501,14 +507,14 @@
       local.get $5
       f64.mul
       f64.sub
-      local.get $11
+      local.get $12
       f64.add
       f64.const 2
       local.get $4
       f64.mul
       local.get $5
       f64.mul
-      local.get $10
+      local.get $11
       f64.add
       local.set $5
       local.set $4
@@ -520,11 +526,11 @@
      end
     end
     i32.const 2047
-    local.set $2
+    local.set $9
     local.get $7
     i32.const 1
     i32.shl
-    local.get $0
+    local.get $2
     i32.add
     local.get $4
     local.get $4
@@ -548,7 +554,7 @@
      f64.mul
      call $~lib/math/NativeMath.log2
      f64.sub
-     local.get $13
+     local.get $14
      f64.mul
      f64.const 0
      f64.max

--- a/tests/compiler/mandelbrot.untouched.wat
+++ b/tests/compiler/mandelbrot.untouched.wat
@@ -473,19 +473,19 @@
  (func $../../examples/mandelbrot/assembly/index/computeLine (; 2 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   (local $4 f64)
   (local $5 f64)
-  (local $6 f64)
-  (local $7 f64)
+  (local $6 i32)
+  (local $7 i32)
   (local $8 f64)
-  (local $9 i32)
+  (local $9 f64)
   (local $10 f64)
-  (local $11 f64)
-  (local $12 i32)
-  (local $13 f64)
+  (local $11 i32)
+  (local $12 f64)
+  (local $13 i32)
   (local $14 f64)
   (local $15 f64)
   (local $16 f64)
   (local $17 f64)
-  (local $18 i32)
+  (local $18 f64)
   (local $19 f64)
   (local $20 i32)
   (local $21 f64)
@@ -507,141 +507,148 @@
   f64.mul
   local.set $5
   f64.const 10
-  f64.const 3
+  i32.const 3
   local.get $1
-  f64.convert_i32_u
-  f64.mul
-  f64.const 4
+  i32.mul
+  local.tee $6
+  i32.const 4
   local.get $2
-  f64.convert_i32_u
-  f64.mul
-  f64.min
+  i32.mul
+  local.tee $7
+  local.get $6
+  local.get $7
+  i32.lt_s
+  select
+  f64.convert_i32_s
   f64.div
-  local.set $6
+  local.set $8
   local.get $0
   f64.convert_i32_u
   local.get $5
   f64.sub
-  local.get $6
+  local.get $8
   f64.mul
-  local.set $7
+  local.set $9
   local.get $4
-  local.get $6
+  local.get $8
   f64.mul
-  local.set $8
+  local.set $10
   local.get $0
   local.get $1
   i32.mul
   i32.const 1
   i32.shl
-  local.set $9
+  local.set $11
   f64.const 1
   local.get $3
   f64.convert_i32_u
   f64.div
-  local.set $10
-  f64.const 8
+  local.set $12
+  i32.const 8
+  local.tee $6
   local.get $3
-  f64.convert_i32_u
-  f64.min
-  local.set $11
+  local.tee $7
+  local.get $6
+  local.get $7
+  i32.lt_u
+  select
+  local.set $13
   block $break|0
    i32.const 0
-   local.set $12
+   local.set $6
    loop $loop|0
-    local.get $12
+    local.get $6
     local.get $1
     i32.lt_u
     i32.eqz
     br_if $break|0
-    local.get $12
-    f64.convert_i32_u
     local.get $6
-    f64.mul
+    f64.convert_i32_u
     local.get $8
+    f64.mul
+    local.get $10
     f64.sub
-    local.set $13
-    f64.const 0
     local.set $14
     f64.const 0
     local.set $15
+    f64.const 0
+    local.set $16
     i32.const 0
-    local.set $18
+    local.set $7
     block $break|1
      loop $continue|1
-      local.get $14
-      local.get $14
-      f64.mul
-      local.tee $16
       local.get $15
       local.get $15
       f64.mul
       local.tee $17
+      local.get $16
+      local.get $16
+      f64.mul
+      local.tee $18
       f64.add
       f64.const 4
       f64.le
       i32.eqz
       br_if $break|1
       f64.const 2
-      local.get $14
-      f64.mul
       local.get $15
       f64.mul
-      local.get $7
+      local.get $16
+      f64.mul
+      local.get $9
+      f64.add
+      local.set $16
+      local.get $17
+      local.get $18
+      f64.sub
+      local.get $14
       f64.add
       local.set $15
-      local.get $16
-      local.get $17
-      f64.sub
-      local.get $13
-      f64.add
-      local.set $14
-      local.get $18
+      local.get $7
       local.get $3
       i32.ge_u
       if
        br $break|1
       end
-      local.get $18
+      local.get $7
       i32.const 1
       i32.add
-      local.set $18
+      local.set $7
       br $continue|1
      end
      unreachable
     end
     block $break|2
      loop $continue|2
-      local.get $18
-      f64.convert_i32_u
-      local.get $11
-      f64.lt
+      local.get $7
+      local.get $13
+      i32.lt_u
       i32.eqz
       br_if $break|2
-      local.get $14
-      local.get $14
+      local.get $15
+      local.get $15
       f64.mul
-      local.get $15
-      local.get $15
+      local.get $16
+      local.get $16
       f64.mul
       f64.sub
-      local.get $13
+      local.get $14
       f64.add
       local.set $19
       f64.const 2
-      local.get $14
-      f64.mul
       local.get $15
       f64.mul
-      local.get $7
+      local.get $16
+      f64.mul
+      local.get $9
       f64.add
-      local.set $15
+      local.set $16
       local.get $19
-      local.set $14
-      local.get $18
+      local.set $15
+      local.get $7
       i32.const 1
       i32.add
-      local.set $18
+      local.set $7
       br $continue|2
      end
      unreachable
@@ -650,11 +657,11 @@
     i32.const 1
     i32.sub
     local.set $20
-    local.get $14
-    local.get $14
+    local.get $15
+    local.get $15
     f64.mul
-    local.get $15
-    local.get $15
+    local.get $16
+    local.get $16
     f64.mul
     f64.add
     local.set $19
@@ -672,13 +679,13 @@
      i32.const 1
      i32.sub
      f64.convert_i32_s
-     local.get $18
+     local.get $7
      i32.const 1
      i32.add
      f64.convert_i32_u
      local.get $21
      f64.sub
-     local.get $10
+     local.get $12
      f64.mul
      local.set $24
      f64.const 0
@@ -694,17 +701,17 @@
      i32.trunc_f64_u
      local.set $20
     end
-    local.get $9
-    local.get $12
+    local.get $11
+    local.get $6
     i32.const 1
     i32.shl
     i32.add
     local.get $20
     i32.store16
-    local.get $12
+    local.get $6
     i32.const 1
     i32.add
-    local.set $12
+    local.set $6
     br $loop|0
    end
    unreachable


### PR DESCRIPTION
This resolves some issues with literals being the first argument to type-inferred builtins as reported in https://github.com/AssemblyScript/assemblyscript/issues/896. There are other edge cases this doesn't cover (for example `min(someF32Expr, someF64Expr)`), but while trying to implement a proper fix I hit road blocks in the resolver that must be investigated in more detail.