### PR TITLE
Added missing type declaration for 'u64'

### DIFF
--- a/dist/assemblyscript.d.ts
+++ b/dist/assemblyscript.d.ts
@@ -6,6 +6,7 @@ declare type isize = number;
 declare type u8 = number;
 declare type u16 = number;
 declare type u32 = number;
+declare type u64 = number;
 declare type usize = number;
 declare type f32 = number;
 declare type f64 = number;


### PR DESCRIPTION
The type 'u64' was missing a type declaration and making it hard for VSCode to know what 'u64' meant.