### PR TITLE
Properly resolve namespace siblings

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -80,8 +80,7 @@ import {
   PropertyPrototype,
   IndexSignature,
   File,
-  mangleInternalName,
-  Namespace
+  mangleInternalName
 } from "./program";
 
 import {

--- a/tests/compiler/features/simd.optimized.wat
+++ b/tests/compiler/features/simd.optimized.wat
@@ -93,7 +93,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 71
+   i32.const 70
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -108,7 +108,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 73
+   i32.const 72
    i32.const 13
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/features/simd.untouched.wat
+++ b/tests/compiler/features/simd.untouched.wat
@@ -144,7 +144,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 71
+   i32.const 70
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -161,7 +161,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 73
+   i32.const 72
    i32.const 13
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/namespace.optimized.wat
+++ b/tests/compiler/namespace.optimized.wat
@@ -1,8 +1,17 @@
 (module
  (type $FUNCSIG$v (func))
  (memory $0 0)
+ (global $namespace/Outer.Inner.anotherVar (mut i32) (i32.const 0))
+ (global $namespace/Outer.Inner.evenAnotherVar (mut i32) (i32.const 0))
  (export "memory" (memory $0))
+ (start $start)
  (func $start (; 0 ;) (type $FUNCSIG$v)
+  i32.const 0
+  global.set $namespace/Outer.Inner.anotherVar
+  i32.const 1
+  global.set $namespace/Outer.Inner.evenAnotherVar
+ )
+ (func $null (; 1 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/namespace.ts
+++ b/tests/compiler/namespace.ts
@@ -1,6 +1,9 @@
 namespace Outer {
+  export var outerVar: i32 = 1;
   export namespace Inner {
     export var aVar: i32 = 0;
+    export var anotherVar: i32 = aVar;
+    export var evenAnotherVar: i32 = outerVar;
     export function aFunc(): i32 { return aVar; }
     export enum anEnum { ONE = 1, TWO = 2 }
     export const enum aConstEnum { ONE = 1, TWO = 2 }

--- a/tests/compiler/namespace.untouched.wat
+++ b/tests/compiler/namespace.untouched.wat
@@ -4,7 +4,10 @@
  (memory $0 0)
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
+ (global $namespace/Outer.outerVar (mut i32) (i32.const 1))
  (global $namespace/Outer.Inner.aVar (mut i32) (i32.const 0))
+ (global $namespace/Outer.Inner.anotherVar (mut i32) (i32.const 0))
+ (global $namespace/Outer.Inner.evenAnotherVar (mut i32) (i32.const 0))
  (global $namespace/Outer.Inner.anEnum.ONE i32 (i32.const 1))
  (global $namespace/Outer.Inner.anEnum.TWO i32 (i32.const 2))
  (export "memory" (memory $0))
@@ -16,6 +19,10 @@
   i32.const 3
  )
  (func $start:namespace (; 2 ;) (type $FUNCSIG$v)
+  global.get $namespace/Outer.Inner.aVar
+  global.set $namespace/Outer.Inner.anotherVar
+  global.get $namespace/Outer.outerVar
+  global.set $namespace/Outer.Inner.evenAnotherVar
   global.get $namespace/Outer.Inner.aVar
   drop
   call $namespace/Outer.Inner.aFunc


### PR DESCRIPTION
fixes https://github.com/AssemblyScript/assemblyscript/issues/575

We already had special logic for enum members but were missing namespaces, so this generalizes the `currentParent` to any element and fixes the issue.