### PR TITLE
Add AssemblyScript as a dependency when using asinit

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -16,6 +16,7 @@ under the licensing terms detailed in LICENSE:
 * Willem Wyndham <willem@cs.umd.edu>
 * Bowen Wang <bowen@nearprotocol.com>
 * Emil Laine <laine.emil@gmail.com>
+* Danny Guo <danny@dannyguo.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/bin/asinit
+++ b/bin/asinit
@@ -217,6 +217,9 @@ function ensurePackageJson() {
         "asbuild:untouched": buildUntouched,
         "asbuild:optimized": buildOptimized,
         "asbuild": buildAll
+      },
+      "devDependencies": {
+        "assemblyscript": "github:AssemblyScript/assemblyscript"
       }
     }, null, 2));
     console.log(colors.green("  Created: ") + packageFile);


### PR DESCRIPTION
When I followed the [quick start guide](https://docs.assemblyscript.org/quick-start), I ended up with a `package.json` with no dependencies even though the guide says `package.json` will have AssemblyScript as a development dependency after running `npx asinit .`.

It may also be worth amending the guide to recommend running `npm init` before `npm install --save-dev AssemblyScript/assemblyscript`.