### PR TITLE
Align loader API with WebAssembly API

### DIFF
--- a/lib/loader/README.md
+++ b/lib/loader/README.md
@@ -14,14 +14,14 @@ const loader = require("assemblyscript/lib/loader");
 API
 ---
 
-* **instantiate**<`T`>(module: `WebAssembly.Module`, imports?: `WasmImports`): `ASUtil & T`<br />
-  Instantiates an AssemblyScript module using the specified imports.
+* **instantiate**<`T`>(moduleOrBuffer: `WebAssembly.Module | BufferSource`, imports?: `WasmImports`): `Promise<ASUtil & T>`<br />
+  Asynchronously instantiates an AssemblyScript module from a module or buffer using the specified imports.
 
-* **instantiateBuffer**<`T`>(buffer: `Uint8Array`, imports?: `WasmImports`): `ASUtil & T`<br />
-  Instantiates an AssemblyScript module from a buffer using the specified imports.
+* **instantiateSync**<`T`>(moduleOrBuffer: `WebAssembly.Module | BufferSource`, imports?: `WasmImports`): `ASUtil & T`<br />
+  Synchronously instantiates an AssemblyScript module from a module or buffer using the specified imports.
 
 * **instantiateStreaming**<`T`>(response: `Response`, imports?: `WasmImports`): `Promise<ASUtil & T>`<br />
-  Instantiates an AssemblyScript module from a response using the specified imports.
+  Asynchronously instantiates an AssemblyScript module from a response object using the specified imports.
 
 * **demangle**<`T`>(exports: `WasmExports`, baseModule?: `Object`): `T`<br />
   Demangles an AssemblyScript module's exports to a friendly object structure. You usually don't have to call this manually as instantiation does this implicitly.
@@ -141,10 +141,13 @@ Examples
 
 ```js
 // From a module provided as a buffer, i.e. as returned by fs.readFileSync
-const myModule = loader.instantiateBuffer(fs.readFileSync("myModule.wasm"), myImports);
+const myModule = await loader.instantiate(fs.readFileSync("myModule.wasm"), myImports);
 
 // From a response object, i.e. as returned by window.fetch
 const myModule = await loader.instantiateStreaming(fetch("myModule.wasm"), myImports);
+
+// Synchronously, i.e. if the goal is to immediately re-export as a node module
+const myModule = loader.instantiateSync(fs.readFileSync("myModule.wasm"), myImports);
 ```
 
 ### Usage with TypeScript definitions produced by the compiler
@@ -152,5 +155,5 @@ const myModule = await loader.instantiateStreaming(fetch("myModule.wasm"), myImp
 ```ts
 import MyModule from "myModule"; // pointing at the d.ts
 
-const myModule = loader.instatiateBuffer<typeof MyModule>(fs.readFileSync("myModule.wasm"), myImports);
+const myModule = await loader.instatiate<typeof MyModule>(fs.readFileSync("myModule.wasm"), myImports);
 ```

--- a/lib/loader/README.md
+++ b/lib/loader/README.md
@@ -14,14 +14,14 @@ const loader = require("assemblyscript/lib/loader");
 API
 ---
 
-* **instantiate**<`T`>(moduleOrBuffer: `WebAssembly.Module | BufferSource | Response`, imports?: `WasmImports`): `Promise<ASUtil & T>`<br />
-  Asynchronously instantiates an AssemblyScript module from a module, buffer or response using the specified imports.
+* **instantiate**<`T`>(moduleOrBuffer: `WebAssembly.Module | BufferSource | Response | PromiseLike<WebAssembly.Module | BufferSource | Response>`, imports?: `WasmImports`): `Promise<ASUtil & T>`<br />
+  Asynchronously instantiates an AssemblyScript module from anything that can be instantiated.
 
 * **instantiateSync**<`T`>(moduleOrBuffer: `WebAssembly.Module | BufferSource`, imports?: `WasmImports`): `ASUtil & T`<br />
-  Synchronously instantiates an AssemblyScript module from a module or buffer using the specified imports.
+  Synchronously instantiates an AssemblyScript module from a WebAssembly.Module or binary buffer.
 
-* **instantiateStreaming**<`T`>(response: `Response`, imports?: `WasmImports`): `Promise<ASUtil & T>`<br />
-  Asynchronously instantiates an AssemblyScript module from a response object using the specified imports.
+* **instantiateStreaming**<`T`>(response: `Response | PromiseLike<Response>`, imports?: `WasmImports`): `Promise<ASUtil & T>`<br />
+  Asynchronously instantiates an AssemblyScript module from a response, i.e. as obtained by `fetch`.
 
 * **demangle**<`T`>(exports: `WasmExports`, baseModule?: `Object`): `T`<br />
   Demangles an AssemblyScript module's exports to a friendly object structure. You usually don't have to call this manually as instantiation does this implicitly.

--- a/lib/loader/README.md
+++ b/lib/loader/README.md
@@ -14,8 +14,8 @@ const loader = require("assemblyscript/lib/loader");
 API
 ---
 
-* **instantiate**<`T`>(moduleOrBuffer: `WebAssembly.Module | BufferSource`, imports?: `WasmImports`): `Promise<ASUtil & T>`<br />
-  Asynchronously instantiates an AssemblyScript module from a module or buffer using the specified imports.
+* **instantiate**<`T`>(moduleOrBuffer: `WebAssembly.Module | BufferSource | Response`, imports?: `WasmImports`): `Promise<ASUtil & T>`<br />
+  Asynchronously instantiates an AssemblyScript module from a module, buffer or response using the specified imports.
 
 * **instantiateSync**<`T`>(moduleOrBuffer: `WebAssembly.Module | BufferSource`, imports?: `WasmImports`): `ASUtil & T`<br />
   Synchronously instantiates an AssemblyScript module from a module or buffer using the specified imports.

--- a/lib/loader/index.d.ts
+++ b/lib/loader/index.d.ts
@@ -65,13 +65,13 @@ interface ASUtil {
   __collect(): void;
 }
 
-/** Asynchronously instantiates an AssemblyScript module from a module, buffer or response using the specified imports. */
+/** Asynchronously instantiates an AssemblyScript module from anything that can be instantiated. */
 export declare function instantiate<T extends {}>(moduleOrBuffer: WebAssembly.Module | BufferSource | Response | PromiseLike<Response>, imports?: ImportsObject): Promise<ASUtil & T>;
 
-/** Synchronously instantiates an AssemblyScript module from a module or buffer using the specified imports. */
+/** Synchronously instantiates an AssemblyScript module from a WebAssembly.Module or binary buffer. */
 export declare function instantiateSync<T extends {}>(moduleOrBuffer: WebAssembly.Module | BufferSource, imports?: ImportsObject): ASUtil & T;
 
-/** Asynchronously instantiates an AssemblyScript module from a response object using the specified imports. */
+/** Asynchronously instantiates an AssemblyScript module from a response, i.e. as obtained by `fetch`. */
 export declare function instantiateStreaming<T extends {}>(response: Response | PromiseLike<Response>, imports?: ImportsObject): Promise<ASUtil & T>;
 
 /** Demangles an AssemblyScript module's exports to a friendly object structure. */

--- a/lib/loader/index.d.ts
+++ b/lib/loader/index.d.ts
@@ -65,14 +65,14 @@ interface ASUtil {
   __collect(): void;
 }
 
-/** Instantiates an AssemblyScript module using the specified imports. */
-export declare function instantiate<T extends {}>(module: WebAssembly.Module, imports?: ImportsObject): ASUtil & T;
+/** Asynchronously instantiates an AssemblyScript module from a module or buffer using the specified imports. */
+export declare function instantiate<T extends {}>(moduleOrBuffer: WebAssembly.Module | BufferSource, imports?: ImportsObject): Promise<ASUtil & T>;
 
-/** Instantiates an AssemblyScript module from a buffer using the specified imports. */
-export declare function instantiateBuffer<T extends {}>(buffer: BufferSource, imports?: ImportsObject): ASUtil & T;
+/** Synchronously instantiates an AssemblyScript module from a module or buffer using the specified imports. */
+export declare function instantiateSync<T extends {}>(moduleOrBuffer: WebAssembly.Module | BufferSource, imports?: ImportsObject): ASUtil & T;
 
-/** Instantiates an AssemblyScript module from a response using the specified imports. */
-export declare function instantiateStreaming<T extends {}>(result: Response | PromiseLike<Response>, imports?: ImportsObject): Promise<ASUtil & T>;
+/** Asynchronously instantiates an AssemblyScript module from a response object using the specified imports. */
+export declare function instantiateStreaming<T extends {}>(response: Response | PromiseLike<Response>, imports?: ImportsObject): Promise<ASUtil & T>;
 
 /** Demangles an AssemblyScript module's exports to a friendly object structure. */
 export declare function demangle<T extends {}>(exports: {}, baseModule?: {}): T;

--- a/lib/loader/index.d.ts
+++ b/lib/loader/index.d.ts
@@ -66,13 +66,13 @@ interface ASUtil {
 }
 
 /** Asynchronously instantiates an AssemblyScript module from anything that can be instantiated. */
-export declare function instantiate<T extends {}>(moduleOrBuffer: WebAssembly.Module | BufferSource | Response | PromiseLike<Response>, imports?: ImportsObject): Promise<ASUtil & T>;
+export declare function instantiate<T extends {}>(source: WebAssembly.Module | BufferSource | Response | PromiseLike<WebAssembly.Module | BufferSource | Response>, imports?: ImportsObject): Promise<ASUtil & T>;
 
 /** Synchronously instantiates an AssemblyScript module from a WebAssembly.Module or binary buffer. */
-export declare function instantiateSync<T extends {}>(moduleOrBuffer: WebAssembly.Module | BufferSource, imports?: ImportsObject): ASUtil & T;
+export declare function instantiateSync<T extends {}>(source: WebAssembly.Module | BufferSource, imports?: ImportsObject): ASUtil & T;
 
 /** Asynchronously instantiates an AssemblyScript module from a response, i.e. as obtained by `fetch`. */
-export declare function instantiateStreaming<T extends {}>(response: Response | PromiseLike<Response>, imports?: ImportsObject): Promise<ASUtil & T>;
+export declare function instantiateStreaming<T extends {}>(source: Response | PromiseLike<Response>, imports?: ImportsObject): Promise<ASUtil & T>;
 
 /** Demangles an AssemblyScript module's exports to a friendly object structure. */
 export declare function demangle<T extends {}>(exports: {}, baseModule?: {}): T;

--- a/lib/loader/index.d.ts
+++ b/lib/loader/index.d.ts
@@ -65,8 +65,8 @@ interface ASUtil {
   __collect(): void;
 }
 
-/** Asynchronously instantiates an AssemblyScript module from a module or buffer using the specified imports. */
-export declare function instantiate<T extends {}>(moduleOrBuffer: WebAssembly.Module | BufferSource, imports?: ImportsObject): Promise<ASUtil & T>;
+/** Asynchronously instantiates an AssemblyScript module from a module, buffer or response using the specified imports. */
+export declare function instantiate<T extends {}>(moduleOrBuffer: WebAssembly.Module | BufferSource | Response | PromiseLike<Response>, imports?: ImportsObject): Promise<ASUtil & T>;
 
 /** Synchronously instantiates an AssemblyScript module from a module or buffer using the specified imports. */
 export declare function instantiateSync<T extends {}>(moduleOrBuffer: WebAssembly.Module | BufferSource, imports?: ImportsObject): ASUtil & T;

--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -280,26 +280,34 @@ function wrapFunction(fn, setargc) {
   return wrap;
 }
 
+function isResponse(o) {
+  return typeof Response !== "undefined" && o instanceof Response;
+}
+
 /** Asynchronously instantiates an AssemblyScript module from anything that can be instantiated. */
-async function instantiate(moduleOrBuffer, imports) {
-  if (typeof moduleOrBuffer.then === "function") moduleOrBuffer = await moduleOrBuffer;
-  if (typeof Response !== "undefined" && moduleOrBuffer instanceof Response) return instantiateStreaming(moduleOrBuffer, imports);
+async function instantiate(source, imports) {
+  if (isResponse(source = await source)) return instantiateStreaming(source, imports);
   return postInstantiate(
     preInstantiate(imports || (imports = {})),
-    (await WebAssembly.instantiate(moduleOrBuffer, imports)).instance
+    await WebAssembly.instantiate(
+      source instanceof WebAssembly.Module
+        ? source
+        : await WebAssembly.compile(source),
+      imports
+    )
   );
 }
 
 exports.instantiate = instantiate;
 
 /** Synchronously instantiates an AssemblyScript module from a WebAssembly.Module or binary buffer. */
-function instantiateSync(moduleOrBuffer, imports) {
+function instantiateSync(source, imports) {
   return postInstantiate(
     preInstantiate(imports || (imports = {})),
     new WebAssembly.Instance(
-      moduleOrBuffer instanceof WebAssembly.Module
-        ? moduleOrBuffer
-        : new WebAssembly.Module(moduleOrBuffer),
+      source instanceof WebAssembly.Module
+        ? source
+        : new WebAssembly.Module(source),
       imports
     )
   )
@@ -308,11 +316,18 @@ function instantiateSync(moduleOrBuffer, imports) {
 exports.instantiateSync = instantiateSync;
 
 /** Asynchronously instantiates an AssemblyScript module from a response, i.e. as obtained by `fetch`. */
-async function instantiateStreaming(response, imports) {
-  if (!WebAssembly.instantiateStreaming) return instantiate(await (await response).arrayBuffer(), imports);
+async function instantiateStreaming(source, imports) {
+  if (!WebAssembly.instantiateStreaming) {
+    return instantiate(
+      isResponse(source = await source)
+        ? source.arrayBuffer()
+        : source,
+      imports
+    );
+  }
   return postInstantiate(
     preInstantiate(imports || (imports = {})),
-    (await WebAssembly.instantiateStreaming(response, imports)).instance
+    (await WebAssembly.instantiateStreaming(source, imports)).instance
   );
 }
 

--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -280,8 +280,10 @@ function wrapFunction(fn, setargc) {
   return wrap;
 }
 
-/** Asynchronously instantiates an AssemblyScript module from a module or buffer using the specified imports. */
+/** Asynchronously instantiates an AssemblyScript module from a module, buffer or response using the specified imports. */
 async function instantiate(moduleOrBuffer, imports) {
+  if (typeof moduleOrBuffer.then === "function") moduleOrBuffer = await moduleOrBuffer;
+  if (typeof Response !== "undefined" && moduleOrBuffer instanceof Response) return instantiateStreaming(moduleOrBuffer, imports);
   return postInstantiate(
     preInstantiate(imports || (imports = {})),
     (await WebAssembly.instantiate(moduleOrBuffer, imports)).instance
@@ -295,9 +297,9 @@ function instantiateSync(moduleOrBuffer, imports) {
   return postInstantiate(
     preInstantiate(imports || (imports = {})),
     new WebAssembly.Instance(
-      moduleOrBuffer instanceof ArrayBuffer || ArrayBuffer.isView(moduleOrBuffer)
-        ? new WebAssembly.Module(moduleOrBuffer)
-        : moduleOrBuffer,
+      moduleOrBuffer instanceof WebAssembly.Module
+        ? moduleOrBuffer
+        : new WebAssembly.Module(moduleOrBuffer),
       imports
     )
   )

--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -309,6 +309,7 @@ exports.instantiateSync = instantiateSync;
 
 /** Asynchronously instantiates an AssemblyScript module from a response object using the specified imports. */
 async function instantiateStreaming(response, imports) {
+  if (!WebAssembly.instantiateStreaming) return instantiate(await (await response).arrayBuffer(), imports);
   return postInstantiate(
     preInstantiate(imports || (imports = {})),
     (await WebAssembly.instantiateStreaming(response, imports)).instance

--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -280,24 +280,32 @@ function wrapFunction(fn, setargc) {
   return wrap;
 }
 
-/** Instantiates an AssemblyScript module using the specified imports. */
-function instantiate(module, imports) {
+/** Asynchronously instantiates an AssemblyScript module from a module or buffer using the specified imports. */
+async function instantiate(moduleOrBuffer, imports) {
   return postInstantiate(
     preInstantiate(imports || (imports = {})),
-    new WebAssembly.Instance(module, imports)
+    (await WebAssembly.instantiate(moduleOrBuffer, imports)).instance
   );
 }
 
 exports.instantiate = instantiate;
 
-/** Instantiates an AssemblyScript module from a buffer using the specified imports. */
-function instantiateBuffer(buffer, imports) {
-  return instantiate(new WebAssembly.Module(buffer), imports);
+/** Synchronously instantiates an AssemblyScript module from a module or buffer using the specified imports. */
+function instantiateSync(moduleOrBuffer, imports) {
+  return postInstantiate(
+    preInstantiate(imports || (imports = {})),
+    new WebAssembly.Instance(
+      moduleOrBuffer instanceof ArrayBuffer || ArrayBuffer.isView(moduleOrBuffer)
+        ? new WebAssembly.Module(moduleOrBuffer)
+        : moduleOrBuffer,
+      imports
+    )
+  )
 }
 
-exports.instantiateBuffer = instantiateBuffer;
+exports.instantiateSync = instantiateSync;
 
-/** Instantiates an AssemblyScript module from a response using the specified imports. */
+/** Asynchronously instantiates an AssemblyScript module from a response object using the specified imports. */
 async function instantiateStreaming(response, imports) {
   return postInstantiate(
     preInstantiate(imports || (imports = {})),

--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -280,7 +280,7 @@ function wrapFunction(fn, setargc) {
   return wrap;
 }
 
-/** Asynchronously instantiates an AssemblyScript module from a module, buffer or response using the specified imports. */
+/** Asynchronously instantiates an AssemblyScript module from anything that can be instantiated. */
 async function instantiate(moduleOrBuffer, imports) {
   if (typeof moduleOrBuffer.then === "function") moduleOrBuffer = await moduleOrBuffer;
   if (typeof Response !== "undefined" && moduleOrBuffer instanceof Response) return instantiateStreaming(moduleOrBuffer, imports);
@@ -292,7 +292,7 @@ async function instantiate(moduleOrBuffer, imports) {
 
 exports.instantiate = instantiate;
 
-/** Synchronously instantiates an AssemblyScript module from a module or buffer using the specified imports. */
+/** Synchronously instantiates an AssemblyScript module from a WebAssembly.Module or binary buffer. */
 function instantiateSync(moduleOrBuffer, imports) {
   return postInstantiate(
     preInstantiate(imports || (imports = {})),
@@ -307,7 +307,7 @@ function instantiateSync(moduleOrBuffer, imports) {
 
 exports.instantiateSync = instantiateSync;
 
-/** Asynchronously instantiates an AssemblyScript module from a response object using the specified imports. */
+/** Asynchronously instantiates an AssemblyScript module from a response, i.e. as obtained by `fetch`. */
 async function instantiateStreaming(response, imports) {
   if (!WebAssembly.instantiateStreaming) return instantiate(await (await response).arrayBuffer(), imports);
   return postInstantiate(

--- a/lib/loader/tests/index.html
+++ b/lib/loader/tests/index.html
@@ -2,6 +2,10 @@
 <script src="../index.js"></script>
 <script>
 (async () => {
+  var module = await exports.instantiate(fetch("./build/untouched.wasm"));
+  console.log(module);
+})();
+(async () => {
   var module = await exports.instantiateStreaming(fetch("./build/untouched.wasm"));
   console.log(module);
 })();

--- a/lib/loader/tests/index.html
+++ b/lib/loader/tests/index.html
@@ -2,11 +2,41 @@
 <script src="../index.js"></script>
 <script>
 (async () => {
-  var module = await exports.instantiate(fetch("./build/untouched.wasm"));
+  var module;
+
+  module = await exports.instantiate(fetch("./build/untouched.wasm"));
   console.log(module);
-})();
-(async () => {
-  var module = await exports.instantiateStreaming(fetch("./build/untouched.wasm"));
+
+  module = await exports.instantiate(await fetch("./build/untouched.wasm"));
   console.log(module);
+
+  module = await exports.instantiate((await fetch("./build/untouched.wasm")).arrayBuffer());
+  console.log(module);
+
+  module = await exports.instantiate(await (await fetch("./build/untouched.wasm")).arrayBuffer());
+  console.log(module);
+
+  module = await exports.instantiateStreaming(fetch("./build/untouched.wasm"));
+  console.log(module);
+
+  module = await exports.instantiateStreaming(await fetch("./build/untouched.wasm"));
+  console.log(module);
+
+  var instantiateStreaming = WebAssembly.instantiateStreaming;
+  delete WebAssembly.instantiateStreaming;
+
+  module = await exports.instantiate(fetch("./build/untouched.wasm"));
+  console.log(module);
+
+  module = await exports.instantiate(await fetch("./build/untouched.wasm"));
+  console.log(module);
+
+  module = await exports.instantiateStreaming(fetch("./build/untouched.wasm"));
+  console.log(module);
+
+  module = await exports.instantiateStreaming(await fetch("./build/untouched.wasm"));
+  console.log(module);
+
+  WebAssembly.instantiateStreaming = instantiateStreaming;
 })();
 </script>

--- a/lib/loader/tests/index.html
+++ b/lib/loader/tests/index.html
@@ -1,42 +1,47 @@
 <script>var exports = {};</script>
 <script src="../index.js"></script>
 <script>
+function assert(c) {
+  if (!c) throw Error("assertion failed");
+}
 (async () => {
   var module;
 
   module = await exports.instantiate(fetch("./build/untouched.wasm"));
-  console.log(module);
+  assert(module.memory);
 
   module = await exports.instantiate(await fetch("./build/untouched.wasm"));
-  console.log(module);
+  assert(module.memory);
 
   module = await exports.instantiate((await fetch("./build/untouched.wasm")).arrayBuffer());
-  console.log(module);
+  assert(module.memory);
 
   module = await exports.instantiate(await (await fetch("./build/untouched.wasm")).arrayBuffer());
-  console.log(module);
+  assert(module.memory);
 
   module = await exports.instantiateStreaming(fetch("./build/untouched.wasm"));
-  console.log(module);
+  assert(module.memory);
 
   module = await exports.instantiateStreaming(await fetch("./build/untouched.wasm"));
-  console.log(module);
+  assert(module.memory);
 
   var instantiateStreaming = WebAssembly.instantiateStreaming;
   delete WebAssembly.instantiateStreaming;
 
   module = await exports.instantiate(fetch("./build/untouched.wasm"));
-  console.log(module);
+  assert(module.memory);
 
   module = await exports.instantiate(await fetch("./build/untouched.wasm"));
-  console.log(module);
+  assert(module.memory);
 
   module = await exports.instantiateStreaming(fetch("./build/untouched.wasm"));
-  console.log(module);
+  assert(module.memory);
 
   module = await exports.instantiateStreaming(await fetch("./build/untouched.wasm"));
-  console.log(module);
+  assert(module.memory);
 
   WebAssembly.instantiateStreaming = instantiateStreaming;
+
+  console.log("ok");
 })();
 </script>

--- a/lib/loader/tests/index.js
+++ b/lib/loader/tests/index.js
@@ -4,7 +4,7 @@ var inspect = require("util").inspect;
 
 var loader = require("..");
 var buffer = fs.readFileSync(__dirname + "/build/untouched.wasm");
-var module = loader.instantiateBuffer(buffer, {});
+var module = loader.instantiateSync(buffer, {});
 
 console.log(inspect(module, true, 100, true));
 

--- a/lib/loader/tests/index.js
+++ b/lib/loader/tests/index.js
@@ -173,3 +173,28 @@ module.dotrace(42);
   assert.deepEqual(view, new Float32Array([3, 2, 1]));
   module.__release(ptr);
 }
+
+// should be able to instantiate from a buffer
+(async () => {
+  const module = await loader.instantiate(fs.readFileSync(__dirname + "/build/untouched.wasm"), {});
+  assert(module.memory);
+})();
+
+// should be able to instantiate from a wasm module
+(async () => {
+  const wasmModule = new WebAssembly.Module(fs.readFileSync(__dirname + "/build/untouched.wasm"));
+  const module = await loader.instantiate(wasmModule, {});
+  assert(module.memory);
+})();
+
+// should be able to instantiate from a promise yielding a buffer
+(async () => {
+  const module = await loader.instantiate(fs.promises.readFile(__dirname + "/build/untouched.wasm"), {});
+  assert(module.memory);
+})();
+
+// should be able to mimic instantiateStreaming under node (for now)
+(async () => {
+  const module = await loader.instantiateStreaming(fs.promises.readFile(__dirname + "/build/untouched.wasm"), {});
+  assert(module.memory);
+})();


### PR DESCRIPTION
This makes `loader.instantiate` asynchronous to align with `WebAssembly.instantiate` and replaces `loader.instantiateBuffer` with `loader.instantiateSync` accepting both a pre-compiled module or a buffer, just like `loader.instantiate`.