### PR TITLE
Consider NaN falseish

### DIFF
--- a/src/flow.ts
+++ b/src/flow.ts
@@ -384,13 +384,6 @@ export class Flow {
     temps.push(local);
   }
 
-  /** Gets and immediately frees a temporary local of the specified type. */
-  getAndFreeTempLocal(type: Type, except: Set<i32> | null = null): Local {
-    var local = this.getTempLocal(type, except);
-    this.freeTempLocal(local);
-    return local;
-  }
-
   /** Gets the scoped local of the specified name. */
   getScopedLocal(name: string): Local | null {
     var scopedLocals = this.scopedLocals;

--- a/src/module.ts
+++ b/src/module.ts
@@ -1755,44 +1755,44 @@ export class Relooper {
   }
 }
 
-// export function hasSideEffects(expr: ExpressionRef): bool {
-//   // TODO: there's more
-//   switch (_BinaryenExpressionGetId(expr)) {
-//     case ExpressionId.LocalGet:
-//     case ExpressionId.GlobalGet:
-//     case ExpressionId.Const:
-//     case ExpressionId.Nop: {
-//       return false;
-//     }
-//     case ExpressionId.Block: {
-//       for (let i = 0, k = _BinaryenBlockGetNumChildren(expr); i < k; ++i) {
-//         if (hasSideEffects(_BinaryenBlockGetChild(expr, i))) return true;
-//       }
-//       return false;
-//     }
-//     case ExpressionId.If: {
-//       return hasSideEffects(_BinaryenIfGetCondition(expr))
-//           || hasSideEffects(_BinaryenIfGetIfTrue(expr))
-//           || hasSideEffects(_BinaryenIfGetIfFalse(expr));
-//     }
-//     case ExpressionId.Unary: {
-//       return hasSideEffects(_BinaryenUnaryGetValue(expr));
-//     }
-//     case ExpressionId.Binary: {
-//       return hasSideEffects(_BinaryenBinaryGetLeft(expr))
-//           || hasSideEffects(_BinaryenBinaryGetRight(expr));
-//     }
-//     case ExpressionId.Drop: {
-//       return hasSideEffects(_BinaryenDropGetValue(expr));
-//     }
-//     case ExpressionId.Select: {
-//       return hasSideEffects(_BinaryenSelectGetIfTrue(expr))
-//           || hasSideEffects(_BinaryenSelectGetIfFalse(expr))
-//           || hasSideEffects(_BinaryenSelectGetCondition(expr));
-//     }
-//   }
-//   return true;
-// }
+export function hasSideEffects(expr: ExpressionRef): bool {
+  // TODO: there's more
+  switch (_BinaryenExpressionGetId(expr)) {
+    case ExpressionId.LocalGet:
+    case ExpressionId.GlobalGet:
+    case ExpressionId.Const:
+    case ExpressionId.Nop: {
+      return false;
+    }
+    case ExpressionId.Block: {
+      for (let i = 0, k = _BinaryenBlockGetNumChildren(expr); i < k; ++i) {
+        if (hasSideEffects(_BinaryenBlockGetChild(expr, i))) return true;
+      }
+      return false;
+    }
+    case ExpressionId.If: {
+      return hasSideEffects(_BinaryenIfGetCondition(expr))
+          || hasSideEffects(_BinaryenIfGetIfTrue(expr))
+          || hasSideEffects(_BinaryenIfGetIfFalse(expr));
+    }
+    case ExpressionId.Unary: {
+      return hasSideEffects(_BinaryenUnaryGetValue(expr));
+    }
+    case ExpressionId.Binary: {
+      return hasSideEffects(_BinaryenBinaryGetLeft(expr))
+          || hasSideEffects(_BinaryenBinaryGetRight(expr));
+    }
+    case ExpressionId.Drop: {
+      return hasSideEffects(_BinaryenDropGetValue(expr));
+    }
+    case ExpressionId.Select: {
+      return hasSideEffects(_BinaryenSelectGetIfTrue(expr))
+          || hasSideEffects(_BinaryenSelectGetIfFalse(expr))
+          || hasSideEffects(_BinaryenSelectGetCondition(expr));
+    }
+  }
+  return true;
+}
 
 // helpers
 // can't do stack allocation here: STACKTOP is a global in WASM but a hidden variable in asm.js

--- a/src/program.ts
+++ b/src/program.ts
@@ -999,10 +999,10 @@ export class Program extends DiagnosticEmitter {
     return this.resolver.resolveFunction(<FunctionPrototype>prototype, null);
   }
 
-  /** Requires that a non-generic global function is present and returns it. */
-  private requireFunction(name: string): Function {
+  /** Requires that a global function is present and returns it. */
+  private requireFunction(name: string, typeArguments: Type[] | null = null): Function {
     var prototype = this.require(name, ElementKind.FUNCTION_PROTOTYPE);
-    var resolved = this.resolver.resolveFunction(<FunctionPrototype>prototype, null);
+    var resolved = this.resolver.resolveFunction(<FunctionPrototype>prototype, typeArguments);
     if (!resolved) throw new Error("invalid " + name);
     return resolved;
   }

--- a/std/assembly/number.ts
+++ b/std/assembly/number.ts
@@ -9,18 +9,20 @@ export const NaN: f64 = 0 / 0;
 @builtin @inline
 export const Infinity: f64 = 1 / 0;
 
+// @ts-ignore: decorator
+@builtin
 export function isNaN<T extends number>(value: T): bool {
-  if (!isFloat<T>()) {
-    if (!isInteger<T>()) ERROR("numeric type expected");
-  }
-  return value != value;
+  if (isFloat<T>()) return value != value;
+  if (!isInteger<T>()) ERROR("numeric type expected");
+  return false;
 }
 
+// @ts-ignore: decorator
+@builtin
 export function isFinite<T extends number>(value: T): bool {
-  if (!isFloat<T>()) {
-    if (!isInteger<T>()) ERROR("numeric type expected");
-  }
-  return value - value == 0;
+  if (isFloat<T>()) return value - value == 0;
+  if (!isInteger<T>()) ERROR("numeric type expected");
+  return true;
 }
 
 @sealed @unmanaged

--- a/std/assembly/number.ts
+++ b/std/assembly/number.ts
@@ -11,19 +11,11 @@ export const Infinity: f64 = 1 / 0;
 
 // @ts-ignore: decorator
 @builtin
-export function isNaN<T extends number>(value: T): bool {
-  if (isFloat<T>()) return value != value;
-  if (!isInteger<T>()) ERROR("numeric type expected");
-  return false;
-}
+export declare function isNaN<T extends number>(value: T): bool;
 
 // @ts-ignore: decorator
 @builtin
-export function isFinite<T extends number>(value: T): bool {
-  if (isFloat<T>()) return value - value == 0;
-  if (!isInteger<T>()) ERROR("numeric type expected");
-  return true;
-}
+export declare function isFinite<T extends number>(value: T): bool;
 
 @sealed @unmanaged
 export abstract class I8 {

--- a/tests/compiler/binary.optimized.wat
+++ b/tests/compiler/binary.optimized.wat
@@ -57,23 +57,22 @@
   (local $4 i32)
   local.get $0
   i32.reinterpret_f32
-  local.tee $2
-  i32.const -2147483648
-  i32.and
-  local.set $4
-  local.get $2
+  local.tee $1
   i32.const 23
   i32.shr_u
   i32.const 255
   i32.and
-  local.tee $3
+  local.set $2
+  local.get $1
+  i32.const -2147483648
+  i32.and
+  local.set $4
+  i32.const 1
+  i32.const 0
+  local.get $2
   i32.const 255
   i32.eq
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
+  select
   if
    local.get $0
    local.get $0
@@ -81,50 +80,50 @@
    return
   end
   block $folding-inner0
-   local.get $2
+   local.get $1
    i32.const 1
    i32.shl
-   local.tee $1
+   local.tee $3
    i32.const 2130706432
    i32.le_u
    if
-    local.get $1
+    local.get $3
     i32.const 2130706432
     i32.eq
     br_if $folding-inner0
     local.get $0
     return
    end
-   local.get $3
+   local.get $2
    if (result i32)
-    local.get $2
+    local.get $1
     i32.const 8388607
     i32.and
     i32.const 8388608
     i32.or
    else
-    local.get $2
+    local.get $1
     i32.const 1
-    local.get $3
     local.get $2
+    local.get $1
     i32.const 9
     i32.shl
     i32.clz
     i32.sub
-    local.tee $3
+    local.tee $2
     i32.sub
     i32.shl
    end
    local.set $1
    loop $continue|0
-    local.get $3
+    local.get $2
     i32.const 127
     i32.gt_s
     if
      local.get $1
      i32.const 8388608
      i32.ge_u
-     if (result i32)
+     if
       local.get $1
       i32.const 8388608
       i32.eq
@@ -132,16 +131,16 @@
       local.get $1
       i32.const 8388608
       i32.sub
-     else
-      local.get $1
+      local.set $1
      end
+     local.get $1
      i32.const 1
      i32.shl
      local.set $1
-     local.get $3
+     local.get $2
      i32.const 1
      i32.sub
-     local.set $3
+     local.set $2
      br $continue|0
     end
    end
@@ -163,27 +162,27 @@
    i32.const 8
    i32.shl
    i32.clz
-   local.tee $1
+   local.tee $3
    i32.shl
-   local.set $2
+   local.set $1
+   local.get $2
    local.get $3
-   local.get $1
    i32.sub
-   local.tee $1
+   local.tee $2
    i32.const 0
    i32.gt_s
    if (result i32)
-    local.get $2
+    local.get $1
     i32.const 8388608
     i32.sub
-    local.get $1
+    local.get $2
     i32.const 23
     i32.shl
     i32.or
    else
-    local.get $2
-    i32.const 1
     local.get $1
+    i32.const 1
+    local.get $2
     i32.sub
     i32.shr_u
    end
@@ -223,23 +222,22 @@
   (local $4 i64)
   local.get $0
   i64.reinterpret_f64
-  local.tee $2
-  i64.const 63
-  i64.shr_u
-  local.set $4
-  local.get $2
+  local.tee $1
   i64.const 52
   i64.shr_u
   i64.const 2047
   i64.and
-  local.tee $3
+  local.set $2
+  local.get $1
+  i64.const 63
+  i64.shr_u
+  local.set $4
+  i32.const 1
+  i32.const 0
+  local.get $2
   i64.const 2047
   i64.eq
-  if (result i32)
-   i32.const 1
-  else
-   i32.const 0
-  end
+  select
   if
    local.get $0
    local.get $0
@@ -247,39 +245,39 @@
    return
   end
   block $folding-inner0
-   local.get $2
+   local.get $1
    i64.const 1
    i64.shl
-   local.tee $1
+   local.tee $3
    i64.const 9214364837600034816
    i64.le_u
    if
-    local.get $1
+    local.get $3
     i64.const 9214364837600034816
     i64.eq
     br_if $folding-inner0
     local.get $0
     return
    end
-   local.get $3
+   local.get $2
    i64.const 0
    i64.eq
    if (result i64)
-    local.get $2
+    local.get $1
     i64.const 0
-    local.get $3
     local.get $2
+    local.get $1
     i64.const 12
     i64.shl
     i64.clz
     i64.sub
-    local.tee $3
+    local.tee $2
     i64.sub
     i64.const 1
     i64.add
     i64.shl
    else
-    local.get $2
+    local.get $1
     i64.const 4503599627370495
     i64.and
     i64.const 4503599627370496
@@ -287,14 +285,14 @@
    end
    local.set $1
    loop $continue|0
-    local.get $3
+    local.get $2
     i64.const 1023
     i64.gt_s
     if
      local.get $1
      i64.const 4503599627370496
      i64.ge_u
-     if (result i64)
+     if
       local.get $1
       i64.const 4503599627370496
       i64.eq
@@ -302,16 +300,16 @@
       local.get $1
       i64.const 4503599627370496
       i64.sub
-     else
-      local.get $1
+      local.set $1
      end
+     local.get $1
      i64.const 1
      i64.shl
      local.set $1
-     local.get $3
+     local.get $2
      i64.const 1
      i64.sub
-     local.set $3
+     local.set $2
      br $continue|0
     end
    end
@@ -333,27 +331,27 @@
    i64.const 11
    i64.shl
    i64.clz
-   local.tee $1
+   local.tee $3
    i64.shl
-   local.set $2
+   local.set $1
+   local.get $2
    local.get $3
-   local.get $1
    i64.sub
-   local.tee $1
+   local.tee $2
    i64.const 0
    i64.gt_s
    if (result i64)
-    local.get $2
+    local.get $1
     i64.const 4503599627370496
     i64.sub
-    local.get $1
+    local.get $2
     i64.const 52
     i64.shl
     i64.or
    else
-    local.get $2
-    i64.const 0
     local.get $1
+    i64.const 0
+    local.get $2
     i64.sub
     i64.const 1
     i64.add

--- a/tests/compiler/binary.optimized.wat
+++ b/tests/compiler/binary.optimized.wat
@@ -262,7 +262,8 @@
     return
    end
    local.get $3
-   i64.eqz
+   i64.const 0
+   i64.eq
    if (result i64)
     local.get $2
     i64.const 0

--- a/tests/compiler/binary.untouched.wat
+++ b/tests/compiler/binary.untouched.wat
@@ -2,9 +2,7 @@
  (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))
  (type $FUNCSIG$ddi (func (param f64 i32) (result f64)))
  (type $FUNCSIG$fff (func (param f32 f32) (result f32)))
- (type $FUNCSIG$if (func (param f32) (result i32)))
  (type $FUNCSIG$ffi (func (param f32 i32) (result f32)))
- (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$v (func))
  (memory $0 0)
  (table $0 1 funcref)
@@ -1187,12 +1185,7 @@
   local.get $16
   f64.mul
  )
- (func $~lib/number/isNaN<f32> (; 2 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
-  local.get $0
-  local.get $0
-  f32.ne
- )
- (func $~lib/math/NativeMathf.mod (; 3 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (; 2 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -1242,7 +1235,9 @@
    i32.const 1
   else
    local.get $1
-   call $~lib/number/isNaN<f32>
+   local.tee $8
+   local.get $8
+   f32.ne
   end
   if
    local.get $0
@@ -1439,7 +1434,7 @@
   local.get $2
   f32.reinterpret_i32
  )
- (func $~lib/math/NativeMathf.scalbn (; 4 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
+ (func $~lib/math/NativeMathf.scalbn (; 3 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
   (local $2 f32)
   (local $3 i32)
   (local $4 i32)
@@ -1529,7 +1524,7 @@
   f32.reinterpret_i32
   f32.mul
  )
- (func $~lib/math/NativeMathf.pow (; 5 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.pow (; 4 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2463,12 +2458,7 @@
   local.get $11
   f32.mul
  )
- (func $~lib/number/isNaN<f64> (; 6 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.ne
- )
- (func $~lib/math/NativeMath.mod (; 7 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (; 5 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -2518,7 +2508,9 @@
    i32.const 1
   else
    local.get $1
-   call $~lib/number/isNaN<f64>
+   local.tee $8
+   local.get $8
+   f64.ne
   end
   if
    local.get $0
@@ -2721,7 +2713,7 @@
   local.get $2
   f64.reinterpret_i64
  )
- (func $start:binary (; 8 ;) (type $FUNCSIG$v)
+ (func $start:binary (; 6 ;) (type $FUNCSIG$v)
   global.get $binary/i
   i32.const 1
   i32.lt_s
@@ -3329,9 +3321,9 @@
   call $~lib/math/NativeMath.pow
   global.set $binary/F
  )
- (func $start (; 9 ;) (type $FUNCSIG$v)
+ (func $start (; 7 ;) (type $FUNCSIG$v)
   call $start:binary
  )
- (func $null (; 10 ;) (type $FUNCSIG$v)
+ (func $null (; 8 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/binary.untouched.wat
+++ b/tests/compiler/binary.untouched.wat
@@ -1235,8 +1235,7 @@
    i32.const 1
   else
    local.get $1
-   local.tee $8
-   local.get $8
+   local.get $1
    f32.ne
   end
   if
@@ -2508,8 +2507,7 @@
    i32.const 1
   else
    local.get $1
-   local.tee $8
-   local.get $8
+   local.get $1
    f64.ne
   end
   if

--- a/tests/compiler/binary.untouched.wat
+++ b/tests/compiler/binary.untouched.wat
@@ -2551,7 +2551,9 @@
    return
   end
   local.get $4
-  i64.eqz
+  i64.const 0
+  i64.ne
+  i32.eqz
   if
    local.get $4
    local.get $2
@@ -2583,7 +2585,9 @@
    local.set $2
   end
   local.get $5
-  i64.eqz
+  i64.const 0
+  i64.ne
+  i32.eqz
   if
    local.get $5
    local.get $3

--- a/tests/compiler/builtins.optimized.wat
+++ b/tests/compiler/builtins.optimized.wat
@@ -1,7 +1,5 @@
 (module
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
- (type $FUNCSIG$if (func (param f32) (result i32)))
- (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$vii (func (param i32 i32)))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$viiddddd (func (param i32 i32 f64 f64 f64 f64 f64)))
@@ -47,34 +45,10 @@
  (export "memory" (memory $0))
  (export "test" (func $start:builtins~anonymous|1))
  (start $start)
- (func $~lib/number/isNaN<f32> (; 2 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
-  local.get $0
-  local.get $0
-  f32.ne
- )
- (func $~lib/number/isFinite<f32> (; 3 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
-  local.get $0
-  local.get $0
-  f32.sub
-  f32.const 0
-  f32.eq
- )
- (func $~lib/number/isNaN<f64> (; 4 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.ne
- )
- (func $~lib/number/isFinite<f64> (; 5 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.sub
-  f64.const 0
-  f64.eq
- )
- (func $start:builtins~anonymous|0 (; 6 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $start:builtins~anonymous|0 (; 2 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/atomics/Atomics.isLockFree (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/atomics/Atomics.isLockFree (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   local.get $0
   i32.const 4
@@ -89,7 +63,7 @@
   select
   select
  )
- (func $~lib/string/String#get:length (; 8 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -97,7 +71,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 9 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/compareImpl (; 5 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -177,7 +151,7 @@
   end
   i32.const 0
  )
- (func $~lib/string/String.__eq (; 10 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 6 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -209,13 +183,13 @@
   end
   i32.const 0
  )
- (func $start:builtins~anonymous|1 (; 11 ;) (type $FUNCSIG$v)
+ (func $start:builtins~anonymous|1 (; 7 ;) (type $FUNCSIG$v)
   nop
  )
- (func $start:builtins~anonymous|2 (; 12 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $start:builtins~anonymous|2 (; 8 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   nop
  )
- (func $start:builtins (; 13 ;) (type $FUNCSIG$v)
+ (func $start:builtins (; 9 ;) (type $FUNCSIG$v)
   i32.const 31
   global.set $builtins/i
   i32.const 0
@@ -259,70 +233,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.25
-  call $~lib/number/isNaN<f32>
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 104
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  call $~lib/number/isNaN<f32>
-  i32.const 1
-  i32.ne
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 105
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.25
-  call $~lib/number/isFinite<f32>
-  i32.const 1
-  i32.ne
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 106
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  call $~lib/number/isFinite<f32>
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 107
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  call $~lib/number/isFinite<f32>
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 108
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  call $~lib/number/isFinite<f32>
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 109
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const nan:0x400000
   global.set $builtins/f
   f32.const inf
@@ -345,76 +255,10 @@
   global.set $builtins/f
   f32.const 1
   global.set $builtins/f
-  f32.const 1.25
-  call $~lib/number/isNaN<f32>
+  i32.const 0
   global.set $builtins/b
-  f32.const 1.25
-  call $~lib/number/isFinite<f32>
+  i32.const 1
   global.set $builtins/b
-  f64.const 1.25
-  call $~lib/number/isNaN<f64>
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 140
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  call $~lib/number/isNaN<f64>
-  i32.const 1
-  i32.ne
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 141
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.25
-  call $~lib/number/isFinite<f64>
-  i32.const 1
-  i32.ne
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 142
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  call $~lib/number/isFinite<f64>
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 143
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  call $~lib/number/isFinite<f64>
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 144
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  call $~lib/number/isFinite<f64>
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 145
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const nan:0x8000000000000
   global.set $builtins/F
   f64.const inf
@@ -437,17 +281,13 @@
   global.set $builtins/F
   f64.const 1
   global.set $builtins/F
-  f64.const 1.25
-  call $~lib/number/isNaN<f64>
+  i32.const 0
   global.set $builtins/b
-  f64.const 1.25
-  call $~lib/number/isFinite<f64>
+  i32.const 1
   global.set $builtins/b
   f64.const 0
   global.set $builtins/F
-  f32.const 0
-  global.get $builtins/f
-  f32.max
+  f32.const 1
   global.set $builtins/f
   i32.const 8
   i32.load
@@ -642,90 +482,6 @@
   i32.const 1
   i32.const 2
   call $start:builtins~anonymous|0
-  f32.const nan:0x400000
-  call $~lib/number/isNaN<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 299
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  call $~lib/number/isNaN<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 300
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  call $~lib/number/isFinite<f32>
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 301
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  call $~lib/number/isFinite<f32>
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 302
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  call $~lib/number/isFinite<f64>
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 303
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  call $~lib/number/isFinite<f64>
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 304
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  call $~lib/number/isFinite<f32>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 305
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  call $~lib/number/isFinite<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 306
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   i32.const 8
   i32.load8_s
   drop
@@ -876,8 +632,8 @@
   f64.const 0
   f64.const 0
   f64.const 12
-  f64.const 25
-  f64.const 25
+  f64.const 23
+  f64.const 23
   call $~lib/builtins/trace
   i32.const 176
   i32.const 176
@@ -1120,7 +876,7 @@
    unreachable
   end
  )
- (func $start (; 14 ;) (type $FUNCSIG$v)
+ (func $start (; 10 ;) (type $FUNCSIG$v)
   call $start:builtins
  )
 )

--- a/tests/compiler/builtins.untouched.wat
+++ b/tests/compiler/builtins.untouched.wat
@@ -1,7 +1,5 @@
 (module
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
- (type $FUNCSIG$if (func (param f32) (result i32)))
- (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$vii (func (param i32 i32)))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$viiddddd (func (param i32 i32 f64 f64 f64 f64 f64)))
@@ -81,34 +79,10 @@
  (export "memory" (memory $0))
  (export "test" (func $builtins/test))
  (start $start)
- (func $~lib/number/isNaN<f32> (; 2 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
-  local.get $0
-  local.get $0
-  f32.ne
- )
- (func $~lib/number/isFinite<f32> (; 3 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
-  local.get $0
-  local.get $0
-  f32.sub
-  f32.const 0
-  f32.eq
- )
- (func $~lib/number/isNaN<f64> (; 4 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.ne
- )
- (func $~lib/number/isFinite<f64> (; 5 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.sub
-  f64.const 0
-  f64.eq
- )
- (func $start:builtins~anonymous|0 (; 6 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $start:builtins~anonymous|0 (; 2 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/atomics/Atomics.isLockFree (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/atomics/Atomics.isLockFree (; 3 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 1
   i32.eq
@@ -127,13 +101,13 @@
    i32.eq
   end
  )
- (func $~lib/rt/stub/__retain (; 8 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (; 4 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 9 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/rt/stub/__release (; 5 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $~lib/string/String#get:length (; 10 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -141,7 +115,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 11 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (; 7 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -261,7 +235,7 @@
   call $~lib/rt/stub/__release
   local.get $8
  )
- (func $~lib/string/String.__eq (; 12 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 8 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -334,20 +308,22 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $start:builtins~anonymous|1 (; 13 ;) (type $FUNCSIG$v)
+ (func $start:builtins~anonymous|1 (; 9 ;) (type $FUNCSIG$v)
   nop
  )
- (func $start:builtins~anonymous|2 (; 14 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
+ (func $start:builtins~anonymous|2 (; 10 ;) (type $FUNCSIG$viiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32)
   nop
  )
- (func $start:builtins (; 15 ;) (type $FUNCSIG$v)
+ (func $start:builtins (; 11 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i64)
   (local $3 i64)
-  (local $4 i32)
-  (local $5 i32)
+  (local $4 f32)
+  (local $5 f64)
   (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
   i32.const 1
   i32.clz
   drop
@@ -617,7 +593,9 @@
   f32.trunc
   drop
   f32.const 1.25
-  call $~lib/number/isNaN<f32>
+  local.tee $4
+  local.get $4
+  f32.ne
   i32.const 0
   i32.eq
   i32.eqz
@@ -630,7 +608,9 @@
    unreachable
   end
   f32.const nan:0x400000
-  call $~lib/number/isNaN<f32>
+  local.tee $4
+  local.get $4
+  f32.ne
   i32.const 1
   i32.eq
   i32.eqz
@@ -643,7 +623,11 @@
    unreachable
   end
   f32.const 1.25
-  call $~lib/number/isFinite<f32>
+  local.tee $4
+  local.get $4
+  f32.sub
+  f32.const 0
+  f32.eq
   i32.const 1
   i32.eq
   i32.eqz
@@ -656,7 +640,11 @@
    unreachable
   end
   f32.const inf
-  call $~lib/number/isFinite<f32>
+  local.tee $4
+  local.get $4
+  f32.sub
+  f32.const 0
+  f32.eq
   i32.const 0
   i32.eq
   i32.eqz
@@ -669,7 +657,11 @@
    unreachable
   end
   f32.const -inf
-  call $~lib/number/isFinite<f32>
+  local.tee $4
+  local.get $4
+  f32.sub
+  f32.const 0
+  f32.eq
   i32.const 0
   i32.eq
   i32.eqz
@@ -682,7 +674,11 @@
    unreachable
   end
   f32.const nan:0x400000
-  call $~lib/number/isFinite<f32>
+  local.tee $4
+  local.get $4
+  f32.sub
+  f32.const 0
+  f32.eq
   i32.const 0
   i32.eq
   i32.eqz
@@ -729,10 +725,16 @@
   f32.trunc
   global.set $builtins/f
   f32.const 1.25
-  call $~lib/number/isNaN<f32>
+  local.tee $4
+  local.get $4
+  f32.ne
   global.set $builtins/b
   f32.const 1.25
-  call $~lib/number/isFinite<f32>
+  local.tee $4
+  local.get $4
+  f32.sub
+  f32.const 0
+  f32.eq
   global.set $builtins/b
   f64.const nan:0x8000000000000
   drop
@@ -773,7 +775,9 @@
   f64.trunc
   drop
   f64.const 1.25
-  call $~lib/number/isNaN<f64>
+  local.tee $5
+  local.get $5
+  f64.ne
   i32.const 0
   i32.eq
   i32.eqz
@@ -786,7 +790,9 @@
    unreachable
   end
   f64.const nan:0x8000000000000
-  call $~lib/number/isNaN<f64>
+  local.tee $5
+  local.get $5
+  f64.ne
   i32.const 1
   i32.eq
   i32.eqz
@@ -799,7 +805,11 @@
    unreachable
   end
   f64.const 1.25
-  call $~lib/number/isFinite<f64>
+  local.tee $5
+  local.get $5
+  f64.sub
+  f64.const 0
+  f64.eq
   i32.const 1
   i32.eq
   i32.eqz
@@ -812,7 +822,11 @@
    unreachable
   end
   f64.const inf
-  call $~lib/number/isFinite<f64>
+  local.tee $5
+  local.get $5
+  f64.sub
+  f64.const 0
+  f64.eq
   i32.const 0
   i32.eq
   i32.eqz
@@ -825,7 +839,11 @@
    unreachable
   end
   f64.const -inf
-  call $~lib/number/isFinite<f64>
+  local.tee $5
+  local.get $5
+  f64.sub
+  f64.const 0
+  f64.eq
   i32.const 0
   i32.eq
   i32.eqz
@@ -838,7 +856,11 @@
    unreachable
   end
   f64.const nan:0x8000000000000
-  call $~lib/number/isFinite<f64>
+  local.tee $5
+  local.get $5
+  f64.sub
+  f64.const 0
+  f64.eq
   i32.const 0
   i32.eq
   i32.eqz
@@ -885,10 +907,16 @@
   f64.trunc
   global.set $builtins/F
   f64.const 1.25
-  call $~lib/number/isNaN<f64>
+  local.tee $5
+  local.get $5
+  f64.ne
   global.set $builtins/b
   f64.const 1.25
-  call $~lib/number/isFinite<f64>
+  local.tee $5
+  local.get $5
+  f64.sub
+  f64.const 0
+  f64.eq
   global.set $builtins/b
   f64.const 0
   f64.const 1
@@ -1151,7 +1179,9 @@
   i32.const 4
   drop
   f32.const nan:0x400000
-  call $~lib/number/isNaN<f32>
+  local.tee $4
+  local.get $4
+  f32.ne
   i32.eqz
   if
    i32.const 0
@@ -1162,7 +1192,9 @@
    unreachable
   end
   f64.const nan:0x8000000000000
-  call $~lib/number/isNaN<f64>
+  local.tee $5
+  local.get $5
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -1173,7 +1205,11 @@
    unreachable
   end
   f32.const nan:0x400000
-  call $~lib/number/isFinite<f32>
+  local.tee $4
+  local.get $4
+  f32.sub
+  f32.const 0
+  f32.eq
   i32.eqz
   i32.eqz
   if
@@ -1185,7 +1221,11 @@
    unreachable
   end
   f32.const inf
-  call $~lib/number/isFinite<f32>
+  local.tee $4
+  local.get $4
+  f32.sub
+  f32.const 0
+  f32.eq
   i32.eqz
   i32.eqz
   if
@@ -1197,7 +1237,11 @@
    unreachable
   end
   f64.const nan:0x8000000000000
-  call $~lib/number/isFinite<f64>
+  local.tee $5
+  local.get $5
+  f64.sub
+  f64.const 0
+  f64.eq
   i32.eqz
   i32.eqz
   if
@@ -1209,7 +1253,11 @@
    unreachable
   end
   f64.const inf
-  call $~lib/number/isFinite<f64>
+  local.tee $5
+  local.get $5
+  f64.sub
+  f64.const 0
+  f64.eq
   i32.eqz
   i32.eqz
   if
@@ -1221,7 +1269,11 @@
    unreachable
   end
   f32.const 0
-  call $~lib/number/isFinite<f32>
+  local.tee $4
+  local.get $4
+  f32.sub
+  f32.const 0
+  f32.eq
   i32.eqz
   if
    i32.const 0
@@ -1232,7 +1284,11 @@
    unreachable
   end
   f64.const 0
-  call $~lib/number/isFinite<f64>
+  local.tee $5
+  local.get $5
+  f64.sub
+  f64.const 0
+  f64.eq
   i32.eqz
   if
    i32.const 0
@@ -1513,22 +1569,22 @@
   i32.const 0
   local.set $1
   i32.const 12
-  local.set $4
-  i32.const 25
-  local.set $5
-  i32.const 25
   local.set $6
+  i32.const 23
+  local.set $7
+  i32.const 23
+  local.set $8
   i32.const 104
   i32.const 5
   local.get $0
   f64.convert_i32_u
   local.get $1
   f64.convert_i32_u
-  local.get $4
-  f64.convert_i32_u
-  local.get $5
-  f64.convert_i32_u
   local.get $6
+  f64.convert_i32_u
+  local.get $7
+  f64.convert_i32_u
+  local.get $8
   f64.convert_i32_u
   call $~lib/builtins/trace
   local.get $0
@@ -1544,7 +1600,7 @@
    unreachable
   end
   local.get $0
-  local.get $4
+  local.get $6
   i32.ne
   i32.eqz
   if
@@ -1555,7 +1611,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $4
+  local.get $6
   i32.const 12
   i32.eq
   i32.eqz
@@ -1567,8 +1623,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $5
-  local.get $6
+  local.get $7
+  local.get $8
   i32.eq
   i32.eqz
   if
@@ -1820,12 +1876,12 @@
    unreachable
   end
  )
- (func $builtins/test (; 16 ;) (type $FUNCSIG$v)
+ (func $builtins/test (; 12 ;) (type $FUNCSIG$v)
   nop
  )
- (func $start (; 17 ;) (type $FUNCSIG$v)
+ (func $start (; 13 ;) (type $FUNCSIG$v)
   call $start:builtins
  )
- (func $null (; 18 ;) (type $FUNCSIG$v)
+ (func $null (; 14 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/i64-polyfill.optimized.wat
+++ b/tests/compiler/i64-polyfill.optimized.wat
@@ -94,7 +94,8 @@
   i64.const 32
   i64.shl
   i64.or
-  i64.eqz
+  i64.const 0
+  i64.eq
   global.set $../../lib/i64/assembly/i64/lo
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi

--- a/tests/compiler/i64-polyfill.untouched.wat
+++ b/tests/compiler/i64-polyfill.untouched.wat
@@ -106,7 +106,9 @@
   i64.const 32
   i64.shl
   i64.or
-  i64.eqz
+  i64.const 0
+  i64.ne
+  i32.eqz
   local.set $2
   local.get $2
   global.set $../../lib/i64/assembly/i64/lo

--- a/tests/compiler/logical.optimized.wat
+++ b/tests/compiler/logical.optimized.wat
@@ -1,5 +1,9 @@
 (module
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$if (func (param f32) (result i32)))
+ (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$v (func))
+ (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
  (data (i32.const 8) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00l\00o\00g\00i\00c\00a\00l\00.\00t\00s")
  (global $logical/i (mut i32) (i32.const 0))
@@ -8,7 +12,17 @@
  (global $logical/F (mut f64) (f64.const 0))
  (export "memory" (memory $0))
  (start $start)
- (func $start:logical (; 0 ;) (type $FUNCSIG$v)
+ (func $~lib/number/isNaN<f32> (; 1 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
+  local.get $0
+  local.get $0
+  f32.ne
+ )
+ (func $~lib/number/isNaN<f64> (; 2 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+  local.get $0
+  local.get $0
+  f64.ne
+ )
+ (func $start:logical (; 3 ;) (type $FUNCSIG$v)
   i32.const 2
   global.set $logical/i
   i32.const 1
@@ -25,11 +39,71 @@
   global.set $logical/F
   f64.const 1
   global.set $logical/F
+  f32.const 1
+  global.set $logical/f
+  f32.const 1
+  global.set $logical/f
+  f64.const 1
+  global.set $logical/F
+  f64.const 1
+  global.set $logical/F
+  f32.const nan:0x400000
+  global.set $logical/f
+  f32.const nan:0x400000
+  call $~lib/number/isNaN<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 56
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  global.set $logical/f
+  f32.const nan:0x400000
+  call $~lib/number/isNaN<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 59
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  global.set $logical/F
+  f64.const nan:0x8000000000000
+  call $~lib/number/isNaN<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 62
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  global.set $logical/F
+  f64.const nan:0x8000000000000
+  call $~lib/number/isNaN<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 65
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
  )
- (func $start (; 1 ;) (type $FUNCSIG$v)
+ (func $start (; 4 ;) (type $FUNCSIG$v)
   call $start:logical
  )
- (func $null (; 2 ;) (type $FUNCSIG$v)
+ (func $null (; 5 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/logical.optimized.wat
+++ b/tests/compiler/logical.optimized.wat
@@ -1,7 +1,5 @@
 (module
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
- (type $FUNCSIG$if (func (param f32) (result i32)))
- (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -12,17 +10,9 @@
  (global $logical/F (mut f64) (f64.const 0))
  (export "memory" (memory $0))
  (start $start)
- (func $~lib/number/isNaN<f32> (; 1 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
-  local.get $0
-  local.get $0
-  f32.ne
- )
- (func $~lib/number/isNaN<f64> (; 2 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.ne
- )
- (func $start:logical (; 3 ;) (type $FUNCSIG$v)
+ (func $start:logical (; 1 ;) (type $FUNCSIG$v)
+  (local $0 f32)
+  (local $1 f64)
   i32.const 2
   global.set $logical/i
   i32.const 1
@@ -50,8 +40,9 @@
   f32.const nan:0x400000
   global.set $logical/f
   f32.const nan:0x400000
-  call $~lib/number/isNaN<f32>
-  i32.eqz
+  local.tee $0
+  local.get $0
+  f32.eq
   if
    i32.const 0
    i32.const 24
@@ -63,8 +54,9 @@
   f32.const nan:0x400000
   global.set $logical/f
   f32.const nan:0x400000
-  call $~lib/number/isNaN<f32>
-  i32.eqz
+  local.tee $0
+  local.get $0
+  f32.eq
   if
    i32.const 0
    i32.const 24
@@ -76,8 +68,9 @@
   f64.const nan:0x8000000000000
   global.set $logical/F
   f64.const nan:0x8000000000000
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $1
+  local.get $1
+  f64.eq
   if
    i32.const 0
    i32.const 24
@@ -89,8 +82,9 @@
   f64.const nan:0x8000000000000
   global.set $logical/F
   f64.const nan:0x8000000000000
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $1
+  local.get $1
+  f64.eq
   if
    i32.const 0
    i32.const 24
@@ -100,10 +94,10 @@
    unreachable
   end
  )
- (func $start (; 4 ;) (type $FUNCSIG$v)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   call $start:logical
  )
- (func $null (; 5 ;) (type $FUNCSIG$v)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/logical.ts
+++ b/tests/compiler/logical.ts
@@ -37,3 +37,29 @@ assert(F == 2.0);
 
 F = 0.0 || 1.0;
 assert(F == 1.0);
+
+// NaN is considered falseish
+
+f = NaN as f32 || 1.0 as f32;
+assert(f == 1.0);
+
+f = 1.0 as f32 || NaN as f32;
+assert(f == 1.0);
+
+F = NaN || 1.0;
+assert(F == 1.0);
+
+F = 1.0 || NaN;
+assert(F == 1.0);
+
+f = 1.0 as f32 && NaN as f32;
+assert(isNaN(f));
+
+f = NaN as f32 && 1.0 as f32;
+assert(isNaN(f));
+
+F = 1.0 && NaN;
+assert(isNaN(F));
+
+F = NaN && 1.0;
+assert(isNaN(F));

--- a/tests/compiler/logical.untouched.wat
+++ b/tests/compiler/logical.untouched.wat
@@ -1,5 +1,7 @@
 (module
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$if (func (param f32) (result i32)))
+ (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -12,7 +14,19 @@
  (global $logical/F (mut f64) (f64.const 0))
  (export "memory" (memory $0))
  (start $start)
- (func $start:logical (; 1 ;) (type $FUNCSIG$v)
+ (func $~lib/number/isNaN<f32> (; 1 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
+  local.get $0
+  local.get $0
+  f32.ne
+ )
+ (func $~lib/number/isNaN<f64> (; 2 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+  local.get $0
+  local.get $0
+  f64.ne
+ )
+ (func $start:logical (; 3 ;) (type $FUNCSIG$v)
+  (local $0 f64)
+  (local $1 f32)
   i32.const 0
   if (result i32)
    unreachable
@@ -21,8 +35,13 @@
   end
   drop
   f64.const 0
+  local.tee $0
   f64.const 0
   f64.ne
+  local.get $0
+  local.get $0
+  f64.eq
+  i32.and
   if (result i32)
    unreachable
   else
@@ -37,8 +56,13 @@
   end
   drop
   f64.const 1
+  local.tee $0
   f64.const 0
   f64.ne
+  local.get $0
+  local.get $0
+  f64.eq
+  i32.and
   if (result i32)
    i32.const 1
   else
@@ -58,15 +82,25 @@
   end
   drop
   f64.const 1
+  local.tee $0
   f64.const 0
   f64.ne
+  local.get $0
+  local.get $0
+  f64.eq
+  i32.and
   if (result f64)
    f64.const 2
   else
    f64.const 1
   end
+  local.tee $0
   f64.const 0
   f64.ne
+  local.get $0
+  local.get $0
+  f64.eq
+  i32.and
   if (result i32)
    i32.const 1
   else
@@ -154,8 +188,13 @@
    unreachable
   end
   f32.const 1
+  local.tee $1
   f32.const 0
   f32.ne
+  local.get $1
+  local.get $1
+  f32.eq
+  i32.and
   if (result f32)
    f32.const 2
   else
@@ -175,8 +214,13 @@
    unreachable
   end
   f32.const 0
+  local.tee $1
   f32.const 0
   f32.ne
+  local.get $1
+  local.get $1
+  f32.eq
+  i32.and
   if (result f32)
    f32.const 0
   else
@@ -196,8 +240,13 @@
    unreachable
   end
   f64.const 1
+  local.tee $0
   f64.const 0
   f64.ne
+  local.get $0
+  local.get $0
+  f64.eq
+  i32.and
   if (result f64)
    f64.const 2
   else
@@ -217,8 +266,13 @@
    unreachable
   end
   f64.const 0
+  local.tee $0
   f64.const 0
   f64.ne
+  local.get $0
+  local.get $0
+  f64.eq
+  i32.and
   if (result f64)
    f64.const 0
   else
@@ -237,10 +291,214 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const nan:0x400000
+  local.tee $1
+  f32.const 0
+  f32.ne
+  local.get $1
+  local.get $1
+  f32.eq
+  i32.and
+  if (result f32)
+   f32.const nan:0x400000
+  else
+   f32.const 1
+  end
+  global.set $logical/f
+  global.get $logical/f
+  f32.const 1
+  f32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 44
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  local.tee $1
+  f32.const 0
+  f32.ne
+  local.get $1
+  local.get $1
+  f32.eq
+  i32.and
+  if (result f32)
+   f32.const 1
+  else
+   f32.const nan:0x400000
+  end
+  global.set $logical/f
+  global.get $logical/f
+  f32.const 1
+  f32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 47
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  local.tee $0
+  f64.const 0
+  f64.ne
+  local.get $0
+  local.get $0
+  f64.eq
+  i32.and
+  if (result f64)
+   f64.const nan:0x8000000000000
+  else
+   f64.const 1
+  end
+  global.set $logical/F
+  global.get $logical/F
+  f64.const 1
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 50
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  local.tee $0
+  f64.const 0
+  f64.ne
+  local.get $0
+  local.get $0
+  f64.eq
+  i32.and
+  if (result f64)
+   f64.const 1
+  else
+   f64.const nan:0x8000000000000
+  end
+  global.set $logical/F
+  global.get $logical/F
+  f64.const 1
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 53
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  local.tee $1
+  f32.const 0
+  f32.ne
+  local.get $1
+  local.get $1
+  f32.eq
+  i32.and
+  if (result f32)
+   f32.const nan:0x400000
+  else
+   f32.const 1
+  end
+  global.set $logical/f
+  global.get $logical/f
+  call $~lib/number/isNaN<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 56
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  local.tee $1
+  f32.const 0
+  f32.ne
+  local.get $1
+  local.get $1
+  f32.eq
+  i32.and
+  if (result f32)
+   f32.const 1
+  else
+   f32.const nan:0x400000
+  end
+  global.set $logical/f
+  global.get $logical/f
+  call $~lib/number/isNaN<f32>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 59
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  local.tee $0
+  f64.const 0
+  f64.ne
+  local.get $0
+  local.get $0
+  f64.eq
+  i32.and
+  if (result f64)
+   f64.const nan:0x8000000000000
+  else
+   f64.const 1
+  end
+  global.set $logical/F
+  global.get $logical/F
+  call $~lib/number/isNaN<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 62
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  local.tee $0
+  f64.const 0
+  f64.ne
+  local.get $0
+  local.get $0
+  f64.eq
+  i32.and
+  if (result f64)
+   f64.const 1
+  else
+   f64.const nan:0x8000000000000
+  end
+  global.set $logical/F
+  global.get $logical/F
+  call $~lib/number/isNaN<f64>
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 65
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
  )
- (func $start (; 2 ;) (type $FUNCSIG$v)
+ (func $start (; 4 ;) (type $FUNCSIG$v)
   call $start:logical
  )
- (func $null (; 3 ;) (type $FUNCSIG$v)
+ (func $null (; 5 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/logical.untouched.wat
+++ b/tests/compiler/logical.untouched.wat
@@ -1,7 +1,5 @@
 (module
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
- (type $FUNCSIG$if (func (param f32) (result i32)))
- (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$v (func))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
@@ -14,17 +12,7 @@
  (global $logical/F (mut f64) (f64.const 0))
  (export "memory" (memory $0))
  (start $start)
- (func $~lib/number/isNaN<f32> (; 1 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
-  local.get $0
-  local.get $0
-  f32.ne
- )
- (func $~lib/number/isNaN<f64> (; 2 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.ne
- )
- (func $start:logical (; 3 ;) (type $FUNCSIG$v)
+ (func $start:logical (; 1 ;) (type $FUNCSIG$v)
   (local $0 f64)
   (local $1 f32)
   i32.const 0
@@ -410,7 +398,9 @@
   end
   global.set $logical/f
   global.get $logical/f
-  call $~lib/number/isNaN<f32>
+  local.tee $1
+  local.get $1
+  f32.ne
   i32.eqz
   if
    i32.const 0
@@ -435,7 +425,9 @@
   end
   global.set $logical/f
   global.get $logical/f
-  call $~lib/number/isNaN<f32>
+  local.tee $1
+  local.get $1
+  f32.ne
   i32.eqz
   if
    i32.const 0
@@ -460,7 +452,9 @@
   end
   global.set $logical/F
   global.get $logical/F
-  call $~lib/number/isNaN<f64>
+  local.tee $0
+  local.get $0
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -485,7 +479,9 @@
   end
   global.set $logical/F
   global.get $logical/F
-  call $~lib/number/isNaN<f64>
+  local.tee $0
+  local.get $0
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -496,9 +492,9 @@
    unreachable
   end
  )
- (func $start (; 4 ;) (type $FUNCSIG$v)
+ (func $start (; 2 ;) (type $FUNCSIG$v)
   call $start:logical
  )
- (func $null (; 5 ;) (type $FUNCSIG$v)
+ (func $null (; 3 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/number.optimized.wat
+++ b/tests/compiler/number.optimized.wat
@@ -367,19 +367,7 @@
   end
   i32.const 0
  )
- (func $~lib/number/isFinite<f64> (; 9 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.sub
-  f64.const 0
-  f64.eq
- )
- (func $~lib/number/isNaN<f64> (; 10 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.ne
- )
- (func $~lib/util/number/genDigits (; 11 ;) (type $FUNCSIG$iijijij) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (result i32)
+ (func $~lib/util/number/genDigits (; 9 ;) (type $FUNCSIG$iijijij) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (result i32)
   (local $6 i32)
   (local $7 i32)
   (local $8 i64)
@@ -779,7 +767,7 @@
   i32.store16
   local.get $2
  )
- (func $~lib/memory/memory.copy (; 12 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 10 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -954,7 +942,7 @@
    end
   end
  )
- (func $~lib/util/number/prettify (; 13 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (; 11 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
@@ -1201,7 +1189,7 @@
    end
   end
  )
- (func $~lib/util/number/dtoa_core (; 14 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/dtoa_core (; 12 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -1369,7 +1357,7 @@
   global.get $~lib/util/number/_K
   call $~lib/util/number/prettify
  )
- (func $~lib/string/String#substring (; 15 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#substring (; 13 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 0
@@ -1442,7 +1430,7 @@
   call $~lib/memory/memory.copy
   local.get $1
  )
- (func $~lib/rt/stub/__free (; 16 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/rt/stub/__free (; 14 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.const 15
@@ -1486,22 +1474,9 @@
    global.set $~lib/rt/stub/offset
   end
  )
- (func $~lib/util/number/dtoa (; 17 ;) (type $FUNCSIG$i) (result i32)
+ (func $~lib/util/number/dtoa (; 15 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   (local $1 i32)
-  f64.const 2
-  call $~lib/number/isFinite<f64>
-  i32.eqz
-  if
-   f64.const 2
-   call $~lib/number/isNaN<f64>
-   if
-    i32.const 136
-    return
-   end
-   i32.const 200
-   return
-  end
   i32.const 56
   call $~lib/rt/stub/__alloc
   local.tee $0
@@ -1519,13 +1494,13 @@
   local.get $0
   call $~lib/rt/stub/__free
  )
- (func $~lib/number/Bool#toString (; 18 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/number/Bool#toString (; 16 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1472
   i32.const 1496
   local.get $0
   select
  )
- (func $~lib/number/F32.isSafeInteger (; 19 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
+ (func $~lib/number/F32.isSafeInteger (; 17 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
   local.get $0
   f32.trunc
   local.get $0
@@ -1537,7 +1512,7 @@
   f32.le
   select
  )
- (func $~lib/number/F32.isInteger (; 20 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
+ (func $~lib/number/F32.isInteger (; 18 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
   local.get $0
   f32.trunc
   local.get $0
@@ -1550,7 +1525,7 @@
   f32.eq
   select
  )
- (func $~lib/number/F64.isSafeInteger (; 21 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/number/F64.isSafeInteger (; 19 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   f64.trunc
   local.get $0
@@ -1562,19 +1537,20 @@
   f64.le
   select
  )
- (func $~lib/number/F64.isInteger (; 22 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/number/F64.isInteger (; 20 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
-  call $~lib/number/isFinite<f64>
-  if (result i32)
-   local.get $0
-   f64.trunc
-   local.get $0
-   f64.eq
-  else
-   i32.const 0
-  end
+  f64.trunc
+  local.get $0
+  f64.eq
+  i32.const 0
+  local.get $0
+  local.get $0
+  f64.sub
+  f64.const 0
+  f64.eq
+  select
  )
- (func $start:number (; 23 ;) (type $FUNCSIG$v)
+ (func $start:number (; 21 ;) (type $FUNCSIG$v)
   (local $0 i32)
   i32.const 1520
   global.set $~lib/rt/stub/startOffset
@@ -1960,17 +1936,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  call $~lib/number/isNaN<f64>
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 72
-   i32.const 46
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const -9007199254740992
   call $~lib/number/F64.isSafeInteger
   if
@@ -2192,10 +2157,10 @@
    unreachable
   end
  )
- (func $start (; 24 ;) (type $FUNCSIG$v)
+ (func $start (; 22 ;) (type $FUNCSIG$v)
   call $start:number
  )
- (func $null (; 25 ;) (type $FUNCSIG$v)
+ (func $null (; 23 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/number.untouched.wat
+++ b/tests/compiler/number.untouched.wat
@@ -648,19 +648,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/number/isFinite<f64> (; 13 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.sub
-  f64.const 0
-  f64.eq
- )
- (func $~lib/number/isNaN<f64> (; 14 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.ne
- )
- (func $~lib/array/Array<u64>#__unchecked_get (; 15 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__unchecked_get (; 13 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -669,7 +657,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<i16>#__unchecked_get (; 16 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__unchecked_get (; 14 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -678,7 +666,7 @@
   i32.add
   i32.load16_s
  )
- (func $~lib/util/number/genDigits (; 17 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (; 15 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -1180,7 +1168,7 @@
   end
   unreachable
  )
- (func $~lib/util/memory/memcpy (; 18 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (; 16 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2208,7 +2196,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 19 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 17 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2433,7 +2421,7 @@
    end
   end
  )
- (func $~lib/util/number/prettify (; 20 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (; 18 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2752,7 +2740,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/dtoa_core (; 21 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (; 19 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3174,7 +3162,7 @@
   local.get $2
   i32.add
  )
- (func $~lib/string/String#substring (; 22 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substring (; 20 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3281,7 +3269,7 @@
   local.get $10
   call $~lib/rt/stub/__retain
  )
- (func $~lib/rt/stub/__free (; 23 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/rt/stub/__free (; 21 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.const 0
@@ -3331,10 +3319,11 @@
    global.set $~lib/rt/stub/offset
   end
  )
- (func $~lib/util/number/dtoa (; 24 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  (local $1 i32)
+ (func $~lib/util/number/dtoa (; 22 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+  (local $1 f64)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   local.get $0
   f64.const 0
   f64.eq
@@ -3344,11 +3333,17 @@
    return
   end
   local.get $0
-  call $~lib/number/isFinite<f64>
+  local.tee $1
+  local.get $1
+  f64.sub
+  f64.const 0
+  f64.eq
   i32.eqz
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.tee $1
+   local.get $1
+   f64.ne
    if
     i32.const 584
     call $~lib/rt/stub/__retain
@@ -3368,33 +3363,33 @@
   i32.shl
   i32.const 1
   call $~lib/rt/stub/__alloc
-  local.set $1
-  local.get $1
-  local.get $0
-  call $~lib/util/number/dtoa_core
   local.set $2
   local.get $2
+  local.get $0
+  call $~lib/util/number/dtoa_core
+  local.set $3
+  local.get $3
   i32.const 28
   i32.eq
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/stub/__retain
    return
   end
-  local.get $1
-  i32.const 0
   local.get $2
-  call $~lib/string/String#substring
-  local.set $3
-  local.get $1
-  call $~lib/rt/stub/__free
+  i32.const 0
   local.get $3
+  call $~lib/string/String#substring
+  local.set $4
+  local.get $2
+  call $~lib/rt/stub/__free
+  local.get $4
  )
- (func $~lib/number/F64#toString (; 25 ;) (type $FUNCSIG$idi) (param $0 f64) (param $1 i32) (result i32)
+ (func $~lib/number/F64#toString (; 23 ;) (type $FUNCSIG$idi) (param $0 f64) (param $1 i32) (result i32)
   local.get $0
   call $~lib/util/number/dtoa
  )
- (func $~lib/number/Bool#toString (; 26 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/number/Bool#toString (; 24 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -3409,12 +3404,7 @@
   end
   call $~lib/rt/stub/__retain
  )
- (func $~lib/number/isNaN<f32> (; 27 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
-  local.get $0
-  local.get $0
-  f32.ne
- )
- (func $~lib/number/F32.isSafeInteger (; 28 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
+ (func $~lib/number/F32.isSafeInteger (; 25 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
   local.get $0
   f32.abs
   global.get $~lib/builtins/f32.MAX_SAFE_INTEGER
@@ -3428,16 +3418,14 @@
    i32.const 0
   end
  )
- (func $~lib/number/isFinite<f32> (; 29 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
+ (func $~lib/number/F32.isInteger (; 26 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
+  (local $1 f32)
   local.get $0
-  local.get $0
+  local.tee $1
+  local.get $1
   f32.sub
   f32.const 0
   f32.eq
- )
- (func $~lib/number/F32.isInteger (; 30 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
-  local.get $0
-  call $~lib/number/isFinite<f32>
   if (result i32)
    local.get $0
    f32.trunc
@@ -3447,7 +3435,7 @@
    i32.const 0
   end
  )
- (func $~lib/number/F64.isSafeInteger (; 31 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/number/F64.isSafeInteger (; 27 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   f64.abs
   global.get $~lib/builtins/f64.MAX_SAFE_INTEGER
@@ -3461,9 +3449,14 @@
    i32.const 0
   end
  )
- (func $~lib/number/F64.isInteger (; 32 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/number/F64.isInteger (; 28 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+  (local $1 f64)
   local.get $0
-  call $~lib/number/isFinite<f64>
+  local.tee $1
+  local.get $1
+  f64.sub
+  f64.const 0
+  f64.eq
   if (result i32)
    local.get $0
    f64.trunc
@@ -3473,7 +3466,7 @@
    i32.const 0
   end
  )
- (func $start:number (; 33 ;) (type $FUNCSIG$v)
+ (func $start:number (; 29 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -3485,6 +3478,8 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 f32)
+  (local $12 f64)
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -3669,7 +3664,9 @@
    unreachable
   end
   f32.const nan:0x400000
-  call $~lib/number/isNaN<f32>
+  local.tee $11
+  local.get $11
+  f32.ne
   i32.eqz
   if
    i32.const 0
@@ -3940,7 +3937,9 @@
    unreachable
   end
   f64.const nan:0x8000000000000
-  call $~lib/number/isNaN<f64>
+  local.tee $12
+  local.get $12
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -4233,9 +4232,9 @@
   local.get $10
   call $~lib/rt/stub/__release
  )
- (func $start (; 34 ;) (type $FUNCSIG$v)
+ (func $start (; 30 ;) (type $FUNCSIG$v)
   call $start:number
  )
- (func $null (; 35 ;) (type $FUNCSIG$v)
+ (func $null (; 31 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/number.untouched.wat
+++ b/tests/compiler/number.untouched.wat
@@ -3320,10 +3320,9 @@
   end
  )
  (func $~lib/util/number/dtoa (; 22 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  (local $1 f64)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
   local.get $0
   f64.const 0
   f64.eq
@@ -3333,16 +3332,14 @@
    return
   end
   local.get $0
-  local.tee $1
-  local.get $1
+  local.get $0
   f64.sub
   f64.const 0
   f64.eq
   i32.eqz
   if
    local.get $0
-   local.tee $1
-   local.get $1
+   local.get $0
    f64.ne
    if
     i32.const 584
@@ -3363,27 +3360,27 @@
   i32.shl
   i32.const 1
   call $~lib/rt/stub/__alloc
-  local.set $2
-  local.get $2
+  local.set $1
+  local.get $1
   local.get $0
   call $~lib/util/number/dtoa_core
-  local.set $3
-  local.get $3
+  local.set $2
+  local.get $2
   i32.const 28
   i32.eq
   if
-   local.get $2
+   local.get $1
    call $~lib/rt/stub/__retain
    return
   end
-  local.get $2
+  local.get $1
   i32.const 0
-  local.get $3
-  call $~lib/string/String#substring
-  local.set $4
   local.get $2
+  call $~lib/string/String#substring
+  local.set $3
+  local.get $1
   call $~lib/rt/stub/__free
-  local.get $4
+  local.get $3
  )
  (func $~lib/number/F64#toString (; 23 ;) (type $FUNCSIG$idi) (param $0 f64) (param $1 i32) (result i32)
   local.get $0
@@ -3419,10 +3416,8 @@
   end
  )
  (func $~lib/number/F32.isInteger (; 26 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
-  (local $1 f32)
   local.get $0
-  local.tee $1
-  local.get $1
+  local.get $0
   f32.sub
   f32.const 0
   f32.eq
@@ -3450,10 +3445,8 @@
   end
  )
  (func $~lib/number/F64.isInteger (; 28 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  (local $1 f64)
   local.get $0
-  local.tee $1
-  local.get $1
+  local.get $0
   f64.sub
   f64.const 0
   f64.eq

--- a/tests/compiler/resolve-access.optimized.wat
+++ b/tests/compiler/resolve-access.optimized.wat
@@ -485,7 +485,8 @@
   (local $2 i32)
   (local $3 i32)
   local.get $0
-  i64.eqz
+  i64.const 0
+  i64.eq
   if
    i32.const 152
    return

--- a/tests/compiler/resolve-access.untouched.wat
+++ b/tests/compiler/resolve-access.untouched.wat
@@ -1877,7 +1877,9 @@
   (local $6 i32)
   (local $7 i64)
   local.get $0
-  i64.eqz
+  i64.const 0
+  i64.ne
+  i32.eqz
   if
    i32.const 152
    call $~lib/rt/stub/__retain

--- a/tests/compiler/resolve-binary.untouched.wat
+++ b/tests/compiler/resolve-binary.untouched.wat
@@ -1844,19 +1844,7 @@
   local.get $16
   f64.mul
  )
- (func $~lib/number/isFinite<f64> (; 16 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.sub
-  f64.const 0
-  f64.eq
- )
- (func $~lib/number/isNaN<f64> (; 17 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.ne
- )
- (func $~lib/array/Array<u64>#__unchecked_get (; 18 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__unchecked_get (; 16 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -1865,7 +1853,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<i16>#__unchecked_get (; 19 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__unchecked_get (; 17 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -1874,7 +1862,7 @@
   i32.add
   i32.load16_s
  )
- (func $~lib/util/number/genDigits (; 20 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (; 18 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -2376,7 +2364,7 @@
   end
   unreachable
  )
- (func $~lib/util/memory/memcpy (; 21 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (; 19 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3404,7 +3392,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 22 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 20 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3629,7 +3617,7 @@
    end
   end
  )
- (func $~lib/util/number/prettify (; 23 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (; 21 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3948,7 +3936,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/dtoa_core (; 24 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (; 22 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4370,7 +4358,7 @@
   local.get $2
   i32.add
  )
- (func $~lib/string/String#substring (; 25 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substring (; 23 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4477,7 +4465,7 @@
   local.get $10
   call $~lib/rt/stub/__retain
  )
- (func $~lib/rt/stub/__free (; 26 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/rt/stub/__free (; 24 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.const 0
@@ -4527,10 +4515,11 @@
    global.set $~lib/rt/stub/offset
   end
  )
- (func $~lib/util/number/dtoa (; 27 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  (local $1 i32)
+ (func $~lib/util/number/dtoa (; 25 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+  (local $1 f64)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   local.get $0
   f64.const 0
   f64.eq
@@ -4540,11 +4529,17 @@
    return
   end
   local.get $0
-  call $~lib/number/isFinite<f64>
+  local.tee $1
+  local.get $1
+  f64.sub
+  f64.const 0
+  f64.eq
   i32.eqz
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.tee $1
+   local.get $1
+   f64.ne
    if
     i32.const 704
     call $~lib/rt/stub/__retain
@@ -4564,33 +4559,33 @@
   i32.shl
   i32.const 1
   call $~lib/rt/stub/__alloc
-  local.set $1
-  local.get $1
-  local.get $0
-  call $~lib/util/number/dtoa_core
   local.set $2
   local.get $2
+  local.get $0
+  call $~lib/util/number/dtoa_core
+  local.set $3
+  local.get $3
   i32.const 28
   i32.eq
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/stub/__retain
    return
   end
-  local.get $1
-  i32.const 0
   local.get $2
-  call $~lib/string/String#substring
-  local.set $3
-  local.get $1
-  call $~lib/rt/stub/__free
+  i32.const 0
   local.get $3
+  call $~lib/string/String#substring
+  local.set $4
+  local.get $2
+  call $~lib/rt/stub/__free
+  local.get $4
  )
- (func $~lib/number/F64#toString (; 28 ;) (type $FUNCSIG$idi) (param $0 f64) (param $1 i32) (result i32)
+ (func $~lib/number/F64#toString (; 26 ;) (type $FUNCSIG$idi) (param $0 f64) (param $1 i32) (result i32)
   local.get $0
   call $~lib/util/number/dtoa
  )
- (func $resolve-binary/Foo#constructor (; 29 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $resolve-binary/Foo#constructor (; 27 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -4602,7 +4597,7 @@
   end
   local.get $0
  )
- (func $resolve-binary/Foo#lt (; 30 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Foo#lt (; 28 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/stub/__retain
@@ -4614,11 +4609,11 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/string/String#toString (; 31 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/string/String#toString (; 29 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/rt/stub/__retain
  )
- (func $resolve-binary/Foo#gt (; 32 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Foo#gt (; 30 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/stub/__retain
@@ -4630,7 +4625,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $resolve-binary/Foo#le (; 33 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Foo#le (; 31 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/stub/__retain
@@ -4642,7 +4637,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $resolve-binary/Foo#ge (; 34 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Foo#ge (; 32 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/stub/__retain
@@ -4654,7 +4649,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $resolve-binary/Foo#eq (; 35 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Foo#eq (; 33 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/stub/__retain
@@ -4666,7 +4661,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $resolve-binary/Foo#ne (; 36 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Foo#ne (; 34 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/stub/__retain
@@ -4678,7 +4673,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $resolve-binary/Foo#add (; 37 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Foo#add (; 35 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/stub/__retain
@@ -4690,7 +4685,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $resolve-binary/Foo.sub (; 38 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Foo.sub (; 36 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -4707,7 +4702,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $resolve-binary/Foo#mul (; 39 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Foo#mul (; 37 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/stub/__retain
@@ -4719,7 +4714,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $resolve-binary/Foo#div (; 40 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Foo#div (; 38 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/stub/__retain
@@ -4731,7 +4726,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $resolve-binary/Foo#rem (; 41 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Foo#rem (; 39 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/stub/__retain
@@ -4743,7 +4738,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $resolve-binary/Foo#pow (; 42 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Foo#pow (; 40 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/stub/__retain
@@ -4755,7 +4750,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $resolve-binary/Bar#constructor (; 43 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $resolve-binary/Bar#constructor (; 41 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -4767,17 +4762,17 @@
   end
   local.get $0
  )
- (func $resolve-binary/Bar#add (; 44 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $resolve-binary/Bar#add (; 42 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   call $~lib/rt/stub/__retain
   drop
   local.get $1
  )
- (func $resolve-binary/Bar#self (; 45 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $resolve-binary/Bar#self (; 43 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/rt/stub/__retain
  )
- (func $start:resolve-binary (; 46 ;) (type $FUNCSIG$v)
+ (func $start:resolve-binary (; 44 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -5811,9 +5806,9 @@
   local.get $62
   call $~lib/rt/stub/__release
  )
- (func $start (; 47 ;) (type $FUNCSIG$v)
+ (func $start (; 45 ;) (type $FUNCSIG$v)
   call $start:resolve-binary
  )
- (func $null (; 48 ;) (type $FUNCSIG$v)
+ (func $null (; 46 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/resolve-binary.untouched.wat
+++ b/tests/compiler/resolve-binary.untouched.wat
@@ -4516,10 +4516,9 @@
   end
  )
  (func $~lib/util/number/dtoa (; 25 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  (local $1 f64)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
   local.get $0
   f64.const 0
   f64.eq
@@ -4529,16 +4528,14 @@
    return
   end
   local.get $0
-  local.tee $1
-  local.get $1
+  local.get $0
   f64.sub
   f64.const 0
   f64.eq
   i32.eqz
   if
    local.get $0
-   local.tee $1
-   local.get $1
+   local.get $0
    f64.ne
    if
     i32.const 704
@@ -4559,27 +4556,27 @@
   i32.shl
   i32.const 1
   call $~lib/rt/stub/__alloc
-  local.set $2
-  local.get $2
+  local.set $1
+  local.get $1
   local.get $0
   call $~lib/util/number/dtoa_core
-  local.set $3
-  local.get $3
+  local.set $2
+  local.get $2
   i32.const 28
   i32.eq
   if
-   local.get $2
+   local.get $1
    call $~lib/rt/stub/__retain
    return
   end
-  local.get $2
+  local.get $1
   i32.const 0
-  local.get $3
-  call $~lib/string/String#substring
-  local.set $4
   local.get $2
+  call $~lib/string/String#substring
+  local.set $3
+  local.get $1
   call $~lib/rt/stub/__free
-  local.get $4
+  local.get $3
  )
  (func $~lib/number/F64#toString (; 26 ;) (type $FUNCSIG$idi) (param $0 f64) (param $1 i32) (result i32)
   local.get $0

--- a/tests/compiler/resolve-elementaccess.untouched.wat
+++ b/tests/compiler/resolve-elementaccess.untouched.wat
@@ -3452,10 +3452,9 @@
   end
  )
  (func $~lib/util/number/dtoa (; 22 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  (local $1 f64)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
   local.get $0
   f64.const 0
   f64.eq
@@ -3465,16 +3464,14 @@
    return
   end
   local.get $0
-  local.tee $1
-  local.get $1
+  local.get $0
   f64.sub
   f64.const 0
   f64.eq
   i32.eqz
   if
    local.get $0
-   local.tee $1
-   local.get $1
+   local.get $0
    f64.ne
    if
     i32.const 264
@@ -3495,27 +3492,27 @@
   i32.shl
   i32.const 1
   call $~lib/rt/stub/__alloc
-  local.set $2
-  local.get $2
+  local.set $1
+  local.get $1
   local.get $0
   call $~lib/util/number/dtoa_core
-  local.set $3
-  local.get $3
+  local.set $2
+  local.get $2
   i32.const 28
   i32.eq
   if
-   local.get $2
+   local.get $1
    call $~lib/rt/stub/__retain
    return
   end
-  local.get $2
+  local.get $1
   i32.const 0
-  local.get $3
-  call $~lib/string/String#substring
-  local.set $4
   local.get $2
+  call $~lib/string/String#substring
+  local.set $3
+  local.get $1
   call $~lib/rt/stub/__free
-  local.get $4
+  local.get $3
  )
  (func $~lib/number/F32#toString (; 23 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
   local.get $0

--- a/tests/compiler/resolve-elementaccess.untouched.wat
+++ b/tests/compiler/resolve-elementaccess.untouched.wat
@@ -564,19 +564,7 @@
   i32.add
   f32.load
  )
- (func $~lib/number/isFinite<f64> (; 10 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.sub
-  f64.const 0
-  f64.eq
- )
- (func $~lib/number/isNaN<f64> (; 11 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.ne
- )
- (func $~lib/array/Array<u64>#__unchecked_get (; 12 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__unchecked_get (; 10 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -585,7 +573,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<i16>#__unchecked_get (; 13 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__unchecked_get (; 11 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -594,7 +582,7 @@
   i32.add
   i32.load16_s
  )
- (func $~lib/util/number/decimalCount32 (; 14 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (; 12 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 100000
@@ -660,7 +648,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/genDigits (; 15 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (; 13 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -1162,7 +1150,7 @@
   end
   unreachable
  )
- (func $~lib/util/memory/memcpy (; 16 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/memory/memcpy (; 14 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2190,7 +2178,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 17 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 15 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2415,7 +2403,7 @@
    end
   end
  )
- (func $~lib/util/number/utoa32_lut (; 18 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa32_lut (; 16 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2557,7 +2545,7 @@
    i32.store16
   end
  )
- (func $~lib/util/number/prettify (; 19 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (; 17 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2876,7 +2864,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/dtoa_core (; 20 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (; 18 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3298,7 +3286,7 @@
   local.get $2
   i32.add
  )
- (func $~lib/string/String#get:length (; 21 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (; 19 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -3306,7 +3294,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/string/String#substring (; 22 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substring (; 20 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3413,7 +3401,7 @@
   local.get $10
   call $~lib/rt/stub/__retain
  )
- (func $~lib/rt/stub/__free (; 23 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/rt/stub/__free (; 21 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   local.get $0
   i32.const 0
@@ -3463,10 +3451,11 @@
    global.set $~lib/rt/stub/offset
   end
  )
- (func $~lib/util/number/dtoa (; 24 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  (local $1 i32)
+ (func $~lib/util/number/dtoa (; 22 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+  (local $1 f64)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   local.get $0
   f64.const 0
   f64.eq
@@ -3476,11 +3465,17 @@
    return
   end
   local.get $0
-  call $~lib/number/isFinite<f64>
+  local.tee $1
+  local.get $1
+  f64.sub
+  f64.const 0
+  f64.eq
   i32.eqz
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.tee $1
+   local.get $1
+   f64.ne
    if
     i32.const 264
     call $~lib/rt/stub/__retain
@@ -3500,34 +3495,34 @@
   i32.shl
   i32.const 1
   call $~lib/rt/stub/__alloc
-  local.set $1
-  local.get $1
-  local.get $0
-  call $~lib/util/number/dtoa_core
   local.set $2
   local.get $2
+  local.get $0
+  call $~lib/util/number/dtoa_core
+  local.set $3
+  local.get $3
   i32.const 28
   i32.eq
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/stub/__retain
    return
   end
-  local.get $1
-  i32.const 0
   local.get $2
-  call $~lib/string/String#substring
-  local.set $3
-  local.get $1
-  call $~lib/rt/stub/__free
+  i32.const 0
   local.get $3
+  call $~lib/string/String#substring
+  local.set $4
+  local.get $2
+  call $~lib/rt/stub/__free
+  local.get $4
  )
- (func $~lib/number/F32#toString (; 25 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
+ (func $~lib/number/F32#toString (; 23 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
   local.get $0
   f64.promote_f32
   call $~lib/util/number/dtoa
  )
- (func $~lib/util/string/compareImpl (; 26 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (; 24 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -3647,7 +3642,7 @@
   call $~lib/rt/stub/__release
   local.get $8
  )
- (func $~lib/string/String.__eq (; 27 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 25 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -3720,7 +3715,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $start:resolve-elementaccess (; 28 ;) (type $FUNCSIG$v)
+ (func $start:resolve-elementaccess (; 26 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -3834,9 +3829,9 @@
   local.get $2
   call $~lib/rt/stub/__release
  )
- (func $start (; 29 ;) (type $FUNCSIG$v)
+ (func $start (; 27 ;) (type $FUNCSIG$v)
   call $start:resolve-elementaccess
  )
- (func $null (; 30 ;) (type $FUNCSIG$v)
+ (func $null (; 28 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/resolve-ternary.untouched.wat
+++ b/tests/compiler/resolve-ternary.untouched.wat
@@ -5123,10 +5123,9 @@
   call $~lib/rt/pure/__retain
  )
  (func $~lib/util/number/dtoa (; 41 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  (local $1 f64)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
   local.get $0
   f64.const 0
   f64.eq
@@ -5136,16 +5135,14 @@
    return
   end
   local.get $0
-  local.tee $1
-  local.get $1
+  local.get $0
   f64.sub
   f64.const 0
   f64.eq
   i32.eqz
   if
    local.get $0
-   local.tee $1
-   local.get $1
+   local.get $0
    f64.ne
    if
     i32.const 848
@@ -5166,27 +5163,27 @@
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
-  local.set $2
-  local.get $2
+  local.set $1
+  local.get $1
   local.get $0
   call $~lib/util/number/dtoa_core
-  local.set $3
-  local.get $3
+  local.set $2
+  local.get $2
   i32.const 28
   i32.eq
   if
-   local.get $2
+   local.get $1
    call $~lib/rt/pure/__retain
    return
   end
-  local.get $2
+  local.get $1
   i32.const 0
-  local.get $3
-  call $~lib/string/String#substring
-  local.set $4
   local.get $2
+  call $~lib/string/String#substring
+  local.set $3
+  local.get $1
   call $~lib/rt/tlsf/__free
-  local.get $4
+  local.get $3
  )
  (func $~lib/number/F64#toString (; 42 ;) (type $FUNCSIG$idi) (param $0 f64) (param $1 i32) (result i32)
   local.get $0

--- a/tests/compiler/resolve-ternary.untouched.wat
+++ b/tests/compiler/resolve-ternary.untouched.wat
@@ -3754,19 +3754,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/number/isFinite<f64> (; 35 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.sub
-  f64.const 0
-  f64.eq
- )
- (func $~lib/number/isNaN<f64> (; 36 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.ne
- )
- (func $~lib/array/Array<u64>#__unchecked_get (; 37 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__unchecked_get (; 35 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -3775,7 +3763,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<i16>#__unchecked_get (; 38 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__unchecked_get (; 36 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -3784,7 +3772,7 @@
   i32.add
   i32.load16_s
  )
- (func $~lib/util/number/genDigits (; 39 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (; 37 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -4286,7 +4274,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/prettify (; 40 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (; 38 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4605,7 +4593,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/dtoa_core (; 41 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (; 39 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5027,7 +5015,7 @@
   local.get $2
   i32.add
  )
- (func $~lib/string/String#substring (; 42 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substring (; 40 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5134,10 +5122,11 @@
   local.get $10
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/dtoa (; 43 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  (local $1 i32)
+ (func $~lib/util/number/dtoa (; 41 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+  (local $1 f64)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   local.get $0
   f64.const 0
   f64.eq
@@ -5147,11 +5136,17 @@
    return
   end
   local.get $0
-  call $~lib/number/isFinite<f64>
+  local.tee $1
+  local.get $1
+  f64.sub
+  f64.const 0
+  f64.eq
   i32.eqz
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.tee $1
+   local.get $1
+   f64.ne
    if
     i32.const 848
     call $~lib/rt/pure/__retain
@@ -5171,53 +5166,53 @@
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
-  local.set $1
-  local.get $1
-  local.get $0
-  call $~lib/util/number/dtoa_core
   local.set $2
   local.get $2
+  local.get $0
+  call $~lib/util/number/dtoa_core
+  local.set $3
+  local.get $3
   i32.const 28
   i32.eq
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__retain
    return
   end
-  local.get $1
-  i32.const 0
   local.get $2
-  call $~lib/string/String#substring
-  local.set $3
-  local.get $1
-  call $~lib/rt/tlsf/__free
+  i32.const 0
   local.get $3
+  call $~lib/string/String#substring
+  local.set $4
+  local.get $2
+  call $~lib/rt/tlsf/__free
+  local.get $4
  )
- (func $~lib/number/F64#toString (; 44 ;) (type $FUNCSIG$idi) (param $0 f64) (param $1 i32) (result i32)
+ (func $~lib/number/F64#toString (; 42 ;) (type $FUNCSIG$idi) (param $0 f64) (param $1 i32) (result i32)
   local.get $0
   call $~lib/util/number/dtoa
  )
- (func $start:resolve-ternary~anonymous|0 (; 45 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $start:resolve-ternary~anonymous|0 (; 43 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 1
   i32.add
  )
- (func $start:resolve-ternary~anonymous|1 (; 46 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $start:resolve-ternary~anonymous|1 (; 44 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 2
   i32.add
  )
- (func $resolve-ternary/g1 (; 47 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $resolve-ternary/g1 (; 45 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 3
   i32.add
  )
- (func $resolve-ternary/g2 (; 48 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $resolve-ternary/g2 (; 46 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4
   i32.add
  )
- (func $start:resolve-ternary (; 49 ;) (type $FUNCSIG$v)
+ (func $start:resolve-ternary (; 47 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   global.get $resolve-ternary/b
@@ -5327,19 +5322,19 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $start (; 50 ;) (type $FUNCSIG$v)
+ (func $start (; 48 ;) (type $FUNCSIG$v)
   call $start:resolve-ternary
  )
- (func $~lib/array/Array<u32>#__visit_impl (; 51 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u32>#__visit_impl (; 49 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u64>#__visit_impl (; 52 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u64>#__visit_impl (; 50 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<i16>#__visit_impl (; 53 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i16>#__visit_impl (; 51 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/rt/pure/__visit (; 54 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 52 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -5469,7 +5464,7 @@
    end
   end
  )
- (func $~lib/rt/__visit_members (; 55 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (; 53 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $block$4$break
    block $switch$1$default
@@ -5515,6 +5510,6 @@
   end
   return
  )
- (func $null (; 56 ;) (type $FUNCSIG$v)
+ (func $null (; 54 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -8,8 +8,6 @@
  (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$viii (func (param i32 i32 i32)))
  (type $FUNCSIG$iiiii (func (param i32 i32 i32 i32) (result i32)))
- (type $FUNCSIG$if (func (param f32) (result i32)))
- (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$fiii (func (param i32 i32 i32) (result f32)))
  (type $FUNCSIG$fii (func (param i32 i32) (result f32)))
  (type $FUNCSIG$d (func (result f64)))
@@ -18,6 +16,7 @@
  (type $FUNCSIG$iff (func (param f32 f32) (result i32)))
  (type $FUNCSIG$idd (func (param f64 f64) (result i32)))
  (type $FUNCSIG$dii (func (param i32 i32) (result f64)))
+ (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$iid (func (param i32 f64) (result i32)))
  (type $FUNCSIG$iijijiji (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
  (type $FUNCSIG$iiid (func (param i32 i32 f64) (result i32)))
@@ -3438,12 +3437,7 @@
   i32.const 0
   i32.ge_s
  )
- (func $~lib/number/isNaN<f32> (; 60 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
-  local.get $0
-  local.get $0
-  f32.ne
- )
- (func $~lib/array/Array<f32>#includes (; 61 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f32>#includes (; 60 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -3482,10 +3476,8 @@
      i32.const 1
     else
      local.get $3
-     call $~lib/number/isNaN<f32>
-     f32.const nan:0x400000
-     call $~lib/number/isNaN<f32>
-     i32.and
+     local.get $3
+     f32.ne
     end
     if
      i32.const 1
@@ -3502,12 +3494,7 @@
   end
   i32.const 0
  )
- (func $~lib/number/isNaN<f64> (; 62 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.ne
- )
- (func $~lib/array/Array<f64>#includes (; 63 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f64>#includes (; 61 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -3546,10 +3533,8 @@
      i32.const 1
     else
      local.get $3
-     call $~lib/number/isNaN<f64>
-     f64.const nan:0x8000000000000
-     call $~lib/number/isNaN<f64>
-     i32.and
+     local.get $3
+     f64.ne
     end
     if
      i32.const 1
@@ -3566,7 +3551,7 @@
   end
   i32.const 0
  )
- (func $~lib/array/Array<i32>#splice (; 64 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#splice (; 62 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3656,7 +3641,7 @@
   i32.store offset=12
   local.get $4
  )
- (func $~lib/array/Array<std/array/Ref>#splice (; 65 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#splice (; 63 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3747,7 +3732,7 @@
   i32.store offset=12
   local.get $4
  )
- (func $~lib/array/Array<std/array/Ref>#__unchecked_get (; 66 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#__unchecked_get (; 64 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -3757,7 +3742,7 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<std/array/Ref>#__get (; 67 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#__get (; 65 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -3787,7 +3772,7 @@
   end
   local.get $0
  )
- (func $~lib/array/Array<std/array/Ref | null>#splice (; 68 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#splice (; 66 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -3865,7 +3850,7 @@
   i32.store offset=12
   local.get $4
  )
- (func $~lib/array/Array<std/array/Ref | null>#__get (; 69 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#__get (; 67 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -3882,7 +3867,7 @@
   local.get $1
   call $~lib/array/Array<std/array/Ref>#__unchecked_get
  )
- (func $~lib/array/Array<i32>#__set (; 70 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__set (; 68 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -3908,7 +3893,7 @@
    i32.store offset=12
   end
  )
- (func $start:std/array~anonymous|0 (; 71 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|0 (; 69 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -3917,7 +3902,7 @@
   local.get $0
   i32.eqz
  )
- (func $~lib/array/Array<i32>#findIndex (; 72 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#findIndex (; 70 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3965,7 +3950,7 @@
   end
   i32.const -1
  )
- (func $start:std/array~anonymous|1 (; 73 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|1 (; 71 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -3975,7 +3960,7 @@
   i32.const 1
   i32.eq
  )
- (func $start:std/array~anonymous|2 (; 74 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|2 (; 72 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -3985,7 +3970,7 @@
   i32.const 100
   i32.eq
  )
- (func $start:std/array~anonymous|3 (; 75 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|3 (; 73 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -3998,7 +3983,7 @@
   i32.const 100
   i32.eq
  )
- (func $start:std/array~anonymous|5 (; 76 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|5 (; 74 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -4011,7 +3996,7 @@
   i32.const 100
   i32.eq
  )
- (func $start:std/array~anonymous|6 (; 77 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|6 (; 75 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -4021,7 +4006,7 @@
   i32.const 0
   i32.ge_s
  )
- (func $~lib/array/Array<i32>#every (; 78 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#every (; 76 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4069,7 +4054,7 @@
   end
   i32.const 1
  )
- (func $start:std/array~anonymous|7 (; 79 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|7 (; 77 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -4079,7 +4064,7 @@
   i32.const 0
   i32.le_s
  )
- (func $start:std/array~anonymous|8 (; 80 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|8 (; 78 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -4092,7 +4077,7 @@
   i32.const 10
   i32.lt_s
  )
- (func $start:std/array~anonymous|9 (; 81 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|9 (; 79 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -4102,7 +4087,7 @@
   i32.const 10
   i32.lt_s
  )
- (func $start:std/array~anonymous|10 (; 82 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|10 (; 80 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -4115,7 +4100,7 @@
   i32.const 3
   i32.lt_s
  )
- (func $start:std/array~anonymous|11 (; 83 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|11 (; 81 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -4125,7 +4110,7 @@
   i32.const 3
   i32.ge_s
  )
- (func $~lib/array/Array<i32>#some (; 84 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#some (; 82 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4173,7 +4158,7 @@
   end
   i32.const 0
  )
- (func $start:std/array~anonymous|12 (; 85 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|12 (; 83 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -4183,7 +4168,7 @@
   i32.const -1
   i32.le_s
  )
- (func $start:std/array~anonymous|13 (; 86 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|13 (; 84 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -4196,7 +4181,7 @@
   i32.const 10
   i32.gt_s
  )
- (func $start:std/array~anonymous|14 (; 87 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|14 (; 85 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -4206,7 +4191,7 @@
   i32.const 10
   i32.gt_s
  )
- (func $start:std/array~anonymous|15 (; 88 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|15 (; 86 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -4219,7 +4204,7 @@
   i32.const 3
   i32.gt_s
  )
- (func $start:std/array~anonymous|16 (; 89 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|16 (; 87 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -4230,7 +4215,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<i32>#forEach (; 90 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#forEach (; 88 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4272,7 +4257,7 @@
    unreachable
   end
  )
- (func $start:std/array~anonymous|17 (; 91 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|17 (; 89 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -4286,7 +4271,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|19 (; 92 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|19 (; 90 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -4300,7 +4285,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|20 (; 93 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|20 (; 91 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -4402,7 +4387,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|21 (; 94 ;) (type $FUNCSIG$fiii) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
+ (func $start:std/array~anonymous|21 (; 92 ;) (type $FUNCSIG$fiii) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -4411,7 +4396,7 @@
   local.get $0
   f32.convert_i32_s
  )
- (func $~lib/array/Array<i32>#map<f32> (; 95 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#map<f32> (; 93 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4469,7 +4454,7 @@
   end
   local.get $4
  )
- (func $~lib/array/Array<f32>#__get (; 96 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__get (; 94 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -4490,7 +4475,7 @@
   i32.add
   f32.load
  )
- (func $start:std/array~anonymous|22 (; 97 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|22 (; 95 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -4505,7 +4490,7 @@
   call $~lib/rt/pure/__release
   local.get $0
  )
- (func $~lib/array/Array<i32>#map<i32> (; 98 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#map<i32> (; 96 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4565,7 +4550,7 @@
   end
   local.get $5
  )
- (func $start:std/array~anonymous|23 (; 99 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|23 (; 97 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -4577,7 +4562,7 @@
   call $~lib/rt/pure/__release
   local.get $0
  )
- (func $start:std/array~anonymous|24 (; 100 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|24 (; 98 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -4592,7 +4577,7 @@
   call $~lib/rt/pure/__release
   local.get $0
  )
- (func $start:std/array~anonymous|25 (; 101 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|25 (; 99 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -4602,7 +4587,7 @@
   i32.const 2
   i32.ge_s
  )
- (func $~lib/array/Array<i32>#filter (; 102 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#filter (; 100 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4659,7 +4644,7 @@
   end
   local.get $4
  )
- (func $start:std/array~anonymous|26 (; 103 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|26 (; 101 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -4676,7 +4661,7 @@
   i32.const 2
   i32.ge_s
  )
- (func $start:std/array~anonymous|27 (; 104 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|27 (; 102 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -4690,7 +4675,7 @@
   i32.const 2
   i32.ge_s
  )
- (func $start:std/array~anonymous|28 (; 105 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|28 (; 103 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -4707,7 +4692,7 @@
   i32.const 2
   i32.ge_s
  )
- (func $start:std/array~anonymous|29 (; 106 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|29 (; 104 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $3
   call $~lib/rt/pure/__retain
   drop
@@ -4717,7 +4702,7 @@
   local.get $1
   i32.add
  )
- (func $~lib/array/Array<i32>#reduce<i32> (; 107 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduce<i32> (; 105 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4761,7 +4746,7 @@
   end
   local.get $2
  )
- (func $start:std/array~anonymous|31 (; 108 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|31 (; 106 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $3
   call $~lib/rt/pure/__retain
   drop
@@ -4774,7 +4759,7 @@
   local.get $0
   select
  )
- (func $start:std/array~anonymous|32 (; 109 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|32 (; 107 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $3
   call $~lib/rt/pure/__retain
   drop
@@ -4787,7 +4772,7 @@
   local.get $0
   select
  )
- (func $start:std/array~anonymous|33 (; 110 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|33 (; 108 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $3
   call $~lib/rt/pure/__retain
   drop
@@ -4800,7 +4785,7 @@
   local.get $1
   i32.add
  )
- (func $start:std/array~anonymous|35 (; 111 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|35 (; 109 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   local.get $3
   call $~lib/rt/pure/__retain
   drop
@@ -4813,7 +4798,7 @@
   local.get $1
   i32.add
  )
- (func $~lib/array/Array<i32>#reduceRight<i32> (; 112 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduceRight<i32> (; 110 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load offset=12
@@ -4850,7 +4835,7 @@
   end
   local.get $2
  )
- (func $~lib/math/murmurHash3 (; 113 ;) (type $FUNCSIG$jj) (param $0 i64) (result i64)
+ (func $~lib/math/murmurHash3 (; 111 ;) (type $FUNCSIG$jj) (param $0 i64) (result i64)
   local.get $0
   i64.const 33
   i64.shr_u
@@ -4871,7 +4856,7 @@
   i64.shr_u
   i64.xor
  )
- (func $~lib/math/splitMix32 (; 114 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/math/splitMix32 (; 112 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 1831565813
   i32.add
@@ -4903,7 +4888,7 @@
   i32.shr_u
   i32.xor
  )
- (func $~lib/math/NativeMath.seedRandom (; 115 ;) (type $FUNCSIG$vj) (param $0 i64)
+ (func $~lib/math/NativeMath.seedRandom (; 113 ;) (type $FUNCSIG$vj) (param $0 i64)
   i32.const 1
   global.set $~lib/math/random_seeded
   local.get $0
@@ -4947,7 +4932,7 @@
    unreachable
   end
  )
- (func $~lib/util/sort/insertionSort<f32> (; 116 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<f32> (; 114 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 f32)
@@ -5027,7 +5012,7 @@
    unreachable
   end
  )
- (func $~lib/util/sort/weakHeapSort<f32> (; 117 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/weakHeapSort<f32> (; 115 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 f32)
@@ -5290,7 +5275,7 @@
   local.get $5
   f32.store
  )
- (func $~lib/array/Array<f32>#sort (; 118 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f32>#sort (; 116 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 f32)
@@ -5355,7 +5340,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/sort/COMPARATOR<f32>~anonymous|0 (; 119 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<f32>~anonymous|0 (; 117 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -5384,9 +5369,10 @@
   i32.lt_s
   i32.sub
  )
- (func $std/array/isArraysEqual<f32> (; 120 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isArraysEqual<f32> (; 118 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
-  (local $3 i32)
+  (local $3 f32)
+  (local $4 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   drop
@@ -5397,7 +5383,7 @@
    block $folding-inner0
     local.get $0
     i32.load offset=12
-    local.tee $3
+    local.tee $4
     local.get $1
     i32.load offset=12
     i32.ne
@@ -5408,18 +5394,22 @@
     br_if $folding-inner1
     loop $loop|0
      local.get $2
-     local.get $3
+     local.get $4
      i32.lt_s
      if
       local.get $0
       local.get $2
       call $~lib/array/Array<f32>#__get
-      call $~lib/number/isNaN<f32>
+      local.tee $3
+      local.get $3
+      f32.ne
       if (result i32)
        local.get $1
        local.get $2
        call $~lib/array/Array<f32>#__get
-       call $~lib/number/isNaN<f32>
+       local.tee $3
+       local.get $3
+       f32.ne
       else
        i32.const 0
       end
@@ -5456,7 +5446,7 @@
   call $~lib/rt/pure/__release
   i32.const 1
  )
- (func $~lib/util/sort/insertionSort<f64> (; 121 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<f64> (; 119 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 f64)
@@ -5536,7 +5526,7 @@
    unreachable
   end
  )
- (func $~lib/util/sort/weakHeapSort<f64> (; 122 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/weakHeapSort<f64> (; 120 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 f64)
@@ -5799,7 +5789,7 @@
   local.get $5
   f64.store
  )
- (func $~lib/array/Array<f64>#sort (; 123 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f64>#sort (; 121 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 f64)
@@ -5864,7 +5854,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0 (; 124 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0 (; 122 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   local.get $0
@@ -5893,7 +5883,7 @@
   i64.lt_s
   i32.sub
  )
- (func $~lib/array/Array<f64>#__get (; 125 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__get (; 123 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -5914,9 +5904,10 @@
   i32.add
   f64.load
  )
- (func $std/array/isArraysEqual<f64> (; 126 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isArraysEqual<f64> (; 124 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
-  (local $3 i32)
+  (local $3 f64)
+  (local $4 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   drop
@@ -5927,7 +5918,7 @@
    block $folding-inner0
     local.get $0
     i32.load offset=12
-    local.tee $3
+    local.tee $4
     local.get $1
     i32.load offset=12
     i32.ne
@@ -5938,18 +5929,22 @@
     br_if $folding-inner1
     loop $loop|0
      local.get $2
-     local.get $3
+     local.get $4
      i32.lt_s
      if
       local.get $0
       local.get $2
       call $~lib/array/Array<f64>#__get
-      call $~lib/number/isNaN<f64>
+      local.tee $3
+      local.get $3
+      f64.ne
       if (result i32)
        local.get $1
        local.get $2
        call $~lib/array/Array<f64>#__get
-       call $~lib/number/isNaN<f64>
+       local.tee $3
+       local.get $3
+       f64.ne
       else
        i32.const 0
       end
@@ -5986,7 +5981,7 @@
   call $~lib/rt/pure/__release
   i32.const 1
  )
- (func $~lib/util/sort/insertionSort<i32> (; 127 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<i32> (; 125 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6066,7 +6061,7 @@
    unreachable
   end
  )
- (func $~lib/util/sort/weakHeapSort<i32> (; 128 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/weakHeapSort<i32> (; 126 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6329,7 +6324,7 @@
   local.get $1
   i32.store
  )
- (func $~lib/array/Array<i32>#sort (; 129 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#sort (; 127 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6393,12 +6388,12 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/sort/COMPARATOR<i32>~anonymous|0 (; 130 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<i32>~anonymous|0 (; 128 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $~lib/util/sort/COMPARATOR<u32>~anonymous|0 (; 131 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<u32>~anonymous|0 (; 129 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.gt_u
@@ -6407,7 +6402,7 @@
   i32.lt_u
   i32.sub
  )
- (func $std/array/createReverseOrderedArray (; 132 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/array/createReverseOrderedArray (; 130 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -6436,7 +6431,7 @@
   end
   local.get $2
  )
- (func $~lib/math/NativeMath.random (; 133 ;) (type $FUNCSIG$d) (result f64)
+ (func $~lib/math/NativeMath.random (; 131 ;) (type $FUNCSIG$d) (result f64)
   (local $0 i64)
   (local $1 i64)
   global.get $~lib/math/random_seeded
@@ -6480,7 +6475,7 @@
   f64.const 1
   f64.sub
  )
- (func $std/array/createRandomOrderedArray (; 134 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/array/createRandomOrderedArray (; 132 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -6509,7 +6504,7 @@
   end
   local.get $2
  )
- (func $std/array/isSorted<i32> (; 135 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<i32> (; 133 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -6558,7 +6553,7 @@
   call $~lib/rt/pure/__release
   i32.const 1
  )
- (func $std/array/assertSorted<i32> (; 136 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<i32> (; 134 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -6583,7 +6578,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/array/assertSortedDefault<i32> (; 137 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $std/array/assertSortedDefault<i32> (; 135 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   drop
@@ -6593,12 +6588,12 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|44 (; 138 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|44 (; 136 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.sub
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_set (; 139 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_set (; 137 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -6624,7 +6619,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__set (; 140 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__set (; 138 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -6651,7 +6646,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/array/createReverseOrderedNestedArray (; 141 ;) (type $FUNCSIG$i) (result i32)
+ (func $std/array/createReverseOrderedNestedArray (; 139 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -6696,7 +6691,7 @@
   end
   local.get $1
  )
- (func $start:std/array~anonymous|47 (; 142 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|47 (; 140 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -6716,7 +6711,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/sort/insertionSort<~lib/array/Array<i32>> (; 143 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<~lib/array/Array<i32>> (; 141 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6805,7 +6800,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#sort (; 144 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#sort (; 142 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6865,7 +6860,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $std/array/isSorted<~lib/array/Array<i32>> (; 145 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<~lib/array/Array<i32>> (; 143 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6926,7 +6921,7 @@
   call $~lib/rt/pure/__release
   i32.const 1
  )
- (func $std/array/assertSorted<~lib/array/Array<i32>> (; 146 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/array/Array<i32>> (; 144 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -6951,7 +6946,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/array/createReverseOrderedElementsArray (; 147 ;) (type $FUNCSIG$i) (result i32)
+ (func $std/array/createReverseOrderedElementsArray (; 145 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -6997,7 +6992,7 @@
   end
   local.get $1
  )
- (func $start:std/array~anonymous|48 (; 148 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|48 (; 146 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -7015,7 +7010,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/array/isSorted<~lib/string/String | null> (; 149 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<~lib/string/String | null> (; 147 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7076,7 +7071,7 @@
   call $~lib/rt/pure/__release
   i32.const 1
  )
- (func $std/array/assertSorted<~lib/string/String | null> (; 150 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/string/String | null> (; 148 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -7101,7 +7096,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/string/String#get:length (; 151 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (; 149 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -7109,7 +7104,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 152 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/compareImpl (; 150 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7207,7 +7202,7 @@
   call $~lib/rt/pure/__release
   i32.const 0
  )
- (func $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0 (; 153 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0 (; 151 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -7286,7 +7281,7 @@
   call $~lib/rt/pure/__release
   i32.const 0
  )
- (func $~lib/string/String.__eq (; 154 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 152 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -7340,7 +7335,7 @@
   call $~lib/rt/pure/__release
   i32.const 0
  )
- (func $~lib/string/String.__ne (; 155 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__ne (; 153 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -7357,7 +7352,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/array/isArraysEqual<~lib/string/String | null> (; 156 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isArraysEqual<~lib/string/String | null> (; 154 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7438,7 +7433,7 @@
   call $~lib/rt/pure/__release
   i32.const 1
  )
- (func $~lib/string/String#charAt (; 157 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/string/String#charAt (; 155 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 3520
@@ -7463,7 +7458,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#concat (; 158 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#concat (; 156 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7524,7 +7519,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__concat (; 159 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (; 157 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -7543,7 +7538,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/array/createRandomString (; 160 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/array/createRandomString (; 158 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7594,7 +7589,7 @@
   end
   local.get $1
  )
- (func $std/array/createRandomStringArray (; 161 ;) (type $FUNCSIG$i) (result i32)
+ (func $std/array/createRandomStringArray (; 159 ;) (type $FUNCSIG$i) (result i32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -7636,7 +7631,7 @@
   end
   local.get $0
  )
- (func $~lib/string/String#substring (; 162 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#substring (; 160 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 0
@@ -7713,7 +7708,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/string/joinBooleanArray (; 163 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinBooleanArray (; 161 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7865,7 +7860,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/util/number/decimalCount32 (; 164 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (; 162 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   i32.const 2
   local.get $0
@@ -7913,7 +7908,7 @@
   i32.lt_u
   select
  )
- (func $~lib/util/number/utoa_simple<u32> (; 165 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u32> (; 163 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   loop $continue|0
    local.get $1
@@ -7940,7 +7935,7 @@
    br_if $continue|0
   end
  )
- (func $~lib/util/number/itoa32 (; 166 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (; 164 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7983,7 +7978,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<i32> (; 167 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i32> (; 165 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   i32.const 1
   i32.shl
@@ -8025,7 +8020,7 @@
   end
   local.get $2
  )
- (func $~lib/util/string/joinIntegerArray<i32> (; 168 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i32> (; 166 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8148,7 +8143,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<i32>#join (; 169 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#join (; 167 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   call $~lib/rt/pure/__retain
   drop
@@ -8161,7 +8156,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/utoa32 (; 170 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/utoa32 (; 168 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -8185,7 +8180,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<u32> (; 171 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u32> (; 169 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   i32.const 1
   i32.shl
@@ -8209,7 +8204,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $0
  )
- (func $~lib/util/string/joinIntegerArray<u32> (; 172 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u32> (; 170 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8332,7 +8327,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<u32>#join (; 173 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#join (; 171 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   call $~lib/rt/pure/__retain
   drop
@@ -8345,14 +8340,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/number/isFinite<f64> (; 174 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.sub
-  f64.const 0
-  f64.eq
- )
- (func $~lib/util/number/genDigits (; 175 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (; 172 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i32)
   (local $9 i64)
@@ -8751,7 +8739,7 @@
    local.get $6
   end
  )
- (func $~lib/util/number/prettify (; 176 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (; 173 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
@@ -8998,7 +8986,7 @@
    end
   end
  )
- (func $~lib/util/number/dtoa_core (; 177 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (; 174 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i64)
@@ -9286,7 +9274,7 @@
   local.get $10
   i32.add
  )
- (func $~lib/util/number/dtoa (; 178 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/util/number/dtoa (; 175 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -9298,11 +9286,14 @@
    return
   end
   local.get $0
-  call $~lib/number/isFinite<f64>
-  i32.eqz
+  local.get $0
+  f64.sub
+  f64.const 0
+  f64.ne
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.get $0
+   f64.ne
    if
     i32.const 5104
     call $~lib/rt/pure/__retain
@@ -9337,7 +9328,7 @@
   local.get $1
   call $~lib/rt/tlsf/__free
  )
- (func $~lib/util/number/dtoa_stream (; 179 ;) (type $FUNCSIG$iiid) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
+ (func $~lib/util/number/dtoa_stream (; 176 ;) (type $FUNCSIG$iiid) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 1
@@ -9362,11 +9353,14 @@
    return
   end
   local.get $2
-  call $~lib/number/isFinite<f64>
-  i32.eqz
+  local.get $2
+  f64.sub
+  f64.const 0
+  f64.ne
   if
    local.get $2
-   call $~lib/number/isNaN<f64>
+   local.get $2
+   f64.ne
    if
     local.get $0
     i32.const 78
@@ -9405,7 +9399,7 @@
   local.get $2
   call $~lib/util/number/dtoa_core
  )
- (func $~lib/util/string/joinFloatArray<f64> (; 180 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinFloatArray<f64> (; 177 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9528,7 +9522,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/string/joinReferenceArray<~lib/string/String | null> (; 181 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/string/String | null> (; 178 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9707,7 +9701,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/array/Array<~lib/string/String | null>#join (; 182 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#join (; 179 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   call $~lib/rt/pure/__retain
   drop
@@ -9720,7 +9714,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/string/joinReferenceArray<std/array/Ref | null> (; 183 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<std/array/Ref | null> (; 180 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9899,7 +9893,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/array/Array<std/array/Ref | null>#join (; 184 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#join (; 181 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 4672
   call $~lib/rt/pure/__retain
   drop
@@ -9911,12 +9905,12 @@
   i32.const 4672
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<i32>#toString (; 185 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#toString (; 182 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4672
   call $~lib/array/Array<i32>#join
  )
- (func $~lib/util/number/itoa_stream<i8> (; 186 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i8> (; 183 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 1
@@ -9971,7 +9965,7 @@
   end
   local.get $2
  )
- (func $~lib/util/string/joinIntegerArray<i8> (; 187 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i8> (; 184 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10090,7 +10084,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/number/itoa_stream<u16> (; 188 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u16> (; 185 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   i32.const 1
   i32.shl
@@ -10120,7 +10114,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u16> (; 189 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u16> (; 186 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10243,7 +10237,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/number/decimalCount64 (; 190 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64 (; 187 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   i32.const 10
   i32.const 11
   i32.const 12
@@ -10296,7 +10290,7 @@
   i64.lt_u
   select
  )
- (func $~lib/util/number/utoa_simple<u64> (; 191 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u64> (; 188 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   loop $continue|0
    local.get $1
@@ -10326,7 +10320,7 @@
    br_if $continue|0
   end
  )
- (func $~lib/util/number/utoa64 (; 192 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/utoa64 (; 189 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -10371,7 +10365,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<u64> (; 193 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<u64> (; 190 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 1
@@ -10412,7 +10406,7 @@
   end
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u64> (; 194 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u64> (; 191 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10535,7 +10529,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/number/itoa64 (; 195 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa64 (; 192 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -10601,7 +10595,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<i64> (; 196 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<i64> (; 193 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -10663,7 +10657,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<i64> (; 197 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i64> (; 194 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10786,12 +10780,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/array/Array<~lib/string/String | null>#toString (; 198 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#toString (; 195 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4672
   call $~lib/array/Array<~lib/string/String | null>#join
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>> (; 199 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>> (; 196 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10968,7 +10962,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/util/number/itoa_stream<u8> (; 200 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u8> (; 197 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   i32.const 1
   i32.shl
@@ -10998,7 +10992,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u8> (; 201 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u8> (; 198 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11117,7 +11111,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/array/Array<u8>#toString (; 202 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u8>#toString (; 199 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 4672
   call $~lib/rt/pure/__retain
   drop
@@ -11129,7 +11123,7 @@
   i32.const 4672
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u8>> (; 203 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u8>> (; 200 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11306,12 +11300,12 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/array/Array<u32>#toString (; 204 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u32>#toString (; 201 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4672
   call $~lib/array/Array<u32>#join
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>> (; 205 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>> (; 202 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11488,7 +11482,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/array/Array<~lib/array/Array<u32>>#toString (; 206 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u32>>#toString (; 203 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 4672
   call $~lib/rt/pure/__retain
   drop
@@ -11500,7 +11494,7 @@
   i32.const 4672
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>> (; 207 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>> (; 204 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11677,7 +11671,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $start:std/array (; 208 ;) (type $FUNCSIG$v)
+ (func $start:std/array (; 205 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -17598,7 +17592,7 @@
   local.get $10
   call $~lib/rt/pure/__release
  )
- (func $start (; 209 ;) (type $FUNCSIG$v)
+ (func $start (; 206 ;) (type $FUNCSIG$v)
   global.get $~lib/started
   if
    return
@@ -17608,7 +17602,7 @@
   end
   call $start:std/array
  )
- (func $~lib/rt/pure/__visit (; 210 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 207 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   i32.const 7700
   i32.lt_u
@@ -17718,7 +17712,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<std/array/Ref>#__visit_impl (; 211 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<std/array/Ref>#__visit_impl (; 208 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -17751,7 +17745,7 @@
    end
   end
  )
- (func $~lib/rt/__visit_members (; 212 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (; 209 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   block $block$4$break
    block $switch$1$default
     block $switch$1$case$27
@@ -17828,7 +17822,7 @@
    call $~lib/rt/pure/__visit
   end
  )
- (func $null (; 213 ;) (type $FUNCSIG$v)
+ (func $null (; 210 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -10331,7 +10331,8 @@
   (local $2 i32)
   (local $3 i32)
   local.get $0
-  i64.eqz
+  i64.const 0
+  i64.eq
   if
    i32.const 4768
    call $~lib/rt/pure/__retain
@@ -10379,7 +10380,8 @@
   i32.add
   local.set $0
   local.get $2
-  i64.eqz
+  i64.const 0
+  i64.eq
   if
    local.get $0
    i32.const 48
@@ -10539,7 +10541,8 @@
   (local $3 i32)
   (local $4 i32)
   local.get $0
-  i64.eqz
+  i64.const 0
+  i64.eq
   if
    i32.const 4768
    call $~lib/rt/pure/__retain
@@ -10608,7 +10611,8 @@
   i32.add
   local.set $0
   local.get $2
-  i64.eqz
+  i64.const 0
+  i64.eq
   if
    local.get $0
    i32.const 48

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -6259,8 +6259,6 @@
     local.get $0
     local.get $1
     call_indirect (type $FUNCSIG$iiii)
-    i32.const 0
-    i32.ne
     i32.eqz
     if
      i32.const 0
@@ -12588,8 +12586,6 @@
     local.set $10
     i32.const 4
     local.get $10
-    i32.const 0
-    i32.ne
     i32.eqz
     i32.add
     local.set $6
@@ -12642,8 +12638,6 @@
   local.set $10
   i32.const 4
   local.get $10
-  i32.const 0
-  i32.ne
   i32.eqz
   i32.add
   local.set $6
@@ -16451,7 +16445,9 @@
   (local $6 i32)
   (local $7 i64)
   local.get $0
-  i64.eqz
+  i64.const 0
+  i64.ne
+  i32.eqz
   if
    i32.const 4768
    call $~lib/rt/pure/__retain
@@ -16526,7 +16522,9 @@
   i32.add
   local.set $0
   local.get $2
-  i64.eqz
+  i64.const 0
+  i64.ne
+  i32.eqz
   if
    local.get $0
    i32.const 48
@@ -16759,7 +16757,9 @@
   (local $7 i32)
   (local $8 i64)
   local.get $0
-  i64.eqz
+  i64.const 0
+  i64.ne
+  i32.eqz
   if
    i32.const 4768
    call $~lib/rt/pure/__retain
@@ -16856,7 +16856,9 @@
   i32.add
   local.set $0
   local.get $2
-  i64.eqz
+  i64.const 0
+  i64.ne
+  i32.eqz
   if
    local.get $0
    i32.const 48

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -10,8 +10,6 @@
  (type $FUNCSIG$iiiii (func (param i32 i32 i32 i32) (result i32)))
  (type $FUNCSIG$iifi (func (param i32 f32 i32) (result i32)))
  (type $FUNCSIG$iidi (func (param i32 f64 i32) (result i32)))
- (type $FUNCSIG$if (func (param f32) (result i32)))
- (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$fiii (func (param i32 i32 i32) (result f32)))
  (type $FUNCSIG$fii (func (param i32 i32) (result f32)))
  (type $FUNCSIG$d (func (result f64)))
@@ -21,6 +19,7 @@
  (type $FUNCSIG$idd (func (param f64 f64) (result i32)))
  (type $FUNCSIG$dii (func (param i32 i32) (result f64)))
  (type $FUNCSIG$iiiiii (func (param i32 i32 i32 i32 i32) (result i32)))
+ (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$iid (func (param i32 f64) (result i32)))
  (type $FUNCSIG$jii (func (param i32 i32) (result i64)))
  (type $FUNCSIG$iijijiji (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
@@ -5464,16 +5463,12 @@
   i32.ge_s
   return
  )
- (func $~lib/number/isNaN<f32> (; 76 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
-  local.get $0
-  local.get $0
-  f32.ne
- )
- (func $~lib/array/Array<f32>#includes (; 77 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<f32>#includes (; 76 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 f32)
+  (local $7 f32)
   local.get $0
   i32.load offset=12
   local.set $3
@@ -5531,9 +5526,13 @@
      i32.const 1
     else
      local.get $6
-     call $~lib/number/isNaN<f32>
+     local.tee $7
+     local.get $7
+     f32.ne
      local.get $1
-     call $~lib/number/isNaN<f32>
+     local.tee $7
+     local.get $7
+     f32.ne
      i32.and
     end
     if
@@ -5551,16 +5550,12 @@
   i32.const 0
   return
  )
- (func $~lib/number/isNaN<f64> (; 78 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.ne
- )
- (func $~lib/array/Array<f64>#includes (; 79 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/array/Array<f64>#includes (; 77 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 f64)
+  (local $7 f64)
   local.get $0
   i32.load offset=12
   local.set $3
@@ -5618,9 +5613,13 @@
      i32.const 1
     else
      local.get $6
-     call $~lib/number/isNaN<f64>
+     local.tee $7
+     local.get $7
+     f64.ne
      local.get $1
-     call $~lib/number/isNaN<f64>
+     local.tee $7
+     local.get $7
+     f64.ne
      i32.and
     end
     if
@@ -5638,7 +5637,7 @@
   i32.const 0
   return
  )
- (func $~lib/array/Array<i32>#splice (; 80 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#splice (; 78 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5746,7 +5745,7 @@
   i32.store offset=12
   local.get $6
  )
- (func $~lib/array/Array<std/array/Ref>#splice (; 81 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#splice (; 79 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5854,7 +5853,7 @@
   i32.store offset=12
   local.get $6
  )
- (func $~lib/array/Array<std/array/Ref>#__unchecked_get (; 82 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#__unchecked_get (; 80 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -5864,7 +5863,7 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<std/array/Ref>#__get (; 83 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#__get (; 81 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -5896,7 +5895,7 @@
   end
   local.get $2
  )
- (func $~lib/array/Array<std/array/Ref | null>#splice (; 84 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#splice (; 82 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6004,11 +6003,11 @@
   i32.store offset=12
   local.get $6
  )
- (func $~lib/array/Array<std/array/Ref | null>#get:length (; 85 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#get:length (; 83 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<std/array/Ref | null>#__unchecked_get (; 86 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#__unchecked_get (; 84 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -6018,7 +6017,7 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<std/array/Ref | null>#__get (; 87 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#__get (; 85 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -6038,7 +6037,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/array/Array<i32>#__unchecked_set (; 88 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__unchecked_set (; 86 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -6048,7 +6047,7 @@
   local.get $2
   i32.store
  )
- (func $~lib/array/Array<i32>#__set (; 89 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i32>#__set (; 87 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -6071,7 +6070,7 @@
    i32.store offset=12
   end
  )
- (func $start:std/array~anonymous|0 (; 90 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|0 (; 88 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6084,7 +6083,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<i32>#findIndex (; 91 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#findIndex (; 89 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6136,7 +6135,7 @@
   end
   i32.const -1
  )
- (func $start:std/array~anonymous|1 (; 92 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|1 (; 90 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6149,7 +6148,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|2 (; 93 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|2 (; 91 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6162,7 +6161,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|3 (; 94 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|3 (; 92 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6179,7 +6178,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|4 (; 95 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|4 (; 93 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6192,7 +6191,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|5 (; 96 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|5 (; 94 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6208,7 +6207,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|6 (; 97 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|6 (; 95 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6221,7 +6220,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<i32>#every (; 98 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#every (; 96 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6274,7 +6273,7 @@
   end
   i32.const 1
  )
- (func $start:std/array~anonymous|7 (; 99 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|7 (; 97 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6287,7 +6286,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|8 (; 100 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|8 (; 98 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6304,7 +6303,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|9 (; 101 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|9 (; 99 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6317,7 +6316,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|10 (; 102 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|10 (; 100 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6333,7 +6332,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|11 (; 103 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|11 (; 101 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6346,7 +6345,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<i32>#some (; 104 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#some (; 102 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6398,7 +6397,7 @@
   end
   i32.const 0
  )
- (func $start:std/array~anonymous|12 (; 105 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|12 (; 103 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6411,7 +6410,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|13 (; 106 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|13 (; 104 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6428,7 +6427,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|14 (; 107 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|14 (; 105 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6441,7 +6440,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|15 (; 108 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|15 (; 106 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6457,7 +6456,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|16 (; 109 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|16 (; 107 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -6468,7 +6467,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<i32>#forEach (; 110 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#forEach (; 108 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6515,7 +6514,7 @@
    unreachable
   end
  )
- (func $start:std/array~anonymous|17 (; 111 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|17 (; 109 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -6530,7 +6529,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|18 (; 112 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|18 (; 110 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -6541,7 +6540,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|19 (; 113 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|19 (; 111 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -6555,7 +6554,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|20 (; 114 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $start:std/array~anonymous|20 (; 112 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6671,7 +6670,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|21 (; 115 ;) (type $FUNCSIG$fiii) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
+ (func $start:std/array~anonymous|21 (; 113 ;) (type $FUNCSIG$fiii) (param $0 i32) (param $1 i32) (param $2 i32) (result f32)
   (local $3 f32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6683,7 +6682,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<i32>#map<f32> (; 116 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#map<f32> (; 114 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6752,11 +6751,11 @@
   end
   local.get $3
  )
- (func $~lib/array/Array<f32>#get:length (; 117 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f32>#get:length (; 115 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<f32>#__unchecked_get (; 118 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__unchecked_get (; 116 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -6765,7 +6764,7 @@
   i32.add
   f32.load
  )
- (func $~lib/array/Array<f32>#__get (; 119 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__get (; 117 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
   (local $2 f32)
   local.get $1
   local.get $0
@@ -6785,7 +6784,7 @@
   local.set $2
   local.get $2
  )
- (func $start:std/array~anonymous|22 (; 120 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|22 (; 118 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6804,7 +6803,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<i32>#map<i32> (; 121 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#map<i32> (; 119 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6872,7 +6871,7 @@
   end
   local.get $3
  )
- (func $start:std/array~anonymous|23 (; 122 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|23 (; 120 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6887,7 +6886,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|24 (; 123 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|24 (; 121 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6905,7 +6904,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|25 (; 124 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|25 (; 122 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -6918,7 +6917,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<i32>#filter (; 125 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#filter (; 123 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6982,7 +6981,7 @@
   end
   local.get $2
  )
- (func $start:std/array~anonymous|26 (; 126 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|26 (; 124 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -7003,7 +7002,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|27 (; 127 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|27 (; 125 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -7020,7 +7019,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|28 (; 128 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $start:std/array~anonymous|28 (; 126 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -7040,7 +7039,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $start:std/array~anonymous|29 (; 129 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|29 (; 127 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7053,7 +7052,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i32>#reduce<i32> (; 130 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduce<i32> (; 128 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7106,7 +7105,7 @@
   end
   local.get $3
  )
- (func $start:std/array~anonymous|30 (; 131 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|30 (; 129 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7119,7 +7118,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|31 (; 132 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|31 (; 130 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7137,7 +7136,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i32>#reduce<bool> (; 133 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduce<bool> (; 131 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7190,7 +7189,7 @@
   end
   local.get $3
  )
- (func $start:std/array~anonymous|32 (; 134 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|32 (; 132 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7208,7 +7207,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|33 (; 135 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|33 (; 133 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7225,7 +7224,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|34 (; 136 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|34 (; 134 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7238,7 +7237,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|35 (; 137 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|35 (; 135 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7254,7 +7253,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|36 (; 138 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|36 (; 136 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7267,7 +7266,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i32>#reduceRight<i32> (; 139 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduceRight<i32> (; 137 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -7309,7 +7308,7 @@
   end
   local.get $3
  )
- (func $start:std/array~anonymous|37 (; 140 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|37 (; 138 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7322,7 +7321,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|38 (; 141 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|38 (; 139 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7340,7 +7339,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i32>#reduceRight<bool> (; 142 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/array/Array<i32>#reduceRight<bool> (; 140 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -7382,7 +7381,7 @@
   end
   local.get $3
  )
- (func $start:std/array~anonymous|39 (; 143 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|39 (; 141 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7400,7 +7399,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|40 (; 144 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|40 (; 142 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7417,7 +7416,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|41 (; 145 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|41 (; 143 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7430,7 +7429,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $start:std/array~anonymous|42 (; 146 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $start:std/array~anonymous|42 (; 144 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   local.get $3
   call $~lib/rt/pure/__retain
@@ -7446,7 +7445,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/math/murmurHash3 (; 147 ;) (type $FUNCSIG$jj) (param $0 i64) (result i64)
+ (func $~lib/math/murmurHash3 (; 145 ;) (type $FUNCSIG$jj) (param $0 i64) (result i64)
   local.get $0
   local.get $0
   i64.const 33
@@ -7475,7 +7474,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/math/splitMix32 (; 148 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/math/splitMix32 (; 146 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 1831565813
   i32.add
@@ -7510,7 +7509,7 @@
   i32.shr_u
   i32.xor
  )
- (func $~lib/math/NativeMath.seedRandom (; 149 ;) (type $FUNCSIG$vj) (param $0 i64)
+ (func $~lib/math/NativeMath.seedRandom (; 147 ;) (type $FUNCSIG$vj) (param $0 i64)
   i32.const 1
   global.set $~lib/math/random_seeded
   local.get $0
@@ -7562,7 +7561,7 @@
    unreachable
   end
  )
- (func $~lib/util/sort/insertionSort<f32> (; 150 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<f32> (; 148 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 f32)
   (local $5 i32)
@@ -7650,7 +7649,7 @@
    unreachable
   end
  )
- (func $~lib/util/sort/weakHeapSort<f32> (; 151 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/weakHeapSort<f32> (; 149 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7942,7 +7941,7 @@
   local.get $10
   f32.store
  )
- (func $~lib/array/Array<f32>#sort (; 152 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f32>#sort (; 150 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 f32)
@@ -8017,7 +8016,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/sort/COMPARATOR<f32>~anonymous|0 (; 153 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<f32>~anonymous|0 (; 151 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -8050,7 +8049,7 @@
   i32.lt_s
   i32.sub
  )
- (func $~lib/array/Array<f32>#sort|trampoline (; 154 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f32>#sort|trampoline (; 152 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -8069,9 +8068,10 @@
   local.get $1
   call $~lib/array/Array<f32>#sort
  )
- (func $std/array/isArraysEqual<f32> (; 155 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<f32> (; 153 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
-  (local $4 i32)
+  (local $4 f32)
+  (local $5 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   drop
@@ -8125,12 +8125,16 @@
      local.get $0
      local.get $3
      call $~lib/array/Array<f32>#__get
-     call $~lib/number/isNaN<f32>
+     local.tee $4
+     local.get $4
+     f32.ne
      if (result i32)
       local.get $1
       local.get $3
       call $~lib/array/Array<f32>#__get
-      call $~lib/number/isNaN<f32>
+      local.tee $4
+      local.get $4
+      f32.ne
      else
       i32.const 0
      end
@@ -8146,12 +8150,12 @@
      f32.ne
      if
       i32.const 0
-      local.set $4
+      local.set $5
       local.get $0
       call $~lib/rt/pure/__release
       local.get $1
       call $~lib/rt/pure/__release
-      local.get $4
+      local.get $5
       return
      end
     end
@@ -8171,7 +8175,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/util/sort/insertionSort<f64> (; 156 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<f64> (; 154 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 f64)
   (local $5 i32)
@@ -8259,7 +8263,7 @@
    unreachable
   end
  )
- (func $~lib/util/sort/weakHeapSort<f64> (; 157 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/weakHeapSort<f64> (; 155 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8551,7 +8555,7 @@
   local.get $10
   f64.store
  )
- (func $~lib/array/Array<f64>#sort (; 158 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f64>#sort (; 156 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 f64)
@@ -8626,7 +8630,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0 (; 159 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0 (; 157 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i64)
   local.get $0
@@ -8659,7 +8663,7 @@
   i64.lt_s
   i32.sub
  )
- (func $~lib/array/Array<f64>#sort|trampoline (; 160 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f64>#sort|trampoline (; 158 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -8678,11 +8682,11 @@
   local.get $1
   call $~lib/array/Array<f64>#sort
  )
- (func $~lib/array/Array<f64>#get:length (; 161 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f64>#get:length (; 159 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<f64>#__unchecked_get (; 162 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__unchecked_get (; 160 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -8691,7 +8695,7 @@
   i32.add
   f64.load
  )
- (func $~lib/array/Array<f64>#__get (; 163 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__get (; 161 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
   (local $2 f64)
   local.get $1
   local.get $0
@@ -8711,9 +8715,10 @@
   local.set $2
   local.get $2
  )
- (func $std/array/isArraysEqual<f64> (; 164 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<f64> (; 162 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
-  (local $4 i32)
+  (local $4 f64)
+  (local $5 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   drop
@@ -8767,12 +8772,16 @@
      local.get $0
      local.get $3
      call $~lib/array/Array<f64>#__get
-     call $~lib/number/isNaN<f64>
+     local.tee $4
+     local.get $4
+     f64.ne
      if (result i32)
       local.get $1
       local.get $3
       call $~lib/array/Array<f64>#__get
-      call $~lib/number/isNaN<f64>
+      local.tee $4
+      local.get $4
+      f64.ne
      else
       i32.const 0
      end
@@ -8788,12 +8797,12 @@
      f64.ne
      if
       i32.const 0
-      local.set $4
+      local.set $5
       local.get $0
       call $~lib/rt/pure/__release
       local.get $1
       call $~lib/rt/pure/__release
-      local.get $4
+      local.get $5
       return
      end
     end
@@ -8813,7 +8822,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/util/sort/insertionSort<i32> (; 165 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<i32> (; 163 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8901,7 +8910,7 @@
    unreachable
   end
  )
- (func $~lib/util/sort/weakHeapSort<i32> (; 166 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/weakHeapSort<i32> (; 164 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9193,7 +9202,7 @@
   local.get $10
   i32.store
  )
- (func $~lib/array/Array<i32>#sort (; 167 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#sort (; 165 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9266,12 +9275,12 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/sort/COMPARATOR<i32>~anonymous|0 (; 168 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<i32>~anonymous|0 (; 166 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $~lib/array/Array<i32>#sort|trampoline (; 169 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#sort|trampoline (; 167 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -9290,7 +9299,7 @@
   local.get $1
   call $~lib/array/Array<i32>#sort
  )
- (func $~lib/util/sort/insertionSort<u32> (; 170 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<u32> (; 168 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9378,7 +9387,7 @@
    unreachable
   end
  )
- (func $~lib/util/sort/weakHeapSort<u32> (; 171 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/weakHeapSort<u32> (; 169 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9670,7 +9679,7 @@
   local.get $10
   i32.store
  )
- (func $~lib/array/Array<u32>#sort (; 172 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#sort (; 170 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9743,7 +9752,7 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/sort/COMPARATOR<u32>~anonymous|0 (; 173 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<u32>~anonymous|0 (; 171 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.gt_u
@@ -9752,7 +9761,7 @@
   i32.lt_u
   i32.sub
  )
- (func $~lib/array/Array<u32>#sort|trampoline (; 174 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#sort|trampoline (; 172 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -9771,7 +9780,7 @@
   local.get $1
   call $~lib/array/Array<u32>#sort
  )
- (func $std/array/createReverseOrderedArray (; 175 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/array/createReverseOrderedArray (; 173 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
@@ -9805,7 +9814,7 @@
   end
   local.get $1
  )
- (func $~lib/math/NativeMath.random (; 176 ;) (type $FUNCSIG$d) (result f64)
+ (func $~lib/math/NativeMath.random (; 174 ;) (type $FUNCSIG$d) (result f64)
   (local $0 i64)
   (local $1 i64)
   (local $2 i64)
@@ -9860,7 +9869,7 @@
   f64.const 1
   f64.sub
  )
- (func $std/array/createRandomOrderedArray (; 177 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/array/createRandomOrderedArray (; 175 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
@@ -9894,12 +9903,12 @@
   end
   local.get $1
  )
- (func $~lib/util/sort/COMPARATOR<i32>~anonymous|1 (; 178 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<i32>~anonymous|1 (; 176 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $std/array/isSorted<i32> (; 179 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<i32> (; 177 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9954,7 +9963,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/array/assertSorted<i32> (; 180 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<i32> (; 178 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -9979,7 +9988,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/array/assertSortedDefault<i32> (; 181 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $std/array/assertSortedDefault<i32> (; 179 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   drop
@@ -9992,27 +10001,27 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $start:std/array~anonymous|43 (; 182 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|43 (; 180 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $start:std/array~anonymous|44 (; 183 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|44 (; 181 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.sub
  )
- (func $start:std/array~anonymous|45 (; 184 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|45 (; 182 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.sub
  )
- (func $start:std/array~anonymous|46 (; 185 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|46 (; 183 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.sub
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#constructor (; 186 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#constructor (; 184 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -10034,7 +10043,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_set (; 187 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_set (; 185 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -10064,7 +10073,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__set (; 188 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__set (; 186 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -10092,7 +10101,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/array/createReverseOrderedNestedArray (; 189 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/array/createReverseOrderedNestedArray (; 187 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -10137,7 +10146,7 @@
   end
   local.get $1
  )
- (func $start:std/array~anonymous|47 (; 190 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|47 (; 188 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -10159,7 +10168,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/sort/insertionSort<~lib/array/Array<i32>> (; 191 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<~lib/array/Array<i32>> (; 189 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -10255,7 +10264,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#sort (; 192 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#sort (; 190 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10326,11 +10335,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#get:length (; 193 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#get:length (; 191 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_get (; 194 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_get (; 192 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -10340,7 +10349,7 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__get (; 195 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__get (; 193 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -10372,7 +10381,7 @@
   end
   local.get $2
  )
- (func $std/array/isSorted<~lib/array/Array<i32>> (; 196 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<~lib/array/Array<i32>> (; 194 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10439,7 +10448,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/array/assertSorted<~lib/array/Array<i32>> (; 197 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/array/Array<i32>> (; 195 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -10464,7 +10473,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#constructor (; 198 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#constructor (; 196 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -10486,7 +10495,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $std/array/Proxy<i32>#constructor (; 199 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/Proxy<i32>#constructor (; 197 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -10501,7 +10510,7 @@
   i32.store
   local.get $0
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#__unchecked_set (; 200 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#__unchecked_set (; 198 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -10531,7 +10540,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#__set (; 201 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#__set (; 199 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -10559,7 +10568,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/array/createReverseOrderedElementsArray (; 202 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/array/createReverseOrderedElementsArray (; 200 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -10599,7 +10608,7 @@
   end
   local.get $1
  )
- (func $start:std/array~anonymous|48 (; 203 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $start:std/array~anonymous|48 (; 201 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -10619,7 +10628,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/sort/insertionSort<std/array/Proxy<i32>> (; 204 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<std/array/Proxy<i32>> (; 202 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -10715,7 +10724,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#sort (; 205 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#sort (; 203 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10786,11 +10795,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#get:length (; 206 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#get:length (; 204 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#__unchecked_get (; 207 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#__unchecked_get (; 205 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -10800,7 +10809,7 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#__get (; 208 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#__get (; 206 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -10832,7 +10841,7 @@
   end
   local.get $2
  )
- (func $std/array/isSorted<std/array/Proxy<i32>> (; 209 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<std/array/Proxy<i32>> (; 207 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10899,7 +10908,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/array/assertSorted<std/array/Proxy<i32>> (; 210 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<std/array/Proxy<i32>> (; 208 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -10924,7 +10933,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/sort/insertionSort<~lib/string/String | null> (; 211 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<~lib/string/String | null> (; 209 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -11020,7 +11029,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/string/String | null>#sort (; 212 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#sort (; 210 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11091,11 +11100,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/string/String | null>#get:length (; 213 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#get:length (; 211 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<~lib/string/String | null>#__unchecked_get (; 214 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#__unchecked_get (; 212 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -11105,7 +11114,7 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/string/String | null>#__get (; 215 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#__get (; 213 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -11125,7 +11134,7 @@
   local.set $2
   local.get $2
  )
- (func $std/array/isSorted<~lib/string/String | null> (; 216 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<~lib/string/String | null> (; 214 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11192,7 +11201,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/array/assertSorted<~lib/string/String | null> (; 217 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/string/String | null> (; 215 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -11217,7 +11226,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/string/String#get:length (; 218 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (; 216 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -11225,7 +11234,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 219 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (; 217 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -11345,7 +11354,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0 (; 220 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<~lib/string/String | null>~anonymous|0 (; 218 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11451,7 +11460,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $std/array/assertSorted<~lib/string/String | null>|trampoline (; 221 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/string/String | null>|trampoline (; 219 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -11472,7 +11481,7 @@
   local.get $1
   call $std/array/assertSorted<~lib/string/String | null>
  )
- (func $~lib/string/String.__eq (; 222 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 220 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -11545,7 +11554,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__ne (; 223 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__ne (; 221 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -11564,7 +11573,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $std/array/isArraysEqual<~lib/string/String | null> (; 224 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/array/isArraysEqual<~lib/string/String | null> (; 222 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -11661,7 +11670,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<~lib/string/String>#constructor (; 225 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#constructor (; 223 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -11683,7 +11692,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/string/String#charAt (; 226 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#charAt (; 224 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -11709,7 +11718,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#concat (; 227 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#concat (; 225 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11785,7 +11794,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__concat (; 228 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (; 226 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -11808,7 +11817,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $std/array/createRandomString (; 229 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/array/createRandomString (; 227 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -11870,7 +11879,7 @@
   end
   local.get $1
  )
- (func $~lib/array/Array<~lib/string/String>#__unchecked_set (; 230 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<~lib/string/String>#__unchecked_set (; 228 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -11900,7 +11909,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<~lib/string/String>#__set (; 231 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<~lib/string/String>#__set (; 229 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -11928,7 +11937,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/array/createRandomStringArray (; 232 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/array/createRandomStringArray (; 230 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -11966,7 +11975,7 @@
   end
   local.get $1
  )
- (func $~lib/util/sort/insertionSort<~lib/string/String> (; 233 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/sort/insertionSort<~lib/string/String> (; 231 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12062,7 +12071,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/string/String>#sort (; 234 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#sort (; 232 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12133,11 +12142,11 @@
   local.get $0
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/string/String>#get:length (; 235 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#get:length (; 233 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<~lib/string/String>#__unchecked_get (; 236 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#__unchecked_get (; 234 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -12147,7 +12156,7 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/string/String>#__get (; 237 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#__get (; 235 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -12179,7 +12188,7 @@
   end
   local.get $2
  )
- (func $std/array/isSorted<~lib/string/String> (; 238 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $std/array/isSorted<~lib/string/String> (; 236 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12246,7 +12255,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/array/assertSorted<~lib/string/String> (; 239 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/string/String> (; 237 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -12271,7 +12280,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/sort/COMPARATOR<~lib/string/String>~anonymous|0 (; 240 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/sort/COMPARATOR<~lib/string/String>~anonymous|0 (; 238 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12377,7 +12386,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $std/array/assertSorted<~lib/string/String>|trampoline (; 241 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $std/array/assertSorted<~lib/string/String>|trampoline (; 239 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -12398,7 +12407,7 @@
   local.get $1
   call $std/array/assertSorted<~lib/string/String>
  )
- (func $~lib/string/String#substring (; 242 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substring (; 240 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12505,7 +12514,7 @@
   local.get $10
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/string/joinBooleanArray (; 243 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinBooleanArray (; 241 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12680,7 +12689,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<bool>#join (; 244 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<bool>#join (; 242 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12703,7 +12712,7 @@
   local.get $4
   return
  )
- (func $~lib/util/number/decimalCount32 (; 245 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (; 243 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 100000
@@ -12769,7 +12778,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/utoa32_lut (; 246 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa32_lut (; 244 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12911,7 +12920,7 @@
    i32.store16
   end
  )
- (func $~lib/util/number/itoa32 (; 247 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (; 245 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -12966,12 +12975,12 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<i32> (; 248 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<i32> (; 246 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/itoa32
   return
  )
- (func $~lib/util/number/itoa_stream<i32> (; 249 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i32> (; 247 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -13028,7 +13037,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<i32> (; 250 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i32> (; 248 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -13176,7 +13185,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i32>#join (; 251 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#join (; 249 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13199,7 +13208,7 @@
   local.get $4
   return
  )
- (func $~lib/util/number/utoa32 (; 252 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/utoa32 (; 250 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -13234,12 +13243,12 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<u32> (; 253 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<u32> (; 251 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/util/number/itoa_stream<u32> (; 254 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u32> (; 252 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -13276,7 +13285,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<u32> (; 255 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u32> (; 253 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -13424,7 +13433,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<u32>#join (; 256 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#join (; 254 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13447,14 +13456,7 @@
   local.get $4
   return
  )
- (func $~lib/number/isFinite<f64> (; 257 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.sub
-  f64.const 0
-  f64.eq
- )
- (func $~lib/array/Array<u64>#__unchecked_get (; 258 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__unchecked_get (; 255 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -13463,7 +13465,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<i16>#__unchecked_get (; 259 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__unchecked_get (; 256 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -13472,7 +13474,7 @@
   i32.add
   i32.load16_s
  )
- (func $~lib/util/number/genDigits (; 260 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (; 257 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -13974,7 +13976,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/prettify (; 261 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (; 258 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -14293,7 +14295,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/dtoa_core (; 262 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (; 259 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14715,10 +14717,11 @@
   local.get $2
   i32.add
  )
- (func $~lib/util/number/dtoa (; 263 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  (local $1 i32)
+ (func $~lib/util/number/dtoa (; 260 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+  (local $1 f64)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   local.get $0
   f64.const 0
   f64.eq
@@ -14728,11 +14731,17 @@
    return
   end
   local.get $0
-  call $~lib/number/isFinite<f64>
+  local.tee $1
+  local.get $1
+  f64.sub
+  f64.const 0
+  f64.eq
   i32.eqz
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.tee $1
+   local.get $1
+   f64.ne
    if
     i32.const 5552
     call $~lib/rt/pure/__retain
@@ -14752,31 +14761,32 @@
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
-  local.set $1
-  local.get $1
-  local.get $0
-  call $~lib/util/number/dtoa_core
   local.set $2
   local.get $2
+  local.get $0
+  call $~lib/util/number/dtoa_core
+  local.set $3
+  local.get $3
   i32.const 28
   i32.eq
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__retain
    return
   end
-  local.get $1
-  i32.const 0
   local.get $2
-  call $~lib/string/String#substring
-  local.set $3
-  local.get $1
-  call $~lib/rt/tlsf/__free
+  i32.const 0
   local.get $3
+  call $~lib/string/String#substring
+  local.set $4
+  local.get $2
+  call $~lib/rt/tlsf/__free
+  local.get $4
  )
- (func $~lib/util/number/dtoa_stream (; 264 ;) (type $FUNCSIG$iiid) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
-  (local $3 i32)
+ (func $~lib/util/number/dtoa_stream (; 261 ;) (type $FUNCSIG$iiid) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
+  (local $3 f64)
   (local $4 i32)
+  (local $5 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -14800,11 +14810,17 @@
    return
   end
   local.get $2
-  call $~lib/number/isFinite<f64>
+  local.tee $3
+  local.get $3
+  f64.sub
+  f64.const 0
+  f64.eq
   i32.eqz
   if
    local.get $2
-   call $~lib/number/isNaN<f64>
+   local.tee $3
+   local.get $3
+   f64.ne
    if
     local.get $0
     i32.const 78
@@ -14821,21 +14837,21 @@
     local.get $2
     f64.const 0
     f64.lt
-    local.set $3
-    i32.const 8
-    local.get $3
-    i32.add
     local.set $4
+    i32.const 8
+    local.get $4
+    i32.add
+    local.set $5
     local.get $0
     i32.const 5576
     i32.const 5616
-    local.get $3
-    select
     local.get $4
+    select
+    local.get $5
     i32.const 1
     i32.shl
     call $~lib/memory/memory.copy
-    local.get $4
+    local.get $5
     return
    end
    unreachable
@@ -14844,7 +14860,7 @@
   local.get $2
   call $~lib/util/number/dtoa_core
  )
- (func $~lib/util/string/joinFloatArray<f64> (; 265 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinFloatArray<f64> (; 262 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -14992,7 +15008,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<f64>#join (; 266 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f64>#join (; 263 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15015,7 +15031,7 @@
   local.get $4
   return
  )
- (func $~lib/util/string/joinStringArray (; 267 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinStringArray (; 264 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15246,7 +15262,7 @@
   call $~lib/rt/pure/__release
   local.get $7
  )
- (func $~lib/array/Array<~lib/string/String | null>#join (; 268 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#join (; 265 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15269,11 +15285,11 @@
   local.get $4
   return
  )
- (func $std/array/Ref#toString (; 269 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $std/array/Ref#toString (; 266 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 6856
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/string/joinReferenceArray<std/array/Ref | null> (; 270 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<std/array/Ref | null> (; 267 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15487,7 +15503,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<std/array/Ref | null>#join (; 271 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref | null>#join (; 268 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15510,7 +15526,7 @@
   local.get $4
   return
  )
- (func $~lib/util/string/joinReferenceArray<std/array/Ref> (; 272 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<std/array/Ref> (; 269 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15724,7 +15740,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<std/array/Ref>#join (; 273 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<std/array/Ref>#join (; 270 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15747,12 +15763,12 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<i32>#toString (; 274 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#toString (; 271 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4672
   call $~lib/array/Array<i32>#join
  )
- (func $~lib/util/number/itoa<i8> (; 275 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<i8> (; 272 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -15761,7 +15777,7 @@
   call $~lib/util/number/itoa32
   return
  )
- (func $~lib/util/number/itoa_stream<i8> (; 276 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i8> (; 273 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15834,7 +15850,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<i8> (; 277 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i8> (; 274 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -15982,7 +15998,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i8>#join (; 278 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#join (; 275 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16005,19 +16021,19 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<i8>#toString (; 279 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i8>#toString (; 276 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4672
   call $~lib/array/Array<i8>#join
  )
- (func $~lib/util/number/itoa<u16> (; 280 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<u16> (; 277 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/util/number/itoa_stream<u16> (; 281 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u16> (; 278 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16060,7 +16076,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<u16> (; 282 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u16> (; 279 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16208,7 +16224,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<u16>#join (; 283 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#join (; 280 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16231,12 +16247,12 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<u16>#toString (; 284 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u16>#toString (; 281 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4672
   call $~lib/array/Array<u16>#join
  )
- (func $~lib/util/number/decimalCount64 (; 285 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64 (; 282 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   local.get $0
   i64.const 1000000000000000
@@ -16309,7 +16325,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/utoa64_lut (; 286 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/util/number/utoa64_lut (; 283 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -16436,7 +16452,7 @@
   local.get $2
   call $~lib/util/number/utoa32_lut
  )
- (func $~lib/util/number/utoa64 (; 287 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/utoa64 (; 284 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -16503,12 +16519,12 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<u64> (; 288 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa<u64> (; 285 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   local.get $0
   call $~lib/util/number/utoa64
   return
  )
- (func $~lib/util/number/itoa_stream<u64> (; 289 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<u64> (; 286 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16571,7 +16587,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<u64> (; 290 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u64> (; 287 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16719,7 +16735,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<u64>#join (; 291 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u64>#join (; 288 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16742,12 +16758,12 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<u64>#toString (; 292 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u64>#toString (; 289 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4672
   call $~lib/array/Array<u64>#join
  )
- (func $~lib/util/number/itoa64 (; 293 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa64 (; 290 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -16836,12 +16852,12 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<i64> (; 294 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa<i64> (; 291 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   local.get $0
   call $~lib/util/number/itoa64
   return
  )
- (func $~lib/util/number/itoa_stream<i64> (; 295 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<i64> (; 292 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -16926,7 +16942,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<i64> (; 296 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i64> (; 293 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -17074,7 +17090,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<i64>#join (; 297 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i64>#join (; 294 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17097,17 +17113,17 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<i64>#toString (; 298 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i64>#toString (; 295 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4672
   call $~lib/array/Array<i64>#join
  )
- (func $~lib/array/Array<~lib/string/String | null>#toString (; 299 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String | null>#toString (; 296 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4672
   call $~lib/array/Array<~lib/string/String | null>#join
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>> (; 300 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<i32>> (; 297 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -17321,7 +17337,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#join (; 301 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#join (; 298 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17344,19 +17360,19 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#toString (; 302 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#toString (; 299 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4672
   call $~lib/array/Array<~lib/array/Array<i32>>#join
  )
- (func $~lib/util/number/itoa<u8> (; 303 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<u8> (; 300 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/util/number/itoa_stream<u8> (; 304 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u8> (; 301 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -17399,7 +17415,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<u8> (; 305 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u8> (; 302 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -17547,7 +17563,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<u8>#join (; 306 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#join (; 303 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17570,12 +17586,12 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<u8>#toString (; 307 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u8>#toString (; 304 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4672
   call $~lib/array/Array<u8>#join
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u8>> (; 308 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u8>> (; 305 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -17789,7 +17805,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<~lib/array/Array<u8>>#join (; 309 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u8>>#join (; 306 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17812,17 +17828,17 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<~lib/array/Array<u8>>#toString (; 310 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u8>>#toString (; 307 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4672
   call $~lib/array/Array<~lib/array/Array<u8>>#join
  )
- (func $~lib/array/Array<u32>#toString (; 311 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u32>#toString (; 308 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4672
   call $~lib/array/Array<u32>#join
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>> (; 312 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<u32>> (; 309 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -18036,7 +18052,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<~lib/array/Array<u32>>#join (; 313 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u32>>#join (; 310 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -18059,12 +18075,12 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<~lib/array/Array<u32>>#toString (; 314 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<u32>>#toString (; 311 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4672
   call $~lib/array/Array<~lib/array/Array<u32>>#join
  )
- (func $~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>> (; 315 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>> (; 312 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -18278,7 +18294,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#join (; 316 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#join (; 313 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -18301,12 +18317,12 @@
   local.get $4
   return
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#toString (; 317 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#toString (; 314 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 4672
   call $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#join
  )
- (func $start:std/array (; 318 ;) (type $FUNCSIG$v)
+ (func $start:std/array (; 315 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -24605,7 +24621,7 @@
   local.get $79
   call $~lib/rt/pure/__release
  )
- (func $start (; 319 ;) (type $FUNCSIG$v)
+ (func $start (; 316 ;) (type $FUNCSIG$v)
   global.get $~lib/started
   if
    return
@@ -24615,16 +24631,16 @@
   end
   call $start:std/array
  )
- (func $~lib/array/Array<i32>#__visit_impl (; 320 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#__visit_impl (; 317 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u8>#__visit_impl (; 321 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u8>#__visit_impl (; 318 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u32>#__visit_impl (; 322 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u32>#__visit_impl (; 319 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/rt/pure/__visit (; 323 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 320 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -24754,7 +24770,7 @@
    end
   end
  )
- (func $~lib/array/Array<std/array/Ref>#__visit_impl (; 324 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<std/array/Ref>#__visit_impl (; 321 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24793,13 +24809,13 @@
    unreachable
   end
  )
- (func $~lib/array/Array<f32>#__visit_impl (; 325 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f32>#__visit_impl (; 322 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<f64>#__visit_impl (; 326 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f64>#__visit_impl (; 323 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<std/array/Ref | null>#__visit_impl (; 327 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<std/array/Ref | null>#__visit_impl (; 324 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24838,7 +24854,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/array/Array<i32>>#__visit_impl (; 328 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__visit_impl (; 325 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24877,7 +24893,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<std/array/Proxy<i32>>#__visit_impl (; 329 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<std/array/Proxy<i32>>#__visit_impl (; 326 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24916,7 +24932,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/string/String | null>#__visit_impl (; 330 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/string/String | null>#__visit_impl (; 327 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24955,7 +24971,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/string/String>#__visit_impl (; 331 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/string/String>#__visit_impl (; 328 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24994,25 +25010,25 @@
    unreachable
   end
  )
- (func $~lib/array/Array<bool>#__visit_impl (; 332 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<bool>#__visit_impl (; 329 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u64>#__visit_impl (; 333 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u64>#__visit_impl (; 330 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<i16>#__visit_impl (; 334 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i16>#__visit_impl (; 331 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<i8>#__visit_impl (; 335 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i8>#__visit_impl (; 332 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u16>#__visit_impl (; 336 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u16>#__visit_impl (; 333 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<i64>#__visit_impl (; 337 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i64>#__visit_impl (; 334 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<~lib/array/Array<u8>>#__visit_impl (; 338 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/array/Array<u8>>#__visit_impl (; 335 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -25051,7 +25067,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/array/Array<u32>>#__visit_impl (; 339 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/array/Array<u32>>#__visit_impl (; 336 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -25090,7 +25106,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#__visit_impl (; 340 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#__visit_impl (; 337 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -25129,7 +25145,7 @@
    unreachable
   end
  )
- (func $~lib/rt/__visit_members (; 341 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (; 338 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $block$4$break
    block $switch$1$default
@@ -25277,6 +25293,6 @@
   end
   return
  )
- (func $null (; 342 ;) (type $FUNCSIG$v)
+ (func $null (; 339 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -5468,7 +5468,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 f32)
-  (local $7 f32)
   local.get $0
   i32.load offset=12
   local.set $3
@@ -5526,12 +5525,10 @@
      i32.const 1
     else
      local.get $6
-     local.tee $7
-     local.get $7
+     local.get $6
      f32.ne
      local.get $1
-     local.tee $7
-     local.get $7
+     local.get $1
      f32.ne
      i32.and
     end
@@ -5555,7 +5552,6 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 f64)
-  (local $7 f64)
   local.get $0
   i32.load offset=12
   local.set $3
@@ -5613,12 +5609,10 @@
      i32.const 1
     else
      local.get $6
-     local.tee $7
-     local.get $7
+     local.get $6
      f64.ne
      local.get $1
-     local.tee $7
-     local.get $7
+     local.get $1
      f64.ne
      i32.and
     end
@@ -14718,10 +14712,9 @@
   i32.add
  )
  (func $~lib/util/number/dtoa (; 260 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  (local $1 f64)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
   local.get $0
   f64.const 0
   f64.eq
@@ -14731,16 +14724,14 @@
    return
   end
   local.get $0
-  local.tee $1
-  local.get $1
+  local.get $0
   f64.sub
   f64.const 0
   f64.eq
   i32.eqz
   if
    local.get $0
-   local.tee $1
-   local.get $1
+   local.get $0
    f64.ne
    if
     i32.const 5552
@@ -14761,32 +14752,31 @@
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
-  local.set $2
-  local.get $2
+  local.set $1
+  local.get $1
   local.get $0
   call $~lib/util/number/dtoa_core
-  local.set $3
-  local.get $3
+  local.set $2
+  local.get $2
   i32.const 28
   i32.eq
   if
-   local.get $2
+   local.get $1
    call $~lib/rt/pure/__retain
    return
   end
-  local.get $2
+  local.get $1
   i32.const 0
-  local.get $3
-  call $~lib/string/String#substring
-  local.set $4
   local.get $2
+  call $~lib/string/String#substring
+  local.set $3
+  local.get $1
   call $~lib/rt/tlsf/__free
-  local.get $4
+  local.get $3
  )
  (func $~lib/util/number/dtoa_stream (; 261 ;) (type $FUNCSIG$iiid) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
-  (local $3 f64)
+  (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -14810,16 +14800,14 @@
    return
   end
   local.get $2
-  local.tee $3
-  local.get $3
+  local.get $2
   f64.sub
   f64.const 0
   f64.eq
   i32.eqz
   if
    local.get $2
-   local.tee $3
-   local.get $3
+   local.get $2
    f64.ne
    if
     local.get $0
@@ -14837,21 +14825,21 @@
     local.get $2
     f64.const 0
     f64.lt
-    local.set $4
+    local.set $3
     i32.const 8
-    local.get $4
+    local.get $3
     i32.add
-    local.set $5
+    local.set $4
     local.get $0
     i32.const 5576
     i32.const 5616
-    local.get $4
+    local.get $3
     select
-    local.get $5
+    local.get $4
     i32.const 1
     i32.shl
     call $~lib/memory/memory.copy
-    local.get $5
+    local.get $4
     return
    end
    unreachable

--- a/tests/compiler/std/libm.optimized.wat
+++ b/tests/compiler/std/libm.optimized.wat
@@ -1,11 +1,10 @@
 (module
  (type $FUNCSIG$dd (func (param f64) (result f64)))
- (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))
+ (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$ddi (func (param f64 i32) (result f64)))
  (type $FUNCSIG$dddi (func (param f64 f64 i32) (result f64)))
  (type $FUNCSIG$ff (func (param f32) (result f32)))
- (type $FUNCSIG$if (func (param f32) (result i32)))
  (type $FUNCSIG$fff (func (param f32 f32) (result f32)))
  (type $FUNCSIG$ffi (func (param f32 i32) (result f32)))
  (type $FUNCSIG$v (func))
@@ -938,12 +937,7 @@
   local.get $0
   call $~lib/math/NativeMath.asinh
  )
- (func $~lib/number/isNaN<f64> (; 12 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.ne
- )
- (func $~lib/math/NativeMath.atan (; 13 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atan (; 12 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -962,7 +956,8 @@
   i32.ge_u
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.get $0
+   f64.ne
    if
     local.get $0
     return
@@ -1168,11 +1163,11 @@
   local.get $3
   f64.copysign
  )
- (func $../../lib/libm/assembly/libm/atan (; 14 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/atan (; 13 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.atan
  )
- (func $~lib/math/NativeMath.atanh (; 15 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atanh (; 14 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i64)
   (local $3 f64)
@@ -1226,25 +1221,25 @@
   local.get $0
   f64.copysign
  )
- (func $../../lib/libm/assembly/libm/atanh (; 16 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/atanh (; 15 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.atanh
  )
- (func $~lib/math/NativeMath.atan2 (; 17 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.atan2 (; 16 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
   (local $6 i32)
   (local $7 i32)
+  i32.const 1
+  local.get $0
+  local.get $0
+  f64.ne
   local.get $1
-  call $~lib/number/isNaN<f64>
-  if (result i32)
-   i32.const 1
-  else
-   local.get $0
-   call $~lib/number/isNaN<f64>
-  end
+  local.get $1
+  f64.ne
+  select
   if
    local.get $1
    local.get $0
@@ -1450,12 +1445,12 @@
   i32.and
   select
  )
- (func $../../lib/libm/assembly/libm/atan2 (; 18 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/atan2 (; 17 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.atan2
  )
- (func $~lib/math/NativeMath.cbrt (; 19 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cbrt (; 18 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -1577,22 +1572,15 @@
   f64.mul
   f64.add
  )
- (func $../../lib/libm/assembly/libm/cbrt (; 20 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/cbrt (; 19 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.cbrt
  )
- (func $../../lib/libm/assembly/libm/ceil (; 21 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/ceil (; 20 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   f64.ceil
  )
- (func $~lib/number/isFinite<f64> (; 22 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.sub
-  f64.const 0
-  f64.eq
- )
- (func $~lib/math/dtoi32 (; 23 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/math/dtoi32 (; 21 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   f64.const 4294967296
   local.get $0
@@ -1604,21 +1592,22 @@
   i64.trunc_f64_s
   i32.wrap_i64
  )
- (func $../../lib/libm/assembly/libm/clz32 (; 24 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
-  block $__inlined_func$~lib/math/NativeMath.clz32 (result f64)
+ (func $../../lib/libm/assembly/libm/clz32 (; 22 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+  local.get $0
+  local.get $0
+  f64.sub
+  f64.const 0
+  f64.ne
+  if (result f64)
    f64.const 32
-   local.get $0
-   call $~lib/number/isFinite<f64>
-   i32.eqz
-   br_if $__inlined_func$~lib/math/NativeMath.clz32
-   drop
+  else
    local.get $0
    call $~lib/math/dtoi32
    i32.clz
    f64.convert_i32_s
   end
  )
- (func $~lib/math/pio2_large_quot (; 25 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/math/pio2_large_quot (; 23 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -1910,7 +1899,7 @@
   i64.sub
   i32.wrap_i64
  )
- (func $~lib/math/NativeMath.cos (; 26 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cos (; 24 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   (local $3 f64)
@@ -2250,11 +2239,11 @@
   end
   local.get $0
  )
- (func $../../lib/libm/assembly/libm/cos (; 27 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/cos (; 25 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.cos
  )
- (func $~lib/math/NativeMath.expm1 (; 28 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.expm1 (; 26 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -2281,7 +2270,8 @@
   i32.ge_u
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.get $0
+   f64.ne
    if
     local.get $0
     return
@@ -2526,7 +2516,7 @@
   local.get $4
   f64.mul
  )
- (func $~lib/math/NativeMath.scalbn (; 29 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/NativeMath.scalbn (; 27 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
   local.get $1
   i32.const 1023
   i32.gt_s
@@ -2603,7 +2593,7 @@
   f64.reinterpret_i64
   f64.mul
  )
- (func $~lib/math/NativeMath.exp (; 30 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.exp (; 28 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 f64)
   (local $3 i32)
@@ -2628,7 +2618,8 @@
   i32.ge_u
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.get $0
+   f64.ne
    if
     local.get $0
     return
@@ -2755,7 +2746,7 @@
   local.get $1
   call $~lib/math/NativeMath.scalbn
  )
- (func $~lib/math/NativeMath.cosh (; 31 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cosh (; 29 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i64)
   local.get $0
@@ -2819,28 +2810,28 @@
   f64.const 2247116418577894884661631e283
   f64.mul
  )
- (func $../../lib/libm/assembly/libm/cosh (; 32 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/cosh (; 30 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.cosh
  )
- (func $../../lib/libm/assembly/libm/exp (; 33 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/exp (; 31 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.exp
  )
- (func $../../lib/libm/assembly/libm/expm1 (; 34 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/expm1 (; 32 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.expm1
  )
- (func $../../lib/libm/assembly/libm/floor (; 35 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/floor (; 33 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   f64.floor
  )
- (func $../../lib/libm/assembly/libm/fround (; 36 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/fround (; 34 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   f32.demote_f64
   f64.promote_f32
  )
- (func $~lib/math/NativeMath.hypot (; 37 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.hypot (; 35 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 f64)
   (local $4 i64)
@@ -3011,34 +3002,42 @@
   f64.sqrt
   f64.mul
  )
- (func $../../lib/libm/assembly/libm/hypot (; 38 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/hypot (; 36 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.hypot
  )
- (func $../../lib/libm/assembly/libm/imul (; 39 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
-  block $__inlined_func$~lib/math/NativeMath.imul (result f64)
+ (func $~lib/math/NativeMath.imul (; 37 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+  (local $2 f64)
+  local.get $0
+  local.get $1
+  f64.add
+  local.tee $2
+  local.get $2
+  f64.sub
+  f64.const 0
+  f64.ne
+  if
    f64.const 0
-   local.get $0
-   local.get $1
-   f64.add
-   call $~lib/number/isFinite<f64>
-   i32.eqz
-   br_if $__inlined_func$~lib/math/NativeMath.imul
-   drop
-   local.get $0
-   call $~lib/math/dtoi32
-   local.get $1
-   call $~lib/math/dtoi32
-   i32.mul
-   f64.convert_i32_s
+   return
   end
+  local.get $0
+  call $~lib/math/dtoi32
+  local.get $1
+  call $~lib/math/dtoi32
+  i32.mul
+  f64.convert_i32_s
  )
- (func $../../lib/libm/assembly/libm/log (; 40 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/imul (; 38 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+  local.get $0
+  local.get $1
+  call $~lib/math/NativeMath.imul
+ )
+ (func $../../lib/libm/assembly/libm/log (; 39 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.log
  )
- (func $~lib/math/NativeMath.log10 (; 41 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log10 (; 40 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i64)
@@ -3242,15 +3241,15 @@
   local.get $1
   f64.add
  )
- (func $../../lib/libm/assembly/libm/log10 (; 42 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/log10 (; 41 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.log10
  )
- (func $../../lib/libm/assembly/libm/log1p (; 43 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/log1p (; 42 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.log1p
  )
- (func $~lib/math/NativeMath.log2 (; 44 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log2 (; 43 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i64)
@@ -3447,21 +3446,21 @@
   local.get $1
   f64.add
  )
- (func $../../lib/libm/assembly/libm/log2 (; 45 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/log2 (; 44 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.log2
  )
- (func $../../lib/libm/assembly/libm/max (; 46 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/max (; 45 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   f64.max
  )
- (func $../../lib/libm/assembly/libm/min (; 47 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/min (; 46 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   f64.min
  )
- (func $~lib/math/NativeMath.pow (; 48 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.pow (; 47 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 f64)
   (local $4 i32)
@@ -4369,12 +4368,12 @@
   f64.const 1e-300
   f64.mul
  )
- (func $../../lib/libm/assembly/libm/pow (; 49 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/pow (; 48 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.pow
  )
- (func $../../lib/libm/assembly/libm/round (; 50 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/round (; 49 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   f64.const 0.5
   f64.add
@@ -4382,7 +4381,7 @@
   local.get $0
   f64.copysign
  )
- (func $../../lib/libm/assembly/libm/sign (; 51 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/sign (; 50 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   f64.abs
   f64.const 0
@@ -4395,7 +4394,7 @@
   end
   local.get $0
  )
- (func $~lib/math/NativeMath.sin (; 52 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.sin (; 51 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   (local $3 f64)
@@ -4717,11 +4716,11 @@
   end
   local.get $0
  )
- (func $../../lib/libm/assembly/libm/sin (; 53 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/sin (; 52 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.sin
  )
- (func $~lib/math/NativeMath.sinh (; 54 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.sinh (; 53 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   (local $3 i32)
@@ -4798,15 +4797,15 @@
   f64.mul
   f64.mul
  )
- (func $../../lib/libm/assembly/libm/sinh (; 55 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/sinh (; 54 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.sinh
  )
- (func $../../lib/libm/assembly/libm/sqrt (; 56 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/sqrt (; 55 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   f64.sqrt
  )
- (func $~lib/math/tan_kern (; 57 ;) (type $FUNCSIG$dddi) (param $0 f64) (param $1 f64) (param $2 i32) (result f64)
+ (func $~lib/math/tan_kern (; 56 ;) (type $FUNCSIG$dddi) (param $0 f64) (param $1 f64) (param $2 i32) (result f64)
   (local $3 f64)
   (local $4 f64)
   (local $5 f64)
@@ -4988,7 +4987,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.tan (; 58 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.tan (; 57 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -5167,11 +5166,11 @@
   i32.sub
   call $~lib/math/tan_kern
  )
- (func $../../lib/libm/assembly/libm/tan (; 59 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/tan (; 58 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.tan
  )
- (func $~lib/math/NativeMath.tanh (; 60 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.tanh (; 59 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i64)
@@ -5250,19 +5249,19 @@
   local.get $0
   f64.copysign
  )
- (func $../../lib/libm/assembly/libm/tanh (; 61 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/tanh (; 60 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.tanh
  )
- (func $../../lib/libm/assembly/libm/trunc (; 62 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/trunc (; 61 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   f64.trunc
  )
- (func $../../lib/libm/assembly/libmf/abs (; 63 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/abs (; 62 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   f32.abs
  )
- (func $~lib/math/Rf (; 64 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/Rf (; 63 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   f32.const 0.16666586697101593
   local.get $0
@@ -5281,7 +5280,7 @@
   f32.add
   f32.div
  )
- (func $~lib/math/NativeMathf.acos (; 65 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.acos (; 64 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -5397,11 +5396,11 @@
   f32.add
   f32.mul
  )
- (func $../../lib/libm/assembly/libmf/acos (; 66 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/acos (; 65 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.acos
  )
- (func $~lib/math/NativeMathf.log1p (; 67 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log1p (; 66 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -5571,7 +5570,7 @@
   f32.mul
   f32.add
  )
- (func $~lib/math/NativeMathf.log (; 68 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log (; 67 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -5705,7 +5704,7 @@
   f32.mul
   f32.add
  )
- (func $~lib/math/NativeMathf.acosh (; 69 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.acosh (; 68 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   local.get $0
   i32.reinterpret_f32
@@ -5755,11 +5754,11 @@
   f32.const 0.6931471824645996
   f32.add
  )
- (func $../../lib/libm/assembly/libmf/acosh (; 70 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/acosh (; 69 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.acosh
  )
- (func $~lib/math/NativeMathf.asin (; 71 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.asin (; 70 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f64)
@@ -5839,11 +5838,11 @@
   local.get $0
   f32.copysign
  )
- (func $../../lib/libm/assembly/libmf/asin (; 72 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/asin (; 71 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.asin
  )
- (func $~lib/math/NativeMathf.asinh (; 73 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.asinh (; 72 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   local.get $0
@@ -5908,16 +5907,11 @@
   local.get $0
   f32.copysign
  )
- (func $../../lib/libm/assembly/libmf/asinh (; 74 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/asinh (; 73 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.asinh
  )
- (func $~lib/number/isNaN<f32> (; 75 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
-  local.get $0
-  local.get $0
-  f32.ne
- )
- (func $~lib/math/NativeMathf.atan (; 76 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.atan (; 74 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -5933,7 +5927,8 @@
   i32.ge_u
   if
    local.get $0
-   call $~lib/number/isNaN<f32>
+   local.get $0
+   f32.ne
    if
     local.get $0
     return
@@ -6115,11 +6110,11 @@
   local.get $4
   f32.copysign
  )
- (func $../../lib/libm/assembly/libmf/atan (; 77 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/atan (; 75 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.atan
  )
- (func $~lib/math/NativeMathf.atanh (; 78 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.atanh (; 76 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   local.get $0
@@ -6167,22 +6162,22 @@
   local.get $0
   f32.copysign
  )
- (func $../../lib/libm/assembly/libmf/atanh (; 79 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/atanh (; 77 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.atanh
  )
- (func $~lib/math/NativeMathf.atan2 (; 80 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.atan2 (; 78 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  i32.const 1
+  local.get $0
+  local.get $0
+  f32.ne
   local.get $1
-  call $~lib/number/isNaN<f32>
-  if (result i32)
-   i32.const 1
-  else
-   local.get $0
-   call $~lib/number/isNaN<f32>
-  end
+  local.get $1
+  f32.ne
+  select
   if
    local.get $1
    local.get $0
@@ -6367,12 +6362,12 @@
   i32.and
   select
  )
- (func $../../lib/libm/assembly/libmf/atan2 (; 81 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/atan2 (; 79 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.atan2
  )
- (func $~lib/math/NativeMathf.cbrt (; 82 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cbrt (; 80 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f64)
   (local $2 f64)
   (local $3 i32)
@@ -6471,29 +6466,23 @@
   f64.div
   f32.demote_f64
  )
- (func $../../lib/libm/assembly/libmf/cbrt (; 83 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/cbrt (; 81 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.cbrt
  )
- (func $../../lib/libm/assembly/libmf/ceil (; 84 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/ceil (; 82 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   f32.ceil
  )
- (func $~lib/number/isFinite<f32> (; 85 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
+ (func $../../lib/libm/assembly/libmf/clz32 (; 83 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   local.get $0
   f32.sub
   f32.const 0
-  f32.eq
- )
- (func $../../lib/libm/assembly/libmf/clz32 (; 86 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
-  block $__inlined_func$~lib/math/NativeMathf.clz32 (result f32)
+  f32.ne
+  if (result f32)
    f32.const 32
-   local.get $0
-   call $~lib/number/isFinite<f32>
-   i32.eqz
-   br_if $__inlined_func$~lib/math/NativeMathf.clz32
-   drop
+  else
    local.get $0
    f64.promote_f32
    call $~lib/math/dtoi32
@@ -6501,7 +6490,7 @@
    f32.convert_i32_s
   end
  )
- (func $~lib/math/NativeMathf.cos (; 87 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cos (; 84 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -6771,11 +6760,11 @@
   end
   local.get $0
  )
- (func $../../lib/libm/assembly/libmf/cos (; 88 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/cos (; 85 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.cos
  )
- (func $~lib/math/NativeMathf.expm1 (; 89 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.expm1 (; 86 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -7027,7 +7016,7 @@
   local.get $4
   f32.mul
  )
- (func $~lib/math/NativeMathf.scalbn (; 90 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
+ (func $~lib/math/NativeMathf.scalbn (; 87 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
   local.get $1
   i32.const 127
   i32.gt_s
@@ -7103,7 +7092,7 @@
   f32.reinterpret_i32
   f32.mul
  )
- (func $~lib/math/NativeMathf.exp (; 91 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.exp (; 88 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -7231,7 +7220,7 @@
   local.get $1
   call $~lib/math/NativeMathf.scalbn
  )
- (func $~lib/math/NativeMathf.cosh (; 92 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cosh (; 89 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   local.get $0
   i32.reinterpret_f32
@@ -7290,26 +7279,26 @@
   f32.const 1661534994731144841129758e11
   f32.mul
  )
- (func $../../lib/libm/assembly/libmf/cosh (; 93 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/cosh (; 90 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.cosh
  )
- (func $../../lib/libm/assembly/libmf/exp (; 94 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/exp (; 91 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.exp
  )
- (func $../../lib/libm/assembly/libmf/expm1 (; 95 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/expm1 (; 92 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.expm1
  )
- (func $../../lib/libm/assembly/libmf/floor (; 96 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/floor (; 93 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   f32.floor
  )
- (func $../../lib/libm/assembly/libmf/fround (; 97 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/fround (; 94 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
  )
- (func $~lib/math/NativeMathf.hypot (; 98 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.hypot (; 95 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 f32)
@@ -7414,19 +7403,23 @@
   f32.sqrt
   f32.mul
  )
- (func $../../lib/libm/assembly/libmf/hypot (; 99 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/hypot (; 96 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.hypot
  )
- (func $../../lib/libm/assembly/libmf/imul (; 100 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/imul (; 97 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+  (local $2 f32)
   block $~lib/math/NativeMathf.imul|inlined.0 (result f32)
    f32.const 0
    local.get $0
    local.get $1
    f32.add
-   call $~lib/number/isFinite<f32>
-   i32.eqz
+   local.tee $2
+   local.get $2
+   f32.sub
+   f32.const 0
+   f32.ne
    br_if $~lib/math/NativeMathf.imul|inlined.0
    drop
    local.get $0
@@ -7439,11 +7432,11 @@
    f32.convert_i32_s
   end
  )
- (func $../../lib/libm/assembly/libmf/log (; 101 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/log (; 98 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.log
  )
- (func $~lib/math/NativeMathf.log10 (; 102 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log10 (; 99 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 i32)
@@ -7601,15 +7594,15 @@
   f32.mul
   f32.add
  )
- (func $../../lib/libm/assembly/libmf/log10 (; 103 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/log10 (; 100 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.log10
  )
- (func $../../lib/libm/assembly/libmf/log1p (; 104 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/log1p (; 101 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.log1p
  )
- (func $~lib/math/NativeMathf.log2 (; 105 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log2 (; 102 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 i32)
@@ -7759,21 +7752,21 @@
   f32.convert_i32_s
   f32.add
  )
- (func $../../lib/libm/assembly/libmf/log2 (; 106 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/log2 (; 103 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.log2
  )
- (func $../../lib/libm/assembly/libmf/max (; 107 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/max (; 104 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   local.get $0
   local.get $1
   f32.max
  )
- (func $../../lib/libm/assembly/libmf/min (; 108 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/min (; 105 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   local.get $0
   local.get $1
   f32.min
  )
- (func $~lib/math/NativeMathf.pow (; 109 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.pow (; 106 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 f32)
   (local $3 f32)
   (local $4 i32)
@@ -8559,12 +8552,12 @@
   f32.const 1.0000000031710769e-30
   f32.mul
  )
- (func $../../lib/libm/assembly/libmf/pow (; 110 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/pow (; 107 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.pow
  )
- (func $../../lib/libm/assembly/libmf/round (; 111 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/round (; 108 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   f32.const 0.5
   f32.add
@@ -8572,7 +8565,7 @@
   local.get $0
   f32.copysign
  )
- (func $../../lib/libm/assembly/libmf/sign (; 112 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/sign (; 109 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   f32.abs
   f32.const 0
@@ -8585,7 +8578,7 @@
   end
   local.get $0
  )
- (func $~lib/math/NativeMathf.sin (; 113 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.sin (; 110 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -8856,11 +8849,11 @@
   end
   local.get $0
  )
- (func $../../lib/libm/assembly/libmf/sin (; 114 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/sin (; 111 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.sin
  )
- (func $~lib/math/NativeMathf.sinh (; 115 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.sinh (; 112 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 f32)
@@ -8932,15 +8925,15 @@
   f32.mul
   f32.mul
  )
- (func $../../lib/libm/assembly/libmf/sinh (; 116 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/sinh (; 113 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.sinh
  )
- (func $../../lib/libm/assembly/libmf/sqrt (; 117 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/sqrt (; 114 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   f32.sqrt
  )
- (func $~lib/math/NativeMathf.tan (; 118 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.tan (; 115 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -9195,11 +9188,11 @@
   local.get $1
   f32.demote_f64
  )
- (func $../../lib/libm/assembly/libmf/tan (; 119 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/tan (; 116 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.tan
  )
- (func $~lib/math/NativeMathf.tanh (; 120 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.tanh (; 117 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   local.get $0
@@ -9273,15 +9266,15 @@
   local.get $0
   f32.copysign
  )
- (func $../../lib/libm/assembly/libmf/tanh (; 121 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/tanh (; 118 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.tanh
  )
- (func $../../lib/libm/assembly/libmf/trunc (; 122 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/trunc (; 119 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   f32.trunc
  )
- (func $null (; 123 ;) (type $FUNCSIG$v)
+ (func $null (; 120 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/libm.untouched.wat
+++ b/tests/compiler/std/libm.untouched.wat
@@ -1114,13 +1114,12 @@
   (local $1 i32)
   (local $2 f64)
   (local $3 f64)
-  (local $4 f64)
-  (local $5 i32)
+  (local $4 i32)
+  (local $5 f64)
   (local $6 f64)
   (local $7 f64)
   (local $8 f64)
-  (local $9 f64)
-  (local $10 i32)
+  (local $9 i32)
   local.get $0
   i64.reinterpret_f64
   i64.const 32
@@ -1138,8 +1137,7 @@
   i32.ge_u
   if
    local.get $0
-   local.tee $4
-   local.get $4
+   local.get $0
    f64.ne
    if
     local.get $0
@@ -1167,7 +1165,7 @@
     return
    end
    i32.const -1
-   local.set $5
+   local.set $4
   else
    local.get $0
    f64.abs
@@ -1181,7 +1179,7 @@
     i32.lt_u
     if
      i32.const 0
-     local.set $5
+     local.set $4
      f64.const 2
      local.get $0
      f64.mul
@@ -1194,7 +1192,7 @@
      local.set $0
     else
      i32.const 1
-     local.set $5
+     local.set $4
      local.get $0
      f64.const 1
      f64.sub
@@ -1210,7 +1208,7 @@
     i32.lt_u
     if
      i32.const 2
-     local.set $5
+     local.set $4
      local.get $0
      f64.const 1.5
      f64.sub
@@ -1223,7 +1221,7 @@
      local.set $0
     else
      i32.const 3
-     local.set $5
+     local.set $4
      f64.const -1
      local.get $0
      f64.div
@@ -1238,18 +1236,18 @@
   local.get $3
   local.get $3
   f64.mul
-  local.set $6
+  local.set $5
   local.get $3
   f64.const 0.3333333333333293
-  local.get $6
+  local.get $5
   f64.const 0.14285714272503466
-  local.get $6
+  local.get $5
   f64.const 0.09090887133436507
-  local.get $6
+  local.get $5
   f64.const 0.06661073137387531
-  local.get $6
+  local.get $5
   f64.const 0.049768779946159324
-  local.get $6
+  local.get $5
   f64.const 0.016285820115365782
   f64.mul
   f64.add
@@ -1262,16 +1260,16 @@
   f64.mul
   f64.add
   f64.mul
-  local.set $7
-  local.get $6
+  local.set $6
+  local.get $5
   f64.const -0.19999999999876483
-  local.get $6
+  local.get $5
   f64.const -0.11111110405462356
-  local.get $6
+  local.get $5
   f64.const -0.0769187620504483
-  local.get $6
+  local.get $5
   f64.const -0.058335701337905735
-  local.get $6
+  local.get $5
   f64.const -0.036531572744216916
   f64.mul
   f64.add
@@ -1282,19 +1280,19 @@
   f64.mul
   f64.add
   f64.mul
-  local.set $8
+  local.set $7
   local.get $0
+  local.get $6
   local.get $7
-  local.get $8
   f64.add
   f64.mul
-  local.set $9
-  local.get $5
+  local.set $8
+  local.get $4
   i32.const 0
   i32.lt_s
   if
    local.get $0
-   local.get $9
+   local.get $8
    f64.sub
    return
   end
@@ -1304,28 +1302,28 @@
      block $case2|0
       block $case1|0
        block $case0|0
-        local.get $5
-        local.set $10
-        local.get $10
+        local.get $4
+        local.set $9
+        local.get $9
         i32.const 0
         i32.eq
         br_if $case0|0
-        local.get $10
+        local.get $9
         i32.const 1
         i32.eq
         br_if $case1|0
-        local.get $10
+        local.get $9
         i32.const 2
         i32.eq
         br_if $case2|0
-        local.get $10
+        local.get $9
         i32.const 3
         i32.eq
         br_if $case3|0
         br $case4|0
        end
        f64.const 0.4636476090008061
-       local.get $9
+       local.get $8
        f64.const 2.2698777452961687e-17
        f64.sub
        local.get $0
@@ -1335,7 +1333,7 @@
        br $break|0
       end
       f64.const 0.7853981633974483
-      local.get $9
+      local.get $8
       f64.const 3.061616997868383e-17
       f64.sub
       local.get $0
@@ -1345,7 +1343,7 @@
       br $break|0
      end
      f64.const 0.982793723247329
-     local.get $9
+     local.get $8
      f64.const 1.3903311031230998e-17
      f64.sub
      local.get $0
@@ -1355,7 +1353,7 @@
      br $break|0
     end
     f64.const 1.5707963267948966
-    local.get $9
+    local.get $8
     f64.const 6.123233995736766e-17
     f64.sub
     local.get $0
@@ -1438,25 +1436,23 @@
   call $~lib/math/NativeMath.atanh
  )
  (func $~lib/math/NativeMath.atan2 (; 16 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
-  (local $2 f64)
-  (local $3 i64)
+  (local $2 i64)
+  (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 i32)
+  (local $9 f64)
   (local $10 f64)
   local.get $1
-  local.tee $2
-  local.get $2
+  local.get $1
   f64.ne
   if (result i32)
    i32.const 1
   else
    local.get $0
-   local.tee $2
-   local.get $2
+   local.get $0
    f64.ne
   end
   if
@@ -1467,30 +1463,30 @@
   end
   local.get $1
   i64.reinterpret_f64
-  local.set $3
-  local.get $3
+  local.set $2
+  local.get $2
   i64.const 32
   i64.shr_u
+  i32.wrap_i64
+  local.set $3
+  local.get $2
   i32.wrap_i64
   local.set $4
-  local.get $3
-  i32.wrap_i64
-  local.set $5
   local.get $0
   i64.reinterpret_f64
-  local.set $3
-  local.get $3
+  local.set $2
+  local.get $2
   i64.const 32
   i64.shr_u
+  i32.wrap_i64
+  local.set $5
+  local.get $2
   i32.wrap_i64
   local.set $6
   local.get $3
-  i32.wrap_i64
-  local.set $7
-  local.get $4
   i32.const 1072693248
   i32.sub
-  local.get $5
+  local.get $4
   i32.or
   i32.const 0
   i32.eq
@@ -1499,28 +1495,28 @@
    call $~lib/math/NativeMath.atan
    return
   end
-  local.get $6
+  local.get $5
   i32.const 31
   i32.shr_u
   i32.const 1
   i32.and
-  local.get $4
+  local.get $3
   i32.const 30
   i32.shr_u
   i32.const 2
   i32.and
   i32.or
-  local.set $8
-  local.get $4
+  local.set $7
+  local.get $3
   i32.const 2147483647
   i32.and
-  local.set $4
-  local.get $6
+  local.set $3
+  local.get $5
   i32.const 2147483647
   i32.and
-  local.set $6
+  local.set $5
+  local.get $5
   local.get $6
-  local.get $7
   i32.or
   i32.const 0
   i32.eq
@@ -1530,21 +1526,21 @@
      block $case2|0
       block $case1|0
        block $case0|0
+        local.get $7
+        local.set $8
         local.get $8
-        local.set $9
-        local.get $9
         i32.const 0
         i32.eq
         br_if $case0|0
-        local.get $9
+        local.get $8
         i32.const 1
         i32.eq
         br_if $case1|0
-        local.get $9
+        local.get $8
         i32.const 2
         i32.eq
         br_if $case2|0
-        local.get $9
+        local.get $8
         i32.const 3
         i32.eq
         br_if $case3|0
@@ -1562,13 +1558,13 @@
     return
    end
   end
+  local.get $3
   local.get $4
-  local.get $5
   i32.or
   i32.const 0
   i32.eq
   if
-   local.get $8
+   local.get $7
    i32.const 1
    i32.and
    if (result f64)
@@ -1583,15 +1579,15 @@
    end
    return
   end
-  local.get $4
+  local.get $3
   i32.const 2146435072
   i32.eq
   if
-   local.get $6
+   local.get $5
    i32.const 2146435072
    i32.eq
    if
-    local.get $8
+    local.get $7
     i32.const 2
     i32.and
     if (result f64)
@@ -1606,19 +1602,19 @@
      f64.const 4
      f64.div
     end
-    local.set $2
-    local.get $8
+    local.set $9
+    local.get $7
     i32.const 1
     i32.and
     if (result f64)
-     local.get $2
+     local.get $9
      f64.neg
     else
-     local.get $2
+     local.get $9
     end
     return
    else
-    local.get $8
+    local.get $7
     i32.const 2
     i32.and
     if (result f64)
@@ -1627,34 +1623,34 @@
      i32.const 0
      f64.convert_i32_s
     end
-    local.set $2
-    local.get $8
+    local.set $9
+    local.get $7
     i32.const 1
     i32.and
     if (result f64)
-     local.get $2
+     local.get $9
      f64.neg
     else
-     local.get $2
+     local.get $9
     end
     return
    end
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 67108864
   i32.add
-  local.get $6
+  local.get $5
   i32.lt_u
   if (result i32)
    i32.const 1
   else
-   local.get $6
+   local.get $5
    i32.const 2146435072
    i32.eq
   end
   if
-   local.get $8
+   local.get $7
    i32.const 1
    i32.and
    if (result f64)
@@ -1669,14 +1665,14 @@
    end
    return
   end
-  local.get $8
+  local.get $7
   i32.const 2
   i32.and
   if (result i32)
-   local.get $6
+   local.get $5
    i32.const 67108864
    i32.add
-   local.get $4
+   local.get $3
    i32.lt_u
   else
    i32.const 0
@@ -1697,21 +1693,21 @@
     block $case2|1
      block $case1|1
       block $case0|1
+       local.get $7
+       local.set $8
        local.get $8
-       local.set $9
-       local.get $9
        i32.const 0
        i32.eq
        br_if $case0|1
-       local.get $9
+       local.get $8
        i32.const 1
        i32.eq
        br_if $case1|1
-       local.get $9
+       local.get $8
        i32.const 2
        i32.eq
        br_if $case2|1
-       local.get $9
+       local.get $8
        i32.const 3
        i32.eq
        br_if $case3|1
@@ -1972,10 +1968,8 @@
   return
  )
  (func $~lib/math/NativeMath.clz32 (; 22 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
-  (local $1 f64)
   local.get $0
-  local.tee $1
-  local.get $1
+  local.get $0
   f64.sub
   f64.const 0
   f64.eq
@@ -2955,8 +2949,7 @@
   i32.ge_u
   if
    local.get $0
-   local.tee $5
-   local.get $5
+   local.get $0
    f64.ne
    if
     local.get $0
@@ -2978,7 +2971,7 @@
    end
   end
   f64.const 0
-  local.set $6
+  local.set $5
   local.get $2
   i32.const 1071001154
   i32.gt_u
@@ -3003,27 +2996,27 @@
    local.set $3
    local.get $3
    f64.convert_i32_s
-   local.set $7
+   local.set $6
    local.get $0
-   local.get $7
+   local.get $6
    f64.const 0.6931471803691238
    f64.mul
    f64.sub
-   local.set $5
-   local.get $7
+   local.set $7
+   local.get $6
    f64.const 1.9082149292705877e-10
    f64.mul
    local.set $8
-   local.get $5
+   local.get $7
    local.get $8
    f64.sub
    local.set $0
-   local.get $5
+   local.get $7
    local.get $0
    f64.sub
    local.get $8
    f64.sub
-   local.set $6
+   local.set $5
   else
    local.get $2
    i32.const 1016070144
@@ -3072,14 +3065,14 @@
   local.get $9
   f64.mul
   f64.sub
-  local.set $7
+  local.set $6
   local.get $10
   local.get $12
-  local.get $7
+  local.get $6
   f64.sub
   f64.const 6
   local.get $0
-  local.get $7
+  local.get $6
   f64.mul
   f64.sub
   f64.div
@@ -3100,10 +3093,10 @@
   end
   local.get $0
   local.get $13
-  local.get $6
+  local.get $5
   f64.sub
   f64.mul
-  local.get $6
+  local.get $5
   f64.sub
   local.set $13
   local.get $13
@@ -3327,12 +3320,11 @@
   (local $2 i32)
   (local $3 f64)
   (local $4 f64)
-  (local $5 f64)
-  (local $6 i32)
+  (local $5 i32)
+  (local $6 f64)
   (local $7 f64)
   (local $8 f64)
   (local $9 f64)
-  (local $10 f64)
   local.get $0
   i64.reinterpret_f64
   i64.const 32
@@ -3352,8 +3344,7 @@
   i32.ge_u
   if
    local.get $0
-   local.tee $3
-   local.get $3
+   local.get $0
    f64.ne
    if
     local.get $0
@@ -3377,9 +3368,9 @@
    end
   end
   f64.const 0
-  local.set $5
+  local.set $4
   i32.const 0
-  local.set $6
+  local.set $5
   local.get $1
   i32.const 1071001154
   i32.gt_u
@@ -3396,29 +3387,29 @@
     f64.copysign
     f64.add
     i32.trunc_f64_s
-    local.set $6
+    local.set $5
    else
     i32.const 1
     local.get $2
     i32.const 1
     i32.shl
     i32.sub
-    local.set $6
+    local.set $5
    end
    local.get $0
-   local.get $6
+   local.get $5
    f64.convert_i32_s
    f64.const 0.6931471803691238
    f64.mul
    f64.sub
-   local.set $4
-   local.get $6
+   local.set $3
+   local.get $5
    f64.convert_i32_s
    f64.const 1.9082149292705877e-10
    f64.mul
-   local.set $5
+   local.set $4
+   local.get $3
    local.get $4
-   local.get $5
    f64.sub
    local.set $0
   else
@@ -3427,7 +3418,7 @@
    i32.gt_u
    if
     local.get $0
-    local.set $4
+    local.set $3
    else
     f64.const 1
     local.get $0
@@ -3438,24 +3429,24 @@
   local.get $0
   local.get $0
   f64.mul
-  local.set $7
-  local.get $7
-  local.get $7
+  local.set $6
+  local.get $6
+  local.get $6
   f64.mul
-  local.set $8
+  local.set $7
   local.get $0
-  local.get $7
+  local.get $6
   f64.const 0.16666666666666602
   f64.mul
-  local.get $8
-  f64.const -2.7777777777015593e-03
   local.get $7
+  f64.const -2.7777777777015593e-03
+  local.get $6
   f64.const 6.613756321437934e-05
   f64.mul
   f64.add
-  local.get $8
-  f64.const -1.6533902205465252e-06
   local.get $7
+  f64.const -1.6533902205465252e-06
+  local.get $6
   f64.const 4.1381367970572385e-08
   f64.mul
   f64.add
@@ -3464,30 +3455,30 @@
   f64.mul
   f64.add
   f64.sub
-  local.set $9
+  local.set $8
   f64.const 1
   local.get $0
-  local.get $9
+  local.get $8
   f64.mul
   f64.const 2
-  local.get $9
+  local.get $8
   f64.sub
   f64.div
-  local.get $5
-  f64.sub
   local.get $4
+  f64.sub
+  local.get $3
   f64.add
   f64.add
-  local.set $10
-  local.get $6
+  local.set $9
+  local.get $5
   i32.const 0
   i32.eq
   if
-   local.get $10
+   local.get $9
    return
   end
-  local.get $10
-  local.get $6
+  local.get $9
+  local.get $5
   call $~lib/math/NativeMath.scalbn
  )
  (func $~lib/math/NativeMath.cosh (; 30 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
@@ -7563,13 +7554,12 @@
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
-  (local $4 f32)
-  (local $5 i32)
+  (local $4 i32)
+  (local $5 f32)
   (local $6 f32)
   (local $7 f32)
   (local $8 f32)
-  (local $9 f32)
-  (local $10 i32)
+  (local $9 i32)
   local.get $0
   i32.reinterpret_f32
   local.set $1
@@ -7584,8 +7574,7 @@
   i32.ge_u
   if
    local.get $0
-   local.tee $4
-   local.get $4
+   local.get $0
    f32.ne
    if
     local.get $0
@@ -7612,7 +7601,7 @@
     return
    end
    i32.const -1
-   local.set $5
+   local.set $4
   else
    local.get $0
    f32.abs
@@ -7626,7 +7615,7 @@
     i32.lt_u
     if
      i32.const 0
-     local.set $5
+     local.set $4
      f32.const 2
      local.get $0
      f32.mul
@@ -7639,7 +7628,7 @@
      local.set $0
     else
      i32.const 1
-     local.set $5
+     local.set $4
      local.get $0
      f32.const 1
      f32.sub
@@ -7655,7 +7644,7 @@
     i32.lt_u
     if
      i32.const 2
-     local.set $5
+     local.set $4
      local.get $0
      f32.const 1.5
      f32.sub
@@ -7668,7 +7657,7 @@
      local.set $0
     else
      i32.const 3
-     local.set $5
+     local.set $4
      f32.const -1
      local.get $0
      f32.div
@@ -7683,39 +7672,39 @@
   local.get $3
   local.get $3
   f32.mul
-  local.set $6
+  local.set $5
   local.get $3
   f32.const 0.333333283662796
-  local.get $6
+  local.get $5
   f32.const 0.14253635704517365
-  local.get $6
+  local.get $5
   f32.const 0.06168760731816292
   f32.mul
   f32.add
   f32.mul
   f32.add
   f32.mul
-  local.set $7
-  local.get $6
+  local.set $6
+  local.get $5
   f32.const -0.19999158382415771
-  local.get $6
+  local.get $5
   f32.const -0.106480173766613
   f32.mul
   f32.add
   f32.mul
-  local.set $8
+  local.set $7
   local.get $0
+  local.get $6
   local.get $7
-  local.get $8
   f32.add
   f32.mul
-  local.set $9
-  local.get $5
+  local.set $8
+  local.get $4
   i32.const 0
   i32.lt_s
   if
    local.get $0
-   local.get $9
+   local.get $8
    f32.sub
    return
   end
@@ -7725,28 +7714,28 @@
      block $case2|0
       block $case1|0
        block $case0|0
-        local.get $5
-        local.set $10
-        local.get $10
+        local.get $4
+        local.set $9
+        local.get $9
         i32.const 0
         i32.eq
         br_if $case0|0
-        local.get $10
+        local.get $9
         i32.const 1
         i32.eq
         br_if $case1|0
-        local.get $10
+        local.get $9
         i32.const 2
         i32.eq
         br_if $case2|0
-        local.get $10
+        local.get $9
         i32.const 3
         i32.eq
         br_if $case3|0
         br $case4|0
        end
        f32.const 0.46364760398864746
-       local.get $9
+       local.get $8
        f32.const 5.01215824399992e-09
        f32.sub
        local.get $0
@@ -7756,7 +7745,7 @@
        br $break|0
       end
       f32.const 0.7853981256484985
-      local.get $9
+      local.get $8
       f32.const 3.774894707930798e-08
       f32.sub
       local.get $0
@@ -7766,7 +7755,7 @@
       br $break|0
      end
      f32.const 0.9827936887741089
-     local.get $9
+     local.get $8
      f32.const 3.447321716976148e-08
      f32.sub
      local.get $0
@@ -7776,7 +7765,7 @@
      br $break|0
     end
     f32.const 1.570796251296997
-    local.get $9
+    local.get $8
     f32.const 7.549789415861596e-08
     f32.sub
     local.get $0
@@ -7850,22 +7839,20 @@
   call $~lib/math/NativeMathf.atanh
  )
  (func $~lib/math/NativeMathf.atan2 (; 79 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
-  (local $2 f32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
+  (local $6 f32)
   (local $7 f32)
   local.get $1
-  local.tee $2
-  local.get $2
+  local.get $1
   f32.ne
   if (result i32)
    i32.const 1
   else
    local.get $0
-   local.tee $2
-   local.get $2
+   local.get $0
    f32.ne
   end
   if
@@ -7876,11 +7863,11 @@
   end
   local.get $1
   i32.reinterpret_f32
-  local.set $3
+  local.set $2
   local.get $0
   i32.reinterpret_f32
-  local.set $4
-  local.get $3
+  local.set $3
+  local.get $2
   i32.const 1065353216
   i32.eq
   if
@@ -7888,27 +7875,27 @@
    call $~lib/math/NativeMathf.atan
    return
   end
-  local.get $4
+  local.get $3
   i32.const 31
   i32.shr_u
   i32.const 1
   i32.and
-  local.get $3
+  local.get $2
   i32.const 30
   i32.shr_u
   i32.const 2
   i32.and
   i32.or
-  local.set $5
+  local.set $4
+  local.get $2
+  i32.const 2147483647
+  i32.and
+  local.set $2
   local.get $3
   i32.const 2147483647
   i32.and
   local.set $3
-  local.get $4
-  i32.const 2147483647
-  i32.and
-  local.set $4
-  local.get $4
+  local.get $3
   i32.const 0
   i32.eq
   if
@@ -7917,21 +7904,21 @@
      block $case2|0
       block $case1|0
        block $case0|0
+        local.get $4
+        local.set $5
         local.get $5
-        local.set $6
-        local.get $6
         i32.const 0
         i32.eq
         br_if $case0|0
-        local.get $6
+        local.get $5
         i32.const 1
         i32.eq
         br_if $case1|0
-        local.get $6
+        local.get $5
         i32.const 2
         i32.eq
         br_if $case2|0
-        local.get $6
+        local.get $5
         i32.const 3
         i32.eq
         br_if $case3|0
@@ -7949,11 +7936,11 @@
     return
    end
   end
-  local.get $3
+  local.get $2
   i32.const 0
   i32.eq
   if
-   local.get $5
+   local.get $4
    i32.const 1
    i32.and
    if (result f32)
@@ -7968,15 +7955,15 @@
    end
    return
   end
-  local.get $3
+  local.get $2
   i32.const 2139095040
   i32.eq
   if
-   local.get $4
+   local.get $3
    i32.const 2139095040
    i32.eq
    if
-    local.get $5
+    local.get $4
     i32.const 2
     i32.and
     if (result f32)
@@ -7990,19 +7977,19 @@
      f32.const 4
      f32.div
     end
-    local.set $2
-    local.get $5
+    local.set $6
+    local.get $4
     i32.const 1
     i32.and
     if (result f32)
-     local.get $2
+     local.get $6
      f32.neg
     else
-     local.get $2
+     local.get $6
     end
     return
    else
-    local.get $5
+    local.get $4
     i32.const 2
     i32.and
     if (result f32)
@@ -8010,34 +7997,34 @@
     else
      f32.const 0
     end
-    local.set $2
-    local.get $5
+    local.set $6
+    local.get $4
     i32.const 1
     i32.and
     if (result f32)
-     local.get $2
+     local.get $6
      f32.neg
     else
-     local.get $2
+     local.get $6
     end
     return
    end
    unreachable
   end
-  local.get $3
+  local.get $2
   i32.const 218103808
   i32.add
-  local.get $4
+  local.get $3
   i32.lt_u
   if (result i32)
    i32.const 1
   else
-   local.get $4
+   local.get $3
    i32.const 2139095040
    i32.eq
   end
   if
-   local.get $5
+   local.get $4
    i32.const 1
    i32.and
    if (result f32)
@@ -8052,14 +8039,14 @@
    end
    return
   end
-  local.get $5
+  local.get $4
   i32.const 2
   i32.and
   if (result i32)
-   local.get $4
+   local.get $3
    i32.const 218103808
    i32.add
-   local.get $3
+   local.get $2
    i32.lt_u
   else
    i32.const 0
@@ -8080,21 +8067,21 @@
     block $case2|1
      block $case1|1
       block $case0|1
+       local.get $4
+       local.set $5
        local.get $5
-       local.set $6
-       local.get $6
        i32.const 0
        i32.eq
        br_if $case0|1
-       local.get $6
+       local.get $5
        i32.const 1
        i32.eq
        br_if $case1|1
-       local.get $6
+       local.get $5
        i32.const 2
        i32.eq
        br_if $case2|1
-       local.get $6
+       local.get $5
        i32.const 3
        i32.eq
        br_if $case3|1
@@ -8256,10 +8243,8 @@
   f32.ceil
  )
  (func $~lib/math/NativeMathf.clz32 (; 84 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
-  (local $1 f32)
   local.get $0
-  local.tee $1
-  local.get $1
+  local.get $0
   f32.sub
   f32.const 0
   f32.eq

--- a/tests/compiler/std/libm.untouched.wat
+++ b/tests/compiler/std/libm.untouched.wat
@@ -1,12 +1,11 @@
 (module
  (type $FUNCSIG$dd (func (param f64) (result f64)))
- (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))
+ (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$idj (func (param f64 i64) (result i32)))
  (type $FUNCSIG$ddi (func (param f64 i32) (result f64)))
  (type $FUNCSIG$dddi (func (param f64 f64 i32) (result f64)))
  (type $FUNCSIG$ff (func (param f32) (result f32)))
- (type $FUNCSIG$if (func (param f32) (result i32)))
  (type $FUNCSIG$fff (func (param f32 f32) (result f32)))
  (type $FUNCSIG$ffi (func (param f32 i32) (result f32)))
  (type $FUNCSIG$v (func))
@@ -1111,21 +1110,17 @@
   local.get $0
   call $~lib/math/NativeMath.asinh
  )
- (func $~lib/number/isNaN<f64> (; 12 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.ne
- )
- (func $~lib/math/NativeMath.atan (; 13 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atan (; 12 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 f64)
   (local $3 f64)
-  (local $4 i32)
-  (local $5 f64)
+  (local $4 f64)
+  (local $5 i32)
   (local $6 f64)
   (local $7 f64)
   (local $8 f64)
-  (local $9 i32)
+  (local $9 f64)
+  (local $10 i32)
   local.get $0
   i64.reinterpret_f64
   i64.const 32
@@ -1143,7 +1138,9 @@
   i32.ge_u
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.tee $4
+   local.get $4
+   f64.ne
    if
     local.get $0
     return
@@ -1170,7 +1167,7 @@
     return
    end
    i32.const -1
-   local.set $4
+   local.set $5
   else
    local.get $0
    f64.abs
@@ -1184,7 +1181,7 @@
     i32.lt_u
     if
      i32.const 0
-     local.set $4
+     local.set $5
      f64.const 2
      local.get $0
      f64.mul
@@ -1197,7 +1194,7 @@
      local.set $0
     else
      i32.const 1
-     local.set $4
+     local.set $5
      local.get $0
      f64.const 1
      f64.sub
@@ -1213,7 +1210,7 @@
     i32.lt_u
     if
      i32.const 2
-     local.set $4
+     local.set $5
      local.get $0
      f64.const 1.5
      f64.sub
@@ -1226,7 +1223,7 @@
      local.set $0
     else
      i32.const 3
-     local.set $4
+     local.set $5
      f64.const -1
      local.get $0
      f64.div
@@ -1241,18 +1238,18 @@
   local.get $3
   local.get $3
   f64.mul
-  local.set $5
+  local.set $6
   local.get $3
   f64.const 0.3333333333333293
-  local.get $5
+  local.get $6
   f64.const 0.14285714272503466
-  local.get $5
+  local.get $6
   f64.const 0.09090887133436507
-  local.get $5
+  local.get $6
   f64.const 0.06661073137387531
-  local.get $5
+  local.get $6
   f64.const 0.049768779946159324
-  local.get $5
+  local.get $6
   f64.const 0.016285820115365782
   f64.mul
   f64.add
@@ -1265,16 +1262,16 @@
   f64.mul
   f64.add
   f64.mul
-  local.set $6
-  local.get $5
+  local.set $7
+  local.get $6
   f64.const -0.19999999999876483
-  local.get $5
+  local.get $6
   f64.const -0.11111110405462356
-  local.get $5
+  local.get $6
   f64.const -0.0769187620504483
-  local.get $5
+  local.get $6
   f64.const -0.058335701337905735
-  local.get $5
+  local.get $6
   f64.const -0.036531572744216916
   f64.mul
   f64.add
@@ -1285,19 +1282,19 @@
   f64.mul
   f64.add
   f64.mul
-  local.set $7
+  local.set $8
   local.get $0
-  local.get $6
   local.get $7
+  local.get $8
   f64.add
   f64.mul
-  local.set $8
-  local.get $4
+  local.set $9
+  local.get $5
   i32.const 0
   i32.lt_s
   if
    local.get $0
-   local.get $8
+   local.get $9
    f64.sub
    return
   end
@@ -1307,28 +1304,28 @@
      block $case2|0
       block $case1|0
        block $case0|0
-        local.get $4
-        local.set $9
-        local.get $9
+        local.get $5
+        local.set $10
+        local.get $10
         i32.const 0
         i32.eq
         br_if $case0|0
-        local.get $9
+        local.get $10
         i32.const 1
         i32.eq
         br_if $case1|0
-        local.get $9
+        local.get $10
         i32.const 2
         i32.eq
         br_if $case2|0
-        local.get $9
+        local.get $10
         i32.const 3
         i32.eq
         br_if $case3|0
         br $case4|0
        end
        f64.const 0.4636476090008061
-       local.get $8
+       local.get $9
        f64.const 2.2698777452961687e-17
        f64.sub
        local.get $0
@@ -1338,7 +1335,7 @@
        br $break|0
       end
       f64.const 0.7853981633974483
-      local.get $8
+      local.get $9
       f64.const 3.061616997868383e-17
       f64.sub
       local.get $0
@@ -1348,7 +1345,7 @@
       br $break|0
      end
      f64.const 0.982793723247329
-     local.get $8
+     local.get $9
      f64.const 1.3903311031230998e-17
      f64.sub
      local.get $0
@@ -1358,7 +1355,7 @@
      br $break|0
     end
     f64.const 1.5707963267948966
-    local.get $8
+    local.get $9
     f64.const 6.123233995736766e-17
     f64.sub
     local.get $0
@@ -1373,11 +1370,11 @@
   local.get $2
   f64.copysign
  )
- (func $../../lib/libm/assembly/libm/atan (; 14 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/atan (; 13 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.atan
  )
- (func $~lib/math/NativeMath.atanh (; 15 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atanh (; 14 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i64)
   (local $3 f64)
@@ -1436,27 +1433,31 @@
   local.get $0
   f64.copysign
  )
- (func $../../lib/libm/assembly/libm/atanh (; 16 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/atanh (; 15 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.atanh
  )
- (func $~lib/math/NativeMath.atan2 (; 17 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
-  (local $2 i64)
-  (local $3 i32)
+ (func $~lib/math/NativeMath.atan2 (; 16 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+  (local $2 f64)
+  (local $3 i64)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 f64)
+  (local $9 i32)
   (local $10 f64)
   local.get $1
-  call $~lib/number/isNaN<f64>
+  local.tee $2
+  local.get $2
+  f64.ne
   if (result i32)
    i32.const 1
   else
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.tee $2
+   local.get $2
+   f64.ne
   end
   if
    local.get $1
@@ -1466,30 +1467,30 @@
   end
   local.get $1
   i64.reinterpret_f64
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   i64.const 32
   i64.shr_u
-  i32.wrap_i64
-  local.set $3
-  local.get $2
   i32.wrap_i64
   local.set $4
-  local.get $0
-  i64.reinterpret_f64
-  local.set $2
-  local.get $2
-  i64.const 32
-  i64.shr_u
+  local.get $3
   i32.wrap_i64
   local.set $5
-  local.get $2
+  local.get $0
+  i64.reinterpret_f64
+  local.set $3
+  local.get $3
+  i64.const 32
+  i64.shr_u
   i32.wrap_i64
   local.set $6
   local.get $3
+  i32.wrap_i64
+  local.set $7
+  local.get $4
   i32.const 1072693248
   i32.sub
-  local.get $4
+  local.get $5
   i32.or
   i32.const 0
   i32.eq
@@ -1498,28 +1499,28 @@
    call $~lib/math/NativeMath.atan
    return
   end
-  local.get $5
+  local.get $6
   i32.const 31
   i32.shr_u
   i32.const 1
   i32.and
-  local.get $3
+  local.get $4
   i32.const 30
   i32.shr_u
   i32.const 2
   i32.and
   i32.or
-  local.set $7
-  local.get $3
+  local.set $8
+  local.get $4
   i32.const 2147483647
   i32.and
-  local.set $3
-  local.get $5
-  i32.const 2147483647
-  i32.and
-  local.set $5
-  local.get $5
+  local.set $4
   local.get $6
+  i32.const 2147483647
+  i32.and
+  local.set $6
+  local.get $6
+  local.get $7
   i32.or
   i32.const 0
   i32.eq
@@ -1529,21 +1530,21 @@
      block $case2|0
       block $case1|0
        block $case0|0
-        local.get $7
-        local.set $8
         local.get $8
+        local.set $9
+        local.get $9
         i32.const 0
         i32.eq
         br_if $case0|0
-        local.get $8
+        local.get $9
         i32.const 1
         i32.eq
         br_if $case1|0
-        local.get $8
+        local.get $9
         i32.const 2
         i32.eq
         br_if $case2|0
-        local.get $8
+        local.get $9
         i32.const 3
         i32.eq
         br_if $case3|0
@@ -1561,13 +1562,13 @@
     return
    end
   end
-  local.get $3
   local.get $4
+  local.get $5
   i32.or
   i32.const 0
   i32.eq
   if
-   local.get $7
+   local.get $8
    i32.const 1
    i32.and
    if (result f64)
@@ -1582,15 +1583,15 @@
    end
    return
   end
-  local.get $3
+  local.get $4
   i32.const 2146435072
   i32.eq
   if
-   local.get $5
+   local.get $6
    i32.const 2146435072
    i32.eq
    if
-    local.get $7
+    local.get $8
     i32.const 2
     i32.and
     if (result f64)
@@ -1605,19 +1606,19 @@
      f64.const 4
      f64.div
     end
-    local.set $9
-    local.get $7
+    local.set $2
+    local.get $8
     i32.const 1
     i32.and
     if (result f64)
-     local.get $9
+     local.get $2
      f64.neg
     else
-     local.get $9
+     local.get $2
     end
     return
    else
-    local.get $7
+    local.get $8
     i32.const 2
     i32.and
     if (result f64)
@@ -1626,34 +1627,34 @@
      i32.const 0
      f64.convert_i32_s
     end
-    local.set $9
-    local.get $7
+    local.set $2
+    local.get $8
     i32.const 1
     i32.and
     if (result f64)
-     local.get $9
+     local.get $2
      f64.neg
     else
-     local.get $9
+     local.get $2
     end
     return
    end
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 67108864
   i32.add
-  local.get $5
+  local.get $6
   i32.lt_u
   if (result i32)
    i32.const 1
   else
-   local.get $5
+   local.get $6
    i32.const 2146435072
    i32.eq
   end
   if
-   local.get $7
+   local.get $8
    i32.const 1
    i32.and
    if (result f64)
@@ -1668,14 +1669,14 @@
    end
    return
   end
-  local.get $7
+  local.get $8
   i32.const 2
   i32.and
   if (result i32)
-   local.get $5
+   local.get $6
    i32.const 67108864
    i32.add
-   local.get $3
+   local.get $4
    i32.lt_u
   else
    i32.const 0
@@ -1696,21 +1697,21 @@
     block $case2|1
      block $case1|1
       block $case0|1
-       local.get $7
-       local.set $8
        local.get $8
+       local.set $9
+       local.get $9
        i32.const 0
        i32.eq
        br_if $case0|1
-       local.get $8
+       local.get $9
        i32.const 1
        i32.eq
        br_if $case1|1
-       local.get $8
+       local.get $9
        i32.const 2
        i32.eq
        br_if $case2|1
-       local.get $8
+       local.get $9
        i32.const 3
        i32.eq
        br_if $case3|1
@@ -1739,12 +1740,12 @@
   end
   unreachable
  )
- (func $../../lib/libm/assembly/libm/atan2 (; 18 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/atan2 (; 17 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.atan2
  )
- (func $~lib/math/NativeMath.cbrt (; 19 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cbrt (; 18 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 f64)
@@ -1888,25 +1889,18 @@
   local.set $3
   local.get $3
  )
- (func $../../lib/libm/assembly/libm/cbrt (; 20 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/cbrt (; 19 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.cbrt
  )
- (func $../../lib/libm/assembly/libm/ceil (; 21 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/ceil (; 20 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   local.get $0
   local.set $1
   local.get $1
   f64.ceil
  )
- (func $~lib/number/isFinite<f64> (; 22 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.sub
-  f64.const 0
-  f64.eq
- )
- (func $~lib/math/dtoi32 (; 23 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/math/dtoi32 (; 21 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i64)
   (local $3 i64)
@@ -1977,9 +1971,14 @@
   local.get $1
   return
  )
- (func $~lib/math/NativeMath.clz32 (; 24 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.clz32 (; 22 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+  (local $1 f64)
   local.get $0
-  call $~lib/number/isFinite<f64>
+  local.tee $1
+  local.get $1
+  f64.sub
+  f64.const 0
+  f64.eq
   i32.eqz
   if
    f64.const 32
@@ -1990,11 +1989,11 @@
   i32.clz
   f64.convert_i32_s
  )
- (func $../../lib/libm/assembly/libm/clz32 (; 25 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/clz32 (; 23 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.clz32
  )
- (func $~lib/math/pio2_large_quot (; 26 ;) (type $FUNCSIG$idj) (param $0 f64) (param $1 i64) (result i32)
+ (func $~lib/math/pio2_large_quot (; 24 ;) (type $FUNCSIG$idj) (param $0 f64) (param $1 i64) (result i32)
   (local $2 i32)
   (local $3 i64)
   (local $4 i64)
@@ -2396,7 +2395,7 @@
   local.get $31
   i32.wrap_i64
  )
- (func $~lib/math/NativeMath.cos (; 27 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cos (; 25 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -2914,11 +2913,11 @@
    local.get $0
   end
  )
- (func $../../lib/libm/assembly/libm/cos (; 28 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/cos (; 26 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.cos
  )
- (func $~lib/math/NativeMath.expm1 (; 29 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.expm1 (; 27 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -2956,7 +2955,9 @@
   i32.ge_u
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.tee $5
+   local.get $5
+   f64.ne
    if
     local.get $0
     return
@@ -2977,7 +2978,7 @@
    end
   end
   f64.const 0
-  local.set $5
+  local.set $6
   local.get $2
   i32.const 1071001154
   i32.gt_u
@@ -3002,27 +3003,27 @@
    local.set $3
    local.get $3
    f64.convert_i32_s
-   local.set $6
+   local.set $7
    local.get $0
-   local.get $6
+   local.get $7
    f64.const 0.6931471803691238
    f64.mul
    f64.sub
-   local.set $7
-   local.get $6
+   local.set $5
+   local.get $7
    f64.const 1.9082149292705877e-10
    f64.mul
    local.set $8
-   local.get $7
+   local.get $5
    local.get $8
    f64.sub
    local.set $0
-   local.get $7
+   local.get $5
    local.get $0
    f64.sub
    local.get $8
    f64.sub
-   local.set $5
+   local.set $6
   else
    local.get $2
    i32.const 1016070144
@@ -3071,14 +3072,14 @@
   local.get $9
   f64.mul
   f64.sub
-  local.set $6
+  local.set $7
   local.get $10
   local.get $12
-  local.get $6
+  local.get $7
   f64.sub
   f64.const 6
   local.get $0
-  local.get $6
+  local.get $7
   f64.mul
   f64.sub
   f64.div
@@ -3099,10 +3100,10 @@
   end
   local.get $0
   local.get $13
-  local.get $5
+  local.get $6
   f64.sub
   f64.mul
-  local.get $5
+  local.get $6
   f64.sub
   local.set $13
   local.get $13
@@ -3230,7 +3231,7 @@
   local.get $14
   f64.mul
  )
- (func $~lib/math/NativeMath.scalbn (; 30 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/NativeMath.scalbn (; 28 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
@@ -3321,16 +3322,17 @@
   f64.reinterpret_i64
   f64.mul
  )
- (func $~lib/math/NativeMath.exp (; 31 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.exp (; 29 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
   (local $4 f64)
-  (local $5 i32)
-  (local $6 f64)
+  (local $5 f64)
+  (local $6 i32)
   (local $7 f64)
   (local $8 f64)
   (local $9 f64)
+  (local $10 f64)
   local.get $0
   i64.reinterpret_f64
   i64.const 32
@@ -3350,7 +3352,9 @@
   i32.ge_u
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.tee $3
+   local.get $3
+   f64.ne
    if
     local.get $0
     return
@@ -3373,9 +3377,9 @@
    end
   end
   f64.const 0
-  local.set $4
-  i32.const 0
   local.set $5
+  i32.const 0
+  local.set $6
   local.get $1
   i32.const 1071001154
   i32.gt_u
@@ -3392,29 +3396,29 @@
     f64.copysign
     f64.add
     i32.trunc_f64_s
-    local.set $5
+    local.set $6
    else
     i32.const 1
     local.get $2
     i32.const 1
     i32.shl
     i32.sub
-    local.set $5
+    local.set $6
    end
    local.get $0
-   local.get $5
+   local.get $6
    f64.convert_i32_s
    f64.const 0.6931471803691238
    f64.mul
    f64.sub
-   local.set $3
-   local.get $5
+   local.set $4
+   local.get $6
    f64.convert_i32_s
    f64.const 1.9082149292705877e-10
    f64.mul
-   local.set $4
-   local.get $3
+   local.set $5
    local.get $4
+   local.get $5
    f64.sub
    local.set $0
   else
@@ -3423,7 +3427,7 @@
    i32.gt_u
    if
     local.get $0
-    local.set $3
+    local.set $4
    else
     f64.const 1
     local.get $0
@@ -3434,24 +3438,24 @@
   local.get $0
   local.get $0
   f64.mul
-  local.set $6
-  local.get $6
-  local.get $6
-  f64.mul
   local.set $7
+  local.get $7
+  local.get $7
+  f64.mul
+  local.set $8
   local.get $0
-  local.get $6
+  local.get $7
   f64.const 0.16666666666666602
   f64.mul
-  local.get $7
+  local.get $8
   f64.const -2.7777777777015593e-03
-  local.get $6
+  local.get $7
   f64.const 6.613756321437934e-05
   f64.mul
   f64.add
-  local.get $7
+  local.get $8
   f64.const -1.6533902205465252e-06
-  local.get $6
+  local.get $7
   f64.const 4.1381367970572385e-08
   f64.mul
   f64.add
@@ -3460,33 +3464,33 @@
   f64.mul
   f64.add
   f64.sub
-  local.set $8
+  local.set $9
   f64.const 1
   local.get $0
-  local.get $8
+  local.get $9
   f64.mul
   f64.const 2
-  local.get $8
+  local.get $9
   f64.sub
   f64.div
-  local.get $4
-  f64.sub
-  local.get $3
-  f64.add
-  f64.add
-  local.set $9
   local.get $5
+  f64.sub
+  local.get $4
+  f64.add
+  f64.add
+  local.set $10
+  local.get $6
   i32.const 0
   i32.eq
   if
-   local.get $9
+   local.get $10
    return
   end
-  local.get $9
-  local.get $5
+  local.get $10
+  local.get $6
   call $~lib/math/NativeMath.scalbn
  )
- (func $~lib/math/NativeMath.cosh (; 32 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cosh (; 30 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 f64)
@@ -3575,26 +3579,26 @@
   local.set $3
   local.get $3
  )
- (func $../../lib/libm/assembly/libm/cosh (; 33 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/cosh (; 31 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.cosh
  )
- (func $../../lib/libm/assembly/libm/exp (; 34 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/exp (; 32 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.exp
  )
- (func $../../lib/libm/assembly/libm/expm1 (; 35 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/expm1 (; 33 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.expm1
  )
- (func $../../lib/libm/assembly/libm/floor (; 36 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/floor (; 34 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   local.get $0
   local.set $1
   local.get $1
   f64.floor
  )
- (func $../../lib/libm/assembly/libm/fround (; 37 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/fround (; 35 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   local.get $0
   local.set $1
@@ -3602,7 +3606,7 @@
   f32.demote_f64
   f64.promote_f32
  )
- (func $~lib/math/NativeMath.hypot (; 38 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.hypot (; 36 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -3797,16 +3801,21 @@
   f64.sqrt
   f64.mul
  )
- (func $../../lib/libm/assembly/libm/hypot (; 39 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/hypot (; 37 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.hypot
  )
- (func $~lib/math/NativeMath.imul (; 40 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.imul (; 38 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+  (local $2 f64)
   local.get $0
   local.get $1
   f64.add
-  call $~lib/number/isFinite<f64>
+  local.tee $2
+  local.get $2
+  f64.sub
+  f64.const 0
+  f64.eq
   i32.eqz
   if
    f64.const 0
@@ -3819,16 +3828,16 @@
   i32.mul
   f64.convert_i32_s
  )
- (func $../../lib/libm/assembly/libm/imul (; 41 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/imul (; 39 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.imul
  )
- (func $../../lib/libm/assembly/libm/log (; 42 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/log (; 40 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.log
  )
- (func $~lib/math/NativeMath.log10 (; 43 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log10 (; 41 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -4088,15 +4097,15 @@
   local.get $8
   f64.add
  )
- (func $../../lib/libm/assembly/libm/log10 (; 44 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/log10 (; 42 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.log10
  )
- (func $../../lib/libm/assembly/libm/log1p (; 45 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/log1p (; 43 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.log1p
  )
- (func $~lib/math/NativeMath.log2 (; 46 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log2 (; 44 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -4349,11 +4358,11 @@
   local.get $14
   f64.add
  )
- (func $../../lib/libm/assembly/libm/log2 (; 47 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/log2 (; 45 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.log2
  )
- (func $../../lib/libm/assembly/libm/max (; 48 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/max (; 46 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 f64)
   local.get $0
@@ -4364,7 +4373,7 @@
   local.get $2
   f64.max
  )
- (func $../../lib/libm/assembly/libm/min (; 49 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/min (; 47 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 f64)
   local.get $0
@@ -4375,7 +4384,7 @@
   local.get $2
   f64.min
  )
- (func $~lib/math/NativeMath.pow (; 50 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.pow (; 48 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -5455,12 +5464,12 @@
   local.get $16
   f64.mul
  )
- (func $../../lib/libm/assembly/libm/pow (; 51 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/pow (; 49 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.pow
  )
- (func $../../lib/libm/assembly/libm/round (; 52 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/round (; 50 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   local.get $0
   local.set $1
@@ -5471,7 +5480,7 @@
   local.get $1
   f64.copysign
  )
- (func $../../lib/libm/assembly/libm/sign (; 53 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/sign (; 51 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   block $~lib/math/NativeMath.sign|inlined.0 (result f64)
    local.get $0
@@ -5494,7 +5503,7 @@
    br $~lib/math/NativeMath.sign|inlined.0
   end
  )
- (func $~lib/math/NativeMath.sin (; 54 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.sin (; 52 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -6023,11 +6032,11 @@
    local.get $0
   end
  )
- (func $../../lib/libm/assembly/libm/sin (; 55 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/sin (; 53 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.sin
  )
- (func $~lib/math/NativeMath.sinh (; 56 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.sinh (; 54 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 f64)
   (local $3 i32)
@@ -6125,18 +6134,18 @@
   local.set $4
   local.get $4
  )
- (func $../../lib/libm/assembly/libm/sinh (; 57 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/sinh (; 55 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.sinh
  )
- (func $../../lib/libm/assembly/libm/sqrt (; 58 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/sqrt (; 56 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   local.get $0
   local.set $1
   local.get $1
   f64.sqrt
  )
- (func $~lib/math/tan_kern (; 59 ;) (type $FUNCSIG$dddi) (param $0 f64) (param $1 f64) (param $2 i32) (result f64)
+ (func $~lib/math/tan_kern (; 57 ;) (type $FUNCSIG$dddi) (param $0 f64) (param $1 f64) (param $2 i32) (result f64)
   (local $3 f64)
   (local $4 f64)
   (local $5 f64)
@@ -6349,7 +6358,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.tan (; 60 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.tan (; 58 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -6661,11 +6670,11 @@
   i32.sub
   call $~lib/math/tan_kern
  )
- (func $../../lib/libm/assembly/libm/tan (; 61 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/tan (; 59 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.tan
  )
- (func $~lib/math/NativeMath.tanh (; 62 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.tanh (; 60 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 f64)
   (local $3 i32)
@@ -6757,25 +6766,25 @@
   local.get $0
   f64.copysign
  )
- (func $../../lib/libm/assembly/libm/tanh (; 63 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/tanh (; 61 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   call $~lib/math/NativeMath.tanh
  )
- (func $../../lib/libm/assembly/libm/trunc (; 64 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $../../lib/libm/assembly/libm/trunc (; 62 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   local.get $0
   local.set $1
   local.get $1
   f64.trunc
  )
- (func $../../lib/libm/assembly/libmf/abs (; 65 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/abs (; 63 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   local.get $0
   local.set $1
   local.get $1
   f32.abs
  )
- (func $~lib/math/Rf (; 66 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/Rf (; 64 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 f32)
   local.get $0
@@ -6800,7 +6809,7 @@
   local.get $2
   f32.div
  )
- (func $~lib/math/NativeMathf.acos (; 67 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.acos (; 65 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -6940,11 +6949,11 @@
   f32.add
   f32.mul
  )
- (func $../../lib/libm/assembly/libmf/acos (; 68 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/acos (; 66 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.acos
  )
- (func $~lib/math/NativeMathf.log1p (; 69 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log1p (; 67 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -7153,7 +7162,7 @@
   f32.mul
   f32.add
  )
- (func $~lib/math/NativeMathf.log (; 70 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log (; 68 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -7321,7 +7330,7 @@
   f32.mul
   f32.add
  )
- (func $~lib/math/NativeMathf.acosh (; 71 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.acosh (; 69 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -7377,11 +7386,11 @@
   f32.const 0.6931471824645996
   f32.add
  )
- (func $../../lib/libm/assembly/libmf/acosh (; 72 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/acosh (; 70 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.acosh
  )
- (func $~lib/math/NativeMathf.asin (; 73 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.asin (; 71 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 f32)
@@ -7473,11 +7482,11 @@
   local.get $1
   f32.copysign
  )
- (func $../../lib/libm/assembly/libmf/asin (; 74 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/asin (; 72 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.asin
  )
- (func $~lib/math/NativeMathf.asinh (; 75 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.asinh (; 73 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   local.get $0
@@ -7546,25 +7555,21 @@
   local.get $0
   f32.copysign
  )
- (func $../../lib/libm/assembly/libmf/asinh (; 76 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/asinh (; 74 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.asinh
  )
- (func $~lib/number/isNaN<f32> (; 77 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
-  local.get $0
-  local.get $0
-  f32.ne
- )
- (func $~lib/math/NativeMathf.atan (; 78 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.atan (; 75 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
-  (local $4 i32)
-  (local $5 f32)
+  (local $4 f32)
+  (local $5 i32)
   (local $6 f32)
   (local $7 f32)
   (local $8 f32)
-  (local $9 i32)
+  (local $9 f32)
+  (local $10 i32)
   local.get $0
   i32.reinterpret_f32
   local.set $1
@@ -7579,7 +7584,9 @@
   i32.ge_u
   if
    local.get $0
-   call $~lib/number/isNaN<f32>
+   local.tee $4
+   local.get $4
+   f32.ne
    if
     local.get $0
     return
@@ -7605,7 +7612,7 @@
     return
    end
    i32.const -1
-   local.set $4
+   local.set $5
   else
    local.get $0
    f32.abs
@@ -7619,7 +7626,7 @@
     i32.lt_u
     if
      i32.const 0
-     local.set $4
+     local.set $5
      f32.const 2
      local.get $0
      f32.mul
@@ -7632,7 +7639,7 @@
      local.set $0
     else
      i32.const 1
-     local.set $4
+     local.set $5
      local.get $0
      f32.const 1
      f32.sub
@@ -7648,7 +7655,7 @@
     i32.lt_u
     if
      i32.const 2
-     local.set $4
+     local.set $5
      local.get $0
      f32.const 1.5
      f32.sub
@@ -7661,7 +7668,7 @@
      local.set $0
     else
      i32.const 3
-     local.set $4
+     local.set $5
      f32.const -1
      local.get $0
      f32.div
@@ -7676,39 +7683,39 @@
   local.get $3
   local.get $3
   f32.mul
-  local.set $5
+  local.set $6
   local.get $3
   f32.const 0.333333283662796
-  local.get $5
+  local.get $6
   f32.const 0.14253635704517365
-  local.get $5
+  local.get $6
   f32.const 0.06168760731816292
   f32.mul
   f32.add
   f32.mul
   f32.add
   f32.mul
-  local.set $6
-  local.get $5
+  local.set $7
+  local.get $6
   f32.const -0.19999158382415771
-  local.get $5
+  local.get $6
   f32.const -0.106480173766613
   f32.mul
   f32.add
   f32.mul
-  local.set $7
+  local.set $8
   local.get $0
-  local.get $6
   local.get $7
+  local.get $8
   f32.add
   f32.mul
-  local.set $8
-  local.get $4
+  local.set $9
+  local.get $5
   i32.const 0
   i32.lt_s
   if
    local.get $0
-   local.get $8
+   local.get $9
    f32.sub
    return
   end
@@ -7718,28 +7725,28 @@
      block $case2|0
       block $case1|0
        block $case0|0
-        local.get $4
-        local.set $9
-        local.get $9
+        local.get $5
+        local.set $10
+        local.get $10
         i32.const 0
         i32.eq
         br_if $case0|0
-        local.get $9
+        local.get $10
         i32.const 1
         i32.eq
         br_if $case1|0
-        local.get $9
+        local.get $10
         i32.const 2
         i32.eq
         br_if $case2|0
-        local.get $9
+        local.get $10
         i32.const 3
         i32.eq
         br_if $case3|0
         br $case4|0
        end
        f32.const 0.46364760398864746
-       local.get $8
+       local.get $9
        f32.const 5.01215824399992e-09
        f32.sub
        local.get $0
@@ -7749,7 +7756,7 @@
        br $break|0
       end
       f32.const 0.7853981256484985
-      local.get $8
+      local.get $9
       f32.const 3.774894707930798e-08
       f32.sub
       local.get $0
@@ -7759,7 +7766,7 @@
       br $break|0
      end
      f32.const 0.9827936887741089
-     local.get $8
+     local.get $9
      f32.const 3.447321716976148e-08
      f32.sub
      local.get $0
@@ -7769,7 +7776,7 @@
      br $break|0
     end
     f32.const 1.570796251296997
-    local.get $8
+    local.get $9
     f32.const 7.549789415861596e-08
     f32.sub
     local.get $0
@@ -7784,11 +7791,11 @@
   local.get $2
   f32.copysign
  )
- (func $../../lib/libm/assembly/libmf/atan (; 79 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/atan (; 76 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.atan
  )
- (func $~lib/math/NativeMathf.atanh (; 80 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.atanh (; 77 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   local.get $0
@@ -7838,24 +7845,28 @@
   local.get $0
   f32.copysign
  )
- (func $../../lib/libm/assembly/libmf/atanh (; 81 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/atanh (; 78 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.atanh
  )
- (func $~lib/math/NativeMathf.atan2 (; 82 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
-  (local $2 i32)
+ (func $~lib/math/NativeMathf.atan2 (; 79 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+  (local $2 f32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 f32)
+  (local $6 i32)
   (local $7 f32)
   local.get $1
-  call $~lib/number/isNaN<f32>
+  local.tee $2
+  local.get $2
+  f32.ne
   if (result i32)
    i32.const 1
   else
    local.get $0
-   call $~lib/number/isNaN<f32>
+   local.tee $2
+   local.get $2
+   f32.ne
   end
   if
    local.get $1
@@ -7865,11 +7876,11 @@
   end
   local.get $1
   i32.reinterpret_f32
-  local.set $2
+  local.set $3
   local.get $0
   i32.reinterpret_f32
-  local.set $3
-  local.get $2
+  local.set $4
+  local.get $3
   i32.const 1065353216
   i32.eq
   if
@@ -7877,27 +7888,27 @@
    call $~lib/math/NativeMathf.atan
    return
   end
-  local.get $3
+  local.get $4
   i32.const 31
   i32.shr_u
   i32.const 1
   i32.and
-  local.get $2
+  local.get $3
   i32.const 30
   i32.shr_u
   i32.const 2
   i32.and
   i32.or
-  local.set $4
-  local.get $2
-  i32.const 2147483647
-  i32.and
-  local.set $2
+  local.set $5
   local.get $3
   i32.const 2147483647
   i32.and
   local.set $3
-  local.get $3
+  local.get $4
+  i32.const 2147483647
+  i32.and
+  local.set $4
+  local.get $4
   i32.const 0
   i32.eq
   if
@@ -7906,21 +7917,21 @@
      block $case2|0
       block $case1|0
        block $case0|0
-        local.get $4
-        local.set $5
         local.get $5
+        local.set $6
+        local.get $6
         i32.const 0
         i32.eq
         br_if $case0|0
-        local.get $5
+        local.get $6
         i32.const 1
         i32.eq
         br_if $case1|0
-        local.get $5
+        local.get $6
         i32.const 2
         i32.eq
         br_if $case2|0
-        local.get $5
+        local.get $6
         i32.const 3
         i32.eq
         br_if $case3|0
@@ -7938,11 +7949,11 @@
     return
    end
   end
-  local.get $2
+  local.get $3
   i32.const 0
   i32.eq
   if
-   local.get $4
+   local.get $5
    i32.const 1
    i32.and
    if (result f32)
@@ -7957,15 +7968,15 @@
    end
    return
   end
-  local.get $2
+  local.get $3
   i32.const 2139095040
   i32.eq
   if
-   local.get $3
+   local.get $4
    i32.const 2139095040
    i32.eq
    if
-    local.get $4
+    local.get $5
     i32.const 2
     i32.and
     if (result f32)
@@ -7979,19 +7990,19 @@
      f32.const 4
      f32.div
     end
-    local.set $6
-    local.get $4
+    local.set $2
+    local.get $5
     i32.const 1
     i32.and
     if (result f32)
-     local.get $6
+     local.get $2
      f32.neg
     else
-     local.get $6
+     local.get $2
     end
     return
    else
-    local.get $4
+    local.get $5
     i32.const 2
     i32.and
     if (result f32)
@@ -7999,34 +8010,34 @@
     else
      f32.const 0
     end
-    local.set $6
-    local.get $4
+    local.set $2
+    local.get $5
     i32.const 1
     i32.and
     if (result f32)
-     local.get $6
+     local.get $2
      f32.neg
     else
-     local.get $6
+     local.get $2
     end
     return
    end
    unreachable
   end
-  local.get $2
+  local.get $3
   i32.const 218103808
   i32.add
-  local.get $3
+  local.get $4
   i32.lt_u
   if (result i32)
    i32.const 1
   else
-   local.get $3
+   local.get $4
    i32.const 2139095040
    i32.eq
   end
   if
-   local.get $4
+   local.get $5
    i32.const 1
    i32.and
    if (result f32)
@@ -8041,14 +8052,14 @@
    end
    return
   end
-  local.get $4
+  local.get $5
   i32.const 2
   i32.and
   if (result i32)
-   local.get $3
+   local.get $4
    i32.const 218103808
    i32.add
-   local.get $2
+   local.get $3
    i32.lt_u
   else
    i32.const 0
@@ -8069,21 +8080,21 @@
     block $case2|1
      block $case1|1
       block $case0|1
-       local.get $4
-       local.set $5
        local.get $5
+       local.set $6
+       local.get $6
        i32.const 0
        i32.eq
        br_if $case0|1
-       local.get $5
+       local.get $6
        i32.const 1
        i32.eq
        br_if $case1|1
-       local.get $5
+       local.get $6
        i32.const 2
        i32.eq
        br_if $case2|1
-       local.get $5
+       local.get $6
        i32.const 3
        i32.eq
        br_if $case3|1
@@ -8112,12 +8123,12 @@
   end
   unreachable
  )
- (func $../../lib/libm/assembly/libmf/atan2 (; 83 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/atan2 (; 80 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.atan2
  )
- (func $~lib/math/NativeMathf.cbrt (; 84 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cbrt (; 81 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -8233,27 +8244,25 @@
   local.get $3
   f32.demote_f64
  )
- (func $../../lib/libm/assembly/libmf/cbrt (; 85 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/cbrt (; 82 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.cbrt
  )
- (func $../../lib/libm/assembly/libmf/ceil (; 86 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/ceil (; 83 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   local.get $0
   local.set $1
   local.get $1
   f32.ceil
  )
- (func $~lib/number/isFinite<f32> (; 87 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
+ (func $~lib/math/NativeMathf.clz32 (; 84 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+  (local $1 f32)
   local.get $0
-  local.get $0
+  local.tee $1
+  local.get $1
   f32.sub
   f32.const 0
   f32.eq
- )
- (func $~lib/math/NativeMathf.clz32 (; 88 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
-  local.get $0
-  call $~lib/number/isFinite<f32>
   i32.eqz
   if
    f32.const 32
@@ -8265,11 +8274,11 @@
   i32.clz
   f32.convert_i32_s
  )
- (func $../../lib/libm/assembly/libmf/clz32 (; 89 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/clz32 (; 85 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.clz32
  )
- (func $~lib/math/NativeMathf.cos (; 90 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cos (; 86 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -8887,11 +8896,11 @@
    local.get $27
   end
  )
- (func $../../lib/libm/assembly/libmf/cos (; 91 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/cos (; 87 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.cos
  )
- (func $~lib/math/NativeMathf.expm1 (; 92 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.expm1 (; 88 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9184,7 +9193,7 @@
   local.get $13
   f32.mul
  )
- (func $~lib/math/NativeMathf.scalbn (; 93 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
+ (func $~lib/math/NativeMathf.scalbn (; 89 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
   (local $2 f32)
   (local $3 i32)
   (local $4 i32)
@@ -9274,7 +9283,7 @@
   f32.reinterpret_i32
   f32.mul
  )
- (func $~lib/math/NativeMathf.exp (; 94 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.exp (; 90 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -9418,7 +9427,7 @@
   local.get $5
   call $~lib/math/NativeMathf.scalbn
  )
- (func $~lib/math/NativeMathf.cosh (; 95 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cosh (; 91 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -9495,32 +9504,32 @@
   local.get $3
   f32.mul
  )
- (func $../../lib/libm/assembly/libmf/cosh (; 96 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/cosh (; 92 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.cosh
  )
- (func $../../lib/libm/assembly/libmf/exp (; 97 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/exp (; 93 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.exp
  )
- (func $../../lib/libm/assembly/libmf/expm1 (; 98 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/expm1 (; 94 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.expm1
  )
- (func $../../lib/libm/assembly/libmf/floor (; 99 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/floor (; 95 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   local.get $0
   local.set $1
   local.get $1
   f32.floor
  )
- (func $../../lib/libm/assembly/libmf/fround (; 100 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/fround (; 96 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   local.get $0
   local.set $1
   local.get $1
  )
- (func $~lib/math/NativeMathf.hypot (; 101 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.hypot (; 97 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9637,14 +9646,15 @@
   f32.sqrt
   f32.mul
  )
- (func $../../lib/libm/assembly/libmf/hypot (; 102 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/hypot (; 98 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.hypot
  )
- (func $../../lib/libm/assembly/libmf/imul (; 103 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/imul (; 99 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 f32)
   (local $3 f32)
+  (local $4 f32)
   block $~lib/math/NativeMathf.imul|inlined.0 (result f32)
    local.get $0
    local.set $3
@@ -9653,7 +9663,11 @@
    local.get $3
    local.get $2
    f32.add
-   call $~lib/number/isFinite<f32>
+   local.tee $4
+   local.get $4
+   f32.sub
+   f32.const 0
+   f32.eq
    i32.eqz
    if
     f32.const 0
@@ -9669,11 +9683,11 @@
    f32.convert_i32_s
   end
  )
- (func $../../lib/libm/assembly/libmf/log (; 104 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/log (; 100 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.log
  )
- (func $~lib/math/NativeMathf.log10 (; 105 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log10 (; 101 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -9873,15 +9887,15 @@
   f32.mul
   f32.add
  )
- (func $../../lib/libm/assembly/libmf/log10 (; 106 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/log10 (; 102 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.log10
  )
- (func $../../lib/libm/assembly/libmf/log1p (; 107 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/log1p (; 103 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.log1p
  )
- (func $~lib/math/NativeMathf.log2 (; 108 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log2 (; 104 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -10076,11 +10090,11 @@
   local.get $14
   f32.add
  )
- (func $../../lib/libm/assembly/libmf/log2 (; 109 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/log2 (; 105 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.log2
  )
- (func $../../lib/libm/assembly/libmf/max (; 110 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/max (; 106 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 f32)
   (local $3 f32)
   local.get $0
@@ -10091,7 +10105,7 @@
   local.get $2
   f32.max
  )
- (func $../../lib/libm/assembly/libmf/min (; 111 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/min (; 107 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 f32)
   (local $3 f32)
   local.get $0
@@ -10102,7 +10116,7 @@
   local.get $2
   f32.min
  )
- (func $~lib/math/NativeMathf.pow (; 112 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.pow (; 108 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11036,12 +11050,12 @@
   local.get $11
   f32.mul
  )
- (func $../../lib/libm/assembly/libmf/pow (; 113 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/pow (; 109 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.pow
  )
- (func $../../lib/libm/assembly/libmf/round (; 114 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/round (; 110 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   local.get $0
   local.set $1
@@ -11052,7 +11066,7 @@
   local.get $1
   f32.copysign
  )
- (func $../../lib/libm/assembly/libmf/sign (; 115 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/sign (; 111 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   block $~lib/math/NativeMathf.sign|inlined.0 (result f32)
    local.get $0
@@ -11075,7 +11089,7 @@
    br $~lib/math/NativeMathf.sign|inlined.0
   end
  )
- (func $~lib/math/NativeMathf.sin (; 116 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.sin (; 112 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -11685,11 +11699,11 @@
    local.get $27
   end
  )
- (func $../../lib/libm/assembly/libmf/sin (; 117 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/sin (; 113 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.sin
  )
- (func $~lib/math/NativeMathf.sinh (; 118 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.sinh (; 114 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -11778,18 +11792,18 @@
   local.set $3
   local.get $3
  )
- (func $../../lib/libm/assembly/libmf/sinh (; 119 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/sinh (; 115 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.sinh
  )
- (func $../../lib/libm/assembly/libmf/sqrt (; 120 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/sqrt (; 116 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   local.get $0
   local.set $1
   local.get $1
   f32.sqrt
  )
- (func $~lib/math/NativeMathf.tan (; 121 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.tan (; 117 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -12440,11 +12454,11 @@
   end
   f32.demote_f64
  )
- (func $../../lib/libm/assembly/libmf/tan (; 122 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/tan (; 118 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.tan
  )
- (func $~lib/math/NativeMathf.tanh (; 123 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.tanh (; 119 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -12530,17 +12544,17 @@
   local.get $0
   f32.copysign
  )
- (func $../../lib/libm/assembly/libmf/tanh (; 124 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/tanh (; 120 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   call $~lib/math/NativeMathf.tanh
  )
- (func $../../lib/libm/assembly/libmf/trunc (; 125 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $../../lib/libm/assembly/libmf/trunc (; 121 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   local.get $0
   local.set $1
   local.get $1
   f32.trunc
  )
- (func $null (; 126 ;) (type $FUNCSIG$v)
+ (func $null (; 122 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -1,9 +1,8 @@
 (module
- (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$dddd (func (param f64 f64 f64) (result f64)))
+ (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$ddi (func (param f64 i32) (result f64)))
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
- (type $FUNCSIG$if (func (param f32) (result i32)))
  (type $FUNCSIG$ffff (func (param f32 f32 f32) (result f32)))
  (type $FUNCSIG$ffi (func (param f32 i32) (result f32)))
  (type $FUNCSIG$dd (func (param f64) (result f64)))
@@ -89,19 +88,7 @@
  (global $~lib/math/NativeMath.sincos_cos (mut f64) (f64.const 0))
  (export "memory" (memory $0))
  (start $start)
- (func $~lib/number/isNaN<f64> (; 32 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.ne
- )
- (func $~lib/number/isFinite<f64> (; 33 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.sub
-  f64.const 0
-  f64.eq
- )
- (func $~lib/math/NativeMath.scalbn (; 34 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/NativeMath.scalbn (; 32 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
   local.get $1
   i32.const 1023
   i32.gt_s
@@ -178,16 +165,16 @@
   f64.reinterpret_i64
   f64.mul
  )
- (func $std/math/ulperr (; 35 ;) (type $FUNCSIG$dddd) (param $0 f64) (param $1 f64) (param $2 f64) (result f64)
+ (func $std/math/ulperr (; 33 ;) (type $FUNCSIG$dddd) (param $0 f64) (param $1 f64) (param $2 f64) (result f64)
   (local $3 i32)
+  local.get $1
+  local.get $1
+  f64.ne
+  i32.const 0
   local.get $0
-  call $~lib/number/isNaN<f64>
-  if (result i32)
-   local.get $1
-   call $~lib/number/isNaN<f64>
-  else
-   i32.const 0
-  end
+  local.get $0
+  f64.ne
+  select
   if
    f64.const 0
    return
@@ -227,8 +214,10 @@
    return
   end
   local.get $0
-  call $~lib/number/isFinite<f64>
-  i32.eqz
+  local.get $0
+  f64.sub
+  f64.const 0
+  f64.ne
   if
    local.get $1
    f64.const 0.5
@@ -266,7 +255,7 @@
   local.get $2
   f64.add
  )
- (func $std/math/check<f64> (; 36 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/check<f64> (; 34 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   f64.eq
@@ -275,10 +264,12 @@
    return
   end
   local.get $1
-  call $~lib/number/isNaN<f64>
+  local.get $1
+  f64.ne
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.get $0
+   f64.ne
    return
   end
   local.get $0
@@ -294,12 +285,7 @@
   end
   i32.const 1
  )
- (func $~lib/number/isNaN<f32> (; 37 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
-  local.get $0
-  local.get $0
-  f32.ne
- )
- (func $~lib/math/NativeMathf.scalbn (; 38 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
+ (func $~lib/math/NativeMathf.scalbn (; 35 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
   local.get $1
   i32.const 127
   i32.gt_s
@@ -375,16 +361,16 @@
   f32.reinterpret_i32
   f32.mul
  )
- (func $std/math/ulperrf (; 39 ;) (type $FUNCSIG$ffff) (param $0 f32) (param $1 f32) (param $2 f32) (result f32)
+ (func $std/math/ulperrf (; 36 ;) (type $FUNCSIG$ffff) (param $0 f32) (param $1 f32) (param $2 f32) (result f32)
   (local $3 i32)
+  local.get $1
+  local.get $1
+  f32.ne
+  i32.const 0
   local.get $0
-  call $~lib/number/isNaN<f32>
-  if (result i32)
-   local.get $1
-   call $~lib/number/isNaN<f32>
-  else
-   i32.const 0
-  end
+  local.get $0
+  f32.ne
+  select
   if
    f32.const 0
    return
@@ -462,7 +448,7 @@
   local.get $2
   f32.add
  )
- (func $std/math/check<f32> (; 40 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/check<f32> (; 37 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   local.get $1
   f32.eq
@@ -471,10 +457,12 @@
    return
   end
   local.get $1
-  call $~lib/number/isNaN<f32>
+  local.get $1
+  f32.ne
   if
    local.get $0
-   call $~lib/number/isNaN<f32>
+   local.get $0
+   f32.ne
    return
   end
   local.get $0
@@ -490,7 +478,7 @@
   end
   i32.const 1
  )
- (func $std/math/test_scalbn (; 41 ;) (type $FUNCSIG$idid) (param $0 f64) (param $1 i32) (param $2 f64) (result i32)
+ (func $std/math/test_scalbn (; 38 ;) (type $FUNCSIG$idid) (param $0 f64) (param $1 i32) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.scalbn
@@ -498,7 +486,7 @@
   f64.const 0
   call $std/math/check<f64>
  )
- (func $std/math/test_scalbnf (; 42 ;) (type $FUNCSIG$ifif) (param $0 f32) (param $1 i32) (param $2 f32) (result i32)
+ (func $std/math/test_scalbnf (; 39 ;) (type $FUNCSIG$ifif) (param $0 f32) (param $1 i32) (param $2 f32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.scalbn
@@ -506,7 +494,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $std/math/test_abs (; 43 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
+ (func $std/math/test_abs (; 40 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
   local.get $0
   f64.abs
   local.get $1
@@ -522,14 +510,14 @@
    i32.const 0
   end
  )
- (func $std/math/test_absf (; 44 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/math/test_absf (; 41 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
   local.get $0
   f32.abs
   local.get $1
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/R (; 45 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/R (; 42 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
   f64.const 0.16666666666666666
   local.get $0
@@ -572,7 +560,7 @@
   f64.add
   f64.div
  )
- (func $~lib/math/NativeMath.acos (; 46 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.acos (; 43 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -696,7 +684,7 @@
   f64.add
   f64.mul
  )
- (func $std/math/test_acos (; 47 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_acos (; 44 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.acos
   local.get $1
@@ -712,7 +700,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/Rf (; 48 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/Rf (; 45 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   local.get $0
   f32.const 0.16666586697101593
   local.get $0
@@ -731,7 +719,7 @@
   f32.add
   f32.div
  )
- (func $~lib/math/NativeMathf.acos (; 49 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.acos (; 46 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -847,14 +835,14 @@
   f32.add
   f32.mul
  )
- (func $std/math/test_acosf (; 50 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_acosf (; 47 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.acos
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log1p (; 51 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log1p (; 48 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -1053,7 +1041,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.log (; 52 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log (; 49 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i64)
   (local $3 f64)
@@ -1223,7 +1211,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.acosh (; 53 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.acosh (; 50 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   local.get $0
   i64.reinterpret_f64
@@ -1277,7 +1265,7 @@
   f64.const 0.6931471805599453
   f64.add
  )
- (func $std/math/test_acosh (; 54 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_acosh (; 51 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.acosh
   local.get $1
@@ -1293,7 +1281,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.log1p (; 55 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log1p (; 52 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -1463,7 +1451,7 @@
   f32.mul
   f32.add
  )
- (func $~lib/math/NativeMathf.log (; 56 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log (; 53 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -1597,7 +1585,7 @@
   f32.mul
   f32.add
  )
- (func $~lib/math/NativeMathf.acosh (; 57 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.acosh (; 54 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   local.get $0
   i32.reinterpret_f32
@@ -1647,14 +1635,14 @@
   f32.const 0.6931471824645996
   f32.add
  )
- (func $std/math/test_acoshf (; 58 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_acoshf (; 55 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.acosh
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.asin (; 59 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.asin (; 56 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -1792,7 +1780,7 @@
   end
   local.get $0
  )
- (func $std/math/test_asin (; 60 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_asin (; 57 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.asin
   local.get $1
@@ -1808,7 +1796,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.asin (; 61 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.asin (; 58 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f64)
@@ -1888,14 +1876,14 @@
   local.get $0
   f32.copysign
  )
- (func $std/math/test_asinf (; 62 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_asinf (; 59 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.asin
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.asinh (; 63 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.asinh (; 60 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i64)
   local.get $0
@@ -1965,7 +1953,7 @@
   local.get $0
   f64.copysign
  )
- (func $std/math/test_asinh (; 64 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_asinh (; 61 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.asinh
   local.get $1
@@ -1981,7 +1969,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.asinh (; 65 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.asinh (; 62 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   local.get $0
@@ -2046,14 +2034,14 @@
   local.get $0
   f32.copysign
  )
- (func $std/math/test_asinhf (; 66 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_asinhf (; 63 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.asinh
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atan (; 67 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atan (; 64 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -2072,7 +2060,8 @@
   i32.ge_u
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.get $0
+   f64.ne
    if
     local.get $0
     return
@@ -2278,7 +2267,7 @@
   local.get $3
   f64.copysign
  )
- (func $std/math/test_atan (; 68 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_atan (; 65 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.atan
   local.get $1
@@ -2294,7 +2283,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.atan (; 69 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.atan (; 66 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -2310,7 +2299,8 @@
   i32.ge_u
   if
    local.get $0
-   call $~lib/number/isNaN<f32>
+   local.get $0
+   f32.ne
    if
     local.get $0
     return
@@ -2492,14 +2482,14 @@
   local.get $4
   f32.copysign
  )
- (func $std/math/test_atanf (; 70 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_atanf (; 67 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.atan
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atanh (; 71 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atanh (; 68 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i64)
   (local $3 f64)
@@ -2553,7 +2543,7 @@
   local.get $0
   f64.copysign
  )
- (func $std/math/test_atanh (; 72 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_atanh (; 69 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.atanh
   local.get $1
@@ -2569,7 +2559,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.atanh (; 73 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.atanh (; 70 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   local.get $0
@@ -2617,28 +2607,28 @@
   local.get $0
   f32.copysign
  )
- (func $std/math/test_atanhf (; 74 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_atanhf (; 71 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.atanh
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atan2 (; 75 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.atan2 (; 72 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i64)
   (local $6 i32)
   (local $7 i32)
+  i32.const 1
+  local.get $0
+  local.get $0
+  f64.ne
   local.get $1
-  call $~lib/number/isNaN<f64>
-  if (result i32)
-   i32.const 1
-  else
-   local.get $0
-   call $~lib/number/isNaN<f64>
-  end
+  local.get $1
+  f64.ne
+  select
   if
    local.get $1
    local.get $0
@@ -2844,7 +2834,7 @@
   i32.and
   select
  )
- (func $std/math/test_atan2 (; 76 ;) (type $FUNCSIG$idddd) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (result i32)
+ (func $std/math/test_atan2 (; 73 ;) (type $FUNCSIG$idddd) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.atan2
@@ -2862,18 +2852,18 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.atan2 (; 77 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.atan2 (; 74 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  i32.const 1
+  local.get $0
+  local.get $0
+  f32.ne
   local.get $1
-  call $~lib/number/isNaN<f32>
-  if (result i32)
-   i32.const 1
-  else
-   local.get $0
-   call $~lib/number/isNaN<f32>
-  end
+  local.get $1
+  f32.ne
+  select
   if
    local.get $1
    local.get $0
@@ -3058,7 +3048,7 @@
   i32.and
   select
  )
- (func $std/math/test_atan2f (; 78 ;) (type $FUNCSIG$iffff) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (result i32)
+ (func $std/math/test_atan2f (; 75 ;) (type $FUNCSIG$iffff) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.atan2
@@ -3066,7 +3056,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.cbrt (; 79 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cbrt (; 76 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -3188,7 +3178,7 @@
   f64.mul
   f64.add
  )
- (func $std/math/test_cbrt (; 80 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_cbrt (; 77 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.cbrt
   local.get $1
@@ -3204,7 +3194,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.cbrt (; 81 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cbrt (; 78 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f64)
   (local $2 f64)
   (local $3 i32)
@@ -3303,14 +3293,14 @@
   f64.div
   f32.demote_f64
  )
- (func $std/math/test_cbrtf (; 82 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_cbrtf (; 79 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.cbrt
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_ceil (; 83 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
+ (func $std/math/test_ceil (; 80 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
   local.get $0
   f64.ceil
   local.get $1
@@ -3326,14 +3316,14 @@
    i32.const 0
   end
  )
- (func $std/math/test_ceilf (; 84 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/math/test_ceilf (; 81 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
   local.get $0
   f32.ceil
   local.get $1
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/pio2_large_quot (; 85 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/math/pio2_large_quot (; 82 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -3625,7 +3615,7 @@
   i64.sub
   i32.wrap_i64
  )
- (func $~lib/math/NativeMath.cos (; 86 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cos (; 83 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   (local $3 f64)
@@ -3965,7 +3955,7 @@
   end
   local.get $0
  )
- (func $std/math/test_cos (; 87 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_cos (; 84 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.cos
   local.get $1
@@ -3981,7 +3971,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.cos (; 88 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cos (; 85 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -4251,14 +4241,14 @@
   end
   local.get $0
  )
- (func $std/math/test_cosf (; 89 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_cosf (; 86 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.cos
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.expm1 (; 90 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.expm1 (; 87 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -4285,7 +4275,8 @@
   i32.ge_u
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.get $0
+   f64.ne
    if
     local.get $0
     return
@@ -4530,7 +4521,7 @@
   local.get $4
   f64.mul
  )
- (func $~lib/math/NativeMath.exp (; 91 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.exp (; 88 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 f64)
   (local $3 i32)
@@ -4555,7 +4546,8 @@
   i32.ge_u
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.get $0
+   f64.ne
    if
     local.get $0
     return
@@ -4682,7 +4674,7 @@
   local.get $1
   call $~lib/math/NativeMath.scalbn
  )
- (func $~lib/math/NativeMath.cosh (; 92 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cosh (; 89 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i64)
   local.get $0
@@ -4746,7 +4738,7 @@
   f64.const 2247116418577894884661631e283
   f64.mul
  )
- (func $std/math/test_cosh (; 93 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_cosh (; 90 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.cosh
   local.get $1
@@ -4762,7 +4754,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.expm1 (; 94 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.expm1 (; 91 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -5014,7 +5006,7 @@
   local.get $4
   f32.mul
  )
- (func $~lib/math/NativeMathf.exp (; 95 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.exp (; 92 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -5142,7 +5134,7 @@
   local.get $1
   call $~lib/math/NativeMathf.scalbn
  )
- (func $~lib/math/NativeMathf.cosh (; 96 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cosh (; 93 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   local.get $0
   i32.reinterpret_f32
@@ -5201,14 +5193,14 @@
   f32.const 1661534994731144841129758e11
   f32.mul
  )
- (func $std/math/test_coshf (; 97 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_coshf (; 94 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.cosh
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_exp (; 98 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_exp (; 95 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.exp
   local.get $1
@@ -5224,14 +5216,14 @@
    i32.const 0
   end
  )
- (func $std/math/test_expf (; 99 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_expf (; 96 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.exp
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_expm1 (; 100 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_expm1 (; 97 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.expm1
   local.get $1
@@ -5247,14 +5239,14 @@
    i32.const 0
   end
  )
- (func $std/math/test_expm1f (; 101 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_expm1f (; 98 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.expm1
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_floor (; 102 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
+ (func $std/math/test_floor (; 99 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
   local.get $0
   f64.floor
   local.get $1
@@ -5270,14 +5262,14 @@
    i32.const 0
   end
  )
- (func $std/math/test_floorf (; 103 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/math/test_floorf (; 100 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
   local.get $0
   f32.floor
   local.get $1
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.hypot (; 104 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.hypot (; 101 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 f64)
   (local $4 i64)
@@ -5448,7 +5440,7 @@
   f64.sqrt
   f64.mul
  )
- (func $std/math/test_hypot (; 105 ;) (type $FUNCSIG$idddd) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (result i32)
+ (func $std/math/test_hypot (; 102 ;) (type $FUNCSIG$idddd) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.hypot
@@ -5456,7 +5448,7 @@
   local.get $3
   call $std/math/check<f64>
  )
- (func $~lib/math/NativeMathf.hypot (; 106 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.hypot (; 103 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 f32)
@@ -5561,7 +5553,7 @@
   f32.sqrt
   f32.mul
  )
- (func $std/math/test_hypotf (; 107 ;) (type $FUNCSIG$iffff) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (result i32)
+ (func $std/math/test_hypotf (; 104 ;) (type $FUNCSIG$iffff) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.hypot
@@ -5569,7 +5561,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_log (; 108 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_log (; 105 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.log
   local.get $1
@@ -5585,14 +5577,14 @@
    i32.const 0
   end
  )
- (func $std/math/test_logf (; 109 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/math/test_logf (; 106 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log
   local.get $1
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log10 (; 110 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log10 (; 107 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i64)
@@ -5796,7 +5788,7 @@
   local.get $1
   f64.add
  )
- (func $std/math/test_log10 (; 111 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_log10 (; 108 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.log10
   local.get $1
@@ -5812,7 +5804,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.log10 (; 112 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log10 (; 109 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 i32)
@@ -5970,14 +5962,14 @@
   f32.mul
   f32.add
  )
- (func $std/math/test_log10f (; 113 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_log10f (; 110 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log10
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_log1p (; 114 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_log1p (; 111 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.log1p
   local.get $1
@@ -5993,14 +5985,14 @@
    i32.const 0
   end
  )
- (func $std/math/test_log1pf (; 115 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_log1pf (; 112 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log1p
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log2 (; 116 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log2 (; 113 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i64)
@@ -6197,7 +6189,7 @@
   local.get $1
   f64.add
  )
- (func $std/math/test_log2 (; 117 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_log2 (; 114 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.log2
   local.get $1
@@ -6213,7 +6205,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.log2 (; 118 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log2 (; 115 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 i32)
@@ -6363,14 +6355,14 @@
   f32.convert_i32_s
   f32.add
  )
- (func $std/math/test_log2f (; 119 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_log2f (; 116 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log2
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_max (; 120 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_max (; 117 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   f64.max
@@ -6388,7 +6380,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_maxf (; 121 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_maxf (; 118 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   local.get $1
   f32.max
@@ -6396,7 +6388,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $std/math/test_min (; 122 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_min (; 119 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   f64.min
@@ -6414,7 +6406,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_minf (; 123 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_minf (; 120 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   local.get $1
   f32.min
@@ -6422,7 +6414,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.mod (; 124 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (; 121 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -6467,7 +6459,8 @@
    i32.const 1
   else
    local.get $1
-   call $~lib/number/isNaN<f64>
+   local.get $1
+   f64.ne
   end
   if
    local.get $0
@@ -6627,7 +6620,7 @@
   local.get $0
   f64.mul
  )
- (func $std/math/test_mod (; 125 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_mod (; 122 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.mod
@@ -6645,7 +6638,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.mod (; 126 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (; 123 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6688,7 +6681,8 @@
    i32.const 1
   else
    local.get $1
-   call $~lib/number/isNaN<f32>
+   local.get $1
+   f32.ne
   end
   if
    local.get $0
@@ -6836,7 +6830,7 @@
   local.get $0
   f32.mul
  )
- (func $std/math/test_modf (; 127 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_modf (; 124 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.mod
@@ -6844,7 +6838,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.pow (; 128 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.pow (; 125 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 f64)
   (local $3 f64)
   (local $4 i32)
@@ -7752,7 +7746,7 @@
   f64.const 1e-300
   f64.mul
  )
- (func $std/math/test_pow (; 129 ;) (type $FUNCSIG$idddd) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (result i32)
+ (func $std/math/test_pow (; 126 ;) (type $FUNCSIG$idddd) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.pow
@@ -7770,7 +7764,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.pow (; 130 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.pow (; 127 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 f32)
   (local $3 f32)
   (local $4 i32)
@@ -8556,7 +8550,7 @@
   f32.const 1.0000000031710769e-30
   f32.mul
  )
- (func $std/math/test_powf (; 131 ;) (type $FUNCSIG$iffff) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (result i32)
+ (func $std/math/test_powf (; 128 ;) (type $FUNCSIG$iffff) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.pow
@@ -8564,7 +8558,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/murmurHash3 (; 132 ;) (type $FUNCSIG$jj) (param $0 i64) (result i64)
+ (func $~lib/math/murmurHash3 (; 129 ;) (type $FUNCSIG$jj) (param $0 i64) (result i64)
   local.get $0
   i64.const 33
   i64.shr_u
@@ -8585,7 +8579,7 @@
   i64.shr_u
   i64.xor
  )
- (func $~lib/math/splitMix32 (; 133 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/math/splitMix32 (; 130 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 1831565813
   i32.add
@@ -8617,7 +8611,7 @@
   i32.shr_u
   i32.xor
  )
- (func $~lib/math/NativeMath.seedRandom (; 134 ;) (type $FUNCSIG$vj) (param $0 i64)
+ (func $~lib/math/NativeMath.seedRandom (; 131 ;) (type $FUNCSIG$vj) (param $0 i64)
   i32.const 1
   global.set $~lib/math/random_seeded
   local.get $0
@@ -8661,7 +8655,7 @@
    unreachable
   end
  )
- (func $~lib/math/NativeMath.random (; 135 ;) (type $FUNCSIG$d) (result f64)
+ (func $~lib/math/NativeMath.random (; 132 ;) (type $FUNCSIG$d) (result f64)
   (local $0 i64)
   (local $1 i64)
   global.get $~lib/math/random_seeded
@@ -8705,7 +8699,7 @@
   f64.const 1
   f64.sub
  )
- (func $~lib/math/NativeMathf.random (; 136 ;) (type $FUNCSIG$f) (result f32)
+ (func $~lib/math/NativeMathf.random (; 133 ;) (type $FUNCSIG$f) (result f32)
   (local $0 i32)
   (local $1 i32)
   global.get $~lib/math/random_seeded
@@ -8751,7 +8745,7 @@
   f32.const 1
   f32.sub
  )
- (func $std/math/test_round (; 137 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
+ (func $std/math/test_round (; 134 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
   local.get $0
   f64.const 0.5
   f64.add
@@ -8762,7 +8756,7 @@
   f64.const 0
   call $std/math/check<f64>
  )
- (func $std/math/test_roundf (; 138 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/math/test_roundf (; 135 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
   local.get $0
   f32.const 0.5
   f32.add
@@ -8773,7 +8767,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $std/math/test_sign (; 139 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
+ (func $std/math/test_sign (; 136 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
   (local $2 f64)
   local.get $0
   local.set $2
@@ -8799,7 +8793,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_signf (; 140 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/math/test_signf (; 137 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
   f32.const 1
   local.get $0
   f32.copysign
@@ -8813,7 +8807,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.rem (; 141 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.rem (; 138 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -8842,6 +8836,10 @@
   i64.shr_u
   i32.wrap_i64
   i32.const 1
+  local.get $1
+  local.get $1
+  f64.ne
+  i32.const 1
   local.get $3
   i64.const 2047
   i64.eq
@@ -8851,12 +8849,7 @@
   i64.const 0
   i64.eq
   select
-  if (result i32)
-   i32.const 1
-  else
-   local.get $1
-   call $~lib/number/isNaN<f64>
-  end
+  select
   if
    local.get $0
    local.get $1
@@ -9071,7 +9064,7 @@
   end
   local.get $0
  )
- (func $std/math/test_rem (; 142 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_rem (; 139 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.rem
@@ -9079,7 +9072,7 @@
   f64.const 0
   call $std/math/check<f64>
  )
- (func $~lib/math/NativeMathf.rem (; 143 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.rem (; 140 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9106,6 +9099,10 @@
   local.get $2
   i32.const 31
   i32.shr_u
+  i32.const 1
+  local.get $1
+  local.get $1
+  f32.ne
   local.get $3
   i32.const 255
   i32.eq
@@ -9114,12 +9111,7 @@
   i32.const 1
   i32.shl
   select
-  if (result i32)
-   i32.const 1
-  else
-   local.get $1
-   call $~lib/number/isNaN<f32>
-  end
+  select
   if
    local.get $0
    local.get $1
@@ -9324,7 +9316,7 @@
   end
   local.get $0
  )
- (func $std/math/test_remf (; 144 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_remf (; 141 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.rem
@@ -9332,7 +9324,7 @@
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.sin (; 145 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.sin (; 142 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   (local $3 f64)
@@ -9654,7 +9646,7 @@
   end
   local.get $0
  )
- (func $std/math/test_sin (; 146 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_sin (; 143 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.sin
   local.get $1
@@ -9670,7 +9662,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.sin (; 147 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.sin (; 144 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -9941,14 +9933,14 @@
   end
   local.get $0
  )
- (func $std/math/test_sinf (; 148 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_sinf (; 145 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.sin
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.sinh (; 149 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.sinh (; 146 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   (local $3 i32)
@@ -10025,7 +10017,7 @@
   f64.mul
   f64.mul
  )
- (func $std/math/test_sinh (; 150 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_sinh (; 147 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.sinh
   local.get $1
@@ -10041,7 +10033,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.sinh (; 151 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.sinh (; 148 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 f32)
@@ -10113,14 +10105,14 @@
   f32.mul
   f32.mul
  )
- (func $std/math/test_sinhf (; 152 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_sinhf (; 149 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.sinh
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_sqrt (; 153 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_sqrt (; 150 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   f64.sqrt
   local.get $1
@@ -10136,14 +10128,14 @@
    i32.const 0
   end
  )
- (func $std/math/test_sqrtf (; 154 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_sqrtf (; 151 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   f32.sqrt
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/tan_kern (; 155 ;) (type $FUNCSIG$dddi) (param $0 f64) (param $1 f64) (param $2 i32) (result f64)
+ (func $~lib/math/tan_kern (; 152 ;) (type $FUNCSIG$dddi) (param $0 f64) (param $1 f64) (param $2 i32) (result f64)
   (local $3 f64)
   (local $4 f64)
   (local $5 f64)
@@ -10325,7 +10317,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.tan (; 156 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.tan (; 153 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -10504,7 +10496,7 @@
   i32.sub
   call $~lib/math/tan_kern
  )
- (func $std/math/test_tan (; 157 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_tan (; 154 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.tan
   local.get $1
@@ -10520,7 +10512,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.tan (; 158 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.tan (; 155 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f64)
   (local $2 i32)
   (local $3 f64)
@@ -10775,14 +10767,14 @@
   local.get $1
   f32.demote_f64
  )
- (func $std/math/test_tanf (; 159 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_tanf (; 156 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.tan
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.tanh (; 160 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.tanh (; 157 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 i32)
   (local $3 i64)
@@ -10861,7 +10853,7 @@
   local.get $0
   f64.copysign
  )
- (func $std/math/test_tanh (; 161 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/math/test_tanh (; 158 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   call $~lib/math/NativeMath.tanh
   local.get $1
@@ -10877,7 +10869,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.tanh (; 162 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.tanh (; 159 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   local.get $0
@@ -10951,14 +10943,14 @@
   local.get $0
   f32.copysign
  )
- (func $std/math/test_tanhf (; 163 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/math/test_tanhf (; 160 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.tanh
   local.get $1
   local.get $2
   call $std/math/check<f32>
  )
- (func $std/math/test_trunc (; 164 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
+ (func $std/math/test_trunc (; 161 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
   local.get $0
   f64.trunc
   local.get $1
@@ -10974,14 +10966,14 @@
    i32.const 0
   end
  )
- (func $std/math/test_truncf (; 165 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/math/test_truncf (; 162 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
   local.get $0
   f32.trunc
   local.get $1
   f32.const 0
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.sincos (; 166 ;) (type $FUNCSIG$vd) (param $0 f64)
+ (func $~lib/math/NativeMath.sincos (; 163 ;) (type $FUNCSIG$vd) (param $0 f64)
   (local $1 f64)
   (local $2 f64)
   (local $3 f64)
@@ -11379,7 +11371,7 @@
   local.get $1
   global.set $~lib/math/NativeMath.sincos_cos
  )
- (func $std/math/test_sincos (; 167 ;) (type $FUNCSIG$vjjjjj) (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64)
+ (func $std/math/test_sincos (; 164 ;) (type $FUNCSIG$vjjjjj) (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64)
   (local $5 f64)
   (local $6 f64)
   local.get $3
@@ -11405,7 +11397,7 @@
    drop
   end
  )
- (func $~lib/math/dtoi32 (; 168 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/math/dtoi32 (; 165 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   local.get $0
   f64.const 4294967296
   local.get $0
@@ -11417,12 +11409,16 @@
   i64.trunc_f64_s
   i32.wrap_i64
  )
- (func $~lib/math/NativeMath.imul (; 169 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.imul (; 166 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+  (local $2 f64)
   local.get $0
   local.get $1
   f64.add
-  call $~lib/number/isFinite<f64>
-  i32.eqz
+  local.tee $2
+  local.get $2
+  f64.sub
+  f64.const 0
+  f64.ne
   if
    f64.const 0
    return
@@ -11434,10 +11430,12 @@
   i32.mul
   f64.convert_i32_s
  )
- (func $~lib/math/NativeMath.clz32 (; 170 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.clz32 (; 167 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   local.get $0
-  call $~lib/number/isFinite<f64>
-  i32.eqz
+  local.get $0
+  f64.sub
+  f64.const 0
+  f64.ne
   if
    f64.const 32
    return
@@ -11447,7 +11445,7 @@
   i32.clz
   f64.convert_i32_s
  )
- (func $~lib/math/ipow64 (; 171 ;) (type $FUNCSIG$jji) (param $0 i64) (param $1 i32) (result i64)
+ (func $~lib/math/ipow64 (; 168 ;) (type $FUNCSIG$jji) (param $0 i64) (param $1 i32) (result i64)
   (local $2 i64)
   i64.const 1
   local.set $2
@@ -11479,7 +11477,7 @@
   end
   local.get $2
  )
- (func $~lib/math/ipow32f (; 172 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
+ (func $~lib/math/ipow32f (; 169 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
   (local $2 f32)
   (local $3 i32)
   local.get $1
@@ -11525,7 +11523,7 @@
   end
   local.get $2
  )
- (func $~lib/math/ipow64f (; 173 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/ipow64f (; 170 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
   (local $2 f64)
   (local $3 i32)
   local.get $1
@@ -11571,7 +11569,7 @@
   end
   local.get $2
  )
- (func $start:std/math (; 174 ;) (type $FUNCSIG$v)
+ (func $start:std/math (; 171 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f64)
   (local $2 f32)
@@ -45800,8 +45798,9 @@
   f32.const nan:0x400000
   i32.const 1
   call $~lib/math/ipow32f
-  call $~lib/number/isNaN<f32>
-  i32.eqz
+  local.tee $2
+  local.get $2
+  f32.eq
   if
    i32.const 0
    i32.const 24
@@ -45813,8 +45812,9 @@
   f32.const nan:0x400000
   i32.const -1
   call $~lib/math/ipow32f
-  call $~lib/number/isNaN<f32>
-  i32.eqz
+  local.tee $2
+  local.get $2
+  f32.eq
   if
    i32.const 0
    i32.const 24
@@ -45826,8 +45826,9 @@
   f32.const nan:0x400000
   i32.const 2
   call $~lib/math/ipow32f
-  call $~lib/number/isNaN<f32>
-  i32.eqz
+  local.tee $2
+  local.get $2
+  f32.eq
   if
    i32.const 0
    i32.const 24
@@ -46008,8 +46009,9 @@
   f64.const nan:0x8000000000000
   i32.const 1
   call $~lib/math/ipow64f
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $1
+  local.get $1
+  f64.eq
   if
    i32.const 0
    i32.const 24
@@ -46021,8 +46023,9 @@
   f64.const nan:0x8000000000000
   i32.const -1
   call $~lib/math/ipow64f
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $1
+  local.get $1
+  f64.eq
   if
    i32.const 0
    i32.const 24
@@ -46034,8 +46037,9 @@
   f64.const nan:0x8000000000000
   i32.const 2
   call $~lib/math/ipow64f
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $1
+  local.get $1
+  f64.eq
   if
    i32.const 0
    i32.const 24
@@ -46188,10 +46192,10 @@
    unreachable
   end
  )
- (func $start (; 175 ;) (type $FUNCSIG$v)
+ (func $start (; 172 ;) (type $FUNCSIG$v)
   call $start:std/math
  )
- (func $null (; 176 ;) (type $FUNCSIG$v)
+ (func $null (; 173 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -6494,7 +6494,8 @@
     return
    end
    local.get $4
-   i64.eqz
+   i64.const 0
+   i64.eq
    if (result i64)
     local.get $2
     i64.const 0
@@ -6518,7 +6519,8 @@
    end
    local.set $2
    local.get $5
-   i64.eqz
+   i64.const 0
+   i64.eq
    if (result i64)
     local.get $3
     i64.const 0
@@ -8874,7 +8876,8 @@
    return
   end
   local.get $3
-  i64.eqz
+  i64.const 0
+  i64.eq
   if (result i64)
    local.get $2
    i64.const 0
@@ -8898,7 +8901,8 @@
   end
   local.set $2
   local.get $6
-  i64.eqz
+  i64.const 0
+  i64.eq
   if (result i64)
    local.get $4
    i64.const 0

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -241,13 +241,11 @@
  (func $std/math/ulperr (; 34 ;) (type $FUNCSIG$dddd) (param $0 f64) (param $1 f64) (param $2 f64) (result f64)
   (local $3 f64)
   local.get $0
-  local.tee $3
-  local.get $3
+  local.get $0
   f64.ne
   if (result i32)
    local.get $1
-   local.tee $3
-   local.get $3
+   local.get $1
    f64.ne
   else
    i32.const 0
@@ -295,8 +293,7 @@
    return
   end
   local.get $0
-  local.tee $3
-  local.get $3
+  local.get $0
   f64.sub
   f64.const 0
   f64.eq
@@ -324,7 +321,6 @@
  )
  (func $std/math/check<f64> (; 35 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
-  (local $5 f64)
   local.get $0
   local.get $1
   f64.eq
@@ -333,13 +329,11 @@
    return
   end
   local.get $1
-  local.tee $4
-  local.get $4
+  local.get $1
   f64.ne
   if
    local.get $0
-   local.tee $4
-   local.get $4
+   local.get $0
    f64.ne
    return
   end
@@ -347,8 +341,8 @@
   local.get $1
   local.get $2
   call $std/math/ulperr
-  local.set $5
-  local.get $5
+  local.set $4
+  local.get $4
   f64.abs
   f64.const 1.5
   f64.ge
@@ -477,13 +471,11 @@
  (func $std/math/ulperrf (; 38 ;) (type $FUNCSIG$ffff) (param $0 f32) (param $1 f32) (param $2 f32) (result f32)
   (local $3 f32)
   local.get $0
-  local.tee $3
-  local.get $3
+  local.get $0
   f32.ne
   if (result i32)
    local.get $1
-   local.tee $3
-   local.get $3
+   local.get $1
    f32.ne
   else
    i32.const 0
@@ -529,8 +521,7 @@
    return
   end
   local.get $0
-  local.tee $3
-  local.get $3
+  local.get $0
   f32.sub
   f32.const 0
   f32.eq
@@ -558,7 +549,6 @@
  )
  (func $std/math/check<f32> (; 39 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
-  (local $5 f32)
   local.get $0
   local.get $1
   f32.eq
@@ -567,13 +557,11 @@
    return
   end
   local.get $1
-  local.tee $4
-  local.get $4
+  local.get $1
   f32.ne
   if
    local.get $0
-   local.tee $4
-   local.get $4
+   local.get $0
    f32.ne
    return
   end
@@ -581,8 +569,8 @@
   local.get $1
   local.get $2
   call $std/math/ulperrf
-  local.set $5
-  local.get $5
+  local.set $4
+  local.get $4
   f32.abs
   f32.const 1.5
   f32.ge
@@ -2486,13 +2474,12 @@
   (local $1 i32)
   (local $2 f64)
   (local $3 f64)
-  (local $4 f64)
-  (local $5 i32)
+  (local $4 i32)
+  (local $5 f64)
   (local $6 f64)
   (local $7 f64)
   (local $8 f64)
-  (local $9 f64)
-  (local $10 i32)
+  (local $9 i32)
   local.get $0
   i64.reinterpret_f64
   i64.const 32
@@ -2510,8 +2497,7 @@
   i32.ge_u
   if
    local.get $0
-   local.tee $4
-   local.get $4
+   local.get $0
    f64.ne
    if
     local.get $0
@@ -2539,7 +2525,7 @@
     return
    end
    i32.const -1
-   local.set $5
+   local.set $4
   else
    local.get $0
    f64.abs
@@ -2553,7 +2539,7 @@
     i32.lt_u
     if
      i32.const 0
-     local.set $5
+     local.set $4
      f64.const 2
      local.get $0
      f64.mul
@@ -2566,7 +2552,7 @@
      local.set $0
     else
      i32.const 1
-     local.set $5
+     local.set $4
      local.get $0
      f64.const 1
      f64.sub
@@ -2582,7 +2568,7 @@
     i32.lt_u
     if
      i32.const 2
-     local.set $5
+     local.set $4
      local.get $0
      f64.const 1.5
      f64.sub
@@ -2595,7 +2581,7 @@
      local.set $0
     else
      i32.const 3
-     local.set $5
+     local.set $4
      f64.const -1
      local.get $0
      f64.div
@@ -2610,18 +2596,18 @@
   local.get $3
   local.get $3
   f64.mul
-  local.set $6
+  local.set $5
   local.get $3
   f64.const 0.3333333333333293
-  local.get $6
+  local.get $5
   f64.const 0.14285714272503466
-  local.get $6
+  local.get $5
   f64.const 0.09090887133436507
-  local.get $6
+  local.get $5
   f64.const 0.06661073137387531
-  local.get $6
+  local.get $5
   f64.const 0.049768779946159324
-  local.get $6
+  local.get $5
   f64.const 0.016285820115365782
   f64.mul
   f64.add
@@ -2634,16 +2620,16 @@
   f64.mul
   f64.add
   f64.mul
-  local.set $7
-  local.get $6
+  local.set $6
+  local.get $5
   f64.const -0.19999999999876483
-  local.get $6
+  local.get $5
   f64.const -0.11111110405462356
-  local.get $6
+  local.get $5
   f64.const -0.0769187620504483
-  local.get $6
+  local.get $5
   f64.const -0.058335701337905735
-  local.get $6
+  local.get $5
   f64.const -0.036531572744216916
   f64.mul
   f64.add
@@ -2654,19 +2640,19 @@
   f64.mul
   f64.add
   f64.mul
-  local.set $8
+  local.set $7
   local.get $0
+  local.get $6
   local.get $7
-  local.get $8
   f64.add
   f64.mul
-  local.set $9
-  local.get $5
+  local.set $8
+  local.get $4
   i32.const 0
   i32.lt_s
   if
    local.get $0
-   local.get $9
+   local.get $8
    f64.sub
    return
   end
@@ -2676,28 +2662,28 @@
      block $case2|0
       block $case1|0
        block $case0|0
-        local.get $5
-        local.set $10
-        local.get $10
+        local.get $4
+        local.set $9
+        local.get $9
         i32.const 0
         i32.eq
         br_if $case0|0
-        local.get $10
+        local.get $9
         i32.const 1
         i32.eq
         br_if $case1|0
-        local.get $10
+        local.get $9
         i32.const 2
         i32.eq
         br_if $case2|0
-        local.get $10
+        local.get $9
         i32.const 3
         i32.eq
         br_if $case3|0
         br $case4|0
        end
        f64.const 0.4636476090008061
-       local.get $9
+       local.get $8
        f64.const 2.2698777452961687e-17
        f64.sub
        local.get $0
@@ -2707,7 +2693,7 @@
        br $break|0
       end
       f64.const 0.7853981633974483
-      local.get $9
+      local.get $8
       f64.const 3.061616997868383e-17
       f64.sub
       local.get $0
@@ -2717,7 +2703,7 @@
       br $break|0
      end
      f64.const 0.982793723247329
-     local.get $9
+     local.get $8
      f64.const 1.3903311031230998e-17
      f64.sub
      local.get $0
@@ -2727,7 +2713,7 @@
      br $break|0
     end
     f64.const 1.5707963267948966
-    local.get $9
+    local.get $8
     f64.const 6.123233995736766e-17
     f64.sub
     local.get $0
@@ -2770,13 +2756,12 @@
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
-  (local $4 f32)
-  (local $5 i32)
+  (local $4 i32)
+  (local $5 f32)
   (local $6 f32)
   (local $7 f32)
   (local $8 f32)
-  (local $9 f32)
-  (local $10 i32)
+  (local $9 i32)
   local.get $0
   i32.reinterpret_f32
   local.set $1
@@ -2791,8 +2776,7 @@
   i32.ge_u
   if
    local.get $0
-   local.tee $4
-   local.get $4
+   local.get $0
    f32.ne
    if
     local.get $0
@@ -2819,7 +2803,7 @@
     return
    end
    i32.const -1
-   local.set $5
+   local.set $4
   else
    local.get $0
    f32.abs
@@ -2833,7 +2817,7 @@
     i32.lt_u
     if
      i32.const 0
-     local.set $5
+     local.set $4
      f32.const 2
      local.get $0
      f32.mul
@@ -2846,7 +2830,7 @@
      local.set $0
     else
      i32.const 1
-     local.set $5
+     local.set $4
      local.get $0
      f32.const 1
      f32.sub
@@ -2862,7 +2846,7 @@
     i32.lt_u
     if
      i32.const 2
-     local.set $5
+     local.set $4
      local.get $0
      f32.const 1.5
      f32.sub
@@ -2875,7 +2859,7 @@
      local.set $0
     else
      i32.const 3
-     local.set $5
+     local.set $4
      f32.const -1
      local.get $0
      f32.div
@@ -2890,39 +2874,39 @@
   local.get $3
   local.get $3
   f32.mul
-  local.set $6
+  local.set $5
   local.get $3
   f32.const 0.333333283662796
-  local.get $6
+  local.get $5
   f32.const 0.14253635704517365
-  local.get $6
+  local.get $5
   f32.const 0.06168760731816292
   f32.mul
   f32.add
   f32.mul
   f32.add
   f32.mul
-  local.set $7
-  local.get $6
+  local.set $6
+  local.get $5
   f32.const -0.19999158382415771
-  local.get $6
+  local.get $5
   f32.const -0.106480173766613
   f32.mul
   f32.add
   f32.mul
-  local.set $8
+  local.set $7
   local.get $0
+  local.get $6
   local.get $7
-  local.get $8
   f32.add
   f32.mul
-  local.set $9
-  local.get $5
+  local.set $8
+  local.get $4
   i32.const 0
   i32.lt_s
   if
    local.get $0
-   local.get $9
+   local.get $8
    f32.sub
    return
   end
@@ -2932,28 +2916,28 @@
      block $case2|0
       block $case1|0
        block $case0|0
-        local.get $5
-        local.set $10
-        local.get $10
+        local.get $4
+        local.set $9
+        local.get $9
         i32.const 0
         i32.eq
         br_if $case0|0
-        local.get $10
+        local.get $9
         i32.const 1
         i32.eq
         br_if $case1|0
-        local.get $10
+        local.get $9
         i32.const 2
         i32.eq
         br_if $case2|0
-        local.get $10
+        local.get $9
         i32.const 3
         i32.eq
         br_if $case3|0
         br $case4|0
        end
        f32.const 0.46364760398864746
-       local.get $9
+       local.get $8
        f32.const 5.01215824399992e-09
        f32.sub
        local.get $0
@@ -2963,7 +2947,7 @@
        br $break|0
       end
       f32.const 0.7853981256484985
-      local.get $9
+      local.get $8
       f32.const 3.774894707930798e-08
       f32.sub
       local.get $0
@@ -2973,7 +2957,7 @@
       br $break|0
      end
      f32.const 0.9827936887741089
-     local.get $9
+     local.get $8
      f32.const 3.447321716976148e-08
      f32.sub
      local.get $0
@@ -2983,7 +2967,7 @@
      br $break|0
     end
     f32.const 1.570796251296997
-    local.get $9
+    local.get $8
     f32.const 7.549789415861596e-08
     f32.sub
     local.get $0
@@ -3148,25 +3132,23 @@
   call $std/math/check<f32>
  )
  (func $~lib/math/NativeMath.atan2 (; 74 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
-  (local $2 f64)
-  (local $3 i64)
+  (local $2 i64)
+  (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 i32)
+  (local $9 f64)
   (local $10 f64)
   local.get $1
-  local.tee $2
-  local.get $2
+  local.get $1
   f64.ne
   if (result i32)
    i32.const 1
   else
    local.get $0
-   local.tee $2
-   local.get $2
+   local.get $0
    f64.ne
   end
   if
@@ -3177,30 +3159,30 @@
   end
   local.get $1
   i64.reinterpret_f64
-  local.set $3
-  local.get $3
+  local.set $2
+  local.get $2
   i64.const 32
   i64.shr_u
+  i32.wrap_i64
+  local.set $3
+  local.get $2
   i32.wrap_i64
   local.set $4
-  local.get $3
-  i32.wrap_i64
-  local.set $5
   local.get $0
   i64.reinterpret_f64
-  local.set $3
-  local.get $3
+  local.set $2
+  local.get $2
   i64.const 32
   i64.shr_u
+  i32.wrap_i64
+  local.set $5
+  local.get $2
   i32.wrap_i64
   local.set $6
   local.get $3
-  i32.wrap_i64
-  local.set $7
-  local.get $4
   i32.const 1072693248
   i32.sub
-  local.get $5
+  local.get $4
   i32.or
   i32.const 0
   i32.eq
@@ -3209,28 +3191,28 @@
    call $~lib/math/NativeMath.atan
    return
   end
-  local.get $6
+  local.get $5
   i32.const 31
   i32.shr_u
   i32.const 1
   i32.and
-  local.get $4
+  local.get $3
   i32.const 30
   i32.shr_u
   i32.const 2
   i32.and
   i32.or
-  local.set $8
-  local.get $4
+  local.set $7
+  local.get $3
   i32.const 2147483647
   i32.and
-  local.set $4
-  local.get $6
+  local.set $3
+  local.get $5
   i32.const 2147483647
   i32.and
-  local.set $6
+  local.set $5
+  local.get $5
   local.get $6
-  local.get $7
   i32.or
   i32.const 0
   i32.eq
@@ -3240,21 +3222,21 @@
      block $case2|0
       block $case1|0
        block $case0|0
+        local.get $7
+        local.set $8
         local.get $8
-        local.set $9
-        local.get $9
         i32.const 0
         i32.eq
         br_if $case0|0
-        local.get $9
+        local.get $8
         i32.const 1
         i32.eq
         br_if $case1|0
-        local.get $9
+        local.get $8
         i32.const 2
         i32.eq
         br_if $case2|0
-        local.get $9
+        local.get $8
         i32.const 3
         i32.eq
         br_if $case3|0
@@ -3272,13 +3254,13 @@
     return
    end
   end
+  local.get $3
   local.get $4
-  local.get $5
   i32.or
   i32.const 0
   i32.eq
   if
-   local.get $8
+   local.get $7
    i32.const 1
    i32.and
    if (result f64)
@@ -3293,15 +3275,15 @@
    end
    return
   end
-  local.get $4
+  local.get $3
   i32.const 2146435072
   i32.eq
   if
-   local.get $6
+   local.get $5
    i32.const 2146435072
    i32.eq
    if
-    local.get $8
+    local.get $7
     i32.const 2
     i32.and
     if (result f64)
@@ -3316,19 +3298,19 @@
      f64.const 4
      f64.div
     end
-    local.set $2
-    local.get $8
+    local.set $9
+    local.get $7
     i32.const 1
     i32.and
     if (result f64)
-     local.get $2
+     local.get $9
      f64.neg
     else
-     local.get $2
+     local.get $9
     end
     return
    else
-    local.get $8
+    local.get $7
     i32.const 2
     i32.and
     if (result f64)
@@ -3337,34 +3319,34 @@
      i32.const 0
      f64.convert_i32_s
     end
-    local.set $2
-    local.get $8
+    local.set $9
+    local.get $7
     i32.const 1
     i32.and
     if (result f64)
-     local.get $2
+     local.get $9
      f64.neg
     else
-     local.get $2
+     local.get $9
     end
     return
    end
    unreachable
   end
-  local.get $4
+  local.get $3
   i32.const 67108864
   i32.add
-  local.get $6
+  local.get $5
   i32.lt_u
   if (result i32)
    i32.const 1
   else
-   local.get $6
+   local.get $5
    i32.const 2146435072
    i32.eq
   end
   if
-   local.get $8
+   local.get $7
    i32.const 1
    i32.and
    if (result f64)
@@ -3379,14 +3361,14 @@
    end
    return
   end
-  local.get $8
+  local.get $7
   i32.const 2
   i32.and
   if (result i32)
-   local.get $6
+   local.get $5
    i32.const 67108864
    i32.add
-   local.get $4
+   local.get $3
    i32.lt_u
   else
    i32.const 0
@@ -3407,21 +3389,21 @@
     block $case2|1
      block $case1|1
       block $case0|1
+       local.get $7
+       local.set $8
        local.get $8
-       local.set $9
-       local.get $9
        i32.const 0
        i32.eq
        br_if $case0|1
-       local.get $9
+       local.get $8
        i32.const 1
        i32.eq
        br_if $case1|1
-       local.get $9
+       local.get $8
        i32.const 2
        i32.eq
        br_if $case2|1
-       local.get $9
+       local.get $8
        i32.const 3
        i32.eq
        br_if $case3|1
@@ -3477,22 +3459,20 @@
   end
  )
  (func $~lib/math/NativeMathf.atan2 (; 76 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
-  (local $2 f32)
+  (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
+  (local $6 f32)
   (local $7 f32)
   local.get $1
-  local.tee $2
-  local.get $2
+  local.get $1
   f32.ne
   if (result i32)
    i32.const 1
   else
    local.get $0
-   local.tee $2
-   local.get $2
+   local.get $0
    f32.ne
   end
   if
@@ -3503,11 +3483,11 @@
   end
   local.get $1
   i32.reinterpret_f32
-  local.set $3
+  local.set $2
   local.get $0
   i32.reinterpret_f32
-  local.set $4
-  local.get $3
+  local.set $3
+  local.get $2
   i32.const 1065353216
   i32.eq
   if
@@ -3515,27 +3495,27 @@
    call $~lib/math/NativeMathf.atan
    return
   end
-  local.get $4
+  local.get $3
   i32.const 31
   i32.shr_u
   i32.const 1
   i32.and
-  local.get $3
+  local.get $2
   i32.const 30
   i32.shr_u
   i32.const 2
   i32.and
   i32.or
-  local.set $5
+  local.set $4
+  local.get $2
+  i32.const 2147483647
+  i32.and
+  local.set $2
   local.get $3
   i32.const 2147483647
   i32.and
   local.set $3
-  local.get $4
-  i32.const 2147483647
-  i32.and
-  local.set $4
-  local.get $4
+  local.get $3
   i32.const 0
   i32.eq
   if
@@ -3544,21 +3524,21 @@
      block $case2|0
       block $case1|0
        block $case0|0
+        local.get $4
+        local.set $5
         local.get $5
-        local.set $6
-        local.get $6
         i32.const 0
         i32.eq
         br_if $case0|0
-        local.get $6
+        local.get $5
         i32.const 1
         i32.eq
         br_if $case1|0
-        local.get $6
+        local.get $5
         i32.const 2
         i32.eq
         br_if $case2|0
-        local.get $6
+        local.get $5
         i32.const 3
         i32.eq
         br_if $case3|0
@@ -3576,11 +3556,11 @@
     return
    end
   end
-  local.get $3
+  local.get $2
   i32.const 0
   i32.eq
   if
-   local.get $5
+   local.get $4
    i32.const 1
    i32.and
    if (result f32)
@@ -3595,15 +3575,15 @@
    end
    return
   end
-  local.get $3
+  local.get $2
   i32.const 2139095040
   i32.eq
   if
-   local.get $4
+   local.get $3
    i32.const 2139095040
    i32.eq
    if
-    local.get $5
+    local.get $4
     i32.const 2
     i32.and
     if (result f32)
@@ -3617,19 +3597,19 @@
      f32.const 4
      f32.div
     end
-    local.set $2
-    local.get $5
+    local.set $6
+    local.get $4
     i32.const 1
     i32.and
     if (result f32)
-     local.get $2
+     local.get $6
      f32.neg
     else
-     local.get $2
+     local.get $6
     end
     return
    else
-    local.get $5
+    local.get $4
     i32.const 2
     i32.and
     if (result f32)
@@ -3637,34 +3617,34 @@
     else
      f32.const 0
     end
-    local.set $2
-    local.get $5
+    local.set $6
+    local.get $4
     i32.const 1
     i32.and
     if (result f32)
-     local.get $2
+     local.get $6
      f32.neg
     else
-     local.get $2
+     local.get $6
     end
     return
    end
    unreachable
   end
-  local.get $3
+  local.get $2
   i32.const 218103808
   i32.add
-  local.get $4
+  local.get $3
   i32.lt_u
   if (result i32)
    i32.const 1
   else
-   local.get $4
+   local.get $3
    i32.const 2139095040
    i32.eq
   end
   if
-   local.get $5
+   local.get $4
    i32.const 1
    i32.and
    if (result f32)
@@ -3679,14 +3659,14 @@
    end
    return
   end
-  local.get $5
+  local.get $4
   i32.const 2
   i32.and
   if (result i32)
-   local.get $4
+   local.get $3
    i32.const 218103808
    i32.add
-   local.get $3
+   local.get $2
    i32.lt_u
   else
    i32.const 0
@@ -3707,21 +3687,21 @@
     block $case2|1
      block $case1|1
       block $case0|1
+       local.get $4
+       local.set $5
        local.get $5
-       local.set $6
-       local.get $6
        i32.const 0
        i32.eq
        br_if $case0|1
-       local.get $6
+       local.get $5
        i32.const 1
        i32.eq
        br_if $case1|1
-       local.get $6
+       local.get $5
        i32.const 2
        i32.eq
        br_if $case2|1
-       local.get $6
+       local.get $5
        i32.const 3
        i32.eq
        br_if $case3|1
@@ -5697,8 +5677,7 @@
   i32.ge_u
   if
    local.get $0
-   local.tee $5
-   local.get $5
+   local.get $0
    f64.ne
    if
     local.get $0
@@ -5720,7 +5699,7 @@
    end
   end
   f64.const 0
-  local.set $6
+  local.set $5
   local.get $2
   i32.const 1071001154
   i32.gt_u
@@ -5745,27 +5724,27 @@
    local.set $3
    local.get $3
    f64.convert_i32_s
-   local.set $7
+   local.set $6
    local.get $0
-   local.get $7
+   local.get $6
    f64.const 0.6931471803691238
    f64.mul
    f64.sub
-   local.set $5
-   local.get $7
+   local.set $7
+   local.get $6
    f64.const 1.9082149292705877e-10
    f64.mul
    local.set $8
-   local.get $5
+   local.get $7
    local.get $8
    f64.sub
    local.set $0
-   local.get $5
+   local.get $7
    local.get $0
    f64.sub
    local.get $8
    f64.sub
-   local.set $6
+   local.set $5
   else
    local.get $2
    i32.const 1016070144
@@ -5814,14 +5793,14 @@
   local.get $9
   f64.mul
   f64.sub
-  local.set $7
+  local.set $6
   local.get $10
   local.get $12
-  local.get $7
+  local.get $6
   f64.sub
   f64.const 6
   local.get $0
-  local.get $7
+  local.get $6
   f64.mul
   f64.sub
   f64.div
@@ -5842,10 +5821,10 @@
   end
   local.get $0
   local.get $13
-  local.get $6
+  local.get $5
   f64.sub
   f64.mul
-  local.get $6
+  local.get $5
   f64.sub
   local.set $13
   local.get $13
@@ -5978,12 +5957,11 @@
   (local $2 i32)
   (local $3 f64)
   (local $4 f64)
-  (local $5 f64)
-  (local $6 i32)
+  (local $5 i32)
+  (local $6 f64)
   (local $7 f64)
   (local $8 f64)
   (local $9 f64)
-  (local $10 f64)
   local.get $0
   i64.reinterpret_f64
   i64.const 32
@@ -6003,8 +5981,7 @@
   i32.ge_u
   if
    local.get $0
-   local.tee $3
-   local.get $3
+   local.get $0
    f64.ne
    if
     local.get $0
@@ -6028,9 +6005,9 @@
    end
   end
   f64.const 0
-  local.set $5
+  local.set $4
   i32.const 0
-  local.set $6
+  local.set $5
   local.get $1
   i32.const 1071001154
   i32.gt_u
@@ -6047,29 +6024,29 @@
     f64.copysign
     f64.add
     i32.trunc_f64_s
-    local.set $6
+    local.set $5
    else
     i32.const 1
     local.get $2
     i32.const 1
     i32.shl
     i32.sub
-    local.set $6
+    local.set $5
    end
    local.get $0
-   local.get $6
+   local.get $5
    f64.convert_i32_s
    f64.const 0.6931471803691238
    f64.mul
    f64.sub
-   local.set $4
-   local.get $6
+   local.set $3
+   local.get $5
    f64.convert_i32_s
    f64.const 1.9082149292705877e-10
    f64.mul
-   local.set $5
+   local.set $4
+   local.get $3
    local.get $4
-   local.get $5
    f64.sub
    local.set $0
   else
@@ -6078,7 +6055,7 @@
    i32.gt_u
    if
     local.get $0
-    local.set $4
+    local.set $3
    else
     f64.const 1
     local.get $0
@@ -6089,24 +6066,24 @@
   local.get $0
   local.get $0
   f64.mul
-  local.set $7
-  local.get $7
-  local.get $7
+  local.set $6
+  local.get $6
+  local.get $6
   f64.mul
-  local.set $8
+  local.set $7
   local.get $0
-  local.get $7
+  local.get $6
   f64.const 0.16666666666666602
   f64.mul
-  local.get $8
-  f64.const -2.7777777777015593e-03
   local.get $7
+  f64.const -2.7777777777015593e-03
+  local.get $6
   f64.const 6.613756321437934e-05
   f64.mul
   f64.add
-  local.get $8
-  f64.const -1.6533902205465252e-06
   local.get $7
+  f64.const -1.6533902205465252e-06
+  local.get $6
   f64.const 4.1381367970572385e-08
   f64.mul
   f64.add
@@ -6115,30 +6092,30 @@
   f64.mul
   f64.add
   f64.sub
-  local.set $9
+  local.set $8
   f64.const 1
   local.get $0
-  local.get $9
+  local.get $8
   f64.mul
   f64.const 2
-  local.get $9
+  local.get $8
   f64.sub
   f64.div
-  local.get $5
-  f64.sub
   local.get $4
+  f64.sub
+  local.get $3
   f64.add
   f64.add
-  local.set $10
-  local.get $6
+  local.set $9
+  local.get $5
   i32.const 0
   i32.eq
   if
-   local.get $10
+   local.get $9
    return
   end
-  local.get $10
-  local.get $6
+  local.get $9
+  local.get $5
   call $~lib/math/NativeMath.scalbn
  )
  (func $~lib/math/NativeMath.cosh (; 91 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
@@ -8388,8 +8365,7 @@
    i32.const 1
   else
    local.get $1
-   local.tee $8
-   local.get $8
+   local.get $1
    f64.ne
   end
   if
@@ -8669,8 +8645,7 @@
    i32.const 1
   else
    local.get $1
-   local.tee $8
-   local.get $8
+   local.get $1
    f32.ne
   end
   if
@@ -11302,8 +11277,7 @@
    i32.const 1
   else
    local.get $1
-   local.tee $7
-   local.get $7
+   local.get $1
    f64.ne
   end
   if
@@ -11584,10 +11558,9 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 f32)
+  (local $8 i32)
   (local $9 i32)
-  (local $10 i32)
-  (local $11 f32)
+  (local $10 f32)
   local.get $0
   i32.reinterpret_f32
   local.set $2
@@ -11628,8 +11601,7 @@
    i32.const 1
   else
    local.get $1
-   local.tee $8
-   local.get $8
+   local.get $1
    f32.ne
   end
   if
@@ -11716,7 +11688,7 @@
    local.set $3
   end
   i32.const 0
-  local.set $9
+  local.set $8
   block $break|0
    local.get $4
    local.get $5
@@ -11748,19 +11720,19 @@
       local.get $3
       i32.sub
       local.set $7
-      local.get $9
+      local.get $8
       i32.const 1
       i32.add
-      local.set $9
+      local.set $8
      end
      local.get $7
      i32.const 1
      i32.shl
      local.set $7
-     local.get $9
+     local.get $8
      i32.const 1
      i32.shl
-     local.set $9
+     local.set $8
      local.get $4
      i32.const 1
      i32.sub
@@ -11777,10 +11749,10 @@
     local.get $3
     i32.sub
     local.set $7
-    local.get $9
+    local.get $8
     i32.const 1
     i32.add
-    local.set $9
+    local.set $8
    end
    local.get $7
    i32.const 0
@@ -11793,13 +11765,13 @@
     i32.const 8
     i32.shl
     i32.clz
-    local.set $10
+    local.set $9
     local.get $4
-    local.get $10
+    local.get $9
     i32.sub
     local.set $4
     local.get $7
-    local.get $10
+    local.get $9
     i32.shl
     local.set $7
    end
@@ -11840,7 +11812,7 @@
   local.get $0
   local.get $0
   f32.add
-  local.set $11
+  local.set $10
   local.get $4
   local.get $5
   i32.eq
@@ -11853,17 +11825,17 @@
    local.get $5
    i32.eq
    if (result i32)
-    local.get $11
+    local.get $10
     local.get $1
     f32.gt
     if (result i32)
      i32.const 1
     else
-     local.get $11
+     local.get $10
      local.get $1
      f32.eq
      if (result i32)
-      local.get $9
+      local.get $8
       i32.const 1
       i32.and
      else
@@ -15532,10 +15504,8 @@
   f64.convert_i32_s
  )
  (func $~lib/math/NativeMath.clz32 (; 169 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
-  (local $1 f64)
   local.get $0
-  local.tee $1
-  local.get $1
+  local.get $0
   f64.sub
   f64.const 0
   f64.eq

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -1,12 +1,12 @@
 (module
  (type $FUNCSIG$idddi (func (param f64 f64 f64 i32) (result i32)))
- (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$dddd (func (param f64 f64 f64) (result f64)))
+ (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$ddi (func (param f64 i32) (result f64)))
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$ifffi (func (param f32 f32 f32 i32) (result i32)))
- (type $FUNCSIG$if (func (param f32) (result i32)))
  (type $FUNCSIG$ffff (func (param f32 f32 f32) (result f32)))
+ (type $FUNCSIG$if (func (param f32) (result i32)))
  (type $FUNCSIG$ffi (func (param f32 i32) (result f32)))
  (type $FUNCSIG$ididdi (func (param f64 i32 f64 f64 i32) (result i32)))
  (type $FUNCSIG$ififfi (func (param f32 i32 f32 f32 i32) (result i32)))
@@ -120,19 +120,7 @@
  (global $~lib/builtins/f32.MIN_VALUE f32 (f32.const 1.401298464324817e-45))
  (export "memory" (memory $0))
  (start $start)
- (func $~lib/number/isNaN<f64> (; 32 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.ne
- )
- (func $~lib/number/isFinite<f64> (; 33 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.sub
-  f64.const 0
-  f64.eq
- )
- (func $std/math/eulp (; 34 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $std/math/eulp (; 32 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   (local $1 i64)
   (local $2 i32)
   local.get $0
@@ -159,7 +147,7 @@
   i32.const 52
   i32.sub
  )
- (func $~lib/math/NativeMath.scalbn (; 35 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/NativeMath.scalbn (; 33 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
@@ -250,13 +238,17 @@
   f64.reinterpret_i64
   f64.mul
  )
- (func $std/math/ulperr (; 36 ;) (type $FUNCSIG$dddd) (param $0 f64) (param $1 f64) (param $2 f64) (result f64)
+ (func $std/math/ulperr (; 34 ;) (type $FUNCSIG$dddd) (param $0 f64) (param $1 f64) (param $2 f64) (result f64)
   (local $3 f64)
   local.get $0
-  call $~lib/number/isNaN<f64>
+  local.tee $3
+  local.get $3
+  f64.ne
   if (result i32)
    local.get $1
-   call $~lib/number/isNaN<f64>
+   local.tee $3
+   local.get $3
+   f64.ne
   else
    i32.const 0
   end
@@ -303,7 +295,11 @@
    return
   end
   local.get $0
-  call $~lib/number/isFinite<f64>
+  local.tee $3
+  local.get $3
+  f64.sub
+  f64.const 0
+  f64.eq
   i32.eqz
   if
    f64.const 8988465674311579538646525e283
@@ -326,8 +322,9 @@
   local.get $2
   f64.add
  )
- (func $std/math/check<f64> (; 37 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/check<f64> (; 35 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
+  (local $5 f64)
   local.get $0
   local.get $1
   f64.eq
@@ -336,18 +333,22 @@
    return
   end
   local.get $1
-  call $~lib/number/isNaN<f64>
+  local.tee $4
+  local.get $4
+  f64.ne
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.tee $4
+   local.get $4
+   f64.ne
    return
   end
   local.get $0
   local.get $1
   local.get $2
   call $std/math/ulperr
-  local.set $4
-  local.get $4
+  local.set $5
+  local.get $5
   f64.abs
   f64.const 1.5
   f64.ge
@@ -357,19 +358,7 @@
   end
   i32.const 1
  )
- (func $~lib/number/isNaN<f32> (; 38 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
-  local.get $0
-  local.get $0
-  f32.ne
- )
- (func $~lib/number/isFinite<f32> (; 39 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
-  local.get $0
-  local.get $0
-  f32.sub
-  f32.const 0
-  f32.eq
- )
- (func $std/math/eulpf (; 40 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
+ (func $std/math/eulpf (; 36 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -395,7 +384,7 @@
   i32.const 23
   i32.sub
  )
- (func $~lib/math/NativeMathf.scalbn (; 41 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
+ (func $~lib/math/NativeMathf.scalbn (; 37 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
   (local $2 f32)
   (local $3 i32)
   (local $4 i32)
@@ -485,13 +474,17 @@
   f32.reinterpret_i32
   f32.mul
  )
- (func $std/math/ulperrf (; 42 ;) (type $FUNCSIG$ffff) (param $0 f32) (param $1 f32) (param $2 f32) (result f32)
+ (func $std/math/ulperrf (; 38 ;) (type $FUNCSIG$ffff) (param $0 f32) (param $1 f32) (param $2 f32) (result f32)
   (local $3 f32)
   local.get $0
-  call $~lib/number/isNaN<f32>
+  local.tee $3
+  local.get $3
+  f32.ne
   if (result i32)
    local.get $1
-   call $~lib/number/isNaN<f32>
+   local.tee $3
+   local.get $3
+   f32.ne
   else
    i32.const 0
   end
@@ -536,7 +529,11 @@
    return
   end
   local.get $0
-  call $~lib/number/isFinite<f32>
+  local.tee $3
+  local.get $3
+  f32.sub
+  f32.const 0
+  f32.eq
   i32.eqz
   if
    f32.const 1701411834604692317316873e14
@@ -559,8 +556,9 @@
   local.get $2
   f32.add
  )
- (func $std/math/check<f32> (; 43 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/check<f32> (; 39 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
+  (local $5 f32)
   local.get $0
   local.get $1
   f32.eq
@@ -569,18 +567,22 @@
    return
   end
   local.get $1
-  call $~lib/number/isNaN<f32>
+  local.tee $4
+  local.get $4
+  f32.ne
   if
    local.get $0
-   call $~lib/number/isNaN<f32>
+   local.tee $4
+   local.get $4
+   f32.ne
    return
   end
   local.get $0
   local.get $1
   local.get $2
   call $std/math/ulperrf
-  local.set $4
-  local.get $4
+  local.set $5
+  local.get $5
   f32.abs
   f32.const 1.5
   f32.ge
@@ -590,7 +592,7 @@
   end
   i32.const 1
  )
- (func $std/math/test_scalbn (; 44 ;) (type $FUNCSIG$ididdi) (param $0 f64) (param $1 i32) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_scalbn (; 40 ;) (type $FUNCSIG$ididdi) (param $0 f64) (param $1 i32) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.scalbn
@@ -599,7 +601,7 @@
   local.get $4
   call $std/math/check<f64>
  )
- (func $std/math/test_scalbnf (; 45 ;) (type $FUNCSIG$ififfi) (param $0 f32) (param $1 i32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_scalbnf (; 41 ;) (type $FUNCSIG$ififfi) (param $0 f32) (param $1 i32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.scalbn
@@ -608,7 +610,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $std/math/test_abs (; 46 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_abs (; 42 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   local.get $0
   local.set $4
@@ -635,7 +637,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_absf (; 47 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_absf (; 43 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   local.get $0
   local.set $4
@@ -646,7 +648,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/R (; 48 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/R (; 44 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 f64)
   (local $2 f64)
   local.get $0
@@ -695,7 +697,7 @@
   local.get $2
   f64.div
  )
- (func $~lib/math/NativeMath.acos (; 49 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.acos (; 45 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -847,7 +849,7 @@
   f64.add
   f64.mul
  )
- (func $std/math/test_acos (; 50 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_acos (; 46 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.acos
   local.get $1
@@ -871,7 +873,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/Rf (; 51 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/Rf (; 47 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 f32)
   local.get $0
@@ -896,7 +898,7 @@
   local.get $2
   f32.div
  )
- (func $~lib/math/NativeMathf.acos (; 52 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.acos (; 48 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -1036,7 +1038,7 @@
   f32.add
   f32.mul
  )
- (func $std/math/test_acosf (; 53 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_acosf (; 49 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.acos
   local.get $1
@@ -1044,7 +1046,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log1p (; 54 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log1p (; 50 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -1286,7 +1288,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.log (; 55 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log (; 51 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -1495,7 +1497,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.acosh (; 56 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.acosh (; 52 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   local.get $0
   i64.reinterpret_f64
@@ -1555,7 +1557,7 @@
   f64.const 0.6931471805599453
   f64.add
  )
- (func $std/math/test_acosh (; 57 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_acosh (; 53 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.acosh
   local.get $1
@@ -1579,7 +1581,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.log1p (; 58 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log1p (; 54 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -1788,7 +1790,7 @@
   f32.mul
   f32.add
  )
- (func $~lib/math/NativeMathf.log (; 59 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log (; 55 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -1956,7 +1958,7 @@
   f32.mul
   f32.add
  )
- (func $~lib/math/NativeMathf.acosh (; 60 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.acosh (; 56 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -2012,7 +2014,7 @@
   f32.const 0.6931471824645996
   f32.add
  )
- (func $std/math/test_acoshf (; 61 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_acoshf (; 57 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.acosh
   local.get $1
@@ -2020,7 +2022,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.asin (; 62 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.asin (; 58 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2179,7 +2181,7 @@
   end
   local.get $0
  )
- (func $std/math/test_asin (; 63 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_asin (; 59 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.asin
   local.get $1
@@ -2203,7 +2205,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.asin (; 64 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.asin (; 60 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 f32)
   (local $2 i32)
   (local $3 f32)
@@ -2295,7 +2297,7 @@
   local.get $1
   f32.copysign
  )
- (func $std/math/test_asinf (; 65 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_asinf (; 61 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.asin
   local.get $1
@@ -2303,7 +2305,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.asinh (; 66 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.asinh (; 62 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i64)
   (local $3 f64)
@@ -2379,7 +2381,7 @@
   local.get $0
   f64.copysign
  )
- (func $std/math/test_asinh (; 67 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_asinh (; 63 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.asinh
   local.get $1
@@ -2403,7 +2405,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.asinh (; 68 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.asinh (; 64 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   local.get $0
@@ -2472,7 +2474,7 @@
   local.get $0
   f32.copysign
  )
- (func $std/math/test_asinhf (; 69 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_asinhf (; 65 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.asinh
   local.get $1
@@ -2480,16 +2482,17 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atan (; 70 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atan (; 66 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 f64)
   (local $3 f64)
-  (local $4 i32)
-  (local $5 f64)
+  (local $4 f64)
+  (local $5 i32)
   (local $6 f64)
   (local $7 f64)
   (local $8 f64)
-  (local $9 i32)
+  (local $9 f64)
+  (local $10 i32)
   local.get $0
   i64.reinterpret_f64
   i64.const 32
@@ -2507,7 +2510,9 @@
   i32.ge_u
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.tee $4
+   local.get $4
+   f64.ne
    if
     local.get $0
     return
@@ -2534,7 +2539,7 @@
     return
    end
    i32.const -1
-   local.set $4
+   local.set $5
   else
    local.get $0
    f64.abs
@@ -2548,7 +2553,7 @@
     i32.lt_u
     if
      i32.const 0
-     local.set $4
+     local.set $5
      f64.const 2
      local.get $0
      f64.mul
@@ -2561,7 +2566,7 @@
      local.set $0
     else
      i32.const 1
-     local.set $4
+     local.set $5
      local.get $0
      f64.const 1
      f64.sub
@@ -2577,7 +2582,7 @@
     i32.lt_u
     if
      i32.const 2
-     local.set $4
+     local.set $5
      local.get $0
      f64.const 1.5
      f64.sub
@@ -2590,7 +2595,7 @@
      local.set $0
     else
      i32.const 3
-     local.set $4
+     local.set $5
      f64.const -1
      local.get $0
      f64.div
@@ -2605,18 +2610,18 @@
   local.get $3
   local.get $3
   f64.mul
-  local.set $5
+  local.set $6
   local.get $3
   f64.const 0.3333333333333293
-  local.get $5
+  local.get $6
   f64.const 0.14285714272503466
-  local.get $5
+  local.get $6
   f64.const 0.09090887133436507
-  local.get $5
+  local.get $6
   f64.const 0.06661073137387531
-  local.get $5
+  local.get $6
   f64.const 0.049768779946159324
-  local.get $5
+  local.get $6
   f64.const 0.016285820115365782
   f64.mul
   f64.add
@@ -2629,16 +2634,16 @@
   f64.mul
   f64.add
   f64.mul
-  local.set $6
-  local.get $5
+  local.set $7
+  local.get $6
   f64.const -0.19999999999876483
-  local.get $5
+  local.get $6
   f64.const -0.11111110405462356
-  local.get $5
+  local.get $6
   f64.const -0.0769187620504483
-  local.get $5
+  local.get $6
   f64.const -0.058335701337905735
-  local.get $5
+  local.get $6
   f64.const -0.036531572744216916
   f64.mul
   f64.add
@@ -2649,19 +2654,19 @@
   f64.mul
   f64.add
   f64.mul
-  local.set $7
+  local.set $8
   local.get $0
-  local.get $6
   local.get $7
+  local.get $8
   f64.add
   f64.mul
-  local.set $8
-  local.get $4
+  local.set $9
+  local.get $5
   i32.const 0
   i32.lt_s
   if
    local.get $0
-   local.get $8
+   local.get $9
    f64.sub
    return
   end
@@ -2671,28 +2676,28 @@
      block $case2|0
       block $case1|0
        block $case0|0
-        local.get $4
-        local.set $9
-        local.get $9
+        local.get $5
+        local.set $10
+        local.get $10
         i32.const 0
         i32.eq
         br_if $case0|0
-        local.get $9
+        local.get $10
         i32.const 1
         i32.eq
         br_if $case1|0
-        local.get $9
+        local.get $10
         i32.const 2
         i32.eq
         br_if $case2|0
-        local.get $9
+        local.get $10
         i32.const 3
         i32.eq
         br_if $case3|0
         br $case4|0
        end
        f64.const 0.4636476090008061
-       local.get $8
+       local.get $9
        f64.const 2.2698777452961687e-17
        f64.sub
        local.get $0
@@ -2702,7 +2707,7 @@
        br $break|0
       end
       f64.const 0.7853981633974483
-      local.get $8
+      local.get $9
       f64.const 3.061616997868383e-17
       f64.sub
       local.get $0
@@ -2712,7 +2717,7 @@
       br $break|0
      end
      f64.const 0.982793723247329
-     local.get $8
+     local.get $9
      f64.const 1.3903311031230998e-17
      f64.sub
      local.get $0
@@ -2722,7 +2727,7 @@
      br $break|0
     end
     f64.const 1.5707963267948966
-    local.get $8
+    local.get $9
     f64.const 6.123233995736766e-17
     f64.sub
     local.get $0
@@ -2737,7 +2742,7 @@
   local.get $2
   f64.copysign
  )
- (func $std/math/test_atan (; 71 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_atan (; 67 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.atan
   local.get $1
@@ -2761,16 +2766,17 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.atan (; 72 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.atan (; 68 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
-  (local $4 i32)
-  (local $5 f32)
+  (local $4 f32)
+  (local $5 i32)
   (local $6 f32)
   (local $7 f32)
   (local $8 f32)
-  (local $9 i32)
+  (local $9 f32)
+  (local $10 i32)
   local.get $0
   i32.reinterpret_f32
   local.set $1
@@ -2785,7 +2791,9 @@
   i32.ge_u
   if
    local.get $0
-   call $~lib/number/isNaN<f32>
+   local.tee $4
+   local.get $4
+   f32.ne
    if
     local.get $0
     return
@@ -2811,7 +2819,7 @@
     return
    end
    i32.const -1
-   local.set $4
+   local.set $5
   else
    local.get $0
    f32.abs
@@ -2825,7 +2833,7 @@
     i32.lt_u
     if
      i32.const 0
-     local.set $4
+     local.set $5
      f32.const 2
      local.get $0
      f32.mul
@@ -2838,7 +2846,7 @@
      local.set $0
     else
      i32.const 1
-     local.set $4
+     local.set $5
      local.get $0
      f32.const 1
      f32.sub
@@ -2854,7 +2862,7 @@
     i32.lt_u
     if
      i32.const 2
-     local.set $4
+     local.set $5
      local.get $0
      f32.const 1.5
      f32.sub
@@ -2867,7 +2875,7 @@
      local.set $0
     else
      i32.const 3
-     local.set $4
+     local.set $5
      f32.const -1
      local.get $0
      f32.div
@@ -2882,39 +2890,39 @@
   local.get $3
   local.get $3
   f32.mul
-  local.set $5
+  local.set $6
   local.get $3
   f32.const 0.333333283662796
-  local.get $5
+  local.get $6
   f32.const 0.14253635704517365
-  local.get $5
+  local.get $6
   f32.const 0.06168760731816292
   f32.mul
   f32.add
   f32.mul
   f32.add
   f32.mul
-  local.set $6
-  local.get $5
+  local.set $7
+  local.get $6
   f32.const -0.19999158382415771
-  local.get $5
+  local.get $6
   f32.const -0.106480173766613
   f32.mul
   f32.add
   f32.mul
-  local.set $7
+  local.set $8
   local.get $0
-  local.get $6
   local.get $7
+  local.get $8
   f32.add
   f32.mul
-  local.set $8
-  local.get $4
+  local.set $9
+  local.get $5
   i32.const 0
   i32.lt_s
   if
    local.get $0
-   local.get $8
+   local.get $9
    f32.sub
    return
   end
@@ -2924,28 +2932,28 @@
      block $case2|0
       block $case1|0
        block $case0|0
-        local.get $4
-        local.set $9
-        local.get $9
+        local.get $5
+        local.set $10
+        local.get $10
         i32.const 0
         i32.eq
         br_if $case0|0
-        local.get $9
+        local.get $10
         i32.const 1
         i32.eq
         br_if $case1|0
-        local.get $9
+        local.get $10
         i32.const 2
         i32.eq
         br_if $case2|0
-        local.get $9
+        local.get $10
         i32.const 3
         i32.eq
         br_if $case3|0
         br $case4|0
        end
        f32.const 0.46364760398864746
-       local.get $8
+       local.get $9
        f32.const 5.01215824399992e-09
        f32.sub
        local.get $0
@@ -2955,7 +2963,7 @@
        br $break|0
       end
       f32.const 0.7853981256484985
-      local.get $8
+      local.get $9
       f32.const 3.774894707930798e-08
       f32.sub
       local.get $0
@@ -2965,7 +2973,7 @@
       br $break|0
      end
      f32.const 0.9827936887741089
-     local.get $8
+     local.get $9
      f32.const 3.447321716976148e-08
      f32.sub
      local.get $0
@@ -2975,7 +2983,7 @@
      br $break|0
     end
     f32.const 1.570796251296997
-    local.get $8
+    local.get $9
     f32.const 7.549789415861596e-08
     f32.sub
     local.get $0
@@ -2990,7 +2998,7 @@
   local.get $2
   f32.copysign
  )
- (func $std/math/test_atanf (; 73 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_atanf (; 69 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.atan
   local.get $1
@@ -2998,7 +3006,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atanh (; 74 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.atanh (; 70 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i64)
   (local $3 f64)
@@ -3057,7 +3065,7 @@
   local.get $0
   f64.copysign
  )
- (func $std/math/test_atanh (; 75 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_atanh (; 71 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.atanh
   local.get $1
@@ -3081,7 +3089,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.atanh (; 76 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.atanh (; 72 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   local.get $0
@@ -3131,7 +3139,7 @@
   local.get $0
   f32.copysign
  )
- (func $std/math/test_atanhf (; 77 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_atanhf (; 73 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.atanh
   local.get $1
@@ -3139,23 +3147,27 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.atan2 (; 78 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
-  (local $2 i64)
-  (local $3 i32)
+ (func $~lib/math/NativeMath.atan2 (; 74 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+  (local $2 f64)
+  (local $3 i64)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 f64)
+  (local $9 i32)
   (local $10 f64)
   local.get $1
-  call $~lib/number/isNaN<f64>
+  local.tee $2
+  local.get $2
+  f64.ne
   if (result i32)
    i32.const 1
   else
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.tee $2
+   local.get $2
+   f64.ne
   end
   if
    local.get $1
@@ -3165,30 +3177,30 @@
   end
   local.get $1
   i64.reinterpret_f64
-  local.set $2
-  local.get $2
+  local.set $3
+  local.get $3
   i64.const 32
   i64.shr_u
-  i32.wrap_i64
-  local.set $3
-  local.get $2
   i32.wrap_i64
   local.set $4
-  local.get $0
-  i64.reinterpret_f64
-  local.set $2
-  local.get $2
-  i64.const 32
-  i64.shr_u
+  local.get $3
   i32.wrap_i64
   local.set $5
-  local.get $2
+  local.get $0
+  i64.reinterpret_f64
+  local.set $3
+  local.get $3
+  i64.const 32
+  i64.shr_u
   i32.wrap_i64
   local.set $6
   local.get $3
+  i32.wrap_i64
+  local.set $7
+  local.get $4
   i32.const 1072693248
   i32.sub
-  local.get $4
+  local.get $5
   i32.or
   i32.const 0
   i32.eq
@@ -3197,28 +3209,28 @@
    call $~lib/math/NativeMath.atan
    return
   end
-  local.get $5
+  local.get $6
   i32.const 31
   i32.shr_u
   i32.const 1
   i32.and
-  local.get $3
+  local.get $4
   i32.const 30
   i32.shr_u
   i32.const 2
   i32.and
   i32.or
-  local.set $7
-  local.get $3
+  local.set $8
+  local.get $4
   i32.const 2147483647
   i32.and
-  local.set $3
-  local.get $5
-  i32.const 2147483647
-  i32.and
-  local.set $5
-  local.get $5
+  local.set $4
   local.get $6
+  i32.const 2147483647
+  i32.and
+  local.set $6
+  local.get $6
+  local.get $7
   i32.or
   i32.const 0
   i32.eq
@@ -3228,21 +3240,21 @@
      block $case2|0
       block $case1|0
        block $case0|0
-        local.get $7
-        local.set $8
         local.get $8
+        local.set $9
+        local.get $9
         i32.const 0
         i32.eq
         br_if $case0|0
-        local.get $8
+        local.get $9
         i32.const 1
         i32.eq
         br_if $case1|0
-        local.get $8
+        local.get $9
         i32.const 2
         i32.eq
         br_if $case2|0
-        local.get $8
+        local.get $9
         i32.const 3
         i32.eq
         br_if $case3|0
@@ -3260,13 +3272,13 @@
     return
    end
   end
-  local.get $3
   local.get $4
+  local.get $5
   i32.or
   i32.const 0
   i32.eq
   if
-   local.get $7
+   local.get $8
    i32.const 1
    i32.and
    if (result f64)
@@ -3281,15 +3293,15 @@
    end
    return
   end
-  local.get $3
+  local.get $4
   i32.const 2146435072
   i32.eq
   if
-   local.get $5
+   local.get $6
    i32.const 2146435072
    i32.eq
    if
-    local.get $7
+    local.get $8
     i32.const 2
     i32.and
     if (result f64)
@@ -3304,19 +3316,19 @@
      f64.const 4
      f64.div
     end
-    local.set $9
-    local.get $7
+    local.set $2
+    local.get $8
     i32.const 1
     i32.and
     if (result f64)
-     local.get $9
+     local.get $2
      f64.neg
     else
-     local.get $9
+     local.get $2
     end
     return
    else
-    local.get $7
+    local.get $8
     i32.const 2
     i32.and
     if (result f64)
@@ -3325,34 +3337,34 @@
      i32.const 0
      f64.convert_i32_s
     end
-    local.set $9
-    local.get $7
+    local.set $2
+    local.get $8
     i32.const 1
     i32.and
     if (result f64)
-     local.get $9
+     local.get $2
      f64.neg
     else
-     local.get $9
+     local.get $2
     end
     return
    end
    unreachable
   end
-  local.get $3
+  local.get $4
   i32.const 67108864
   i32.add
-  local.get $5
+  local.get $6
   i32.lt_u
   if (result i32)
    i32.const 1
   else
-   local.get $5
+   local.get $6
    i32.const 2146435072
    i32.eq
   end
   if
-   local.get $7
+   local.get $8
    i32.const 1
    i32.and
    if (result f64)
@@ -3367,14 +3379,14 @@
    end
    return
   end
-  local.get $7
+  local.get $8
   i32.const 2
   i32.and
   if (result i32)
-   local.get $5
+   local.get $6
    i32.const 67108864
    i32.add
-   local.get $3
+   local.get $4
    i32.lt_u
   else
    i32.const 0
@@ -3395,21 +3407,21 @@
     block $case2|1
      block $case1|1
       block $case0|1
-       local.get $7
-       local.set $8
        local.get $8
+       local.set $9
+       local.get $9
        i32.const 0
        i32.eq
        br_if $case0|1
-       local.get $8
+       local.get $9
        i32.const 1
        i32.eq
        br_if $case1|1
-       local.get $8
+       local.get $9
        i32.const 2
        i32.eq
        br_if $case2|1
-       local.get $8
+       local.get $9
        i32.const 3
        i32.eq
        br_if $case3|1
@@ -3438,7 +3450,7 @@
   end
   unreachable
  )
- (func $std/math/test_atan2 (; 79 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_atan2 (; 75 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.atan2
@@ -3464,20 +3476,24 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.atan2 (; 80 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
-  (local $2 i32)
+ (func $~lib/math/NativeMathf.atan2 (; 76 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+  (local $2 f32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 f32)
+  (local $6 i32)
   (local $7 f32)
   local.get $1
-  call $~lib/number/isNaN<f32>
+  local.tee $2
+  local.get $2
+  f32.ne
   if (result i32)
    i32.const 1
   else
    local.get $0
-   call $~lib/number/isNaN<f32>
+   local.tee $2
+   local.get $2
+   f32.ne
   end
   if
    local.get $1
@@ -3487,11 +3503,11 @@
   end
   local.get $1
   i32.reinterpret_f32
-  local.set $2
+  local.set $3
   local.get $0
   i32.reinterpret_f32
-  local.set $3
-  local.get $2
+  local.set $4
+  local.get $3
   i32.const 1065353216
   i32.eq
   if
@@ -3499,27 +3515,27 @@
    call $~lib/math/NativeMathf.atan
    return
   end
-  local.get $3
+  local.get $4
   i32.const 31
   i32.shr_u
   i32.const 1
   i32.and
-  local.get $2
+  local.get $3
   i32.const 30
   i32.shr_u
   i32.const 2
   i32.and
   i32.or
-  local.set $4
-  local.get $2
-  i32.const 2147483647
-  i32.and
-  local.set $2
+  local.set $5
   local.get $3
   i32.const 2147483647
   i32.and
   local.set $3
-  local.get $3
+  local.get $4
+  i32.const 2147483647
+  i32.and
+  local.set $4
+  local.get $4
   i32.const 0
   i32.eq
   if
@@ -3528,21 +3544,21 @@
      block $case2|0
       block $case1|0
        block $case0|0
-        local.get $4
-        local.set $5
         local.get $5
+        local.set $6
+        local.get $6
         i32.const 0
         i32.eq
         br_if $case0|0
-        local.get $5
+        local.get $6
         i32.const 1
         i32.eq
         br_if $case1|0
-        local.get $5
+        local.get $6
         i32.const 2
         i32.eq
         br_if $case2|0
-        local.get $5
+        local.get $6
         i32.const 3
         i32.eq
         br_if $case3|0
@@ -3560,11 +3576,11 @@
     return
    end
   end
-  local.get $2
+  local.get $3
   i32.const 0
   i32.eq
   if
-   local.get $4
+   local.get $5
    i32.const 1
    i32.and
    if (result f32)
@@ -3579,15 +3595,15 @@
    end
    return
   end
-  local.get $2
+  local.get $3
   i32.const 2139095040
   i32.eq
   if
-   local.get $3
+   local.get $4
    i32.const 2139095040
    i32.eq
    if
-    local.get $4
+    local.get $5
     i32.const 2
     i32.and
     if (result f32)
@@ -3601,19 +3617,19 @@
      f32.const 4
      f32.div
     end
-    local.set $6
-    local.get $4
+    local.set $2
+    local.get $5
     i32.const 1
     i32.and
     if (result f32)
-     local.get $6
+     local.get $2
      f32.neg
     else
-     local.get $6
+     local.get $2
     end
     return
    else
-    local.get $4
+    local.get $5
     i32.const 2
     i32.and
     if (result f32)
@@ -3621,34 +3637,34 @@
     else
      f32.const 0
     end
-    local.set $6
-    local.get $4
+    local.set $2
+    local.get $5
     i32.const 1
     i32.and
     if (result f32)
-     local.get $6
+     local.get $2
      f32.neg
     else
-     local.get $6
+     local.get $2
     end
     return
    end
    unreachable
   end
-  local.get $2
+  local.get $3
   i32.const 218103808
   i32.add
-  local.get $3
+  local.get $4
   i32.lt_u
   if (result i32)
    i32.const 1
   else
-   local.get $3
+   local.get $4
    i32.const 2139095040
    i32.eq
   end
   if
-   local.get $4
+   local.get $5
    i32.const 1
    i32.and
    if (result f32)
@@ -3663,14 +3679,14 @@
    end
    return
   end
-  local.get $4
+  local.get $5
   i32.const 2
   i32.and
   if (result i32)
-   local.get $3
+   local.get $4
    i32.const 218103808
    i32.add
-   local.get $2
+   local.get $3
    i32.lt_u
   else
    i32.const 0
@@ -3691,21 +3707,21 @@
     block $case2|1
      block $case1|1
       block $case0|1
-       local.get $4
-       local.set $5
        local.get $5
+       local.set $6
+       local.get $6
        i32.const 0
        i32.eq
        br_if $case0|1
-       local.get $5
+       local.get $6
        i32.const 1
        i32.eq
        br_if $case1|1
-       local.get $5
+       local.get $6
        i32.const 2
        i32.eq
        br_if $case2|1
-       local.get $5
+       local.get $6
        i32.const 3
        i32.eq
        br_if $case3|1
@@ -3734,7 +3750,7 @@
   end
   unreachable
  )
- (func $std/math/test_atan2f (; 81 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_atan2f (; 77 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.atan2
@@ -3743,7 +3759,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.cbrt (; 82 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cbrt (; 78 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 f64)
@@ -3887,7 +3903,7 @@
   local.set $3
   local.get $3
  )
- (func $std/math/test_cbrt (; 83 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_cbrt (; 79 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.cbrt
   local.get $1
@@ -3911,7 +3927,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.cbrt (; 84 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cbrt (; 80 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -4027,7 +4043,7 @@
   local.get $3
   f32.demote_f64
  )
- (func $std/math/test_cbrtf (; 85 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_cbrtf (; 81 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.cbrt
   local.get $1
@@ -4035,7 +4051,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_ceil (; 86 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_ceil (; 82 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   local.get $0
   local.set $4
@@ -4062,7 +4078,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_ceilf (; 87 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_ceilf (; 83 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   local.get $0
   local.set $4
@@ -4073,7 +4089,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/pio2_large_quot (; 88 ;) (type $FUNCSIG$idj) (param $0 f64) (param $1 i64) (result i32)
+ (func $~lib/math/pio2_large_quot (; 84 ;) (type $FUNCSIG$idj) (param $0 f64) (param $1 i64) (result i32)
   (local $2 i32)
   (local $3 i64)
   (local $4 i64)
@@ -4475,7 +4491,7 @@
   local.get $31
   i32.wrap_i64
  )
- (func $~lib/math/NativeMath.cos (; 89 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cos (; 85 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -4993,7 +5009,7 @@
    local.get $0
   end
  )
- (func $std/math/test_cos (; 90 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_cos (; 86 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.cos
   local.get $1
@@ -5017,7 +5033,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.cos (; 91 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cos (; 87 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -5635,7 +5651,7 @@
    local.get $27
   end
  )
- (func $std/math/test_cosf (; 92 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_cosf (; 88 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.cos
   local.get $1
@@ -5643,7 +5659,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.expm1 (; 93 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.expm1 (; 89 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -5681,7 +5697,9 @@
   i32.ge_u
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.tee $5
+   local.get $5
+   f64.ne
    if
     local.get $0
     return
@@ -5702,7 +5720,7 @@
    end
   end
   f64.const 0
-  local.set $5
+  local.set $6
   local.get $2
   i32.const 1071001154
   i32.gt_u
@@ -5727,27 +5745,27 @@
    local.set $3
    local.get $3
    f64.convert_i32_s
-   local.set $6
+   local.set $7
    local.get $0
-   local.get $6
+   local.get $7
    f64.const 0.6931471803691238
    f64.mul
    f64.sub
-   local.set $7
-   local.get $6
+   local.set $5
+   local.get $7
    f64.const 1.9082149292705877e-10
    f64.mul
    local.set $8
-   local.get $7
+   local.get $5
    local.get $8
    f64.sub
    local.set $0
-   local.get $7
+   local.get $5
    local.get $0
    f64.sub
    local.get $8
    f64.sub
-   local.set $5
+   local.set $6
   else
    local.get $2
    i32.const 1016070144
@@ -5796,14 +5814,14 @@
   local.get $9
   f64.mul
   f64.sub
-  local.set $6
+  local.set $7
   local.get $10
   local.get $12
-  local.get $6
+  local.get $7
   f64.sub
   f64.const 6
   local.get $0
-  local.get $6
+  local.get $7
   f64.mul
   f64.sub
   f64.div
@@ -5824,10 +5842,10 @@
   end
   local.get $0
   local.get $13
-  local.get $5
+  local.get $6
   f64.sub
   f64.mul
-  local.get $5
+  local.get $6
   f64.sub
   local.set $13
   local.get $13
@@ -5955,16 +5973,17 @@
   local.get $14
   f64.mul
  )
- (func $~lib/math/NativeMath.exp (; 94 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.exp (; 90 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
   (local $4 f64)
-  (local $5 i32)
-  (local $6 f64)
+  (local $5 f64)
+  (local $6 i32)
   (local $7 f64)
   (local $8 f64)
   (local $9 f64)
+  (local $10 f64)
   local.get $0
   i64.reinterpret_f64
   i64.const 32
@@ -5984,7 +6003,9 @@
   i32.ge_u
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.tee $3
+   local.get $3
+   f64.ne
    if
     local.get $0
     return
@@ -6007,9 +6028,9 @@
    end
   end
   f64.const 0
-  local.set $4
-  i32.const 0
   local.set $5
+  i32.const 0
+  local.set $6
   local.get $1
   i32.const 1071001154
   i32.gt_u
@@ -6026,29 +6047,29 @@
     f64.copysign
     f64.add
     i32.trunc_f64_s
-    local.set $5
+    local.set $6
    else
     i32.const 1
     local.get $2
     i32.const 1
     i32.shl
     i32.sub
-    local.set $5
+    local.set $6
    end
    local.get $0
-   local.get $5
+   local.get $6
    f64.convert_i32_s
    f64.const 0.6931471803691238
    f64.mul
    f64.sub
-   local.set $3
-   local.get $5
+   local.set $4
+   local.get $6
    f64.convert_i32_s
    f64.const 1.9082149292705877e-10
    f64.mul
-   local.set $4
-   local.get $3
+   local.set $5
    local.get $4
+   local.get $5
    f64.sub
    local.set $0
   else
@@ -6057,7 +6078,7 @@
    i32.gt_u
    if
     local.get $0
-    local.set $3
+    local.set $4
    else
     f64.const 1
     local.get $0
@@ -6068,24 +6089,24 @@
   local.get $0
   local.get $0
   f64.mul
-  local.set $6
-  local.get $6
-  local.get $6
-  f64.mul
   local.set $7
+  local.get $7
+  local.get $7
+  f64.mul
+  local.set $8
   local.get $0
-  local.get $6
+  local.get $7
   f64.const 0.16666666666666602
   f64.mul
-  local.get $7
+  local.get $8
   f64.const -2.7777777777015593e-03
-  local.get $6
+  local.get $7
   f64.const 6.613756321437934e-05
   f64.mul
   f64.add
-  local.get $7
+  local.get $8
   f64.const -1.6533902205465252e-06
-  local.get $6
+  local.get $7
   f64.const 4.1381367970572385e-08
   f64.mul
   f64.add
@@ -6094,33 +6115,33 @@
   f64.mul
   f64.add
   f64.sub
-  local.set $8
+  local.set $9
   f64.const 1
   local.get $0
-  local.get $8
+  local.get $9
   f64.mul
   f64.const 2
-  local.get $8
+  local.get $9
   f64.sub
   f64.div
-  local.get $4
-  f64.sub
-  local.get $3
-  f64.add
-  f64.add
-  local.set $9
   local.get $5
+  f64.sub
+  local.get $4
+  f64.add
+  f64.add
+  local.set $10
+  local.get $6
   i32.const 0
   i32.eq
   if
-   local.get $9
+   local.get $10
    return
   end
-  local.get $9
-  local.get $5
+  local.get $10
+  local.get $6
   call $~lib/math/NativeMath.scalbn
  )
- (func $~lib/math/NativeMath.cosh (; 95 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.cosh (; 91 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 f64)
@@ -6209,7 +6230,7 @@
   local.set $3
   local.get $3
  )
- (func $std/math/test_cosh (; 96 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_cosh (; 92 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.cosh
   local.get $1
@@ -6233,7 +6254,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.expm1 (; 97 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.expm1 (; 93 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6526,7 +6547,7 @@
   local.get $13
   f32.mul
  )
- (func $~lib/math/NativeMathf.exp (; 98 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.exp (; 94 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -6670,7 +6691,7 @@
   local.get $5
   call $~lib/math/NativeMathf.scalbn
  )
- (func $~lib/math/NativeMathf.cosh (; 99 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.cosh (; 95 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -6747,7 +6768,7 @@
   local.get $3
   f32.mul
  )
- (func $std/math/test_coshf (; 100 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_coshf (; 96 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.cosh
   local.get $1
@@ -6755,7 +6776,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_exp (; 101 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_exp (; 97 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.exp
   local.get $1
@@ -6779,7 +6800,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_expf (; 102 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_expf (; 98 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.exp
   local.get $1
@@ -6787,7 +6808,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_expm1 (; 103 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_expm1 (; 99 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.expm1
   local.get $1
@@ -6811,7 +6832,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_expm1f (; 104 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_expm1f (; 100 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.expm1
   local.get $1
@@ -6819,7 +6840,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_floor (; 105 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_floor (; 101 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   local.get $0
   local.set $4
@@ -6846,7 +6867,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_floorf (; 106 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_floorf (; 102 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   local.get $0
   local.set $4
@@ -6857,7 +6878,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.hypot (; 107 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.hypot (; 103 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -7052,7 +7073,7 @@
   f64.sqrt
   f64.mul
  )
- (func $std/math/test_hypot (; 108 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_hypot (; 104 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.hypot
@@ -7061,7 +7082,7 @@
   local.get $4
   call $std/math/check<f64>
  )
- (func $~lib/math/NativeMathf.hypot (; 109 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.hypot (; 105 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7178,7 +7199,7 @@
   f32.sqrt
   f32.mul
  )
- (func $std/math/test_hypotf (; 110 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_hypotf (; 106 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.hypot
@@ -7187,7 +7208,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $std/math/test_log (; 111 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_log (; 107 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.log
   local.get $1
@@ -7211,7 +7232,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_logf (; 112 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_logf (; 108 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log
   local.get $1
@@ -7219,7 +7240,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log10 (; 113 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log10 (; 109 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -7479,7 +7500,7 @@
   local.get $8
   f64.add
  )
- (func $std/math/test_log10 (; 114 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_log10 (; 110 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.log10
   local.get $1
@@ -7503,7 +7524,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.log10 (; 115 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log10 (; 111 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -7703,7 +7724,7 @@
   f32.mul
   f32.add
  )
- (func $std/math/test_log10f (; 116 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_log10f (; 112 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log10
   local.get $1
@@ -7711,7 +7732,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_log1p (; 117 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_log1p (; 113 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.log1p
   local.get $1
@@ -7735,7 +7756,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_log1pf (; 118 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_log1pf (; 114 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log1p
   local.get $1
@@ -7743,7 +7764,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.log2 (; 119 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.log2 (; 115 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -7996,7 +8017,7 @@
   local.get $14
   f64.add
  )
- (func $std/math/test_log2 (; 120 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_log2 (; 116 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.log2
   local.get $1
@@ -8020,7 +8041,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.log2 (; 121 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.log2 (; 117 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f32)
@@ -8215,7 +8236,7 @@
   local.get $14
   f32.add
  )
- (func $std/math/test_log2f (; 122 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_log2f (; 118 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.log2
   local.get $1
@@ -8223,7 +8244,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_max (; 123 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_max (; 119 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   (local $5 f64)
   (local $6 f64)
   local.get $0
@@ -8255,7 +8276,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_maxf (; 124 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_maxf (; 120 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   (local $5 f32)
   (local $6 f32)
   local.get $0
@@ -8270,7 +8291,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $std/math/test_min (; 125 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_min (; 121 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   (local $5 f64)
   (local $6 f64)
   local.get $0
@@ -8302,7 +8323,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_minf (; 126 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_minf (; 122 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   (local $5 f32)
   (local $6 f32)
   local.get $0
@@ -8317,7 +8338,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.mod (; 127 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (; 123 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -8367,7 +8388,9 @@
    i32.const 1
   else
    local.get $1
-   call $~lib/number/isNaN<f64>
+   local.tee $8
+   local.get $8
+   f64.ne
   end
   if
    local.get $0
@@ -8570,7 +8593,7 @@
   local.get $2
   f64.reinterpret_i64
  )
- (func $std/math/test_mod (; 128 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_mod (; 124 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.mod
@@ -8596,7 +8619,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.mod (; 129 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (; 125 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8646,7 +8669,9 @@
    i32.const 1
   else
    local.get $1
-   call $~lib/number/isNaN<f32>
+   local.tee $8
+   local.get $8
+   f32.ne
   end
   if
    local.get $0
@@ -8843,7 +8868,7 @@
   local.get $2
   f32.reinterpret_i32
  )
- (func $std/math/test_modf (; 130 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_modf (; 126 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.mod
@@ -8852,7 +8877,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.pow (; 131 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.pow (; 127 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -9932,7 +9957,7 @@
   local.get $16
   f64.mul
  )
- (func $std/math/test_pow (; 132 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_pow (; 128 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.pow
@@ -9958,7 +9983,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.pow (; 133 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.pow (; 129 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10892,7 +10917,7 @@
   local.get $11
   f32.mul
  )
- (func $std/math/test_powf (; 134 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_powf (; 130 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.pow
@@ -10901,7 +10926,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $~lib/math/murmurHash3 (; 135 ;) (type $FUNCSIG$jj) (param $0 i64) (result i64)
+ (func $~lib/math/murmurHash3 (; 131 ;) (type $FUNCSIG$jj) (param $0 i64) (result i64)
   local.get $0
   local.get $0
   i64.const 33
@@ -10930,7 +10955,7 @@
   local.set $0
   local.get $0
  )
- (func $~lib/math/splitMix32 (; 136 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/math/splitMix32 (; 132 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 1831565813
   i32.add
@@ -10965,7 +10990,7 @@
   i32.shr_u
   i32.xor
  )
- (func $~lib/math/NativeMath.seedRandom (; 137 ;) (type $FUNCSIG$vj) (param $0 i64)
+ (func $~lib/math/NativeMath.seedRandom (; 133 ;) (type $FUNCSIG$vj) (param $0 i64)
   i32.const 1
   global.set $~lib/math/random_seeded
   local.get $0
@@ -11017,7 +11042,7 @@
    unreachable
   end
  )
- (func $~lib/math/NativeMath.random (; 138 ;) (type $FUNCSIG$d) (result f64)
+ (func $~lib/math/NativeMath.random (; 134 ;) (type $FUNCSIG$d) (result f64)
   (local $0 i64)
   (local $1 i64)
   (local $2 i64)
@@ -11072,7 +11097,7 @@
   f64.const 1
   f64.sub
  )
- (func $~lib/math/NativeMathf.random (; 139 ;) (type $FUNCSIG$f) (result f32)
+ (func $~lib/math/NativeMathf.random (; 135 ;) (type $FUNCSIG$f) (result f32)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11127,7 +11152,7 @@
   f32.const 1
   f32.sub
  )
- (func $std/math/test_round (; 140 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_round (; 136 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   local.get $0
   local.set $4
@@ -11142,7 +11167,7 @@
   local.get $3
   call $std/math/check<f64>
  )
- (func $std/math/test_roundf (; 141 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_roundf (; 137 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   local.get $0
   local.set $4
@@ -11157,7 +11182,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_sign (; 142 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_sign (; 138 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   block $~lib/math/NativeMath.sign|inlined.0 (result f64)
    local.get $0
@@ -11200,7 +11225,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_signf (; 143 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_signf (; 139 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   block $~lib/math/NativeMathf.sign|inlined.0 (result f32)
    local.get $0
@@ -11227,7 +11252,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.rem (; 144 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.rem (; 140 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -11277,7 +11302,9 @@
    i32.const 1
   else
    local.get $1
-   call $~lib/number/isNaN<f64>
+   local.tee $7
+   local.get $7
+   f64.ne
   end
   if
    local.get $0
@@ -11541,7 +11568,7 @@
    local.get $0
   end
  )
- (func $std/math/test_rem (; 145 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
+ (func $std/math/test_rem (; 141 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.rem
@@ -11550,16 +11577,17 @@
   local.get $4
   call $std/math/check<f64>
  )
- (func $~lib/math/NativeMathf.rem (; 146 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.rem (; 142 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
+  (local $8 f32)
   (local $9 i32)
-  (local $10 f32)
+  (local $10 i32)
+  (local $11 f32)
   local.get $0
   i32.reinterpret_f32
   local.set $2
@@ -11600,7 +11628,9 @@
    i32.const 1
   else
    local.get $1
-   call $~lib/number/isNaN<f32>
+   local.tee $8
+   local.get $8
+   f32.ne
   end
   if
    local.get $0
@@ -11686,7 +11716,7 @@
    local.set $3
   end
   i32.const 0
-  local.set $8
+  local.set $9
   block $break|0
    local.get $4
    local.get $5
@@ -11718,19 +11748,19 @@
       local.get $3
       i32.sub
       local.set $7
-      local.get $8
+      local.get $9
       i32.const 1
       i32.add
-      local.set $8
+      local.set $9
      end
      local.get $7
      i32.const 1
      i32.shl
      local.set $7
-     local.get $8
+     local.get $9
      i32.const 1
      i32.shl
-     local.set $8
+     local.set $9
      local.get $4
      i32.const 1
      i32.sub
@@ -11747,10 +11777,10 @@
     local.get $3
     i32.sub
     local.set $7
-    local.get $8
+    local.get $9
     i32.const 1
     i32.add
-    local.set $8
+    local.set $9
    end
    local.get $7
    i32.const 0
@@ -11763,13 +11793,13 @@
     i32.const 8
     i32.shl
     i32.clz
-    local.set $9
+    local.set $10
     local.get $4
-    local.get $9
+    local.get $10
     i32.sub
     local.set $4
     local.get $7
-    local.get $9
+    local.get $10
     i32.shl
     local.set $7
    end
@@ -11810,7 +11840,7 @@
   local.get $0
   local.get $0
   f32.add
-  local.set $10
+  local.set $11
   local.get $4
   local.get $5
   i32.eq
@@ -11823,17 +11853,17 @@
    local.get $5
    i32.eq
    if (result i32)
-    local.get $10
+    local.get $11
     local.get $1
     f32.gt
     if (result i32)
      i32.const 1
     else
-     local.get $10
+     local.get $11
      local.get $1
      f32.eq
      if (result i32)
-      local.get $8
+      local.get $9
       i32.const 1
       i32.and
      else
@@ -11858,7 +11888,7 @@
    local.get $0
   end
  )
- (func $std/math/test_remf (; 147 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
+ (func $std/math/test_remf (; 143 ;) (type $FUNCSIG$iffffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 f32) (param $4 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.rem
@@ -11867,7 +11897,7 @@
   local.get $4
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.sin (; 148 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.sin (; 144 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -12396,7 +12426,7 @@
    local.get $0
   end
  )
- (func $std/math/test_sin (; 149 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_sin (; 145 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.sin
   local.get $1
@@ -12420,7 +12450,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.sin (; 150 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.sin (; 146 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 f64)
@@ -13030,7 +13060,7 @@
    local.get $27
   end
  )
- (func $std/math/test_sinf (; 151 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_sinf (; 147 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.sin
   local.get $1
@@ -13038,7 +13068,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.sinh (; 152 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.sinh (; 148 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 f64)
   (local $3 i32)
@@ -13136,7 +13166,7 @@
   local.set $4
   local.get $4
  )
- (func $std/math/test_sinh (; 153 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_sinh (; 149 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.sinh
   local.get $1
@@ -13160,7 +13190,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.sinh (; 154 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.sinh (; 150 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -13249,7 +13279,7 @@
   local.set $3
   local.get $3
  )
- (func $std/math/test_sinhf (; 155 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_sinhf (; 151 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.sinh
   local.get $1
@@ -13257,7 +13287,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_sqrt (; 156 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_sqrt (; 152 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   local.get $0
   local.set $4
@@ -13284,7 +13314,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_sqrtf (; 157 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_sqrtf (; 153 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   local.get $0
   local.set $4
@@ -13295,7 +13325,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/tan_kern (; 158 ;) (type $FUNCSIG$dddi) (param $0 f64) (param $1 f64) (param $2 i32) (result f64)
+ (func $~lib/math/tan_kern (; 154 ;) (type $FUNCSIG$dddi) (param $0 f64) (param $1 f64) (param $2 i32) (result f64)
   (local $3 f64)
   (local $4 f64)
   (local $5 f64)
@@ -13508,7 +13538,7 @@
   f64.mul
   f64.add
  )
- (func $~lib/math/NativeMath.tan (; 159 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.tan (; 155 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -13820,7 +13850,7 @@
   i32.sub
   call $~lib/math/tan_kern
  )
- (func $std/math/test_tan (; 160 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_tan (; 156 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.tan
   local.get $1
@@ -13844,7 +13874,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.tan (; 161 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.tan (; 157 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -14495,7 +14525,7 @@
   end
   f32.demote_f64
  )
- (func $std/math/test_tanf (; 162 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_tanf (; 158 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.tan
   local.get $1
@@ -14503,7 +14533,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.tanh (; 163 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.tanh (; 159 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 f64)
   (local $3 i32)
@@ -14595,7 +14625,7 @@
   local.get $0
   f64.copysign
  )
- (func $std/math/test_tanh (; 164 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_tanh (; 160 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMath.tanh
   local.get $1
@@ -14619,7 +14649,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/NativeMathf.tanh (; 165 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.tanh (; 161 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 f32)
   (local $3 f32)
@@ -14705,7 +14735,7 @@
   local.get $0
   f32.copysign
  )
- (func $std/math/test_tanhf (; 166 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_tanhf (; 162 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   local.get $0
   call $~lib/math/NativeMathf.tanh
   local.get $1
@@ -14713,7 +14743,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $std/math/test_trunc (; 167 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
+ (func $std/math/test_trunc (; 163 ;) (type $FUNCSIG$idddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 i32) (result i32)
   (local $4 f64)
   local.get $0
   local.set $4
@@ -14740,7 +14770,7 @@
    i32.const 0
   end
  )
- (func $std/math/test_truncf (; 168 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
+ (func $std/math/test_truncf (; 164 ;) (type $FUNCSIG$ifffi) (param $0 f32) (param $1 f32) (param $2 f32) (param $3 i32) (result i32)
   (local $4 f32)
   local.get $0
   local.set $4
@@ -14751,7 +14781,7 @@
   local.get $3
   call $std/math/check<f32>
  )
- (func $~lib/math/NativeMath.sincos (; 169 ;) (type $FUNCSIG$vd) (param $0 f64)
+ (func $~lib/math/NativeMath.sincos (; 165 ;) (type $FUNCSIG$vd) (param $0 f64)
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
@@ -15370,7 +15400,7 @@
   local.get $23
   global.set $~lib/math/NativeMath.sincos_cos
  )
- (func $std/math/test_sincos (; 170 ;) (type $FUNCSIG$ijjjjji) (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64) (param $5 i32) (result i32)
+ (func $std/math/test_sincos (; 166 ;) (type $FUNCSIG$ijjjjji) (param $0 i64) (param $1 i64) (param $2 i64) (param $3 i64) (param $4 i64) (param $5 i32) (result i32)
   (local $6 f64)
   (local $7 f64)
   (local $8 f64)
@@ -15408,7 +15438,7 @@
    i32.const 0
   end
  )
- (func $~lib/math/dtoi32 (; 171 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/math/dtoi32 (; 167 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i64)
   (local $3 i64)
@@ -15479,11 +15509,16 @@
   local.get $1
   return
  )
- (func $~lib/math/NativeMath.imul (; 172 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.imul (; 168 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+  (local $2 f64)
   local.get $0
   local.get $1
   f64.add
-  call $~lib/number/isFinite<f64>
+  local.tee $2
+  local.get $2
+  f64.sub
+  f64.const 0
+  f64.eq
   i32.eqz
   if
    f64.const 0
@@ -15496,9 +15531,14 @@
   i32.mul
   f64.convert_i32_s
  )
- (func $~lib/math/NativeMath.clz32 (; 173 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.clz32 (; 169 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+  (local $1 f64)
   local.get $0
-  call $~lib/number/isFinite<f64>
+  local.tee $1
+  local.get $1
+  f64.sub
+  f64.const 0
+  f64.eq
   i32.eqz
   if
    f64.const 32
@@ -15509,7 +15549,7 @@
   i32.clz
   f64.convert_i32_s
  )
- (func $~lib/math/ipow64 (; 174 ;) (type $FUNCSIG$jji) (param $0 i64) (param $1 i32) (result i64)
+ (func $~lib/math/ipow64 (; 170 ;) (type $FUNCSIG$jji) (param $0 i64) (param $1 i32) (result i64)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -15730,7 +15770,7 @@
   end
   local.get $2
  )
- (func $~lib/math/ipow32f (; 175 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
+ (func $~lib/math/ipow32f (; 171 ;) (type $FUNCSIG$ffi) (param $0 f32) (param $1 i32) (result f32)
   (local $2 i32)
   (local $3 f32)
   local.get $1
@@ -15780,7 +15820,7 @@
    local.get $3
   end
  )
- (func $~lib/math/ipow64f (; 176 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
+ (func $~lib/math/ipow64f (; 172 ;) (type $FUNCSIG$ddi) (param $0 f64) (param $1 i32) (result f64)
   (local $2 i32)
   (local $3 f64)
   local.get $1
@@ -15830,7 +15870,7 @@
    local.get $3
   end
  )
- (func $start:std/math (; 177 ;) (type $FUNCSIG$v)
+ (func $start:std/math (; 173 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f64)
   (local $2 i64)
@@ -54116,7 +54156,9 @@
   f32.const nan:0x400000
   i32.const 1
   call $~lib/math/ipow32f
-  call $~lib/number/isNaN<f32>
+  local.tee $3
+  local.get $3
+  f32.ne
   i32.eqz
   if
    i32.const 0
@@ -54129,7 +54171,9 @@
   f32.const nan:0x400000
   i32.const -1
   call $~lib/math/ipow32f
-  call $~lib/number/isNaN<f32>
+  local.tee $3
+  local.get $3
+  f32.ne
   i32.eqz
   if
    i32.const 0
@@ -54142,7 +54186,9 @@
   f32.const nan:0x400000
   i32.const 2
   call $~lib/math/ipow32f
-  call $~lib/number/isNaN<f32>
+  local.tee $3
+  local.get $3
+  f32.ne
   i32.eqz
   if
    i32.const 0
@@ -54337,7 +54383,9 @@
   f64.const nan:0x8000000000000
   i32.const 1
   call $~lib/math/ipow64f
-  call $~lib/number/isNaN<f64>
+  local.tee $1
+  local.get $1
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -54350,7 +54398,9 @@
   f64.const nan:0x8000000000000
   i32.const -1
   call $~lib/math/ipow64f
-  call $~lib/number/isNaN<f64>
+  local.tee $1
+  local.get $1
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -54363,7 +54413,9 @@
   f64.const nan:0x8000000000000
   i32.const 2
   call $~lib/math/ipow64f
-  call $~lib/number/isNaN<f64>
+  local.tee $1
+  local.get $1
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -54528,9 +54580,9 @@
    unreachable
   end
  )
- (func $start (; 178 ;) (type $FUNCSIG$v)
+ (func $start (; 174 ;) (type $FUNCSIG$v)
   call $start:std/math
  )
- (func $null (; 179 ;) (type $FUNCSIG$v)
+ (func $null (; 175 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -8400,7 +8400,9 @@
    return
   end
   local.get $4
-  i64.eqz
+  i64.const 0
+  i64.ne
+  i32.eqz
   if
    local.get $4
    local.get $2
@@ -8432,7 +8434,9 @@
    local.set $2
   end
   local.get $5
-  i64.eqz
+  i64.const 0
+  i64.ne
+  i32.eqz
   if
    local.get $5
    local.get $3
@@ -11297,7 +11301,9 @@
   local.get $2
   local.set $8
   local.get $4
-  i64.eqz
+  i64.const 0
+  i64.ne
+  i32.eqz
   if
    local.get $4
    local.get $8
@@ -11329,7 +11335,9 @@
    local.set $8
   end
   local.get $5
-  i64.eqz
+  i64.const 0
+  i64.ne
+  i32.eqz
   if
    local.get $5
    local.get $3

--- a/tests/compiler/std/mod.optimized.wat
+++ b/tests/compiler/std/mod.optimized.wat
@@ -93,7 +93,8 @@
     return
    end
    local.get $4
-   i64.eqz
+   i64.const 0
+   i64.eq
    if (result i64)
     local.get $2
     i64.const 0
@@ -117,7 +118,8 @@
    end
    local.set $2
    local.get $5
-   i64.eqz
+   i64.const 0
+   i64.eq
    if (result i64)
     local.get $3
     i64.const 0

--- a/tests/compiler/std/mod.optimized.wat
+++ b/tests/compiler/std/mod.optimized.wat
@@ -1,12 +1,10 @@
 (module
  (type $FUNCSIG$iddd (func (param f64 f64 f64) (result i32)))
  (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))
- (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$idd (func (param f64 f64) (result i32)))
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$ifff (func (param f32 f32 f32) (result i32)))
  (type $FUNCSIG$fff (func (param f32 f32) (result f32)))
- (type $FUNCSIG$if (func (param f32) (result i32)))
  (type $FUNCSIG$iff (func (param f32 f32) (result i32)))
  (type $FUNCSIG$v (func))
  (import "mod" "mod" (func $std/mod/mod (param f64 f64) (result f64)))
@@ -16,12 +14,7 @@
  (export "memory" (memory $0))
  (export "mod" (func $std/mod/mod))
  (start $start)
- (func $~lib/number/isNaN<f64> (; 2 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.ne
- )
- (func $~lib/math/NativeMath.mod (; 3 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (; 2 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -66,7 +59,8 @@
    i32.const 1
   else
    local.get $1
-   call $~lib/number/isNaN<f64>
+   local.get $1
+   f64.ne
   end
   if
    local.get $0
@@ -226,12 +220,14 @@
   local.get $0
   f64.mul
  )
- (func $std/mod/check<f64> (; 4 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
+ (func $std/mod/check<f64> (; 3 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
   local.get $1
-  call $~lib/number/isNaN<f64>
+  local.get $1
+  f64.ne
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.get $0
+   f64.ne
    return
   end
   local.get $1
@@ -251,7 +247,7 @@
   local.get $1
   f64.eq
  )
- (func $std/mod/test_fmod (; 5 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/mod/test_fmod (; 4 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.mod
@@ -267,12 +263,7 @@
    i32.const 0
   end
  )
- (func $~lib/number/isNaN<f32> (; 6 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
-  local.get $0
-  local.get $0
-  f32.ne
- )
- (func $~lib/math/NativeMathf.mod (; 7 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (; 5 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -315,7 +306,8 @@
    i32.const 1
   else
    local.get $1
-   call $~lib/number/isNaN<f32>
+   local.get $1
+   f32.ne
   end
   if
    local.get $0
@@ -463,12 +455,14 @@
   local.get $0
   f32.mul
  )
- (func $std/mod/check<f32> (; 8 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/mod/check<f32> (; 6 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
   local.get $1
-  call $~lib/number/isNaN<f32>
+  local.get $1
+  f32.ne
   if
    local.get $0
-   call $~lib/number/isNaN<f32>
+   local.get $0
+   f32.ne
    return
   end
   local.get $1
@@ -488,14 +482,14 @@
   local.get $1
   f32.eq
  )
- (func $std/mod/test_fmodf (; 9 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/mod/test_fmodf (; 7 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.mod
   local.get $2
   call $std/mod/check<f32>
  )
- (func $start:std/mod (; 10 ;) (type $FUNCSIG$v)
+ (func $start:std/mod (; 8 ;) (type $FUNCSIG$v)
   f64.const 3
   f64.const 2
   f64.const 1
@@ -2252,10 +2246,10 @@
    unreachable
   end
  )
- (func $start (; 11 ;) (type $FUNCSIG$v)
+ (func $start (; 9 ;) (type $FUNCSIG$v)
   call $start:std/mod
  )
- (func $null (; 12 ;) (type $FUNCSIG$v)
+ (func $null (; 10 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/mod.untouched.wat
+++ b/tests/compiler/std/mod.untouched.wat
@@ -107,7 +107,9 @@
    return
   end
   local.get $4
-  i64.eqz
+  i64.const 0
+  i64.ne
+  i32.eqz
   if
    local.get $4
    local.get $2
@@ -139,7 +141,9 @@
    local.set $2
   end
   local.get $5
-  i64.eqz
+  i64.const 0
+  i64.ne
+  i32.eqz
   if
    local.get $5
    local.get $3

--- a/tests/compiler/std/mod.untouched.wat
+++ b/tests/compiler/std/mod.untouched.wat
@@ -1,12 +1,10 @@
 (module
  (type $FUNCSIG$iddd (func (param f64 f64 f64) (result i32)))
  (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))
- (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$idd (func (param f64 f64) (result i32)))
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$ifff (func (param f32 f32 f32) (result i32)))
  (type $FUNCSIG$fff (func (param f32 f32) (result f32)))
- (type $FUNCSIG$if (func (param f32) (result i32)))
  (type $FUNCSIG$iff (func (param f32 f32) (result i32)))
  (type $FUNCSIG$v (func))
  (import "mod" "mod" (func $std/mod/mod (param f64 f64) (result f64)))
@@ -19,12 +17,7 @@
  (export "memory" (memory $0))
  (export "mod" (func $std/mod/mod))
  (start $start)
- (func $~lib/number/isNaN<f64> (; 2 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.ne
- )
- (func $~lib/math/NativeMath.mod (; 3 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (; 2 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -74,7 +67,9 @@
    i32.const 1
   else
    local.get $1
-   call $~lib/number/isNaN<f64>
+   local.tee $8
+   local.get $8
+   f64.ne
   end
   if
    local.get $0
@@ -277,12 +272,17 @@
   local.get $2
   f64.reinterpret_i64
  )
- (func $std/mod/check<f64> (; 4 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
+ (func $std/mod/check<f64> (; 3 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
+  (local $2 f64)
   local.get $1
-  call $~lib/number/isNaN<f64>
+  local.tee $2
+  local.get $2
+  f64.ne
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.tee $2
+   local.get $2
+   f64.ne
    return
   end
   local.get $1
@@ -303,7 +303,7 @@
   local.get $1
   f64.eq
  )
- (func $std/mod/test_fmod (; 5 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
+ (func $std/mod/test_fmod (; 4 ;) (type $FUNCSIG$iddd) (param $0 f64) (param $1 f64) (param $2 f64) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMath.mod
@@ -325,12 +325,7 @@
    i32.const 0
   end
  )
- (func $~lib/number/isNaN<f32> (; 6 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
-  local.get $0
-  local.get $0
-  f32.ne
- )
- (func $~lib/math/NativeMathf.mod (; 7 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (; 5 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -380,7 +375,9 @@
    i32.const 1
   else
    local.get $1
-   call $~lib/number/isNaN<f32>
+   local.tee $8
+   local.get $8
+   f32.ne
   end
   if
    local.get $0
@@ -577,12 +574,17 @@
   local.get $2
   f32.reinterpret_i32
  )
- (func $std/mod/check<f32> (; 8 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
+ (func $std/mod/check<f32> (; 6 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
+  (local $2 f32)
   local.get $1
-  call $~lib/number/isNaN<f32>
+  local.tee $2
+  local.get $2
+  f32.ne
   if
    local.get $0
-   call $~lib/number/isNaN<f32>
+   local.tee $2
+   local.get $2
+   f32.ne
    return
   end
   local.get $1
@@ -603,14 +605,14 @@
   local.get $1
   f32.eq
  )
- (func $std/mod/test_fmodf (; 9 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
+ (func $std/mod/test_fmodf (; 7 ;) (type $FUNCSIG$ifff) (param $0 f32) (param $1 f32) (param $2 f32) (result i32)
   local.get $0
   local.get $1
   call $~lib/math/NativeMathf.mod
   local.get $2
   call $std/mod/check<f32>
  )
- (func $start:std/mod (; 10 ;) (type $FUNCSIG$v)
+ (func $start:std/mod (; 8 ;) (type $FUNCSIG$v)
   f64.const 3
   f64.const 2
   f64.const 1
@@ -2367,9 +2369,9 @@
    unreachable
   end
  )
- (func $start (; 11 ;) (type $FUNCSIG$v)
+ (func $start (; 9 ;) (type $FUNCSIG$v)
   call $start:std/mod
  )
- (func $null (; 12 ;) (type $FUNCSIG$v)
+ (func $null (; 10 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/mod.untouched.wat
+++ b/tests/compiler/std/mod.untouched.wat
@@ -67,8 +67,7 @@
    i32.const 1
   else
    local.get $1
-   local.tee $8
-   local.get $8
+   local.get $1
    f64.ne
   end
   if
@@ -273,15 +272,12 @@
   f64.reinterpret_i64
  )
  (func $std/mod/check<f64> (; 3 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
-  (local $2 f64)
   local.get $1
-  local.tee $2
-  local.get $2
+  local.get $1
   f64.ne
   if
    local.get $0
-   local.tee $2
-   local.get $2
+   local.get $0
    f64.ne
    return
   end
@@ -375,8 +371,7 @@
    i32.const 1
   else
    local.get $1
-   local.tee $8
-   local.get $8
+   local.get $1
    f32.ne
   end
   if
@@ -575,15 +570,12 @@
   f32.reinterpret_i32
  )
  (func $std/mod/check<f32> (; 6 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
-  (local $2 f32)
   local.get $1
-  local.tee $2
-  local.get $2
+  local.get $1
   f32.ne
   if
    local.get $0
-   local.tee $2
-   local.get $2
+   local.get $0
    f32.ne
    return
   end

--- a/tests/compiler/std/object.optimized.wat
+++ b/tests/compiler/std/object.optimized.wat
@@ -1,9 +1,7 @@
 (module
  (type $FUNCSIG$idd (func (param f64 f64) (result i32)))
- (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$iff (func (param f32 f32) (result i32)))
- (type $FUNCSIG$if (func (param f32) (result i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$v (func))
@@ -17,12 +15,7 @@
  (data (i32.const 132) "\01\00\00\00\01")
  (export "memory" (memory $0))
  (start $start)
- (func $~lib/number/isNaN<f64> (; 1 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.ne
- )
- (func $~lib/object/Object.is<f64> (; 2 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/object/Object.is<f64> (; 1 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
   local.get $0
   local.get $1
   f64.eq
@@ -35,17 +28,14 @@
    return
   end
   local.get $0
-  call $~lib/number/isNaN<f64>
+  local.get $0
+  f64.ne
   local.get $1
-  call $~lib/number/isNaN<f64>
+  local.get $1
+  f64.ne
   i32.and
  )
- (func $~lib/number/isNaN<f32> (; 3 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
-  local.get $0
-  local.get $0
-  f32.ne
- )
- (func $~lib/object/Object.is<f32> (; 4 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
+ (func $~lib/object/Object.is<f32> (; 2 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
   local.get $0
   local.get $1
   f32.eq
@@ -58,17 +48,19 @@
    return
   end
   local.get $0
-  call $~lib/number/isNaN<f32>
+  local.get $0
+  f32.ne
   local.get $1
-  call $~lib/number/isNaN<f32>
+  local.get $1
+  f32.ne
   i32.and
  )
- (func $~lib/object/Object.is<i32> (; 5 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/object/Object.is<i32> (; 3 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.eq
  )
- (func $~lib/object/Object.is<bool> (; 6 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/object/Object.is<bool> (; 4 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.const 0
   i32.ne
@@ -77,7 +69,7 @@
   i32.ne
   i32.eq
  )
- (func $~lib/string/String#get:length (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -85,7 +77,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 8 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/compareImpl (; 6 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $0
@@ -165,7 +157,7 @@
   end
   i32.const 0
  )
- (func $~lib/string/String.__eq (; 9 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 7 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -197,12 +189,12 @@
   end
   i32.const 0
  )
- (func $~lib/object/Object.is<~lib/string/String> (; 10 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/object/Object.is<~lib/string/String> (; 8 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   call $~lib/string/String.__eq
  )
- (func $start:std/object (; 11 ;) (type $FUNCSIG$v)
+ (func $start:std/object (; 9 ;) (type $FUNCSIG$v)
   f64.const 0
   f64.const 0
   call $~lib/object/Object.is<f64>
@@ -676,10 +668,10 @@
    unreachable
   end
  )
- (func $start (; 12 ;) (type $FUNCSIG$v)
+ (func $start (; 10 ;) (type $FUNCSIG$v)
   call $start:std/object
  )
- (func $null (; 13 ;) (type $FUNCSIG$v)
+ (func $null (; 11 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/object.untouched.wat
+++ b/tests/compiler/std/object.untouched.wat
@@ -20,7 +20,6 @@
  (export "memory" (memory $0))
  (start $start)
  (func $~lib/object/Object.is<f64> (; 1 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
-  (local $2 f64)
   local.get $0
   local.get $1
   f64.eq
@@ -33,18 +32,15 @@
    return
   end
   local.get $0
-  local.tee $2
-  local.get $2
+  local.get $0
   f64.ne
   local.get $1
-  local.tee $2
-  local.get $2
+  local.get $1
   f64.ne
   i32.and
   return
  )
  (func $~lib/object/Object.is<f32> (; 2 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
-  (local $2 f32)
   local.get $0
   local.get $1
   f32.eq
@@ -57,12 +53,10 @@
    return
   end
   local.get $0
-  local.tee $2
-  local.get $2
+  local.get $0
   f32.ne
   local.get $1
-  local.tee $2
-  local.get $2
+  local.get $1
   f32.ne
   i32.and
   return

--- a/tests/compiler/std/object.untouched.wat
+++ b/tests/compiler/std/object.untouched.wat
@@ -1,9 +1,7 @@
 (module
  (type $FUNCSIG$idd (func (param f64 f64) (result i32)))
- (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$iff (func (param f32 f32) (result i32)))
- (type $FUNCSIG$if (func (param f32) (result i32)))
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$vi (func (param i32)))
@@ -21,12 +19,8 @@
  (global $~lib/ASC_SHRINK_LEVEL i32 (i32.const 0))
  (export "memory" (memory $0))
  (start $start)
- (func $~lib/number/isNaN<f64> (; 1 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.ne
- )
- (func $~lib/object/Object.is<f64> (; 2 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
+ (func $~lib/object/Object.is<f64> (; 1 ;) (type $FUNCSIG$idd) (param $0 f64) (param $1 f64) (result i32)
+  (local $2 f64)
   local.get $0
   local.get $1
   f64.eq
@@ -39,18 +33,18 @@
    return
   end
   local.get $0
-  call $~lib/number/isNaN<f64>
+  local.tee $2
+  local.get $2
+  f64.ne
   local.get $1
-  call $~lib/number/isNaN<f64>
+  local.tee $2
+  local.get $2
+  f64.ne
   i32.and
   return
  )
- (func $~lib/number/isNaN<f32> (; 3 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
-  local.get $0
-  local.get $0
-  f32.ne
- )
- (func $~lib/object/Object.is<f32> (; 4 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
+ (func $~lib/object/Object.is<f32> (; 2 ;) (type $FUNCSIG$iff) (param $0 f32) (param $1 f32) (result i32)
+  (local $2 f32)
   local.get $0
   local.get $1
   f32.eq
@@ -63,18 +57,22 @@
    return
   end
   local.get $0
-  call $~lib/number/isNaN<f32>
+  local.tee $2
+  local.get $2
+  f32.ne
   local.get $1
-  call $~lib/number/isNaN<f32>
+  local.tee $2
+  local.get $2
+  f32.ne
   i32.and
   return
  )
- (func $~lib/object/Object.is<i32> (; 5 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/object/Object.is<i32> (; 3 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.eq
  )
- (func $~lib/object/Object.is<bool> (; 6 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/object/Object.is<bool> (; 4 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.const 0
   i32.ne
@@ -83,13 +81,13 @@
   i32.ne
   i32.eq
  )
- (func $~lib/rt/stub/__retain (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/rt/stub/__retain (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
  )
- (func $~lib/rt/stub/__release (; 8 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/rt/stub/__release (; 6 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $~lib/string/String#get:length (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (; 7 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -97,7 +95,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/string/compareImpl (; 10 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (; 8 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -217,7 +215,7 @@
   call $~lib/rt/stub/__release
   local.get $8
  )
- (func $~lib/string/String.__eq (; 11 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 9 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -290,7 +288,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/object/Object.is<~lib/string/String> (; 12 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/object/Object.is<~lib/string/String> (; 10 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -308,12 +306,12 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/object/Object.is<usize> (; 13 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/object/Object.is<usize> (; 11 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   i32.eq
  )
- (func $~lib/object/Object.is<~lib/string/String | null> (; 14 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/object/Object.is<~lib/string/String | null> (; 12 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -331,7 +329,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $start:std/object (; 15 ;) (type $FUNCSIG$v)
+ (func $start:std/object (; 13 ;) (type $FUNCSIG$v)
   f64.const 0
   f64.const 0
   call $~lib/object/Object.is<f64>
@@ -893,9 +891,9 @@
    unreachable
   end
  )
- (func $start (; 16 ;) (type $FUNCSIG$v)
+ (func $start (; 14 ;) (type $FUNCSIG$v)
   call $start:std/object
  )
- (func $null (; 17 ;) (type $FUNCSIG$v)
+ (func $null (; 15 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -9,9 +9,9 @@
  (type $FUNCSIG$viii (func (param i32 i32 i32)))
  (type $FUNCSIG$di (func (param i32) (result f64)))
  (type $FUNCSIG$ddi (func (param f64 i32) (result f64)))
- (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$ij (func (param i64) (result i32)))
  (type $FUNCSIG$viji (func (param i32 i64 i32)))
+ (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$iid (func (param i32 f64) (result i32)))
  (type $FUNCSIG$iijijiji (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
  (type $FUNCSIG$i (func (result i32)))
@@ -4685,12 +4685,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/number/isNaN<f64> (; 57 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.ne
- )
- (func $~lib/string/String#concat (; 58 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#concat (; 57 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4751,7 +4746,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__concat (; 59 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (; 58 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -4770,7 +4765,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/string/String.__ne (; 60 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__ne (; 59 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -4787,7 +4782,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/string/String.__gt (; 61 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__gt (; 60 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -4856,7 +4851,7 @@
   call $~lib/rt/pure/__release
   i32.const 0
  )
- (func $~lib/string/String.__lt (; 62 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__lt (; 61 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -4924,7 +4919,7 @@
   call $~lib/rt/pure/__release
   i32.const 0
  )
- (func $~lib/string/String.__gte (; 63 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__gte (; 62 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -4941,7 +4936,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/string/String.__lte (; 64 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/string/String.__lte (; 63 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   i32.const 120
   call $~lib/rt/pure/__retain
@@ -4958,7 +4953,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/string/String#repeat (; 65 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#repeat (; 64 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -5019,7 +5014,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#replace (; 66 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#replace (; 65 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5138,7 +5133,7 @@
   call $~lib/rt/pure/__release
   local.get $0
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 67 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (; 66 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5260,7 +5255,7 @@
   call $~lib/rt/rtrace/onfree
   local.get $3
  )
- (func $~lib/rt/tlsf/__realloc (; 68 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__realloc (; 67 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   global.get $~lib/rt/tlsf/ROOT
   i32.eqz
   if
@@ -5296,7 +5291,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/string/String#replaceAll (; 69 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#replaceAll (; 68 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5609,7 +5604,7 @@
   call $~lib/rt/pure/__release
   local.get $0
  )
- (func $~lib/string/String#slice (; 70 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#slice (; 69 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   call $~lib/string/String#get:length
@@ -5684,7 +5679,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/rt/__allocArray (; 71 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/rt/__allocArray (; 70 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -5712,7 +5707,7 @@
   i32.store offset=12
   local.get $1
  )
- (func $~lib/memory/memory.fill (; 72 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/memory/memory.fill (; 71 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $~lib/util/memory/memset|inlined.0
    local.get $1
@@ -5921,7 +5916,7 @@
    end
   end
  )
- (func $~lib/array/ensureSize (; 73 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/ensureSize (; 72 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5976,7 +5971,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<~lib/string/String>#push (; 74 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/string/String>#push (; 73 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -6005,7 +6000,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/string/String#split (; 75 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#split (; 74 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6243,7 +6238,7 @@
   call $~lib/rt/pure/__release
   local.get $0
  )
- (func $~lib/array/Array<~lib/string/String>#__get (; 76 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#__get (; 75 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -6278,7 +6273,7 @@
   end
   local.get $0
  )
- (func $~lib/util/number/decimalCount32 (; 77 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (; 76 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   i32.const 2
   local.get $0
@@ -6326,7 +6321,7 @@
   i32.lt_u
   select
  )
- (func $~lib/util/number/utoa_simple<u32> (; 78 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u32> (; 77 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   loop $continue|0
    local.get $1
@@ -6353,7 +6348,7 @@
    br_if $continue|0
   end
  )
- (func $~lib/util/number/itoa32 (; 79 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (; 78 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6396,7 +6391,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/utoa32 (; 80 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/utoa32 (; 79 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -6420,7 +6415,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/decimalCount64 (; 81 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64 (; 80 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   i32.const 10
   i32.const 11
   i32.const 12
@@ -6473,7 +6468,7 @@
   i64.lt_u
   select
  )
- (func $~lib/util/number/utoa_simple<u64> (; 82 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u64> (; 81 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   loop $continue|0
    local.get $1
@@ -6503,7 +6498,7 @@
    br_if $continue|0
   end
  )
- (func $~lib/util/number/utoa64 (; 83 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/utoa64 (; 82 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6548,7 +6543,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa64 (; 84 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa64 (; 83 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6614,7 +6609,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/genDigits (; 85 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (; 84 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i32)
   (local $9 i64)
@@ -7013,7 +7008,7 @@
    local.get $6
   end
  )
- (func $~lib/util/number/prettify (; 86 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (; 85 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
@@ -7260,7 +7255,7 @@
    end
   end
  )
- (func $~lib/util/number/dtoa_core (; 87 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (; 86 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i64)
@@ -7548,7 +7543,7 @@
   local.get $10
   i32.add
  )
- (func $~lib/string/String#substring (; 88 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#substring (; 87 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 0
@@ -7625,7 +7620,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/dtoa (; 89 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/util/number/dtoa (; 88 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -7643,7 +7638,8 @@
   f64.ne
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.get $0
+   f64.ne
    if
     i32.const 4344
     call $~lib/rt/pure/__retain
@@ -7678,11 +7674,11 @@
   local.get $1
   call $~lib/rt/tlsf/__free
  )
- (func $start:std/string (; 90 ;) (type $FUNCSIG$v)
+ (func $start:std/string (; 89 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
+  (local $3 f64)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -7716,8 +7712,8 @@
   (local $34 i32)
   (local $35 i32)
   (local $36 i32)
-  (local $37 i64)
-  (local $38 i32)
+  (local $37 i32)
+  (local $38 i64)
   (local $39 i32)
   (local $40 i32)
   (local $41 i32)
@@ -7871,6 +7867,7 @@
   (local $189 i32)
   (local $190 i32)
   (local $191 i32)
+  (local $192 i32)
   global.get $std/string/str
   i32.const 24
   i32.ne
@@ -7957,7 +7954,7 @@
   global.set $~lib/argc
   i32.const 0
   call $~lib/string/String.fromCharCode|trampoline
-  local.tee $5
+  local.tee $6
   i32.const 384
   call $~lib/string/String.__eq
   i32.eqz
@@ -7973,7 +7970,7 @@
   global.set $~lib/argc
   i32.const 54
   call $~lib/string/String.fromCharCode|trampoline
-  local.tee $6
+  local.tee $7
   i32.const 432
   call $~lib/string/String.__eq
   i32.eqz
@@ -7989,7 +7986,7 @@
   global.set $~lib/argc
   i32.const 65590
   call $~lib/string/String.fromCharCode|trampoline
-  local.tee $7
+  local.tee $8
   i32.const 432
   call $~lib/string/String.__eq
   i32.eqz
@@ -8004,7 +8001,7 @@
   i32.const 55296
   i32.const 57088
   call $~lib/string/String.fromCharCode
-  local.tee $8
+  local.tee $9
   i32.const 456
   call $~lib/string/String.__eq
   i32.eqz
@@ -8018,7 +8015,7 @@
   end
   i32.const 0
   call $~lib/string/String.fromCodePoint
-  local.tee $9
+  local.tee $10
   i32.const 384
   call $~lib/string/String.__eq
   i32.eqz
@@ -8032,7 +8029,7 @@
   end
   i32.const 54
   call $~lib/string/String.fromCodePoint
-  local.tee $10
+  local.tee $11
   i32.const 432
   call $~lib/string/String.__eq
   i32.eqz
@@ -8046,7 +8043,7 @@
   end
   i32.const 119558
   call $~lib/string/String.fromCodePoint
-  local.tee $11
+  local.tee $12
   i32.const 528
   call $~lib/string/String.__eq
   i32.eqz
@@ -8104,7 +8101,7 @@
   i32.const 0
   i32.const 656
   call $~lib/string/String#padStart
-  local.tee $12
+  local.tee $13
   global.get $std/string/str
   call $~lib/string/String.__eq
   i32.eqz
@@ -8120,7 +8117,7 @@
   i32.const 15
   i32.const 656
   call $~lib/string/String#padStart
-  local.tee $13
+  local.tee $14
   global.get $std/string/str
   call $~lib/string/String.__eq
   i32.eqz
@@ -8136,7 +8133,7 @@
   i32.const 3
   i32.const 656
   call $~lib/string/String#padStart
-  local.tee $14
+  local.tee $15
   i32.const 680
   call $~lib/string/String.__eq
   i32.eqz
@@ -8152,7 +8149,7 @@
   i32.const 10
   i32.const 120
   call $~lib/string/String#padStart
-  local.tee $15
+  local.tee $16
   i32.const 120
   call $~lib/string/String.__eq
   i32.eqz
@@ -8168,7 +8165,7 @@
   i32.const 100
   i32.const 120
   call $~lib/string/String#padStart
-  local.tee $16
+  local.tee $17
   i32.const 408
   call $~lib/string/String.__eq
   i32.eqz
@@ -8184,7 +8181,7 @@
   i32.const 5
   i32.const 656
   call $~lib/string/String#padStart
-  local.tee $17
+  local.tee $18
   i32.const 728
   call $~lib/string/String.__eq
   i32.eqz
@@ -8200,7 +8197,7 @@
   i32.const 6
   i32.const 760
   call $~lib/string/String#padStart
-  local.tee $18
+  local.tee $19
   i32.const 784
   call $~lib/string/String.__eq
   i32.eqz
@@ -8216,7 +8213,7 @@
   i32.const 8
   i32.const 760
   call $~lib/string/String#padStart
-  local.tee $19
+  local.tee $20
   i32.const 816
   call $~lib/string/String.__eq
   i32.eqz
@@ -8232,7 +8229,7 @@
   i32.const 0
   i32.const 656
   call $~lib/string/String#padEnd
-  local.tee $20
+  local.tee $21
   global.get $std/string/str
   call $~lib/string/String.__eq
   i32.eqz
@@ -8248,7 +8245,7 @@
   i32.const 15
   i32.const 656
   call $~lib/string/String#padEnd
-  local.tee $21
+  local.tee $22
   global.get $std/string/str
   call $~lib/string/String.__eq
   i32.eqz
@@ -8264,7 +8261,7 @@
   i32.const 3
   i32.const 656
   call $~lib/string/String#padEnd
-  local.tee $22
+  local.tee $23
   i32.const 680
   call $~lib/string/String.__eq
   i32.eqz
@@ -8280,7 +8277,7 @@
   i32.const 10
   i32.const 120
   call $~lib/string/String#padEnd
-  local.tee $23
+  local.tee $24
   i32.const 120
   call $~lib/string/String.__eq
   i32.eqz
@@ -8296,7 +8293,7 @@
   i32.const 100
   i32.const 120
   call $~lib/string/String#padEnd
-  local.tee $24
+  local.tee $25
   i32.const 408
   call $~lib/string/String.__eq
   i32.eqz
@@ -8312,7 +8309,7 @@
   i32.const 5
   i32.const 656
   call $~lib/string/String#padEnd
-  local.tee $25
+  local.tee $26
   i32.const 848
   call $~lib/string/String.__eq
   i32.eqz
@@ -8328,7 +8325,7 @@
   i32.const 6
   i32.const 704
   call $~lib/string/String#padEnd
-  local.tee $26
+  local.tee $27
   i32.const 880
   call $~lib/string/String.__eq
   i32.eqz
@@ -8344,7 +8341,7 @@
   i32.const 8
   i32.const 704
   call $~lib/string/String#padEnd
-  local.tee $27
+  local.tee $28
   i32.const 912
   call $~lib/string/String.__eq
   i32.eqz
@@ -8641,7 +8638,7 @@
   end
   i32.const 120
   call $~lib/string/String#trimStart
-  local.tee $28
+  local.tee $29
   i32.const 120
   call $~lib/string/String.__eq
   i32.eqz
@@ -8655,7 +8652,7 @@
   end
   i32.const 1064
   call $~lib/string/String#trimStart
-  local.tee $29
+  local.tee $30
   i32.const 1064
   call $~lib/string/String.__eq
   i32.eqz
@@ -8669,7 +8666,7 @@
   end
   i32.const 1088
   call $~lib/string/String#trimStart
-  local.tee $30
+  local.tee $31
   i32.const 1128
   call $~lib/string/String.__eq
   i32.eqz
@@ -8683,7 +8680,7 @@
   end
   i32.const 120
   call $~lib/string/String#trimEnd
-  local.tee $31
+  local.tee $32
   i32.const 120
   call $~lib/string/String.__eq
   i32.eqz
@@ -8697,7 +8694,7 @@
   end
   i32.const 1064
   call $~lib/string/String#trimEnd
-  local.tee $32
+  local.tee $33
   i32.const 1064
   call $~lib/string/String.__eq
   i32.eqz
@@ -8711,7 +8708,7 @@
   end
   i32.const 1088
   call $~lib/string/String#trimEnd
-  local.tee $33
+  local.tee $34
   i32.const 1160
   call $~lib/string/String.__eq
   i32.eqz
@@ -8725,7 +8722,7 @@
   end
   i32.const 120
   call $~lib/string/String#trim
-  local.tee $34
+  local.tee $35
   i32.const 120
   call $~lib/string/String.__eq
   i32.eqz
@@ -8739,7 +8736,7 @@
   end
   i32.const 1064
   call $~lib/string/String#trim
-  local.tee $35
+  local.tee $36
   i32.const 1064
   call $~lib/string/String.__eq
   i32.eqz
@@ -8753,7 +8750,7 @@
   end
   i32.const 1088
   call $~lib/string/String#trim
-  local.tee $36
+  local.tee $37
   i32.const 704
   call $~lib/string/String.__eq
   i32.eqz
@@ -9195,8 +9192,9 @@
   end
   i32.const 120
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $3
+  local.get $3
+  f64.eq
   if
    i32.const 0
    i32.const 72
@@ -9843,8 +9841,9 @@
   end
   i32.const 4152
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $3
+  local.get $3
+  f64.eq
   if
    i32.const 0
    i32.const 72
@@ -9855,8 +9854,9 @@
   end
   i32.const 4176
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $3
+  local.get $3
+  f64.eq
   if
    i32.const 0
    i32.const 72
@@ -9867,8 +9867,9 @@
   end
   i32.const 4200
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $3
+  local.get $3
+  f64.eq
   if
    i32.const 0
    i32.const 72
@@ -9879,8 +9880,9 @@
   end
   i32.const 4224
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $3
+  local.get $3
+  f64.eq
   if
    i32.const 0
    i32.const 72
@@ -9891,8 +9893,9 @@
   end
   i32.const 4248
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $3
+  local.get $3
+  f64.eq
   if
    i32.const 0
    i32.const 72
@@ -9903,8 +9906,9 @@
   end
   i32.const 4272
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $3
+  local.get $3
+  f64.eq
   if
    i32.const 0
    i32.const 72
@@ -9915,8 +9919,9 @@
   end
   i32.const 4296
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $3
+  local.get $3
+  f64.eq
   if
    i32.const 0
    i32.const 72
@@ -9927,8 +9932,9 @@
   end
   i32.const 4320
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $3
+  local.get $3
+  f64.eq
   if
    i32.const 0
    i32.const 72
@@ -9939,8 +9945,9 @@
   end
   i32.const 4344
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $3
+  local.get $3
+  f64.eq
   if
    i32.const 0
    i32.const 72
@@ -9951,8 +9958,9 @@
   end
   i32.const 4368
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $3
+  local.get $3
+  f64.eq
   if
    i32.const 0
    i32.const 72
@@ -9963,8 +9971,9 @@
   end
   i32.const 4392
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $3
+  local.get $3
+  f64.eq
   if
    i32.const 0
    i32.const 72
@@ -9975,8 +9984,9 @@
   end
   i32.const 4416
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $3
+  local.get $3
+  f64.eq
   if
    i32.const 0
    i32.const 72
@@ -9987,8 +9997,9 @@
   end
   i32.const 4440
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $3
+  local.get $3
+  f64.eq
   if
    i32.const 0
    i32.const 72
@@ -9999,8 +10010,9 @@
   end
   i32.const 4472
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $3
+  local.get $3
+  f64.eq
   if
    i32.const 0
    i32.const 72
@@ -10011,8 +10023,9 @@
   end
   i32.const 4496
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $3
+  local.get $3
+  f64.eq
   if
    i32.const 0
    i32.const 72
@@ -10023,8 +10036,9 @@
   end
   i32.const 4520
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $3
+  local.get $3
+  f64.eq
   if
    i32.const 0
    i32.const 72
@@ -10239,8 +10253,9 @@
   end
   i32.const 5344
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $3
+  local.get $3
+  f64.eq
   if
    i32.const 0
    i32.const 72
@@ -10251,8 +10266,9 @@
   end
   i32.const 5368
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $3
+  local.get $3
+  f64.eq
   if
    i32.const 0
    i32.const 72
@@ -10263,8 +10279,9 @@
   end
   i32.const 5400
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $3
+  local.get $3
+  f64.eq
   if
    i32.const 0
    i32.const 72
@@ -10312,16 +10329,16 @@
   i32.const 6008
   i32.const 6160
   call $~lib/string/String.__concat
-  local.tee $38
+  local.tee $39
   i32.const 6312
   call $~lib/string/String.__concat
-  local.tee $39
+  local.tee $40
   i32.const 6464
   call $~lib/string/String.__concat
-  local.tee $40
+  local.tee $41
   i32.const 6616
   call $~lib/string/String.__concat
-  local.tee $41
+  local.tee $42
   call $~lib/string/parseFloat
   f64.const 1797693134862315708145274e284
   f64.ne
@@ -10623,8 +10640,9 @@
   end
   i32.const 9312
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
-  i32.eqz
+  local.tee $3
+  local.get $3
+  f64.eq
   if
    i32.const 0
    i32.const 72
@@ -11027,9 +11045,9 @@
   call $~lib/string/String.fromCodePoint
   local.tee $2
   call $~lib/string/String.__concat
-  local.tee $3
-  call $~lib/rt/pure/__retain
   local.tee $4
+  call $~lib/rt/pure/__retain
+  local.tee $5
   call $~lib/string/String.__gt
   i32.eqz
   if
@@ -11046,9 +11064,9 @@
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
-  local.get $3
-  call $~lib/rt/pure/__release
   local.get $4
+  call $~lib/rt/pure/__release
+  local.get $5
   call $~lib/rt/pure/__release
   i32.const 760
   call $~lib/string/String#get:length
@@ -11065,7 +11083,7 @@
   i32.const 120
   i32.const 100
   call $~lib/string/String#repeat
-  local.tee $3
+  local.tee $4
   i32.const 120
   call $~lib/string/String.__eq
   i32.eqz
@@ -11080,7 +11098,7 @@
   i32.const 408
   i32.const 0
   call $~lib/string/String#repeat
-  local.tee $4
+  local.tee $5
   i32.const 120
   call $~lib/string/String.__eq
   i32.eqz
@@ -11095,7 +11113,7 @@
   i32.const 408
   i32.const 1
   call $~lib/string/String#repeat
-  local.tee $42
+  local.tee $43
   i32.const 408
   call $~lib/string/String.__eq
   i32.eqz
@@ -11110,7 +11128,7 @@
   i32.const 408
   i32.const 2
   call $~lib/string/String#repeat
-  local.tee $43
+  local.tee $44
   i32.const 9744
   call $~lib/string/String.__eq
   i32.eqz
@@ -11125,7 +11143,7 @@
   i32.const 408
   i32.const 3
   call $~lib/string/String#repeat
-  local.tee $44
+  local.tee $45
   i32.const 9816
   call $~lib/string/String.__eq
   i32.eqz
@@ -11140,7 +11158,7 @@
   i32.const 9392
   i32.const 4
   call $~lib/string/String#repeat
-  local.tee $45
+  local.tee $46
   i32.const 9840
   call $~lib/string/String.__eq
   i32.eqz
@@ -11155,7 +11173,7 @@
   i32.const 408
   i32.const 5
   call $~lib/string/String#repeat
-  local.tee $46
+  local.tee $47
   i32.const 9872
   call $~lib/string/String.__eq
   i32.eqz
@@ -11170,7 +11188,7 @@
   i32.const 408
   i32.const 6
   call $~lib/string/String#repeat
-  local.tee $47
+  local.tee $48
   i32.const 9904
   call $~lib/string/String.__eq
   i32.eqz
@@ -11185,7 +11203,7 @@
   i32.const 408
   i32.const 7
   call $~lib/string/String#repeat
-  local.tee $48
+  local.tee $49
   i32.const 9936
   call $~lib/string/String.__eq
   i32.eqz
@@ -11201,7 +11219,7 @@
   i32.const 120
   i32.const 120
   call $~lib/string/String#replace
-  local.tee $49
+  local.tee $50
   i32.const 120
   call $~lib/string/String.__eq
   i32.eqz
@@ -11217,7 +11235,7 @@
   i32.const 120
   i32.const 4152
   call $~lib/string/String#replace
-  local.tee $50
+  local.tee $51
   i32.const 4152
   call $~lib/string/String.__eq
   i32.eqz
@@ -11233,7 +11251,7 @@
   i32.const 4152
   i32.const 120
   call $~lib/string/String#replace
-  local.tee $51
+  local.tee $52
   i32.const 120
   call $~lib/string/String.__eq
   i32.eqz
@@ -11249,7 +11267,7 @@
   i32.const 120
   i32.const 120
   call $~lib/string/String#replace
-  local.tee $52
+  local.tee $53
   i32.const 4152
   call $~lib/string/String.__eq
   i32.eqz
@@ -11265,7 +11283,7 @@
   i32.const 4176
   i32.const 4152
   call $~lib/string/String#replace
-  local.tee $53
+  local.tee $54
   i32.const 704
   call $~lib/string/String.__eq
   i32.eqz
@@ -11281,7 +11299,7 @@
   i32.const 704
   i32.const 4152
   call $~lib/string/String#replace
-  local.tee $54
+  local.tee $55
   i32.const 4152
   call $~lib/string/String.__eq
   i32.eqz
@@ -11297,7 +11315,7 @@
   i32.const 9968
   i32.const 4152
   call $~lib/string/String#replace
-  local.tee $55
+  local.tee $56
   i32.const 704
   call $~lib/string/String.__eq
   i32.eqz
@@ -11313,7 +11331,7 @@
   i32.const 9392
   i32.const 9392
   call $~lib/string/String#replace
-  local.tee $56
+  local.tee $57
   i32.const 704
   call $~lib/string/String.__eq
   i32.eqz
@@ -11329,7 +11347,7 @@
   i32.const 4176
   i32.const 4152
   call $~lib/string/String#replace
-  local.tee $57
+  local.tee $58
   i32.const 10024
   call $~lib/string/String.__eq
   i32.eqz
@@ -11345,7 +11363,7 @@
   i32.const 120
   i32.const 4152
   call $~lib/string/String#replace
-  local.tee $58
+  local.tee $59
   i32.const 10056
   call $~lib/string/String.__eq
   i32.eqz
@@ -11361,7 +11379,7 @@
   i32.const 10104
   i32.const 4152
   call $~lib/string/String#replace
-  local.tee $59
+  local.tee $60
   i32.const 10056
   call $~lib/string/String.__eq
   i32.eqz
@@ -11377,7 +11395,7 @@
   i32.const 10128
   i32.const 10152
   call $~lib/string/String#replace
-  local.tee $60
+  local.tee $61
   i32.const 10176
   call $~lib/string/String.__eq
   i32.eqz
@@ -11393,7 +11411,7 @@
   i32.const 10128
   i32.const 120
   call $~lib/string/String#replace
-  local.tee $61
+  local.tee $62
   i32.const 9392
   call $~lib/string/String.__eq
   i32.eqz
@@ -11409,7 +11427,7 @@
   i32.const 120
   i32.const 704
   call $~lib/string/String#replaceAll
-  local.tee $62
+  local.tee $63
   i32.const 704
   call $~lib/string/String.__eq
   i32.eqz
@@ -11425,7 +11443,7 @@
   i32.const 4176
   i32.const 4152
   call $~lib/string/String#replaceAll
-  local.tee $63
+  local.tee $64
   i32.const 704
   call $~lib/string/String.__eq
   i32.eqz
@@ -11441,7 +11459,7 @@
   i32.const 704
   i32.const 4152
   call $~lib/string/String#replaceAll
-  local.tee $64
+  local.tee $65
   i32.const 10152
   call $~lib/string/String.__eq
   i32.eqz
@@ -11457,7 +11475,7 @@
   i32.const 704
   i32.const 4152
   call $~lib/string/String#replaceAll
-  local.tee $65
+  local.tee $66
   i32.const 10240
   call $~lib/string/String.__eq
   i32.eqz
@@ -11473,7 +11491,7 @@
   i32.const 9392
   i32.const 9392
   call $~lib/string/String#replaceAll
-  local.tee $66
+  local.tee $67
   i32.const 880
   call $~lib/string/String.__eq
   i32.eqz
@@ -11489,7 +11507,7 @@
   i32.const 408
   i32.const 10240
   call $~lib/string/String#replaceAll
-  local.tee $67
+  local.tee $68
   i32.const 10296
   call $~lib/string/String.__eq
   i32.eqz
@@ -11505,7 +11523,7 @@
   i32.const 9392
   i32.const 10152
   call $~lib/string/String#replaceAll
-  local.tee $68
+  local.tee $69
   i32.const 10344
   call $~lib/string/String.__eq
   i32.eqz
@@ -11521,7 +11539,7 @@
   i32.const 10400
   i32.const 10152
   call $~lib/string/String#replaceAll
-  local.tee $69
+  local.tee $70
   i32.const 10424
   call $~lib/string/String.__eq
   i32.eqz
@@ -11537,7 +11555,7 @@
   i32.const 9968
   i32.const 4152
   call $~lib/string/String#replaceAll
-  local.tee $70
+  local.tee $71
   i32.const 704
   call $~lib/string/String.__eq
   i32.eqz
@@ -11553,7 +11571,7 @@
   i32.const 10448
   i32.const 10152
   call $~lib/string/String#replaceAll
-  local.tee $71
+  local.tee $72
   i32.const 9968
   call $~lib/string/String.__eq
   i32.eqz
@@ -11569,7 +11587,7 @@
   i32.const 10472
   i32.const 4152
   call $~lib/string/String#replaceAll
-  local.tee $72
+  local.tee $73
   i32.const 10496
   call $~lib/string/String.__eq
   i32.eqz
@@ -11585,7 +11603,7 @@
   i32.const 9392
   i32.const 4152
   call $~lib/string/String#replaceAll
-  local.tee $73
+  local.tee $74
   i32.const 4152
   call $~lib/string/String.__eq
   i32.eqz
@@ -11601,7 +11619,7 @@
   i32.const 4176
   i32.const 4152
   call $~lib/string/String#replaceAll
-  local.tee $74
+  local.tee $75
   i32.const 10520
   call $~lib/string/String.__eq
   i32.eqz
@@ -11617,7 +11635,7 @@
   i32.const 120
   i32.const 120
   call $~lib/string/String#replaceAll
-  local.tee $75
+  local.tee $76
   i32.const 120
   call $~lib/string/String.__eq
   i32.eqz
@@ -11633,7 +11651,7 @@
   i32.const 120
   i32.const 4152
   call $~lib/string/String#replaceAll
-  local.tee $76
+  local.tee $77
   i32.const 4152
   call $~lib/string/String.__eq
   i32.eqz
@@ -11649,7 +11667,7 @@
   i32.const 4152
   i32.const 120
   call $~lib/string/String#replaceAll
-  local.tee $77
+  local.tee $78
   i32.const 120
   call $~lib/string/String.__eq
   i32.eqz
@@ -11665,7 +11683,7 @@
   i32.const 120
   i32.const 120
   call $~lib/string/String#replaceAll
-  local.tee $78
+  local.tee $79
   i32.const 4152
   call $~lib/string/String.__eq
   i32.eqz
@@ -11681,7 +11699,7 @@
   i32.const 704
   i32.const 4176
   call $~lib/string/String#replaceAll
-  local.tee $79
+  local.tee $80
   i32.const 4176
   call $~lib/string/String.__eq
   i32.eqz
@@ -11697,7 +11715,7 @@
   i32.const 10552
   i32.const 4176
   call $~lib/string/String#replaceAll
-  local.tee $80
+  local.tee $81
   i32.const 704
   call $~lib/string/String.__eq
   i32.eqz
@@ -11713,7 +11731,7 @@
   i32.const 120
   i32.const 4152
   call $~lib/string/String#replaceAll
-  local.tee $81
+  local.tee $82
   i32.const 10576
   call $~lib/string/String.__eq
   i32.eqz
@@ -11729,7 +11747,7 @@
   i32.const 120
   i32.const 120
   call $~lib/string/String#replaceAll
-  local.tee $82
+  local.tee $83
   i32.const 704
   call $~lib/string/String.__eq
   i32.eqz
@@ -11758,7 +11776,7 @@
   i32.const 0
   i32.const 2147483647
   call $~lib/string/String#slice
-  local.tee $83
+  local.tee $84
   i32.const 10608
   call $~lib/string/String.__eq
   i32.eqz
@@ -11774,7 +11792,7 @@
   i32.const -1
   i32.const 2147483647
   call $~lib/string/String#slice
-  local.tee $84
+  local.tee $85
   i32.const 10656
   call $~lib/string/String.__eq
   i32.eqz
@@ -11790,7 +11808,7 @@
   i32.const -5
   i32.const 2147483647
   call $~lib/string/String#slice
-  local.tee $85
+  local.tee $86
   i32.const 10680
   call $~lib/string/String.__eq
   i32.eqz
@@ -11806,7 +11824,7 @@
   i32.const 2
   i32.const 7
   call $~lib/string/String#slice
-  local.tee $86
+  local.tee $87
   i32.const 10712
   call $~lib/string/String.__eq
   i32.eqz
@@ -11822,7 +11840,7 @@
   i32.const -11
   i32.const -6
   call $~lib/string/String#slice
-  local.tee $87
+  local.tee $88
   i32.const 10744
   call $~lib/string/String.__eq
   i32.eqz
@@ -11838,7 +11856,7 @@
   i32.const 4
   i32.const 3
   call $~lib/string/String#slice
-  local.tee $88
+  local.tee $89
   i32.const 120
   call $~lib/string/String.__eq
   i32.eqz
@@ -11854,7 +11872,7 @@
   i32.const 0
   i32.const -1
   call $~lib/string/String#slice
-  local.tee $89
+  local.tee $90
   i32.const 10776
   call $~lib/string/String.__eq
   i32.eqz
@@ -12742,7 +12760,7 @@
   end
   i32.const 12
   call $~lib/util/number/itoa32
-  local.tee $90
+  local.tee $91
   i32.const 11192
   call $~lib/string/String.__eq
   i32.eqz
@@ -12756,7 +12774,7 @@
   end
   i32.const 123
   call $~lib/util/number/itoa32
-  local.tee $91
+  local.tee $92
   i32.const 760
   call $~lib/string/String.__eq
   i32.eqz
@@ -12770,7 +12788,7 @@
   end
   i32.const -1000
   call $~lib/util/number/itoa32
-  local.tee $92
+  local.tee $93
   i32.const 11216
   call $~lib/string/String.__eq
   i32.eqz
@@ -12784,7 +12802,7 @@
   end
   i32.const 1234
   call $~lib/util/number/itoa32
-  local.tee $93
+  local.tee $94
   i32.const 11248
   call $~lib/string/String.__eq
   i32.eqz
@@ -12798,7 +12816,7 @@
   end
   i32.const 12345
   call $~lib/util/number/itoa32
-  local.tee $94
+  local.tee $95
   i32.const 11272
   call $~lib/string/String.__eq
   i32.eqz
@@ -12812,7 +12830,7 @@
   end
   i32.const 123456
   call $~lib/util/number/itoa32
-  local.tee $95
+  local.tee $96
   i32.const 11304
   call $~lib/string/String.__eq
   i32.eqz
@@ -12826,7 +12844,7 @@
   end
   i32.const 1111111
   call $~lib/util/number/itoa32
-  local.tee $96
+  local.tee $97
   i32.const 11336
   call $~lib/string/String.__eq
   i32.eqz
@@ -12840,7 +12858,7 @@
   end
   i32.const 1234567
   call $~lib/util/number/itoa32
-  local.tee $97
+  local.tee $98
   i32.const 11368
   call $~lib/string/String.__eq
   i32.eqz
@@ -12854,7 +12872,7 @@
   end
   i32.const 12345678
   call $~lib/util/number/itoa32
-  local.tee $98
+  local.tee $99
   i32.const 11400
   call $~lib/string/String.__eq
   i32.eqz
@@ -12868,7 +12886,7 @@
   end
   i32.const 123456789
   call $~lib/util/number/itoa32
-  local.tee $99
+  local.tee $100
   i32.const 11432
   call $~lib/string/String.__eq
   i32.eqz
@@ -12882,7 +12900,7 @@
   end
   i32.const 2147483646
   call $~lib/util/number/itoa32
-  local.tee $100
+  local.tee $101
   i32.const 11472
   call $~lib/string/String.__eq
   i32.eqz
@@ -12896,7 +12914,7 @@
   end
   i32.const 2147483647
   call $~lib/util/number/itoa32
-  local.tee $101
+  local.tee $102
   i32.const 11512
   call $~lib/string/String.__eq
   i32.eqz
@@ -12910,7 +12928,7 @@
   end
   i32.const -2147483648
   call $~lib/util/number/itoa32
-  local.tee $102
+  local.tee $103
   i32.const 11552
   call $~lib/string/String.__eq
   i32.eqz
@@ -12924,7 +12942,7 @@
   end
   i32.const -1
   call $~lib/util/number/itoa32
-  local.tee $103
+  local.tee $104
   i32.const 11592
   call $~lib/string/String.__eq
   i32.eqz
@@ -12938,7 +12956,7 @@
   end
   i32.const 0
   call $~lib/util/number/utoa32
-  local.tee $104
+  local.tee $105
   i32.const 1192
   call $~lib/string/String.__eq
   i32.eqz
@@ -12952,7 +12970,7 @@
   end
   i32.const 1000
   call $~lib/util/number/utoa32
-  local.tee $105
+  local.tee $106
   i32.const 11616
   call $~lib/string/String.__eq
   i32.eqz
@@ -12966,7 +12984,7 @@
   end
   i32.const 2147483647
   call $~lib/util/number/utoa32
-  local.tee $106
+  local.tee $107
   i32.const 11512
   call $~lib/string/String.__eq
   i32.eqz
@@ -12980,7 +12998,7 @@
   end
   i32.const -2147483648
   call $~lib/util/number/utoa32
-  local.tee $107
+  local.tee $108
   i32.const 11640
   call $~lib/string/String.__eq
   i32.eqz
@@ -12994,7 +13012,7 @@
   end
   i32.const -1
   call $~lib/util/number/utoa32
-  local.tee $108
+  local.tee $109
   i32.const 11680
   call $~lib/string/String.__eq
   i32.eqz
@@ -13008,7 +13026,7 @@
   end
   i64.const 0
   call $~lib/util/number/utoa64
-  local.tee $109
+  local.tee $110
   i32.const 1192
   call $~lib/string/String.__eq
   i32.eqz
@@ -13022,7 +13040,7 @@
   end
   i64.const 12
   call $~lib/util/number/utoa64
-  local.tee $110
+  local.tee $111
   i32.const 11192
   call $~lib/string/String.__eq
   i32.eqz
@@ -13036,7 +13054,7 @@
   end
   i64.const 123
   call $~lib/util/number/utoa64
-  local.tee $111
+  local.tee $112
   i32.const 760
   call $~lib/string/String.__eq
   i32.eqz
@@ -13050,7 +13068,7 @@
   end
   i64.const 1234
   call $~lib/util/number/utoa64
-  local.tee $112
+  local.tee $113
   i32.const 11248
   call $~lib/string/String.__eq
   i32.eqz
@@ -13064,7 +13082,7 @@
   end
   i64.const 12345
   call $~lib/util/number/utoa64
-  local.tee $113
+  local.tee $114
   i32.const 11272
   call $~lib/string/String.__eq
   i32.eqz
@@ -13078,7 +13096,7 @@
   end
   i64.const 123456
   call $~lib/util/number/utoa64
-  local.tee $114
+  local.tee $115
   i32.const 11304
   call $~lib/string/String.__eq
   i32.eqz
@@ -13092,7 +13110,7 @@
   end
   i64.const 1234567
   call $~lib/util/number/utoa64
-  local.tee $115
+  local.tee $116
   i32.const 11368
   call $~lib/string/String.__eq
   i32.eqz
@@ -13106,7 +13124,7 @@
   end
   i64.const 99999999
   call $~lib/util/number/utoa64
-  local.tee $116
+  local.tee $117
   i32.const 11720
   call $~lib/string/String.__eq
   i32.eqz
@@ -13120,7 +13138,7 @@
   end
   i64.const 100000000
   call $~lib/util/number/utoa64
-  local.tee $117
+  local.tee $118
   i32.const 11752
   call $~lib/string/String.__eq
   i32.eqz
@@ -13134,7 +13152,7 @@
   end
   i64.const 4294967295
   call $~lib/util/number/utoa64
-  local.tee $118
+  local.tee $119
   i32.const 11680
   call $~lib/string/String.__eq
   i32.eqz
@@ -13148,7 +13166,7 @@
   end
   i64.const 4294967297
   call $~lib/util/number/utoa64
-  local.tee $119
+  local.tee $120
   i32.const 11792
   call $~lib/string/String.__eq
   i32.eqz
@@ -13162,7 +13180,7 @@
   end
   i64.const 68719476735
   call $~lib/util/number/utoa64
-  local.tee $120
+  local.tee $121
   i32.const 11832
   call $~lib/string/String.__eq
   i32.eqz
@@ -13176,7 +13194,7 @@
   end
   i64.const 868719476735
   call $~lib/util/number/utoa64
-  local.tee $121
+  local.tee $122
   i32.const 11872
   call $~lib/string/String.__eq
   i32.eqz
@@ -13190,7 +13208,7 @@
   end
   i64.const 8687194767350
   call $~lib/util/number/utoa64
-  local.tee $122
+  local.tee $123
   i32.const 11912
   call $~lib/string/String.__eq
   i32.eqz
@@ -13204,7 +13222,7 @@
   end
   i64.const 86871947673501
   call $~lib/util/number/utoa64
-  local.tee $123
+  local.tee $124
   i32.const 11960
   call $~lib/string/String.__eq
   i32.eqz
@@ -13218,7 +13236,7 @@
   end
   i64.const 999868719476735
   call $~lib/util/number/utoa64
-  local.tee $124
+  local.tee $125
   i32.const 12008
   call $~lib/string/String.__eq
   i32.eqz
@@ -13232,7 +13250,7 @@
   end
   i64.const 9999868719476735
   call $~lib/util/number/utoa64
-  local.tee $125
+  local.tee $126
   i32.const 12056
   call $~lib/string/String.__eq
   i32.eqz
@@ -13246,7 +13264,7 @@
   end
   i64.const 19999868719476735
   call $~lib/util/number/utoa64
-  local.tee $126
+  local.tee $127
   i32.const 12104
   call $~lib/string/String.__eq
   i32.eqz
@@ -13260,7 +13278,7 @@
   end
   i64.const 129999868719476735
   call $~lib/util/number/utoa64
-  local.tee $127
+  local.tee $128
   i32.const 12160
   call $~lib/string/String.__eq
   i32.eqz
@@ -13274,7 +13292,7 @@
   end
   i64.const 1239999868719476735
   call $~lib/util/number/utoa64
-  local.tee $128
+  local.tee $129
   i32.const 12216
   call $~lib/string/String.__eq
   i32.eqz
@@ -13288,7 +13306,7 @@
   end
   i64.const -1
   call $~lib/util/number/utoa64
-  local.tee $129
+  local.tee $130
   i32.const 12272
   call $~lib/string/String.__eq
   i32.eqz
@@ -13302,7 +13320,7 @@
   end
   i64.const 0
   call $~lib/util/number/itoa64
-  local.tee $130
+  local.tee $131
   i32.const 1192
   call $~lib/string/String.__eq
   i32.eqz
@@ -13316,7 +13334,7 @@
   end
   i64.const -1234
   call $~lib/util/number/itoa64
-  local.tee $131
+  local.tee $132
   i32.const 12328
   call $~lib/string/String.__eq
   i32.eqz
@@ -13330,7 +13348,7 @@
   end
   i64.const 4294967295
   call $~lib/util/number/itoa64
-  local.tee $132
+  local.tee $133
   i32.const 11680
   call $~lib/string/String.__eq
   i32.eqz
@@ -13344,7 +13362,7 @@
   end
   i64.const 4294967297
   call $~lib/util/number/itoa64
-  local.tee $133
+  local.tee $134
   i32.const 11792
   call $~lib/string/String.__eq
   i32.eqz
@@ -13358,7 +13376,7 @@
   end
   i64.const -4294967295
   call $~lib/util/number/itoa64
-  local.tee $134
+  local.tee $135
   i32.const 12360
   call $~lib/string/String.__eq
   i32.eqz
@@ -13372,7 +13390,7 @@
   end
   i64.const 68719476735
   call $~lib/util/number/itoa64
-  local.tee $135
+  local.tee $136
   i32.const 11832
   call $~lib/string/String.__eq
   i32.eqz
@@ -13386,7 +13404,7 @@
   end
   i64.const -68719476735
   call $~lib/util/number/itoa64
-  local.tee $136
+  local.tee $137
   i32.const 12400
   call $~lib/string/String.__eq
   i32.eqz
@@ -13400,7 +13418,7 @@
   end
   i64.const -868719476735
   call $~lib/util/number/itoa64
-  local.tee $137
+  local.tee $138
   i32.const 12440
   call $~lib/string/String.__eq
   i32.eqz
@@ -13414,7 +13432,7 @@
   end
   i64.const -999868719476735
   call $~lib/util/number/itoa64
-  local.tee $138
+  local.tee $139
   i32.const 12488
   call $~lib/string/String.__eq
   i32.eqz
@@ -13428,7 +13446,7 @@
   end
   i64.const -19999868719476735
   call $~lib/util/number/itoa64
-  local.tee $139
+  local.tee $140
   i32.const 12536
   call $~lib/string/String.__eq
   i32.eqz
@@ -13442,7 +13460,7 @@
   end
   i64.const 9223372036854775807
   call $~lib/util/number/itoa64
-  local.tee $140
+  local.tee $141
   i32.const 12592
   call $~lib/string/String.__eq
   i32.eqz
@@ -13456,7 +13474,7 @@
   end
   i64.const -9223372036854775808
   call $~lib/util/number/itoa64
-  local.tee $141
+  local.tee $142
   i32.const 12648
   call $~lib/string/String.__eq
   i32.eqz
@@ -13470,7 +13488,7 @@
   end
   f64.const 0
   call $~lib/util/number/dtoa
-  local.tee $142
+  local.tee $143
   i32.const 12704
   call $~lib/string/String.__eq
   i32.eqz
@@ -13484,7 +13502,7 @@
   end
   f64.const -0
   call $~lib/util/number/dtoa
-  local.tee $143
+  local.tee $144
   i32.const 12704
   call $~lib/string/String.__eq
   i32.eqz
@@ -13498,7 +13516,7 @@
   end
   f64.const nan:0x8000000000000
   call $~lib/util/number/dtoa
-  local.tee $144
+  local.tee $145
   i32.const 4344
   call $~lib/string/String.__eq
   i32.eqz
@@ -13512,7 +13530,7 @@
   end
   f64.const inf
   call $~lib/util/number/dtoa
-  local.tee $145
+  local.tee $146
   i32.const 12728
   call $~lib/string/String.__eq
   i32.eqz
@@ -13526,7 +13544,7 @@
   end
   f64.const -inf
   call $~lib/util/number/dtoa
-  local.tee $146
+  local.tee $147
   i32.const 5224
   call $~lib/string/String.__eq
   i32.eqz
@@ -13540,7 +13558,7 @@
   end
   f64.const 2.220446049250313e-16
   call $~lib/util/number/dtoa
-  local.tee $147
+  local.tee $148
   i32.const 4552
   call $~lib/string/String.__eq
   i32.eqz
@@ -13554,7 +13572,7 @@
   end
   f64.const -2.220446049250313e-16
   call $~lib/util/number/dtoa
-  local.tee $148
+  local.tee $149
   i32.const 13816
   call $~lib/string/String.__eq
   i32.eqz
@@ -13568,7 +13586,7 @@
   end
   f64.const 1797693134862315708145274e284
   call $~lib/util/number/dtoa
-  local.tee $149
+  local.tee $150
   i32.const 4616
   call $~lib/string/String.__eq
   i32.eqz
@@ -13582,7 +13600,7 @@
   end
   f64.const -1797693134862315708145274e284
   call $~lib/util/number/dtoa
-  local.tee $150
+  local.tee $151
   i32.const 13880
   call $~lib/string/String.__eq
   i32.eqz
@@ -13596,7 +13614,7 @@
   end
   f64.const 4185580496821356722454785e274
   call $~lib/util/number/dtoa
-  local.tee $151
+  local.tee $152
   i32.const 13944
   call $~lib/string/String.__eq
   i32.eqz
@@ -13610,7 +13628,7 @@
   end
   f64.const 2.2250738585072014e-308
   call $~lib/util/number/dtoa
-  local.tee $152
+  local.tee $153
   i32.const 14008
   call $~lib/string/String.__eq
   i32.eqz
@@ -13624,7 +13642,7 @@
   end
   f64.const 4.940656e-318
   call $~lib/util/number/dtoa
-  local.tee $153
+  local.tee $154
   i32.const 14072
   call $~lib/string/String.__eq
   i32.eqz
@@ -13638,7 +13656,7 @@
   end
   f64.const 9060801153433600
   call $~lib/util/number/dtoa
-  local.tee $154
+  local.tee $155
   i32.const 14120
   call $~lib/string/String.__eq
   i32.eqz
@@ -13652,7 +13670,7 @@
   end
   f64.const 4708356024711512064
   call $~lib/util/number/dtoa
-  local.tee $155
+  local.tee $156
   i32.const 14176
   call $~lib/string/String.__eq
   i32.eqz
@@ -13666,7 +13684,7 @@
   end
   f64.const 9409340012568248320
   call $~lib/util/number/dtoa
-  local.tee $156
+  local.tee $157
   i32.const 14240
   call $~lib/string/String.__eq
   i32.eqz
@@ -13680,7 +13698,7 @@
   end
   f64.const 5e-324
   call $~lib/util/number/dtoa
-  local.tee $157
+  local.tee $158
   i32.const 4680
   call $~lib/string/String.__eq
   i32.eqz
@@ -13694,7 +13712,7 @@
   end
   f64.const 1
   call $~lib/util/number/dtoa
-  local.tee $158
+  local.tee $159
   i32.const 14304
   call $~lib/string/String.__eq
   i32.eqz
@@ -13708,7 +13726,7 @@
   end
   f64.const 0.1
   call $~lib/util/number/dtoa
-  local.tee $159
+  local.tee $160
   i32.const 2352
   call $~lib/string/String.__eq
   i32.eqz
@@ -13722,7 +13740,7 @@
   end
   f64.const -1
   call $~lib/util/number/dtoa
-  local.tee $160
+  local.tee $161
   i32.const 14328
   call $~lib/string/String.__eq
   i32.eqz
@@ -13736,7 +13754,7 @@
   end
   f64.const -0.1
   call $~lib/util/number/dtoa
-  local.tee $161
+  local.tee $162
   i32.const 14352
   call $~lib/string/String.__eq
   i32.eqz
@@ -13750,7 +13768,7 @@
   end
   f64.const 1e6
   call $~lib/util/number/dtoa
-  local.tee $162
+  local.tee $163
   i32.const 14376
   call $~lib/string/String.__eq
   i32.eqz
@@ -13764,7 +13782,7 @@
   end
   f64.const 1e-06
   call $~lib/util/number/dtoa
-  local.tee $163
+  local.tee $164
   i32.const 14416
   call $~lib/string/String.__eq
   i32.eqz
@@ -13778,7 +13796,7 @@
   end
   f64.const -1e6
   call $~lib/util/number/dtoa
-  local.tee $164
+  local.tee $165
   i32.const 14448
   call $~lib/string/String.__eq
   i32.eqz
@@ -13792,7 +13810,7 @@
   end
   f64.const -1e-06
   call $~lib/util/number/dtoa
-  local.tee $165
+  local.tee $166
   i32.const 14488
   call $~lib/string/String.__eq
   i32.eqz
@@ -13806,7 +13824,7 @@
   end
   f64.const 1e7
   call $~lib/util/number/dtoa
-  local.tee $166
+  local.tee $167
   i32.const 14528
   call $~lib/string/String.__eq
   i32.eqz
@@ -13820,7 +13838,7 @@
   end
   f64.const 1e-07
   call $~lib/util/number/dtoa
-  local.tee $167
+  local.tee $168
   i32.const 14568
   call $~lib/string/String.__eq
   i32.eqz
@@ -13834,7 +13852,7 @@
   end
   f64.const 1.e+308
   call $~lib/util/number/dtoa
-  local.tee $168
+  local.tee $169
   i32.const 2528
   call $~lib/string/String.__eq
   i32.eqz
@@ -13848,7 +13866,7 @@
   end
   f64.const -1.e+308
   call $~lib/util/number/dtoa
-  local.tee $169
+  local.tee $170
   i32.const 14592
   call $~lib/string/String.__eq
   i32.eqz
@@ -13862,7 +13880,7 @@
   end
   f64.const inf
   call $~lib/util/number/dtoa
-  local.tee $170
+  local.tee $171
   i32.const 12728
   call $~lib/string/String.__eq
   i32.eqz
@@ -13876,7 +13894,7 @@
   end
   f64.const -inf
   call $~lib/util/number/dtoa
-  local.tee $171
+  local.tee $172
   i32.const 5224
   call $~lib/string/String.__eq
   i32.eqz
@@ -13890,7 +13908,7 @@
   end
   f64.const 1e-308
   call $~lib/util/number/dtoa
-  local.tee $172
+  local.tee $173
   i32.const 14624
   call $~lib/string/String.__eq
   i32.eqz
@@ -13904,7 +13922,7 @@
   end
   f64.const -1e-308
   call $~lib/util/number/dtoa
-  local.tee $173
+  local.tee $174
   i32.const 14656
   call $~lib/string/String.__eq
   i32.eqz
@@ -13918,7 +13936,7 @@
   end
   f64.const 1e-323
   call $~lib/util/number/dtoa
-  local.tee $174
+  local.tee $175
   i32.const 14688
   call $~lib/string/String.__eq
   i32.eqz
@@ -13932,7 +13950,7 @@
   end
   f64.const -1e-323
   call $~lib/util/number/dtoa
-  local.tee $175
+  local.tee $176
   i32.const 14720
   call $~lib/string/String.__eq
   i32.eqz
@@ -13946,7 +13964,7 @@
   end
   f64.const 0
   call $~lib/util/number/dtoa
-  local.tee $176
+  local.tee $177
   i32.const 12704
   call $~lib/string/String.__eq
   i32.eqz
@@ -13960,7 +13978,7 @@
   end
   f64.const 4294967272
   call $~lib/util/number/dtoa
-  local.tee $177
+  local.tee $178
   i32.const 14752
   call $~lib/string/String.__eq
   i32.eqz
@@ -13974,7 +13992,7 @@
   end
   f64.const 1.2312145673456234e-08
   call $~lib/util/number/dtoa
-  local.tee $178
+  local.tee $179
   i32.const 14792
   call $~lib/string/String.__eq
   i32.eqz
@@ -13988,7 +14006,7 @@
   end
   f64.const 555555555.5555556
   call $~lib/util/number/dtoa
-  local.tee $179
+  local.tee $180
   i32.const 14856
   call $~lib/string/String.__eq
   i32.eqz
@@ -14002,7 +14020,7 @@
   end
   f64.const 0.9999999999999999
   call $~lib/util/number/dtoa
-  local.tee $180
+  local.tee $181
   i32.const 14912
   call $~lib/string/String.__eq
   i32.eqz
@@ -14016,7 +14034,7 @@
   end
   f64.const 1
   call $~lib/util/number/dtoa
-  local.tee $181
+  local.tee $182
   i32.const 14304
   call $~lib/string/String.__eq
   i32.eqz
@@ -14030,7 +14048,7 @@
   end
   f64.const 12.34
   call $~lib/util/number/dtoa
-  local.tee $182
+  local.tee $183
   i32.const 14968
   call $~lib/string/String.__eq
   i32.eqz
@@ -14044,7 +14062,7 @@
   end
   f64.const 0.3333333333333333
   call $~lib/util/number/dtoa
-  local.tee $183
+  local.tee $184
   i32.const 15000
   call $~lib/string/String.__eq
   i32.eqz
@@ -14058,7 +14076,7 @@
   end
   f64.const 1234e17
   call $~lib/util/number/dtoa
-  local.tee $184
+  local.tee $185
   i32.const 15056
   call $~lib/string/String.__eq
   i32.eqz
@@ -14072,7 +14090,7 @@
   end
   f64.const 1234e18
   call $~lib/util/number/dtoa
-  local.tee $185
+  local.tee $186
   i32.const 15120
   call $~lib/string/String.__eq
   i32.eqz
@@ -14086,7 +14104,7 @@
   end
   f64.const 2.71828
   call $~lib/util/number/dtoa
-  local.tee $186
+  local.tee $187
   i32.const 15160
   call $~lib/string/String.__eq
   i32.eqz
@@ -14100,7 +14118,7 @@
   end
   f64.const 0.0271828
   call $~lib/util/number/dtoa
-  local.tee $187
+  local.tee $188
   i32.const 15192
   call $~lib/string/String.__eq
   i32.eqz
@@ -14114,7 +14132,7 @@
   end
   f64.const 271.828
   call $~lib/util/number/dtoa
-  local.tee $188
+  local.tee $189
   i32.const 15232
   call $~lib/string/String.__eq
   i32.eqz
@@ -14128,7 +14146,7 @@
   end
   f64.const 1.1e+128
   call $~lib/util/number/dtoa
-  local.tee $189
+  local.tee $190
   i32.const 15264
   call $~lib/string/String.__eq
   i32.eqz
@@ -14142,7 +14160,7 @@
   end
   f64.const 1.1e-64
   call $~lib/util/number/dtoa
-  local.tee $190
+  local.tee $191
   i32.const 15296
   call $~lib/string/String.__eq
   i32.eqz
@@ -14156,7 +14174,7 @@
   end
   f64.const 0.000035689
   call $~lib/util/number/dtoa
-  local.tee $191
+  local.tee $192
   i32.const 15328
   call $~lib/string/String.__eq
   i32.eqz
@@ -14169,8 +14187,6 @@
    unreachable
   end
   global.get $std/string/str
-  call $~lib/rt/pure/__release
-  local.get $5
   call $~lib/rt/pure/__release
   local.get $6
   call $~lib/rt/pure/__release
@@ -14234,7 +14250,7 @@
   call $~lib/rt/pure/__release
   local.get $36
   call $~lib/rt/pure/__release
-  local.get $38
+  local.get $37
   call $~lib/rt/pure/__release
   local.get $39
   call $~lib/rt/pure/__release
@@ -14242,17 +14258,17 @@
   call $~lib/rt/pure/__release
   local.get $41
   call $~lib/rt/pure/__release
-  local.get $43
+  local.get $42
   call $~lib/rt/pure/__release
   local.get $44
   call $~lib/rt/pure/__release
-  local.get $42
+  local.get $45
+  call $~lib/rt/pure/__release
+  local.get $43
+  call $~lib/rt/pure/__release
+  local.get $5
   call $~lib/rt/pure/__release
   local.get $4
-  call $~lib/rt/pure/__release
-  local.get $3
-  call $~lib/rt/pure/__release
-  local.get $45
   call $~lib/rt/pure/__release
   local.get $46
   call $~lib/rt/pure/__release
@@ -14342,13 +14358,13 @@
   call $~lib/rt/pure/__release
   local.get $89
   call $~lib/rt/pure/__release
+  local.get $90
+  call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
   local.get $2
   call $~lib/rt/pure/__release
   local.get $0
-  call $~lib/rt/pure/__release
-  local.get $90
   call $~lib/rt/pure/__release
   local.get $91
   call $~lib/rt/pure/__release
@@ -14552,12 +14568,14 @@
   call $~lib/rt/pure/__release
   local.get $191
   call $~lib/rt/pure/__release
+  local.get $192
+  call $~lib/rt/pure/__release
  )
- (func $std/string/getString (; 91 ;) (type $FUNCSIG$i) (result i32)
+ (func $std/string/getString (; 90 ;) (type $FUNCSIG$i) (result i32)
   global.get $std/string/str
   call $~lib/rt/pure/__retain
  )
- (func $start (; 92 ;) (type $FUNCSIG$v)
+ (func $start (; 91 ;) (type $FUNCSIG$v)
   global.get $~lib/started
   if
    return
@@ -14567,7 +14585,7 @@
   end
   call $start:std/string
  )
- (func $~lib/rt/pure/__visit (; 93 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 92 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   i32.const 15428
   i32.lt_u
@@ -14677,7 +14695,7 @@
    unreachable
   end
  )
- (func $~lib/array/Array<~lib/string/String>#__visit_impl (; 94 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/string/String>#__visit_impl (; 93 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -14710,7 +14728,7 @@
    end
   end
  )
- (func $~lib/rt/__visit_members (; 95 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (; 94 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   block $block$4$break
    block $switch$1$default
     block $switch$1$case$6
@@ -14739,7 +14757,7 @@
    call $~lib/rt/pure/__visit
   end
  )
- (func $null (; 96 ;) (type $FUNCSIG$v)
+ (func $null (; 95 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -4366,7 +4366,8 @@
     i32.const -342
     i32.lt_s
     local.get $2
-    i64.eqz
+    i64.const 0
+    i64.eq
     select
     if
      br $~lib/util/string/scientific|inlined.0
@@ -6507,7 +6508,8 @@
   (local $2 i32)
   (local $3 i32)
   local.get $0
-  i64.eqz
+  i64.const 0
+  i64.eq
   if
    i32.const 1192
    call $~lib/rt/pure/__retain
@@ -6552,7 +6554,8 @@
   (local $3 i32)
   (local $4 i32)
   local.get $0
-  i64.eqz
+  i64.const 0
+  i64.eq
   if
    i32.const 1192
    call $~lib/rt/pure/__retain

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -12,10 +12,10 @@
  (type $FUNCSIG$jii (func (param i32 i32) (result i64)))
  (type $FUNCSIG$di (func (param i32) (result f64)))
  (type $FUNCSIG$ddi (func (param f64 i32) (result f64)))
- (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$iiiii (func (param i32 i32 i32 i32) (result i32)))
  (type $FUNCSIG$ij (func (param i64) (result i32)))
  (type $FUNCSIG$viji (func (param i32 i64 i32)))
+ (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$iid (func (param i32 f64) (result i32)))
  (type $FUNCSIG$iijijiji (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
  (type $FUNCSIG$i (func (result i32)))
@@ -7056,12 +7056,7 @@
   call $~lib/rt/pure/__release
   local.get $1
  )
- (func $~lib/number/isNaN<f64> (; 62 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.ne
- )
- (func $~lib/string/String#concat (; 63 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#concat (; 62 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7137,7 +7132,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__concat (; 64 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__concat (; 63 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -7160,7 +7155,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__ne (; 65 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__ne (; 64 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -7179,7 +7174,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__gt (; 66 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__gt (; 65 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7269,7 +7264,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__lt (; 67 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__lt (; 66 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7359,7 +7354,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__gte (; 68 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__gte (; 67 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -7378,7 +7373,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String.__lte (; 69 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__lte (; 68 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -7397,7 +7392,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/string/String#repeat (; 70 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#repeat (; 69 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -7465,7 +7460,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#replace (; 71 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#replace (; 70 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7599,7 +7594,7 @@
   call $~lib/rt/pure/__release
   local.get $5
  )
- (func $~lib/rt/tlsf/reallocateBlock (; 72 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/rt/tlsf/reallocateBlock (; 71 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7737,7 +7732,7 @@
   call $~lib/rt/rtrace/onfree
   local.get $8
  )
- (func $~lib/rt/tlsf/__realloc (; 73 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/__realloc (; 72 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   global.get $~lib/rt/tlsf/ROOT
   i32.eqz
   if
@@ -7777,7 +7772,7 @@
   i32.const 16
   i32.add
  )
- (func $~lib/string/String#replaceAll (; 74 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#replaceAll (; 73 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8150,7 +8145,7 @@
   call $~lib/rt/pure/__release
   local.get $6
  )
- (func $~lib/string/String#slice (; 75 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#slice (; 74 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8239,7 +8234,7 @@
   local.get $6
   call $~lib/rt/pure/__retain
  )
- (func $~lib/rt/__allocArray (; 76 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/rt/__allocArray (; 75 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -8277,7 +8272,7 @@
   end
   local.get $4
  )
- (func $~lib/memory/memory.fill (; 77 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.fill (; 76 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8541,7 +8536,7 @@
    end
   end
  )
- (func $~lib/array/ensureSize (; 78 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/ensureSize (; 77 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8604,7 +8599,7 @@
    i32.store offset=8
   end
  )
- (func $~lib/array/Array<~lib/string/String>#push (; 79 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#push (; 78 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8640,7 +8635,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/string/String#split (; 80 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#split (; 79 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8947,11 +8942,11 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/array/Array<~lib/string/String>#get:length (; 81 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#get:length (; 80 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<~lib/string/String>#__unchecked_get (; 82 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#__unchecked_get (; 81 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -8961,7 +8956,7 @@
   i32.load
   call $~lib/rt/pure/__retain
  )
- (func $~lib/array/Array<~lib/string/String>#__get (; 83 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<~lib/string/String>#__get (; 82 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -8993,7 +8988,7 @@
   end
   local.get $2
  )
- (func $~lib/util/number/decimalCount32 (; 84 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (; 83 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 100000
@@ -9059,7 +9054,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/utoa32_lut (; 85 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa32_lut (; 84 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9201,7 +9196,7 @@
    i32.store16
   end
  )
- (func $~lib/util/number/itoa32 (; 86 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (; 85 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9256,7 +9251,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/utoa32 (; 87 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/utoa32 (; 86 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9291,7 +9286,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/decimalCount64 (; 88 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64 (; 87 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   local.get $0
   i64.const 1000000000000000
@@ -9364,7 +9359,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/utoa64_lut (; 89 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/util/number/utoa64_lut (; 88 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -9491,7 +9486,7 @@
   local.get $2
   call $~lib/util/number/utoa32_lut
  )
- (func $~lib/util/number/utoa64 (; 90 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/utoa64 (; 89 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9558,7 +9553,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa64 (; 91 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa64 (; 90 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9647,14 +9642,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/number/isFinite<f64> (; 92 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.sub
-  f64.const 0
-  f64.eq
- )
- (func $~lib/array/Array<u64>#__unchecked_get (; 93 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__unchecked_get (; 91 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -9663,7 +9651,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<i16>#__unchecked_get (; 94 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__unchecked_get (; 92 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -9672,7 +9660,7 @@
   i32.add
   i32.load16_s
  )
- (func $~lib/util/number/genDigits (; 95 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (; 93 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -10174,7 +10162,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/prettify (; 96 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (; 94 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -10493,7 +10481,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/dtoa_core (; 97 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (; 95 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10915,7 +10903,7 @@
   local.get $2
   i32.add
  )
- (func $~lib/string/String#substring (; 98 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substring (; 96 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -11022,10 +11010,11 @@
   local.get $10
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/dtoa (; 99 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  (local $1 i32)
+ (func $~lib/util/number/dtoa (; 97 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+  (local $1 f64)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   local.get $0
   f64.const 0
   f64.eq
@@ -11035,11 +11024,17 @@
    return
   end
   local.get $0
-  call $~lib/number/isFinite<f64>
+  local.tee $1
+  local.get $1
+  f64.sub
+  f64.const 0
+  f64.eq
   i32.eqz
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.tee $1
+   local.get $1
+   f64.ne
    if
     i32.const 4344
     call $~lib/rt/pure/__retain
@@ -11059,29 +11054,29 @@
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
-  local.set $1
-  local.get $1
-  local.get $0
-  call $~lib/util/number/dtoa_core
   local.set $2
   local.get $2
+  local.get $0
+  call $~lib/util/number/dtoa_core
+  local.set $3
+  local.get $3
   i32.const 28
   i32.eq
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__retain
    return
   end
-  local.get $1
-  i32.const 0
   local.get $2
-  call $~lib/string/String#substring
-  local.set $3
-  local.get $1
-  call $~lib/rt/tlsf/__free
+  i32.const 0
   local.get $3
+  call $~lib/string/String#substring
+  local.set $4
+  local.get $2
+  call $~lib/rt/tlsf/__free
+  local.get $4
  )
- (func $start:std/string (; 100 ;) (type $FUNCSIG$v)
+ (func $start:std/string (; 98 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11114,7 +11109,7 @@
   (local $29 i32)
   (local $30 i32)
   (local $31 i32)
-  (local $32 i32)
+  (local $32 f64)
   (local $33 i32)
   (local $34 i32)
   (local $35 i32)
@@ -11273,6 +11268,7 @@
   (local $188 i32)
   (local $189 i32)
   (local $190 i32)
+  (local $191 i32)
   global.get $std/string/str
   i32.const 24
   i32.eq
@@ -12673,7 +12669,9 @@
   end
   i32.const 120
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
+  local.tee $32
+  local.get $32
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -13374,7 +13372,9 @@
   end
   i32.const 4152
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
+  local.tee $32
+  local.get $32
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -13386,7 +13386,9 @@
   end
   i32.const 4176
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
+  local.tee $32
+  local.get $32
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -13398,7 +13400,9 @@
   end
   i32.const 4200
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
+  local.tee $32
+  local.get $32
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -13410,7 +13414,9 @@
   end
   i32.const 4224
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
+  local.tee $32
+  local.get $32
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -13422,7 +13428,9 @@
   end
   i32.const 4248
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
+  local.tee $32
+  local.get $32
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -13434,7 +13442,9 @@
   end
   i32.const 4272
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
+  local.tee $32
+  local.get $32
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -13446,7 +13456,9 @@
   end
   i32.const 4296
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
+  local.tee $32
+  local.get $32
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -13458,7 +13470,9 @@
   end
   i32.const 4320
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
+  local.tee $32
+  local.get $32
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -13470,7 +13484,9 @@
   end
   i32.const 4344
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
+  local.tee $32
+  local.get $32
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -13482,7 +13498,9 @@
   end
   i32.const 4368
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
+  local.tee $32
+  local.get $32
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -13494,7 +13512,9 @@
   end
   i32.const 4392
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
+  local.tee $32
+  local.get $32
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -13506,7 +13526,9 @@
   end
   i32.const 4416
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
+  local.tee $32
+  local.get $32
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -13518,7 +13540,9 @@
   end
   i32.const 4440
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
+  local.tee $32
+  local.get $32
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -13530,7 +13554,9 @@
   end
   i32.const 4472
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
+  local.tee $32
+  local.get $32
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -13542,7 +13568,9 @@
   end
   i32.const 4496
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
+  local.tee $32
+  local.get $32
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -13554,7 +13582,9 @@
   end
   i32.const 4520
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
+  local.tee $32
+  local.get $32
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -13787,7 +13817,9 @@
   end
   i32.const 5344
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
+  local.tee $32
+  local.get $32
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -13799,7 +13831,9 @@
   end
   i32.const 5368
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
+  local.tee $32
+  local.get $32
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -13811,7 +13845,9 @@
   end
   i32.const 5400
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
+  local.tee $32
+  local.get $32
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -13863,16 +13899,16 @@
   i32.const 6008
   i32.const 6160
   call $~lib/string/String.__concat
-  local.tee $32
+  local.tee $33
   i32.const 6312
   call $~lib/string/String.__concat
-  local.tee $33
+  local.tee $34
   i32.const 6464
   call $~lib/string/String.__concat
-  local.tee $34
+  local.tee $35
   i32.const 6616
   call $~lib/string/String.__concat
-  local.tee $35
+  local.tee $36
   call $~lib/string/parseFloat
   f64.const 1797693134862315708145274e284
   f64.eq
@@ -14199,7 +14235,9 @@
   end
   i32.const 9312
   call $~lib/string/parseFloat
-  call $~lib/number/isNaN<f64>
+  local.tee $32
+  local.get $32
+  f64.ne
   i32.eqz
   if
    i32.const 0
@@ -14225,10 +14263,10 @@
   i32.const 408
   i32.const 9368
   call $~lib/string/String.__concat
-  local.tee $36
+  local.tee $37
   call $~lib/rt/pure/__retain
-  local.set $37
-  local.get $37
+  local.set $38
+  local.get $38
   i32.const 9392
   call $~lib/string/String.__eq
   i32.eqz
@@ -14240,7 +14278,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $37
+  local.get $38
   i32.const 408
   call $~lib/string/String.__ne
   i32.eqz
@@ -14252,9 +14290,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $36
-  call $~lib/rt/pure/__release
   local.get $37
+  call $~lib/rt/pure/__release
+  local.get $38
   call $~lib/rt/pure/__release
   i32.const 120
   i32.const 120
@@ -14613,19 +14651,19 @@
   end
   i32.const 65377
   call $~lib/string/String.fromCodePoint
-  local.set $37
+  local.set $38
   i32.const 55296
   call $~lib/string/String.fromCodePoint
-  local.tee $36
+  local.tee $37
   i32.const 56322
   call $~lib/string/String.fromCodePoint
-  local.tee $38
-  call $~lib/string/String.__concat
   local.tee $39
+  call $~lib/string/String.__concat
+  local.tee $40
   call $~lib/rt/pure/__retain
-  local.set $40
-  local.get $37
-  local.get $40
+  local.set $41
+  local.get $38
+  local.get $41
   call $~lib/string/String.__gt
   i32.eqz
   if
@@ -14636,15 +14674,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $37
-  call $~lib/rt/pure/__release
-  local.get $36
-  call $~lib/rt/pure/__release
   local.get $38
+  call $~lib/rt/pure/__release
+  local.get $37
   call $~lib/rt/pure/__release
   local.get $39
   call $~lib/rt/pure/__release
   local.get $40
+  call $~lib/rt/pure/__release
+  local.get $41
   call $~lib/rt/pure/__release
   i32.const 760
   call $~lib/string/String#get:length
@@ -14662,7 +14700,7 @@
   i32.const 120
   i32.const 100
   call $~lib/string/String#repeat
-  local.tee $40
+  local.tee $41
   i32.const 120
   call $~lib/string/String.__eq
   i32.eqz
@@ -14677,7 +14715,7 @@
   i32.const 408
   i32.const 0
   call $~lib/string/String#repeat
-  local.tee $39
+  local.tee $40
   i32.const 120
   call $~lib/string/String.__eq
   i32.eqz
@@ -14692,7 +14730,7 @@
   i32.const 408
   i32.const 1
   call $~lib/string/String#repeat
-  local.tee $38
+  local.tee $39
   i32.const 408
   call $~lib/string/String.__eq
   i32.eqz
@@ -14707,7 +14745,7 @@
   i32.const 408
   i32.const 2
   call $~lib/string/String#repeat
-  local.tee $36
+  local.tee $37
   i32.const 9744
   call $~lib/string/String.__eq
   i32.eqz
@@ -14722,7 +14760,7 @@
   i32.const 408
   i32.const 3
   call $~lib/string/String#repeat
-  local.tee $37
+  local.tee $38
   i32.const 9816
   call $~lib/string/String.__eq
   i32.eqz
@@ -14737,7 +14775,7 @@
   i32.const 9392
   i32.const 4
   call $~lib/string/String#repeat
-  local.tee $41
+  local.tee $42
   i32.const 9840
   call $~lib/string/String.__eq
   i32.eqz
@@ -14752,7 +14790,7 @@
   i32.const 408
   i32.const 5
   call $~lib/string/String#repeat
-  local.tee $42
+  local.tee $43
   i32.const 9872
   call $~lib/string/String.__eq
   i32.eqz
@@ -14767,7 +14805,7 @@
   i32.const 408
   i32.const 6
   call $~lib/string/String#repeat
-  local.tee $43
+  local.tee $44
   i32.const 9904
   call $~lib/string/String.__eq
   i32.eqz
@@ -14782,7 +14820,7 @@
   i32.const 408
   i32.const 7
   call $~lib/string/String#repeat
-  local.tee $44
+  local.tee $45
   i32.const 9936
   call $~lib/string/String.__eq
   i32.eqz
@@ -14798,7 +14836,7 @@
   i32.const 120
   i32.const 120
   call $~lib/string/String#replace
-  local.tee $45
+  local.tee $46
   i32.const 120
   call $~lib/string/String.__eq
   i32.eqz
@@ -14814,7 +14852,7 @@
   i32.const 120
   i32.const 4152
   call $~lib/string/String#replace
-  local.tee $46
+  local.tee $47
   i32.const 4152
   call $~lib/string/String.__eq
   i32.eqz
@@ -14830,7 +14868,7 @@
   i32.const 4152
   i32.const 120
   call $~lib/string/String#replace
-  local.tee $47
+  local.tee $48
   i32.const 120
   call $~lib/string/String.__eq
   i32.eqz
@@ -14846,7 +14884,7 @@
   i32.const 120
   i32.const 120
   call $~lib/string/String#replace
-  local.tee $48
+  local.tee $49
   i32.const 4152
   call $~lib/string/String.__eq
   i32.eqz
@@ -14862,7 +14900,7 @@
   i32.const 4176
   i32.const 4152
   call $~lib/string/String#replace
-  local.tee $49
+  local.tee $50
   i32.const 704
   call $~lib/string/String.__eq
   i32.eqz
@@ -14878,7 +14916,7 @@
   i32.const 704
   i32.const 4152
   call $~lib/string/String#replace
-  local.tee $50
+  local.tee $51
   i32.const 4152
   call $~lib/string/String.__eq
   i32.eqz
@@ -14894,7 +14932,7 @@
   i32.const 9968
   i32.const 4152
   call $~lib/string/String#replace
-  local.tee $51
+  local.tee $52
   i32.const 704
   call $~lib/string/String.__eq
   i32.eqz
@@ -14910,7 +14948,7 @@
   i32.const 9392
   i32.const 9392
   call $~lib/string/String#replace
-  local.tee $52
+  local.tee $53
   i32.const 704
   call $~lib/string/String.__eq
   i32.eqz
@@ -14926,7 +14964,7 @@
   i32.const 4176
   i32.const 4152
   call $~lib/string/String#replace
-  local.tee $53
+  local.tee $54
   i32.const 10024
   call $~lib/string/String.__eq
   i32.eqz
@@ -14942,7 +14980,7 @@
   i32.const 120
   i32.const 4152
   call $~lib/string/String#replace
-  local.tee $54
+  local.tee $55
   i32.const 10056
   call $~lib/string/String.__eq
   i32.eqz
@@ -14958,7 +14996,7 @@
   i32.const 10104
   i32.const 4152
   call $~lib/string/String#replace
-  local.tee $55
+  local.tee $56
   i32.const 10056
   call $~lib/string/String.__eq
   i32.eqz
@@ -14974,7 +15012,7 @@
   i32.const 10128
   i32.const 10152
   call $~lib/string/String#replace
-  local.tee $56
+  local.tee $57
   i32.const 10176
   call $~lib/string/String.__eq
   i32.eqz
@@ -14990,7 +15028,7 @@
   i32.const 10128
   i32.const 120
   call $~lib/string/String#replace
-  local.tee $57
+  local.tee $58
   i32.const 9392
   call $~lib/string/String.__eq
   i32.eqz
@@ -15006,7 +15044,7 @@
   i32.const 120
   i32.const 704
   call $~lib/string/String#replaceAll
-  local.tee $58
+  local.tee $59
   i32.const 704
   call $~lib/string/String.__eq
   i32.eqz
@@ -15022,7 +15060,7 @@
   i32.const 4176
   i32.const 4152
   call $~lib/string/String#replaceAll
-  local.tee $59
+  local.tee $60
   i32.const 704
   call $~lib/string/String.__eq
   i32.eqz
@@ -15038,7 +15076,7 @@
   i32.const 704
   i32.const 4152
   call $~lib/string/String#replaceAll
-  local.tee $60
+  local.tee $61
   i32.const 10152
   call $~lib/string/String.__eq
   i32.eqz
@@ -15054,7 +15092,7 @@
   i32.const 704
   i32.const 4152
   call $~lib/string/String#replaceAll
-  local.tee $61
+  local.tee $62
   i32.const 10240
   call $~lib/string/String.__eq
   i32.eqz
@@ -15070,7 +15108,7 @@
   i32.const 9392
   i32.const 9392
   call $~lib/string/String#replaceAll
-  local.tee $62
+  local.tee $63
   i32.const 880
   call $~lib/string/String.__eq
   i32.eqz
@@ -15086,7 +15124,7 @@
   i32.const 408
   i32.const 10240
   call $~lib/string/String#replaceAll
-  local.tee $63
+  local.tee $64
   i32.const 10296
   call $~lib/string/String.__eq
   i32.eqz
@@ -15102,7 +15140,7 @@
   i32.const 9392
   i32.const 10152
   call $~lib/string/String#replaceAll
-  local.tee $64
+  local.tee $65
   i32.const 10344
   call $~lib/string/String.__eq
   i32.eqz
@@ -15118,7 +15156,7 @@
   i32.const 10400
   i32.const 10152
   call $~lib/string/String#replaceAll
-  local.tee $65
+  local.tee $66
   i32.const 10424
   call $~lib/string/String.__eq
   i32.eqz
@@ -15134,7 +15172,7 @@
   i32.const 9968
   i32.const 4152
   call $~lib/string/String#replaceAll
-  local.tee $66
+  local.tee $67
   i32.const 704
   call $~lib/string/String.__eq
   i32.eqz
@@ -15150,7 +15188,7 @@
   i32.const 10448
   i32.const 10152
   call $~lib/string/String#replaceAll
-  local.tee $67
+  local.tee $68
   i32.const 9968
   call $~lib/string/String.__eq
   i32.eqz
@@ -15166,7 +15204,7 @@
   i32.const 10472
   i32.const 4152
   call $~lib/string/String#replaceAll
-  local.tee $68
+  local.tee $69
   i32.const 10496
   call $~lib/string/String.__eq
   i32.eqz
@@ -15182,7 +15220,7 @@
   i32.const 9392
   i32.const 4152
   call $~lib/string/String#replaceAll
-  local.tee $69
+  local.tee $70
   i32.const 4152
   call $~lib/string/String.__eq
   i32.eqz
@@ -15198,7 +15236,7 @@
   i32.const 4176
   i32.const 4152
   call $~lib/string/String#replaceAll
-  local.tee $70
+  local.tee $71
   i32.const 10520
   call $~lib/string/String.__eq
   i32.eqz
@@ -15214,7 +15252,7 @@
   i32.const 120
   i32.const 120
   call $~lib/string/String#replaceAll
-  local.tee $71
+  local.tee $72
   i32.const 120
   call $~lib/string/String.__eq
   i32.eqz
@@ -15230,7 +15268,7 @@
   i32.const 120
   i32.const 4152
   call $~lib/string/String#replaceAll
-  local.tee $72
+  local.tee $73
   i32.const 4152
   call $~lib/string/String.__eq
   i32.eqz
@@ -15246,7 +15284,7 @@
   i32.const 4152
   i32.const 120
   call $~lib/string/String#replaceAll
-  local.tee $73
+  local.tee $74
   i32.const 120
   call $~lib/string/String.__eq
   i32.eqz
@@ -15262,7 +15300,7 @@
   i32.const 120
   i32.const 120
   call $~lib/string/String#replaceAll
-  local.tee $74
+  local.tee $75
   i32.const 4152
   call $~lib/string/String.__eq
   i32.eqz
@@ -15278,7 +15316,7 @@
   i32.const 704
   i32.const 4176
   call $~lib/string/String#replaceAll
-  local.tee $75
+  local.tee $76
   i32.const 4176
   call $~lib/string/String.__eq
   i32.eqz
@@ -15294,7 +15332,7 @@
   i32.const 10552
   i32.const 4176
   call $~lib/string/String#replaceAll
-  local.tee $76
+  local.tee $77
   i32.const 704
   call $~lib/string/String.__eq
   i32.eqz
@@ -15310,7 +15348,7 @@
   i32.const 120
   i32.const 4152
   call $~lib/string/String#replaceAll
-  local.tee $77
+  local.tee $78
   i32.const 10576
   call $~lib/string/String.__eq
   i32.eqz
@@ -15326,7 +15364,7 @@
   i32.const 120
   i32.const 120
   call $~lib/string/String#replaceAll
-  local.tee $78
+  local.tee $79
   i32.const 704
   call $~lib/string/String.__eq
   i32.eqz
@@ -15339,24 +15377,24 @@
    unreachable
   end
   i32.const 10608
-  local.tee $79
-  global.get $std/string/str
   local.tee $80
+  global.get $std/string/str
+  local.tee $81
   i32.ne
   if
-   local.get $79
+   local.get $80
    call $~lib/rt/pure/__retain
    drop
-   local.get $80
+   local.get $81
    call $~lib/rt/pure/__release
   end
-  local.get $79
+  local.get $80
   global.set $std/string/str
   global.get $std/string/str
   i32.const 0
   i32.const 2147483647
   call $~lib/string/String#slice
-  local.tee $79
+  local.tee $80
   i32.const 10608
   call $~lib/string/String.__eq
   i32.eqz
@@ -15372,7 +15410,7 @@
   i32.const -1
   i32.const 2147483647
   call $~lib/string/String#slice
-  local.tee $80
+  local.tee $81
   i32.const 10656
   call $~lib/string/String.__eq
   i32.eqz
@@ -15388,7 +15426,7 @@
   i32.const -5
   i32.const 2147483647
   call $~lib/string/String#slice
-  local.tee $81
+  local.tee $82
   i32.const 10680
   call $~lib/string/String.__eq
   i32.eqz
@@ -15404,7 +15442,7 @@
   i32.const 2
   i32.const 7
   call $~lib/string/String#slice
-  local.tee $82
+  local.tee $83
   i32.const 10712
   call $~lib/string/String.__eq
   i32.eqz
@@ -15420,7 +15458,7 @@
   i32.const -11
   i32.const -6
   call $~lib/string/String#slice
-  local.tee $83
+  local.tee $84
   i32.const 10744
   call $~lib/string/String.__eq
   i32.eqz
@@ -15436,7 +15474,7 @@
   i32.const 4
   i32.const 3
   call $~lib/string/String#slice
-  local.tee $84
+  local.tee $85
   i32.const 120
   call $~lib/string/String.__eq
   i32.eqz
@@ -15452,7 +15490,7 @@
   i32.const 0
   i32.const -1
   call $~lib/string/String#slice
-  local.tee $85
+  local.tee $86
   i32.const 10776
   call $~lib/string/String.__eq
   i32.eqz
@@ -15465,31 +15503,31 @@
    unreachable
   end
   i32.const 0
-  local.set $86
+  local.set $87
   i32.const 120
   i32.const 0
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#split
-  local.set $87
-  local.get $86
-  call $~lib/rt/pure/__release
+  local.set $88
   local.get $87
-  local.set $86
-  local.get $86
+  call $~lib/rt/pure/__release
+  local.get $88
+  local.set $87
+  local.get $87
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 1
   i32.eq
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $87
+   local.tee $88
    i32.const 120
    call $~lib/string/String.__eq
-   local.set $88
-   local.get $87
-   call $~lib/rt/pure/__release
+   local.set $89
    local.get $88
+   call $~lib/rt/pure/__release
+   local.get $89
   else
    i32.const 0
   end
@@ -15508,12 +15546,12 @@
   i32.const 120
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#split
-  local.set $88
-  local.get $86
+  local.set $89
+  local.get $87
   call $~lib/rt/pure/__release
-  local.get $88
-  local.set $86
-  local.get $86
+  local.get $89
+  local.set $87
+  local.get $87
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 0
   i32.eq
@@ -15530,26 +15568,26 @@
   i32.const 944
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#split
-  local.set $87
-  local.get $86
-  call $~lib/rt/pure/__release
+  local.set $88
   local.get $87
-  local.set $86
-  local.get $86
+  call $~lib/rt/pure/__release
+  local.get $88
+  local.set $87
+  local.get $87
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 1
   i32.eq
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $87
+   local.tee $88
    i32.const 120
    call $~lib/string/String.__eq
-   local.set $88
-   local.get $87
-   call $~lib/rt/pure/__release
+   local.set $89
    local.get $88
+   call $~lib/rt/pure/__release
+   local.get $89
   else
    i32.const 0
   end
@@ -15568,26 +15606,26 @@
   i32.const 4296
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#split
-  local.set $88
-  local.get $86
+  local.set $89
+  local.get $87
   call $~lib/rt/pure/__release
-  local.get $88
-  local.set $86
-  local.get $86
+  local.get $89
+  local.set $87
+  local.get $87
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 1
   i32.eq
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $88
+   local.tee $89
    i32.const 10984
    call $~lib/string/String.__eq
-   local.set $87
-   local.get $88
+   local.set $88
+   local.get $89
    call $~lib/rt/pure/__release
-   local.get $87
+   local.get $88
   else
    i32.const 0
   end
@@ -15606,58 +15644,58 @@
   i32.const 944
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#split
-  local.set $87
-  local.get $86
-  call $~lib/rt/pure/__release
+  local.set $88
   local.get $87
-  local.set $86
-  local.get $86
+  call $~lib/rt/pure/__release
+  local.get $88
+  local.set $87
+  local.get $87
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 3
   i32.eq
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $87
+   local.tee $88
    i32.const 408
    call $~lib/string/String.__eq
-   local.set $88
-   local.get $87
-   call $~lib/rt/pure/__release
+   local.set $89
    local.get $88
+   call $~lib/rt/pure/__release
+   local.get $89
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $87
+   local.tee $88
    i32.const 9368
    call $~lib/string/String.__eq
-   local.set $88
-   local.get $87
-   call $~lib/rt/pure/__release
+   local.set $89
    local.get $88
+   call $~lib/rt/pure/__release
+   local.get $89
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $87
+   local.tee $88
    i32.const 10128
    call $~lib/string/String.__eq
-   local.set $88
-   local.get $87
-   call $~lib/rt/pure/__release
+   local.set $89
    local.get $88
+   call $~lib/rt/pure/__release
+   local.get $89
   else
    i32.const 0
   end
@@ -15676,58 +15714,58 @@
   i32.const 11048
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#split
-  local.set $88
-  local.get $86
+  local.set $89
+  local.get $87
   call $~lib/rt/pure/__release
-  local.get $88
-  local.set $86
-  local.get $86
+  local.get $89
+  local.set $87
+  local.get $87
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 3
   i32.eq
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $88
+   local.tee $89
    i32.const 408
    call $~lib/string/String.__eq
-   local.set $87
-   local.get $88
+   local.set $88
+   local.get $89
    call $~lib/rt/pure/__release
-   local.get $87
+   local.get $88
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $88
+   local.tee $89
    i32.const 9368
    call $~lib/string/String.__eq
-   local.set $87
-   local.get $88
+   local.set $88
+   local.get $89
    call $~lib/rt/pure/__release
-   local.get $87
+   local.get $88
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $88
+   local.tee $89
    i32.const 10128
    call $~lib/string/String.__eq
-   local.set $87
-   local.get $88
+   local.set $88
+   local.get $89
    call $~lib/rt/pure/__release
-   local.get $87
+   local.get $88
   else
    i32.const 0
   end
@@ -15746,74 +15784,74 @@
   i32.const 944
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#split
-  local.set $87
-  local.get $86
-  call $~lib/rt/pure/__release
+  local.set $88
   local.get $87
-  local.set $86
-  local.get $86
+  call $~lib/rt/pure/__release
+  local.get $88
+  local.set $87
+  local.get $87
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 4
   i32.eq
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $87
+   local.tee $88
    i32.const 408
    call $~lib/string/String.__eq
-   local.set $88
-   local.get $87
-   call $~lib/rt/pure/__release
+   local.set $89
    local.get $88
+   call $~lib/rt/pure/__release
+   local.get $89
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $87
+   local.tee $88
    i32.const 9368
    call $~lib/string/String.__eq
-   local.set $88
-   local.get $87
-   call $~lib/rt/pure/__release
+   local.set $89
    local.get $88
+   call $~lib/rt/pure/__release
+   local.get $89
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $87
+   local.tee $88
    i32.const 120
    call $~lib/string/String.__eq
-   local.set $88
-   local.get $87
-   call $~lib/rt/pure/__release
+   local.set $89
    local.get $88
+   call $~lib/rt/pure/__release
+   local.get $89
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $87
+   local.tee $88
    i32.const 10128
    call $~lib/string/String.__eq
-   local.set $88
-   local.get $87
-   call $~lib/rt/pure/__release
+   local.set $89
    local.get $88
+   call $~lib/rt/pure/__release
+   local.get $89
   else
    i32.const 0
   end
@@ -15832,74 +15870,74 @@
   i32.const 944
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#split
-  local.set $88
-  local.get $86
+  local.set $89
+  local.get $87
   call $~lib/rt/pure/__release
-  local.get $88
-  local.set $86
-  local.get $86
+  local.get $89
+  local.set $87
+  local.get $87
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 4
   i32.eq
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $88
+   local.tee $89
    i32.const 120
    call $~lib/string/String.__eq
-   local.set $87
-   local.get $88
+   local.set $88
+   local.get $89
    call $~lib/rt/pure/__release
-   local.get $87
+   local.get $88
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $88
+   local.tee $89
    i32.const 408
    call $~lib/string/String.__eq
-   local.set $87
-   local.get $88
+   local.set $88
+   local.get $89
    call $~lib/rt/pure/__release
-   local.get $87
+   local.get $88
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $88
+   local.tee $89
    i32.const 9368
    call $~lib/string/String.__eq
-   local.set $87
-   local.get $88
+   local.set $88
+   local.get $89
    call $~lib/rt/pure/__release
-   local.get $87
+   local.get $88
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $88
+   local.tee $89
    i32.const 10128
    call $~lib/string/String.__eq
-   local.set $87
-   local.get $88
+   local.set $88
+   local.get $89
    call $~lib/rt/pure/__release
-   local.get $87
+   local.get $88
   else
    i32.const 0
   end
@@ -15918,74 +15956,74 @@
   i32.const 944
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#split
-  local.set $87
-  local.get $86
-  call $~lib/rt/pure/__release
+  local.set $88
   local.get $87
-  local.set $86
-  local.get $86
+  call $~lib/rt/pure/__release
+  local.get $88
+  local.set $87
+  local.get $87
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 4
   i32.eq
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $87
+   local.tee $88
    i32.const 408
    call $~lib/string/String.__eq
-   local.set $88
-   local.get $87
-   call $~lib/rt/pure/__release
+   local.set $89
    local.get $88
+   call $~lib/rt/pure/__release
+   local.get $89
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $87
+   local.tee $88
    i32.const 9368
    call $~lib/string/String.__eq
-   local.set $88
-   local.get $87
-   call $~lib/rt/pure/__release
+   local.set $89
    local.get $88
+   call $~lib/rt/pure/__release
+   local.get $89
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $87
+   local.tee $88
    i32.const 10128
    call $~lib/string/String.__eq
-   local.set $88
-   local.get $87
-   call $~lib/rt/pure/__release
+   local.set $89
    local.get $88
+   call $~lib/rt/pure/__release
+   local.get $89
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $87
+   local.tee $88
    i32.const 120
    call $~lib/string/String.__eq
-   local.set $88
-   local.get $87
-   call $~lib/rt/pure/__release
+   local.set $89
    local.get $88
+   call $~lib/rt/pure/__release
+   local.get $89
   else
    i32.const 0
   end
@@ -16004,58 +16042,58 @@
   i32.const 120
   global.get $~lib/builtins/i32.MAX_VALUE
   call $~lib/string/String#split
-  local.set $88
-  local.get $86
+  local.set $89
+  local.get $87
   call $~lib/rt/pure/__release
-  local.get $88
-  local.set $86
-  local.get $86
+  local.get $89
+  local.set $87
+  local.get $87
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 3
   i32.eq
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $88
+   local.tee $89
    i32.const 408
    call $~lib/string/String.__eq
-   local.set $87
-   local.get $88
+   local.set $88
+   local.get $89
    call $~lib/rt/pure/__release
-   local.get $87
+   local.get $88
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $88
+   local.tee $89
    i32.const 9368
    call $~lib/string/String.__eq
-   local.set $87
-   local.get $88
+   local.set $88
+   local.get $89
    call $~lib/rt/pure/__release
-   local.get $87
+   local.get $88
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $88
+   local.tee $89
    i32.const 10128
    call $~lib/string/String.__eq
-   local.set $87
-   local.get $88
+   local.set $88
+   local.get $89
    call $~lib/rt/pure/__release
-   local.get $87
+   local.get $88
   else
    i32.const 0
   end
@@ -16074,12 +16112,12 @@
   i32.const 120
   i32.const 0
   call $~lib/string/String#split
-  local.set $87
-  local.get $86
-  call $~lib/rt/pure/__release
+  local.set $88
   local.get $87
-  local.set $86
-  local.get $86
+  call $~lib/rt/pure/__release
+  local.get $88
+  local.set $87
+  local.get $87
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 0
   i32.eq
@@ -16096,26 +16134,26 @@
   i32.const 120
   i32.const 1
   call $~lib/string/String#split
-  local.set $88
-  local.get $86
+  local.set $89
+  local.get $87
   call $~lib/rt/pure/__release
-  local.get $88
-  local.set $86
-  local.get $86
+  local.get $89
+  local.set $87
+  local.get $87
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 1
   i32.eq
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $88
+   local.tee $89
    i32.const 408
    call $~lib/string/String.__eq
-   local.set $87
-   local.get $88
+   local.set $88
+   local.get $89
    call $~lib/rt/pure/__release
-   local.get $87
+   local.get $88
   else
    i32.const 0
   end
@@ -16134,26 +16172,26 @@
   i32.const 944
   i32.const 1
   call $~lib/string/String#split
-  local.set $87
-  local.get $86
-  call $~lib/rt/pure/__release
+  local.set $88
   local.get $87
-  local.set $86
-  local.get $86
+  call $~lib/rt/pure/__release
+  local.get $88
+  local.set $87
+  local.get $87
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 1
   i32.eq
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $87
+   local.tee $88
    i32.const 408
    call $~lib/string/String.__eq
-   local.set $88
-   local.get $87
-   call $~lib/rt/pure/__release
+   local.set $89
    local.get $88
+   call $~lib/rt/pure/__release
+   local.get $89
   else
    i32.const 0
   end
@@ -16172,58 +16210,58 @@
   i32.const 120
   i32.const 4
   call $~lib/string/String#split
-  local.set $88
-  local.get $86
+  local.set $89
+  local.get $87
   call $~lib/rt/pure/__release
-  local.get $88
-  local.set $86
-  local.get $86
+  local.get $89
+  local.set $87
+  local.get $87
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 3
   i32.eq
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $88
+   local.tee $89
    i32.const 408
    call $~lib/string/String.__eq
-   local.set $87
-   local.get $88
+   local.set $88
+   local.get $89
    call $~lib/rt/pure/__release
-   local.get $87
+   local.get $88
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $88
+   local.tee $89
    i32.const 9368
    call $~lib/string/String.__eq
-   local.set $87
-   local.get $88
+   local.set $88
+   local.get $89
    call $~lib/rt/pure/__release
-   local.get $87
+   local.get $88
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $88
+   local.tee $89
    i32.const 10128
    call $~lib/string/String.__eq
-   local.set $87
-   local.get $88
+   local.set $88
+   local.get $89
    call $~lib/rt/pure/__release
-   local.get $87
+   local.get $88
   else
    i32.const 0
   end
@@ -16242,58 +16280,58 @@
   i32.const 120
   i32.const -1
   call $~lib/string/String#split
-  local.set $87
-  local.get $86
-  call $~lib/rt/pure/__release
+  local.set $88
   local.get $87
-  local.set $86
-  local.get $86
+  call $~lib/rt/pure/__release
+  local.get $88
+  local.set $87
+  local.get $87
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 3
   i32.eq
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $87
+   local.tee $88
    i32.const 408
    call $~lib/string/String.__eq
-   local.set $88
-   local.get $87
-   call $~lib/rt/pure/__release
+   local.set $89
    local.get $88
+   call $~lib/rt/pure/__release
+   local.get $89
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $87
+   local.tee $88
    i32.const 9368
    call $~lib/string/String.__eq
-   local.set $88
-   local.get $87
-   call $~lib/rt/pure/__release
+   local.set $89
    local.get $88
+   call $~lib/rt/pure/__release
+   local.get $89
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $87
+   local.tee $88
    i32.const 10128
    call $~lib/string/String.__eq
-   local.set $88
-   local.get $87
-   call $~lib/rt/pure/__release
+   local.set $89
    local.get $88
+   call $~lib/rt/pure/__release
+   local.get $89
   else
    i32.const 0
   end
@@ -16312,58 +16350,58 @@
   i32.const 944
   i32.const -1
   call $~lib/string/String#split
-  local.set $88
-  local.get $86
+  local.set $89
+  local.get $87
   call $~lib/rt/pure/__release
-  local.get $88
-  local.set $86
-  local.get $86
+  local.get $89
+  local.set $87
+  local.get $87
   call $~lib/array/Array<~lib/string/String>#get:length
   i32.const 3
   i32.eq
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $88
+   local.tee $89
    i32.const 408
    call $~lib/string/String.__eq
-   local.set $87
-   local.get $88
+   local.set $88
+   local.get $89
    call $~lib/rt/pure/__release
-   local.get $87
+   local.get $88
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $88
+   local.tee $89
    i32.const 9368
    call $~lib/string/String.__eq
-   local.set $87
-   local.get $88
+   local.set $88
+   local.get $89
    call $~lib/rt/pure/__release
-   local.get $87
+   local.get $88
   else
    i32.const 0
   end
   i32.const 0
   i32.ne
   if (result i32)
-   local.get $86
+   local.get $87
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
-   local.tee $88
+   local.tee $89
    i32.const 10128
    call $~lib/string/String.__eq
-   local.set $87
-   local.get $88
+   local.set $88
+   local.get $89
    call $~lib/rt/pure/__release
-   local.get $87
+   local.get $88
   else
    i32.const 0
   end
@@ -16378,11 +16416,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $86
+  local.get $87
   call $~lib/rt/pure/__release
   i32.const 0
   call $~lib/util/number/itoa32
-  local.tee $86
+  local.tee $87
   i32.const 1192
   call $~lib/string/String.__eq
   i32.eqz
@@ -16396,7 +16434,7 @@
   end
   i32.const 1
   call $~lib/util/number/itoa32
-  local.tee $88
+  local.tee $89
   i32.const 1240
   call $~lib/string/String.__eq
   i32.eqz
@@ -16410,7 +16448,7 @@
   end
   i32.const 8
   call $~lib/util/number/itoa32
-  local.tee $87
+  local.tee $88
   i32.const 11616
   call $~lib/string/String.__eq
   i32.eqz
@@ -16424,7 +16462,7 @@
   end
   i32.const 12
   call $~lib/util/number/itoa32
-  local.tee $89
+  local.tee $90
   i32.const 11640
   call $~lib/string/String.__eq
   i32.eqz
@@ -16438,7 +16476,7 @@
   end
   i32.const 123
   call $~lib/util/number/itoa32
-  local.tee $90
+  local.tee $91
   i32.const 760
   call $~lib/string/String.__eq
   i32.eqz
@@ -16452,7 +16490,7 @@
   end
   i32.const -1000
   call $~lib/util/number/itoa32
-  local.tee $91
+  local.tee $92
   i32.const 11664
   call $~lib/string/String.__eq
   i32.eqz
@@ -16466,7 +16504,7 @@
   end
   i32.const 1234
   call $~lib/util/number/itoa32
-  local.tee $92
+  local.tee $93
   i32.const 11696
   call $~lib/string/String.__eq
   i32.eqz
@@ -16480,7 +16518,7 @@
   end
   i32.const 12345
   call $~lib/util/number/itoa32
-  local.tee $93
+  local.tee $94
   i32.const 11720
   call $~lib/string/String.__eq
   i32.eqz
@@ -16494,7 +16532,7 @@
   end
   i32.const 123456
   call $~lib/util/number/itoa32
-  local.tee $94
+  local.tee $95
   i32.const 11752
   call $~lib/string/String.__eq
   i32.eqz
@@ -16508,7 +16546,7 @@
   end
   i32.const 1111111
   call $~lib/util/number/itoa32
-  local.tee $95
+  local.tee $96
   i32.const 11784
   call $~lib/string/String.__eq
   i32.eqz
@@ -16522,7 +16560,7 @@
   end
   i32.const 1234567
   call $~lib/util/number/itoa32
-  local.tee $96
+  local.tee $97
   i32.const 11816
   call $~lib/string/String.__eq
   i32.eqz
@@ -16536,7 +16574,7 @@
   end
   i32.const 12345678
   call $~lib/util/number/itoa32
-  local.tee $97
+  local.tee $98
   i32.const 11848
   call $~lib/string/String.__eq
   i32.eqz
@@ -16550,7 +16588,7 @@
   end
   i32.const 123456789
   call $~lib/util/number/itoa32
-  local.tee $98
+  local.tee $99
   i32.const 11880
   call $~lib/string/String.__eq
   i32.eqz
@@ -16564,7 +16602,7 @@
   end
   i32.const 2147483646
   call $~lib/util/number/itoa32
-  local.tee $99
+  local.tee $100
   i32.const 11920
   call $~lib/string/String.__eq
   i32.eqz
@@ -16578,7 +16616,7 @@
   end
   i32.const 2147483647
   call $~lib/util/number/itoa32
-  local.tee $100
+  local.tee $101
   i32.const 11960
   call $~lib/string/String.__eq
   i32.eqz
@@ -16592,7 +16630,7 @@
   end
   i32.const -2147483648
   call $~lib/util/number/itoa32
-  local.tee $101
+  local.tee $102
   i32.const 12000
   call $~lib/string/String.__eq
   i32.eqz
@@ -16606,7 +16644,7 @@
   end
   i32.const -1
   call $~lib/util/number/itoa32
-  local.tee $102
+  local.tee $103
   i32.const 12040
   call $~lib/string/String.__eq
   i32.eqz
@@ -16620,7 +16658,7 @@
   end
   i32.const 0
   call $~lib/util/number/utoa32
-  local.tee $103
+  local.tee $104
   i32.const 1192
   call $~lib/string/String.__eq
   i32.eqz
@@ -16634,7 +16672,7 @@
   end
   i32.const 1000
   call $~lib/util/number/utoa32
-  local.tee $104
+  local.tee $105
   i32.const 12064
   call $~lib/string/String.__eq
   i32.eqz
@@ -16648,7 +16686,7 @@
   end
   i32.const 2147483647
   call $~lib/util/number/utoa32
-  local.tee $105
+  local.tee $106
   i32.const 11960
   call $~lib/string/String.__eq
   i32.eqz
@@ -16662,7 +16700,7 @@
   end
   i32.const -2147483648
   call $~lib/util/number/utoa32
-  local.tee $106
+  local.tee $107
   i32.const 12088
   call $~lib/string/String.__eq
   i32.eqz
@@ -16676,7 +16714,7 @@
   end
   i32.const -1
   call $~lib/util/number/utoa32
-  local.tee $107
+  local.tee $108
   i32.const 12128
   call $~lib/string/String.__eq
   i32.eqz
@@ -16690,7 +16728,7 @@
   end
   i64.const 0
   call $~lib/util/number/utoa64
-  local.tee $108
+  local.tee $109
   i32.const 1192
   call $~lib/string/String.__eq
   i32.eqz
@@ -16704,7 +16742,7 @@
   end
   i64.const 12
   call $~lib/util/number/utoa64
-  local.tee $109
+  local.tee $110
   i32.const 11640
   call $~lib/string/String.__eq
   i32.eqz
@@ -16718,7 +16756,7 @@
   end
   i64.const 123
   call $~lib/util/number/utoa64
-  local.tee $110
+  local.tee $111
   i32.const 760
   call $~lib/string/String.__eq
   i32.eqz
@@ -16732,7 +16770,7 @@
   end
   i64.const 1234
   call $~lib/util/number/utoa64
-  local.tee $111
+  local.tee $112
   i32.const 11696
   call $~lib/string/String.__eq
   i32.eqz
@@ -16746,7 +16784,7 @@
   end
   i64.const 12345
   call $~lib/util/number/utoa64
-  local.tee $112
+  local.tee $113
   i32.const 11720
   call $~lib/string/String.__eq
   i32.eqz
@@ -16760,7 +16798,7 @@
   end
   i64.const 123456
   call $~lib/util/number/utoa64
-  local.tee $113
+  local.tee $114
   i32.const 11752
   call $~lib/string/String.__eq
   i32.eqz
@@ -16774,7 +16812,7 @@
   end
   i64.const 1234567
   call $~lib/util/number/utoa64
-  local.tee $114
+  local.tee $115
   i32.const 11816
   call $~lib/string/String.__eq
   i32.eqz
@@ -16788,7 +16826,7 @@
   end
   i64.const 99999999
   call $~lib/util/number/utoa64
-  local.tee $115
+  local.tee $116
   i32.const 12168
   call $~lib/string/String.__eq
   i32.eqz
@@ -16802,7 +16840,7 @@
   end
   i64.const 100000000
   call $~lib/util/number/utoa64
-  local.tee $116
+  local.tee $117
   i32.const 12200
   call $~lib/string/String.__eq
   i32.eqz
@@ -16816,7 +16854,7 @@
   end
   i64.const 4294967295
   call $~lib/util/number/utoa64
-  local.tee $117
+  local.tee $118
   i32.const 12128
   call $~lib/string/String.__eq
   i32.eqz
@@ -16830,7 +16868,7 @@
   end
   i64.const 4294967297
   call $~lib/util/number/utoa64
-  local.tee $118
+  local.tee $119
   i32.const 12240
   call $~lib/string/String.__eq
   i32.eqz
@@ -16844,7 +16882,7 @@
   end
   i64.const 68719476735
   call $~lib/util/number/utoa64
-  local.tee $119
+  local.tee $120
   i32.const 12280
   call $~lib/string/String.__eq
   i32.eqz
@@ -16858,7 +16896,7 @@
   end
   i64.const 868719476735
   call $~lib/util/number/utoa64
-  local.tee $120
+  local.tee $121
   i32.const 12320
   call $~lib/string/String.__eq
   i32.eqz
@@ -16872,7 +16910,7 @@
   end
   i64.const 8687194767350
   call $~lib/util/number/utoa64
-  local.tee $121
+  local.tee $122
   i32.const 12360
   call $~lib/string/String.__eq
   i32.eqz
@@ -16886,7 +16924,7 @@
   end
   i64.const 86871947673501
   call $~lib/util/number/utoa64
-  local.tee $122
+  local.tee $123
   i32.const 12408
   call $~lib/string/String.__eq
   i32.eqz
@@ -16900,7 +16938,7 @@
   end
   i64.const 999868719476735
   call $~lib/util/number/utoa64
-  local.tee $123
+  local.tee $124
   i32.const 12456
   call $~lib/string/String.__eq
   i32.eqz
@@ -16914,7 +16952,7 @@
   end
   i64.const 9999868719476735
   call $~lib/util/number/utoa64
-  local.tee $124
+  local.tee $125
   i32.const 12504
   call $~lib/string/String.__eq
   i32.eqz
@@ -16928,7 +16966,7 @@
   end
   i64.const 19999868719476735
   call $~lib/util/number/utoa64
-  local.tee $125
+  local.tee $126
   i32.const 12552
   call $~lib/string/String.__eq
   i32.eqz
@@ -16942,7 +16980,7 @@
   end
   i64.const 129999868719476735
   call $~lib/util/number/utoa64
-  local.tee $126
+  local.tee $127
   i32.const 12608
   call $~lib/string/String.__eq
   i32.eqz
@@ -16956,7 +16994,7 @@
   end
   i64.const 1239999868719476735
   call $~lib/util/number/utoa64
-  local.tee $127
+  local.tee $128
   i32.const 12664
   call $~lib/string/String.__eq
   i32.eqz
@@ -16970,7 +17008,7 @@
   end
   i64.const -1
   call $~lib/util/number/utoa64
-  local.tee $128
+  local.tee $129
   i32.const 12720
   call $~lib/string/String.__eq
   i32.eqz
@@ -16984,7 +17022,7 @@
   end
   i64.const 0
   call $~lib/util/number/itoa64
-  local.tee $129
+  local.tee $130
   i32.const 1192
   call $~lib/string/String.__eq
   i32.eqz
@@ -16998,7 +17036,7 @@
   end
   i64.const -1234
   call $~lib/util/number/itoa64
-  local.tee $130
+  local.tee $131
   i32.const 12776
   call $~lib/string/String.__eq
   i32.eqz
@@ -17012,7 +17050,7 @@
   end
   i64.const 4294967295
   call $~lib/util/number/itoa64
-  local.tee $131
+  local.tee $132
   i32.const 12128
   call $~lib/string/String.__eq
   i32.eqz
@@ -17026,7 +17064,7 @@
   end
   i64.const 4294967297
   call $~lib/util/number/itoa64
-  local.tee $132
+  local.tee $133
   i32.const 12240
   call $~lib/string/String.__eq
   i32.eqz
@@ -17040,7 +17078,7 @@
   end
   i64.const -4294967295
   call $~lib/util/number/itoa64
-  local.tee $133
+  local.tee $134
   i32.const 12808
   call $~lib/string/String.__eq
   i32.eqz
@@ -17054,7 +17092,7 @@
   end
   i64.const 68719476735
   call $~lib/util/number/itoa64
-  local.tee $134
+  local.tee $135
   i32.const 12280
   call $~lib/string/String.__eq
   i32.eqz
@@ -17068,7 +17106,7 @@
   end
   i64.const -68719476735
   call $~lib/util/number/itoa64
-  local.tee $135
+  local.tee $136
   i32.const 12848
   call $~lib/string/String.__eq
   i32.eqz
@@ -17082,7 +17120,7 @@
   end
   i64.const -868719476735
   call $~lib/util/number/itoa64
-  local.tee $136
+  local.tee $137
   i32.const 12888
   call $~lib/string/String.__eq
   i32.eqz
@@ -17096,7 +17134,7 @@
   end
   i64.const -999868719476735
   call $~lib/util/number/itoa64
-  local.tee $137
+  local.tee $138
   i32.const 12936
   call $~lib/string/String.__eq
   i32.eqz
@@ -17110,7 +17148,7 @@
   end
   i64.const -19999868719476735
   call $~lib/util/number/itoa64
-  local.tee $138
+  local.tee $139
   i32.const 12984
   call $~lib/string/String.__eq
   i32.eqz
@@ -17124,7 +17162,7 @@
   end
   i64.const 9223372036854775807
   call $~lib/util/number/itoa64
-  local.tee $139
+  local.tee $140
   i32.const 13040
   call $~lib/string/String.__eq
   i32.eqz
@@ -17138,7 +17176,7 @@
   end
   i64.const -9223372036854775808
   call $~lib/util/number/itoa64
-  local.tee $140
+  local.tee $141
   i32.const 13096
   call $~lib/string/String.__eq
   i32.eqz
@@ -17152,7 +17190,7 @@
   end
   f64.const 0
   call $~lib/util/number/dtoa
-  local.tee $141
+  local.tee $142
   i32.const 13152
   call $~lib/string/String.__eq
   i32.eqz
@@ -17166,7 +17204,7 @@
   end
   f64.const -0
   call $~lib/util/number/dtoa
-  local.tee $142
+  local.tee $143
   i32.const 13152
   call $~lib/string/String.__eq
   i32.eqz
@@ -17180,7 +17218,7 @@
   end
   f64.const nan:0x8000000000000
   call $~lib/util/number/dtoa
-  local.tee $143
+  local.tee $144
   i32.const 4344
   call $~lib/string/String.__eq
   i32.eqz
@@ -17194,7 +17232,7 @@
   end
   f64.const inf
   call $~lib/util/number/dtoa
-  local.tee $144
+  local.tee $145
   i32.const 13176
   call $~lib/string/String.__eq
   i32.eqz
@@ -17208,7 +17246,7 @@
   end
   f64.const -inf
   call $~lib/util/number/dtoa
-  local.tee $145
+  local.tee $146
   i32.const 5224
   call $~lib/string/String.__eq
   i32.eqz
@@ -17222,7 +17260,7 @@
   end
   f64.const 2.220446049250313e-16
   call $~lib/util/number/dtoa
-  local.tee $146
+  local.tee $147
   i32.const 4552
   call $~lib/string/String.__eq
   i32.eqz
@@ -17236,7 +17274,7 @@
   end
   f64.const -2.220446049250313e-16
   call $~lib/util/number/dtoa
-  local.tee $147
+  local.tee $148
   i32.const 14264
   call $~lib/string/String.__eq
   i32.eqz
@@ -17250,7 +17288,7 @@
   end
   f64.const 1797693134862315708145274e284
   call $~lib/util/number/dtoa
-  local.tee $148
+  local.tee $149
   i32.const 4616
   call $~lib/string/String.__eq
   i32.eqz
@@ -17264,7 +17302,7 @@
   end
   f64.const -1797693134862315708145274e284
   call $~lib/util/number/dtoa
-  local.tee $149
+  local.tee $150
   i32.const 14328
   call $~lib/string/String.__eq
   i32.eqz
@@ -17278,7 +17316,7 @@
   end
   f64.const 4185580496821356722454785e274
   call $~lib/util/number/dtoa
-  local.tee $150
+  local.tee $151
   i32.const 14392
   call $~lib/string/String.__eq
   i32.eqz
@@ -17292,7 +17330,7 @@
   end
   f64.const 2.2250738585072014e-308
   call $~lib/util/number/dtoa
-  local.tee $151
+  local.tee $152
   i32.const 14456
   call $~lib/string/String.__eq
   i32.eqz
@@ -17306,7 +17344,7 @@
   end
   f64.const 4.940656e-318
   call $~lib/util/number/dtoa
-  local.tee $152
+  local.tee $153
   i32.const 14520
   call $~lib/string/String.__eq
   i32.eqz
@@ -17320,7 +17358,7 @@
   end
   f64.const 9060801153433600
   call $~lib/util/number/dtoa
-  local.tee $153
+  local.tee $154
   i32.const 14568
   call $~lib/string/String.__eq
   i32.eqz
@@ -17334,7 +17372,7 @@
   end
   f64.const 4708356024711512064
   call $~lib/util/number/dtoa
-  local.tee $154
+  local.tee $155
   i32.const 14624
   call $~lib/string/String.__eq
   i32.eqz
@@ -17348,7 +17386,7 @@
   end
   f64.const 9409340012568248320
   call $~lib/util/number/dtoa
-  local.tee $155
+  local.tee $156
   i32.const 14688
   call $~lib/string/String.__eq
   i32.eqz
@@ -17362,7 +17400,7 @@
   end
   f64.const 5e-324
   call $~lib/util/number/dtoa
-  local.tee $156
+  local.tee $157
   i32.const 4680
   call $~lib/string/String.__eq
   i32.eqz
@@ -17376,7 +17414,7 @@
   end
   f64.const 1
   call $~lib/util/number/dtoa
-  local.tee $157
+  local.tee $158
   i32.const 14752
   call $~lib/string/String.__eq
   i32.eqz
@@ -17390,7 +17428,7 @@
   end
   f64.const 0.1
   call $~lib/util/number/dtoa
-  local.tee $158
+  local.tee $159
   i32.const 2352
   call $~lib/string/String.__eq
   i32.eqz
@@ -17404,7 +17442,7 @@
   end
   f64.const -1
   call $~lib/util/number/dtoa
-  local.tee $159
+  local.tee $160
   i32.const 14776
   call $~lib/string/String.__eq
   i32.eqz
@@ -17418,7 +17456,7 @@
   end
   f64.const -0.1
   call $~lib/util/number/dtoa
-  local.tee $160
+  local.tee $161
   i32.const 14800
   call $~lib/string/String.__eq
   i32.eqz
@@ -17432,7 +17470,7 @@
   end
   f64.const 1e6
   call $~lib/util/number/dtoa
-  local.tee $161
+  local.tee $162
   i32.const 14824
   call $~lib/string/String.__eq
   i32.eqz
@@ -17446,7 +17484,7 @@
   end
   f64.const 1e-06
   call $~lib/util/number/dtoa
-  local.tee $162
+  local.tee $163
   i32.const 14864
   call $~lib/string/String.__eq
   i32.eqz
@@ -17460,7 +17498,7 @@
   end
   f64.const -1e6
   call $~lib/util/number/dtoa
-  local.tee $163
+  local.tee $164
   i32.const 14896
   call $~lib/string/String.__eq
   i32.eqz
@@ -17474,7 +17512,7 @@
   end
   f64.const -1e-06
   call $~lib/util/number/dtoa
-  local.tee $164
+  local.tee $165
   i32.const 14936
   call $~lib/string/String.__eq
   i32.eqz
@@ -17488,7 +17526,7 @@
   end
   f64.const 1e7
   call $~lib/util/number/dtoa
-  local.tee $165
+  local.tee $166
   i32.const 14976
   call $~lib/string/String.__eq
   i32.eqz
@@ -17502,7 +17540,7 @@
   end
   f64.const 1e-07
   call $~lib/util/number/dtoa
-  local.tee $166
+  local.tee $167
   i32.const 15016
   call $~lib/string/String.__eq
   i32.eqz
@@ -17516,7 +17554,7 @@
   end
   f64.const 1.e+308
   call $~lib/util/number/dtoa
-  local.tee $167
+  local.tee $168
   i32.const 2528
   call $~lib/string/String.__eq
   i32.eqz
@@ -17530,7 +17568,7 @@
   end
   f64.const -1.e+308
   call $~lib/util/number/dtoa
-  local.tee $168
+  local.tee $169
   i32.const 15040
   call $~lib/string/String.__eq
   i32.eqz
@@ -17544,7 +17582,7 @@
   end
   f64.const inf
   call $~lib/util/number/dtoa
-  local.tee $169
+  local.tee $170
   i32.const 13176
   call $~lib/string/String.__eq
   i32.eqz
@@ -17558,7 +17596,7 @@
   end
   f64.const -inf
   call $~lib/util/number/dtoa
-  local.tee $170
+  local.tee $171
   i32.const 5224
   call $~lib/string/String.__eq
   i32.eqz
@@ -17572,7 +17610,7 @@
   end
   f64.const 1e-308
   call $~lib/util/number/dtoa
-  local.tee $171
+  local.tee $172
   i32.const 15072
   call $~lib/string/String.__eq
   i32.eqz
@@ -17586,7 +17624,7 @@
   end
   f64.const -1e-308
   call $~lib/util/number/dtoa
-  local.tee $172
+  local.tee $173
   i32.const 15104
   call $~lib/string/String.__eq
   i32.eqz
@@ -17600,7 +17638,7 @@
   end
   f64.const 1e-323
   call $~lib/util/number/dtoa
-  local.tee $173
+  local.tee $174
   i32.const 15136
   call $~lib/string/String.__eq
   i32.eqz
@@ -17614,7 +17652,7 @@
   end
   f64.const -1e-323
   call $~lib/util/number/dtoa
-  local.tee $174
+  local.tee $175
   i32.const 15168
   call $~lib/string/String.__eq
   i32.eqz
@@ -17628,7 +17666,7 @@
   end
   f64.const 0
   call $~lib/util/number/dtoa
-  local.tee $175
+  local.tee $176
   i32.const 13152
   call $~lib/string/String.__eq
   i32.eqz
@@ -17642,7 +17680,7 @@
   end
   f64.const 4294967272
   call $~lib/util/number/dtoa
-  local.tee $176
+  local.tee $177
   i32.const 15200
   call $~lib/string/String.__eq
   i32.eqz
@@ -17656,7 +17694,7 @@
   end
   f64.const 1.2312145673456234e-08
   call $~lib/util/number/dtoa
-  local.tee $177
+  local.tee $178
   i32.const 15240
   call $~lib/string/String.__eq
   i32.eqz
@@ -17670,7 +17708,7 @@
   end
   f64.const 555555555.5555556
   call $~lib/util/number/dtoa
-  local.tee $178
+  local.tee $179
   i32.const 15304
   call $~lib/string/String.__eq
   i32.eqz
@@ -17684,7 +17722,7 @@
   end
   f64.const 0.9999999999999999
   call $~lib/util/number/dtoa
-  local.tee $179
+  local.tee $180
   i32.const 15360
   call $~lib/string/String.__eq
   i32.eqz
@@ -17698,7 +17736,7 @@
   end
   f64.const 1
   call $~lib/util/number/dtoa
-  local.tee $180
+  local.tee $181
   i32.const 14752
   call $~lib/string/String.__eq
   i32.eqz
@@ -17712,7 +17750,7 @@
   end
   f64.const 12.34
   call $~lib/util/number/dtoa
-  local.tee $181
+  local.tee $182
   i32.const 15416
   call $~lib/string/String.__eq
   i32.eqz
@@ -17726,7 +17764,7 @@
   end
   f64.const 0.3333333333333333
   call $~lib/util/number/dtoa
-  local.tee $182
+  local.tee $183
   i32.const 15448
   call $~lib/string/String.__eq
   i32.eqz
@@ -17740,7 +17778,7 @@
   end
   f64.const 1234e17
   call $~lib/util/number/dtoa
-  local.tee $183
+  local.tee $184
   i32.const 15504
   call $~lib/string/String.__eq
   i32.eqz
@@ -17754,7 +17792,7 @@
   end
   f64.const 1234e18
   call $~lib/util/number/dtoa
-  local.tee $184
+  local.tee $185
   i32.const 15568
   call $~lib/string/String.__eq
   i32.eqz
@@ -17768,7 +17806,7 @@
   end
   f64.const 2.71828
   call $~lib/util/number/dtoa
-  local.tee $185
+  local.tee $186
   i32.const 15608
   call $~lib/string/String.__eq
   i32.eqz
@@ -17782,7 +17820,7 @@
   end
   f64.const 0.0271828
   call $~lib/util/number/dtoa
-  local.tee $186
+  local.tee $187
   i32.const 15640
   call $~lib/string/String.__eq
   i32.eqz
@@ -17796,7 +17834,7 @@
   end
   f64.const 271.828
   call $~lib/util/number/dtoa
-  local.tee $187
+  local.tee $188
   i32.const 15680
   call $~lib/string/String.__eq
   i32.eqz
@@ -17810,7 +17848,7 @@
   end
   f64.const 1.1e+128
   call $~lib/util/number/dtoa
-  local.tee $188
+  local.tee $189
   i32.const 15712
   call $~lib/string/String.__eq
   i32.eqz
@@ -17824,7 +17862,7 @@
   end
   f64.const 1.1e-64
   call $~lib/util/number/dtoa
-  local.tee $189
+  local.tee $190
   i32.const 15744
   call $~lib/string/String.__eq
   i32.eqz
@@ -17838,7 +17876,7 @@
   end
   f64.const 0.000035689
   call $~lib/util/number/dtoa
-  local.tee $190
+  local.tee $191
   i32.const 15776
   call $~lib/string/String.__eq
   i32.eqz
@@ -17915,8 +17953,6 @@
   local.get $30
   call $~lib/rt/pure/__release
   local.get $31
-  call $~lib/rt/pure/__release
-  local.get $32
   call $~lib/rt/pure/__release
   local.get $33
   call $~lib/rt/pure/__release
@@ -18234,12 +18270,14 @@
   call $~lib/rt/pure/__release
   local.get $190
   call $~lib/rt/pure/__release
+  local.get $191
+  call $~lib/rt/pure/__release
  )
- (func $std/string/getString (; 101 ;) (type $FUNCSIG$i) (result i32)
+ (func $std/string/getString (; 99 ;) (type $FUNCSIG$i) (result i32)
   global.get $std/string/str
   call $~lib/rt/pure/__retain
  )
- (func $start (; 102 ;) (type $FUNCSIG$v)
+ (func $start (; 100 ;) (type $FUNCSIG$v)
   global.get $~lib/started
   if
    return
@@ -18249,10 +18287,10 @@
   end
   call $start:std/string
  )
- (func $~lib/array/Array<f64>#__visit_impl (; 103 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f64>#__visit_impl (; 101 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/rt/pure/__visit (; 104 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 102 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -18382,7 +18420,7 @@
    end
   end
  )
- (func $~lib/array/Array<~lib/string/String>#__visit_impl (; 105 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<~lib/string/String>#__visit_impl (; 103 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -18421,19 +18459,19 @@
    unreachable
   end
  )
- (func $~lib/array/Array<i32>#__visit_impl (; 106 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#__visit_impl (; 104 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u32>#__visit_impl (; 107 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u32>#__visit_impl (; 105 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u64>#__visit_impl (; 108 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u64>#__visit_impl (; 106 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<i16>#__visit_impl (; 109 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i16>#__visit_impl (; 107 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/rt/__visit_members (; 110 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (; 108 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $block$4$break
    block $switch$1$default
@@ -18497,6 +18535,6 @@
   end
   return
  )
- (func $null (; 111 ;) (type $FUNCSIG$v)
+ (func $null (; 109 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -11011,10 +11011,9 @@
   call $~lib/rt/pure/__retain
  )
  (func $~lib/util/number/dtoa (; 97 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  (local $1 f64)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
   local.get $0
   f64.const 0
   f64.eq
@@ -11024,16 +11023,14 @@
    return
   end
   local.get $0
-  local.tee $1
-  local.get $1
+  local.get $0
   f64.sub
   f64.const 0
   f64.eq
   i32.eqz
   if
    local.get $0
-   local.tee $1
-   local.get $1
+   local.get $0
    f64.ne
    if
     i32.const 4344
@@ -11054,27 +11051,27 @@
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
-  local.set $2
-  local.get $2
+  local.set $1
+  local.get $1
   local.get $0
   call $~lib/util/number/dtoa_core
-  local.set $3
-  local.get $3
+  local.set $2
+  local.get $2
   i32.const 28
   i32.eq
   if
-   local.get $2
+   local.get $1
    call $~lib/rt/pure/__retain
    return
   end
-  local.get $2
+  local.get $1
   i32.const 0
-  local.get $3
-  call $~lib/string/String#substring
-  local.set $4
   local.get $2
+  call $~lib/string/String#substring
+  local.set $3
+  local.get $1
   call $~lib/rt/tlsf/__free
-  local.get $4
+  local.get $3
  )
  (func $start:std/string (; 98 ;) (type $FUNCSIG$v)
   (local $0 i32)

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -6672,7 +6672,9 @@
    i32.add
    local.set $16
    local.get $17
-   i64.eqz
+   i64.const 0
+   i64.ne
+   i32.eqz
    if (result i32)
     i32.const 1
    else
@@ -9498,7 +9500,9 @@
   (local $6 i32)
   (local $7 i64)
   local.get $0
-  i64.eqz
+  i64.const 0
+  i64.ne
+  i32.eqz
   if
    i32.const 1192
    call $~lib/rt/pure/__retain
@@ -9564,7 +9568,9 @@
   (local $7 i32)
   (local $8 i64)
   local.get $0
-  i64.eqz
+  i64.const 0
+  i64.ne
+  i32.eqz
   if
    i32.const 1192
    call $~lib/rt/pure/__retain

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -13105,7 +13105,8 @@
     return
    end
    local.get $2
-   i64.eqz
+   i64.const 0
+   i64.eq
    if (result i64)
     local.get $1
     i64.const 0
@@ -25053,7 +25054,8 @@
   (local $3 i32)
   (local $4 i32)
   local.get $0
-  i64.eqz
+  i64.const 0
+  i64.eq
   if
    i32.const 1720
    call $~lib/rt/pure/__retain
@@ -25122,7 +25124,8 @@
   i32.add
   local.set $0
   local.get $2
-  i64.eqz
+  i64.const 0
+  i64.eq
   if
    local.get $0
    i32.const 48
@@ -25380,7 +25383,8 @@
   (local $2 i32)
   (local $3 i32)
   local.get $0
-  i64.eqz
+  i64.const 0
+  i64.eq
   if
    i32.const 1720
    call $~lib/rt/pure/__retain
@@ -25428,7 +25432,8 @@
   i32.add
   local.set $0
   local.get $2
-  i64.eqz
+  i64.const 0
+  i64.eq
   if
    local.get $0
    i32.const 48

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -24,8 +24,6 @@
  (type $FUNCSIG$ijii (func (param i64 i32 i32) (result i32)))
  (type $FUNCSIG$ifii (func (param f32 i32 i32) (result i32)))
  (type $FUNCSIG$idii (func (param f64 i32 i32) (result i32)))
- (type $FUNCSIG$if (func (param f32) (result i32)))
- (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$vjii (func (param i64 i32 i32)))
  (type $FUNCSIG$vfii (func (param f32 i32 i32)))
  (type $FUNCSIG$vdii (func (param f64 i32 i32)))
@@ -35,6 +33,7 @@
  (type $FUNCSIG$ij (func (param i64) (result i32)))
  (type $FUNCSIG$viji (func (param i32 i64 i32)))
  (type $FUNCSIG$iiij (func (param i32 i32 i64) (result i32)))
+ (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$iid (func (param i32 f64) (result i32)))
  (type $FUNCSIG$iijijiji (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
  (type $FUNCSIG$iiid (func (param i32 i32 f64) (result i32)))
@@ -12783,12 +12782,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/number/isNaN<f32> (; 265 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
-  local.get $0
-  local.get $0
-  f32.ne
- )
- (func $~lib/math/NativeMathf.mod (; 266 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (; 265 ;) (type $FUNCSIG$ff) (param $0 f32) (result f32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -12805,15 +12799,12 @@
   i32.const -2147483648
   i32.and
   local.set $4
+  i32.const 1
+  i32.const 0
   local.get $2
   i32.const 255
   i32.eq
-  if (result i32)
-   i32.const 1
-  else
-   f32.const 2
-   call $~lib/number/isNaN<f32>
-  end
+  select
   if
    local.get $0
    f32.const 2
@@ -12939,7 +12930,7 @@
   local.get $0
   f32.mul
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 267 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 266 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -12950,7 +12941,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#every (; 268 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#every (; 267 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13002,7 +12993,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32> (; 269 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32> (; 268 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -13049,12 +13040,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/number/isNaN<f64> (; 270 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.ne
- )
- (func $~lib/math/NativeMath.mod (; 271 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (; 269 ;) (type $FUNCSIG$dd) (param $0 f64) (result f64)
   (local $1 i64)
   (local $2 i64)
   (local $3 i64)
@@ -13071,15 +13057,12 @@
   i64.const 63
   i64.shr_u
   local.set $4
+  i32.const 1
+  i32.const 0
   local.get $2
   i64.const 2047
   i64.eq
-  if (result i32)
-   i32.const 1
-  else
-   f64.const 2
-   call $~lib/number/isNaN<f64>
-  end
+  select
   if
    local.get $0
    f64.const 2
@@ -13213,7 +13196,7 @@
   local.get $0
   f64.mul
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 272 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 270 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -13224,7 +13207,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#every (; 273 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#every (; 271 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13276,7 +13259,7 @@
    i32.const 1
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64> (; 274 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64> (; 272 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 3
@@ -13323,7 +13306,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 275 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 273 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -13373,7 +13356,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#forEach (; 276 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/typedarray/Int8Array#forEach (; 274 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -13411,7 +13394,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8> (; 277 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8> (; 275 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -13470,7 +13453,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#forEach (; 278 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Uint8Array#forEach (; 276 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13509,7 +13492,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8> (; 279 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8> (; 277 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -13563,7 +13546,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8> (; 280 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8> (; 278 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -13617,7 +13600,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 281 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 279 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -13667,7 +13650,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#forEach (; 282 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/typedarray/Int16Array#forEach (; 280 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -13707,7 +13690,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16> (; 283 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16> (; 281 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -13766,7 +13749,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#forEach (; 284 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/typedarray/Uint16Array#forEach (; 282 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -13806,7 +13789,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16> (; 285 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16> (; 283 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -13859,7 +13842,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 286 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 284 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -13905,7 +13888,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#forEach (; 287 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int32Array#forEach (; 285 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13947,7 +13930,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32> (; 288 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32> (; 286 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -13995,7 +13978,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32> (; 289 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32> (; 287 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -14043,7 +14026,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 290 ;) (type $FUNCSIG$vjii) (param $0 i64) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 288 ;) (type $FUNCSIG$vjii) (param $0 i64) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -14090,7 +14073,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#forEach (; 291 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int64Array#forEach (; 289 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14132,7 +14115,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64> (; 292 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64> (; 290 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -14183,7 +14166,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64> (; 293 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64> (; 291 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -14234,7 +14217,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 294 ;) (type $FUNCSIG$vfii) (param $0 f32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 292 ;) (type $FUNCSIG$vfii) (param $0 f32) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -14281,7 +14264,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#forEach (; 295 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/typedarray/Float32Array#forEach (; 293 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -14321,7 +14304,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32> (; 296 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32> (; 294 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -14371,7 +14354,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 297 ;) (type $FUNCSIG$vdii) (param $0 f64) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 295 ;) (type $FUNCSIG$vdii) (param $0 f64) (param $1 i32) (param $2 i32)
   local.get $2
   call $~lib/rt/pure/__retain
   drop
@@ -14418,7 +14401,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#forEach (; 298 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/typedarray/Float64Array#forEach (; 296 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -14458,7 +14441,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64> (; 299 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64> (; 297 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -14508,7 +14491,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#reverse (; 300 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#reverse (; 298 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -14560,7 +14543,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Int8Array,i8> (; 301 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int8Array,i8> (; 299 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -14729,7 +14712,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#reverse (; 302 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#reverse (; 300 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -14781,7 +14764,7 @@
   end
   local.get $3
  )
- (func $~lib/typedarray/Uint8Array#subarray (; 303 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#subarray (; 301 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 4
@@ -14846,7 +14829,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8Array,u8> (; 304 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8Array,u8> (; 302 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -15008,7 +14991,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#subarray (; 305 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#subarray (; 303 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 4
@@ -15073,7 +15056,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8ClampedArray,u8> (; 306 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8ClampedArray,u8> (; 304 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -15235,7 +15218,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#reverse (; 307 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#reverse (; 305 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -15292,7 +15275,7 @@
   end
   local.get $3
  )
- (func $~lib/typedarray/Int16Array#subarray (; 308 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#subarray (; 306 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 4
@@ -15361,7 +15344,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Int16Array,i16> (; 309 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int16Array,i16> (; 307 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -15529,7 +15512,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#reverse (; 310 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#reverse (; 308 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -15586,7 +15569,7 @@
   end
   local.get $3
  )
- (func $~lib/typedarray/Uint16Array#subarray (; 311 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#subarray (; 309 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 4
@@ -15655,7 +15638,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint16Array,u16> (; 312 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint16Array,u16> (; 310 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -15817,7 +15800,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#reverse (; 313 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#reverse (; 311 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -15874,7 +15857,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Int32Array,i32> (; 314 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int32Array,i32> (; 312 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -16031,7 +16014,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#subarray (; 315 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#subarray (; 313 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 4
@@ -16100,7 +16083,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint32Array,u32> (; 316 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint32Array,u32> (; 314 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -16256,7 +16239,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#reverse (; 317 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#reverse (; 315 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -16313,7 +16296,7 @@
   end
   local.get $3
  )
- (func $~lib/typedarray/Int64Array#subarray (; 318 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#subarray (; 316 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 4
@@ -16382,7 +16365,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Int64Array,i64> (; 319 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int64Array,i64> (; 317 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -16541,7 +16524,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#subarray (; 320 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#subarray (; 318 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 4
@@ -16610,7 +16593,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint64Array,u64> (; 321 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint64Array,u64> (; 319 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -16769,7 +16752,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#reverse (; 322 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#reverse (; 320 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -16826,7 +16809,7 @@
   end
   local.get $3
  )
- (func $~lib/typedarray/Float32Array#subarray (; 323 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#subarray (; 321 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 4
@@ -16895,7 +16878,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Float32Array,f32> (; 324 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Float32Array,f32> (; 322 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -17054,7 +17037,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#reverse (; 325 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#reverse (; 323 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -17111,7 +17094,7 @@
   end
   local.get $3
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Float64Array,f64> (; 326 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Float64Array,f64> (; 324 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -17271,7 +17254,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#indexOf (; 327 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#indexOf (; 325 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Int8Array,i8>|inlined.0
@@ -17346,7 +17329,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int8Array#lastIndexOf (; 328 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#lastIndexOf (; 326 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int8Array,i8>|inlined.0
    local.get $0
@@ -17415,7 +17398,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int8Array#lastIndexOf|trampoline (; 329 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#lastIndexOf|trampoline (; 327 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   block $1of1
    block $0of1
@@ -17436,7 +17419,7 @@
   local.get $2
   call $~lib/typedarray/Int8Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int8Array,i8> (; 330 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int8Array,i8> (; 328 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -17864,7 +17847,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8Array,u8> (; 331 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8Array,u8> (; 329 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -18289,7 +18272,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8ClampedArray,u8> (; 332 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8ClampedArray,u8> (; 330 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -18714,7 +18697,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#indexOf (; 333 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#indexOf (; 331 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Int16Array,i16>|inlined.0
@@ -18791,7 +18774,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int16Array#lastIndexOf (; 334 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#lastIndexOf (; 332 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int16Array,i16>|inlined.0
    local.get $0
@@ -18862,7 +18845,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int16Array#lastIndexOf|trampoline (; 335 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#lastIndexOf|trampoline (; 333 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   block $1of1
    block $0of1
@@ -18883,7 +18866,7 @@
   local.get $2
   call $~lib/typedarray/Int16Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int16Array,i16> (; 336 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int16Array,i16> (; 334 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -19310,7 +19293,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint16Array,u16> (; 337 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint16Array,u16> (; 335 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -19735,7 +19718,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#indexOf (; 338 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#indexOf (; 336 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Int32Array,i32>|inlined.0
@@ -19810,7 +19793,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int32Array#lastIndexOf (; 339 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#lastIndexOf (; 337 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int32Array,i32>|inlined.0
    local.get $0
@@ -19879,7 +19862,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int32Array#lastIndexOf|trampoline (; 340 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#lastIndexOf|trampoline (; 338 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   block $1of1
    block $0of1
@@ -19900,7 +19883,7 @@
   local.get $2
   call $~lib/typedarray/Int32Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int32Array,i32> (; 341 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int32Array,i32> (; 339 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -20324,7 +20307,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint32Array,u32> (; 342 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint32Array,u32> (; 340 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -20747,7 +20730,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#indexOf (; 343 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#indexOf (; 341 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Int64Array,i64>|inlined.0
@@ -20822,7 +20805,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int64Array#lastIndexOf (; 344 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#lastIndexOf (; 342 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Int64Array,i64>|inlined.0
    local.get $0
@@ -20891,7 +20874,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Int64Array#lastIndexOf|trampoline (; 345 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/typedarray/Int64Array#lastIndexOf|trampoline (; 343 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i32)
   block $1of1
    block $0of1
@@ -20912,7 +20895,7 @@
   local.get $2
   call $~lib/typedarray/Int64Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int64Array,i64> (; 346 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int64Array,i64> (; 344 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -21336,7 +21319,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint64Array,u64> (; 347 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint64Array,u64> (; 345 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -21760,7 +21743,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#indexOf (; 348 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#indexOf (; 346 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Float32Array,f32>|inlined.0
@@ -21835,7 +21818,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Float32Array#lastIndexOf (; 349 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#lastIndexOf (; 347 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Float32Array,f32>|inlined.0
    local.get $0
@@ -21904,7 +21887,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Float32Array#lastIndexOf|trampoline (; 350 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/typedarray/Float32Array#lastIndexOf|trampoline (; 348 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
   (local $2 i32)
   block $1of1
    block $0of1
@@ -21925,7 +21908,7 @@
   local.get $2
   call $~lib/typedarray/Float32Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float32Array,f32> (; 351 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float32Array,f32> (; 349 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -22349,7 +22332,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#indexOf (; 352 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#indexOf (; 350 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/typedarray/INDEX_OF<~lib/typedarray/Float64Array,f64>|inlined.0
@@ -22424,7 +22407,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Float64Array#lastIndexOf (; 353 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#lastIndexOf (; 351 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   block $~lib/typedarray/LAST_INDEX_OF<~lib/typedarray/Float64Array,f64>|inlined.0
    local.get $0
@@ -22493,7 +22476,7 @@
   end
   local.get $2
  )
- (func $~lib/typedarray/Float64Array#lastIndexOf|trampoline (; 354 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/typedarray/Float64Array#lastIndexOf|trampoline (; 352 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   block $1of1
    block $0of1
@@ -22514,7 +22497,7 @@
   local.get $2
   call $~lib/typedarray/Float64Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float64Array,f64> (; 355 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float64Array,f64> (; 353 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -22939,11 +22922,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#includes (; 356 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#includes (; 354 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 f64)
+  (local $3 f64)
+  (local $4 i32)
   block $~lib/typedarray/INCLUDES<~lib/typedarray/Float64Array,f64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -22965,7 +22948,7 @@
    end
    local.get $0
    i32.load offset=4
-   local.set $3
+   local.set $4
    loop $continue|0
     local.get $1
     local.get $2
@@ -22974,20 +22957,18 @@
      local.get $1
      i32.const 3
      i32.shl
-     local.get $3
+     local.get $4
      i32.add
      f64.load
-     local.tee $4
+     local.tee $3
      f64.const nan:0x8000000000000
      f64.eq
      if (result i32)
       i32.const 1
      else
-      local.get $4
-      call $~lib/number/isNaN<f64>
-      f64.const nan:0x8000000000000
-      call $~lib/number/isNaN<f64>
-      i32.and
+      local.get $3
+      local.get $3
+      f64.ne
      end
      if
       local.get $0
@@ -23009,11 +22990,11 @@
    i32.const 0
   end
  )
- (func $~lib/typedarray/Float32Array#includes (; 357 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#includes (; 355 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 f32)
+  (local $3 f32)
+  (local $4 i32)
   block $~lib/typedarray/INCLUDES<~lib/typedarray/Float32Array,f32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -23035,7 +23016,7 @@
    end
    local.get $0
    i32.load offset=4
-   local.set $3
+   local.set $4
    loop $continue|0
     local.get $1
     local.get $2
@@ -23044,20 +23025,18 @@
      local.get $1
      i32.const 2
      i32.shl
-     local.get $3
+     local.get $4
      i32.add
      f32.load
-     local.tee $4
+     local.tee $3
      f32.const nan:0x400000
      f32.eq
      if (result i32)
       i32.const 1
      else
-      local.get $4
-      call $~lib/number/isNaN<f32>
-      f32.const nan:0x400000
-      call $~lib/number/isNaN<f32>
-      i32.and
+      local.get $3
+      local.get $3
+      f32.ne
      end
      if
       local.get $0
@@ -23079,7 +23058,7 @@
    i32.const 0
   end
  )
- (func $~lib/util/number/decimalCount32 (; 358 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (; 356 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1
   i32.const 2
   local.get $0
@@ -23127,7 +23106,7 @@
   i32.lt_u
   select
  )
- (func $~lib/util/number/utoa_simple<u32> (; 359 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u32> (; 357 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   loop $continue|0
    local.get $1
@@ -23154,7 +23133,7 @@
    br_if $continue|0
   end
  )
- (func $~lib/util/number/itoa32 (; 360 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (; 358 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -23197,7 +23176,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/string/String#get:length (; 361 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (; 359 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -23205,7 +23184,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/number/itoa_stream<i8> (; 362 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i8> (; 360 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 1
@@ -23260,7 +23239,7 @@
   end
   local.get $2
  )
- (func $~lib/string/String#substring (; 363 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String#substring (; 361 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   i32.const 0
@@ -23337,7 +23316,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/string/joinIntegerArray<i8> (; 364 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i8> (; 362 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23456,7 +23435,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Int8Array#join (; 365 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#join (; 363 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1744
   call $~lib/rt/pure/__retain
   drop
@@ -23468,7 +23447,7 @@
   i32.const 1744
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/string/compareImpl (; 366 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/compareImpl (; 364 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -23566,7 +23545,7 @@
   call $~lib/rt/pure/__release
   i32.const 0
  )
- (func $~lib/string/String.__eq (; 367 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 365 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/pure/__retain
@@ -23620,7 +23599,7 @@
   call $~lib/rt/pure/__release
   i32.const 0
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int8Array,i8> (; 368 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int8Array,i8> (; 366 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -23687,7 +23666,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/utoa32 (; 369 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/utoa32 (; 367 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -23711,7 +23690,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<u8> (; 370 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u8> (; 368 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   i32.const 1
   i32.shl
@@ -23741,7 +23720,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u8> (; 371 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u8> (; 369 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -23860,7 +23839,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Uint8Array#join (; 372 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#join (; 370 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1744
   call $~lib/rt/pure/__retain
   drop
@@ -23872,7 +23851,7 @@
   i32.const 1744
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint8Array,u8> (; 373 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint8Array,u8> (; 371 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -23939,7 +23918,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint8ClampedArray,u8> (; 374 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint8ClampedArray,u8> (; 372 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -24006,7 +23985,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_stream<i16> (; 375 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i16> (; 373 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 1
@@ -24061,7 +24040,7 @@
   end
   local.get $2
  )
- (func $~lib/util/string/joinIntegerArray<i16> (; 376 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i16> (; 374 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24184,7 +24163,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Int16Array#join (; 377 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#join (; 375 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1744
   call $~lib/rt/pure/__retain
   drop
@@ -24196,7 +24175,7 @@
   i32.const 1744
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int16Array,i16> (; 378 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int16Array,i16> (; 376 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -24263,7 +24242,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_stream<u16> (; 379 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u16> (; 377 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   i32.const 1
   i32.shl
@@ -24293,7 +24272,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u16> (; 380 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u16> (; 378 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24416,7 +24395,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Uint16Array#join (; 381 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#join (; 379 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1744
   call $~lib/rt/pure/__retain
   drop
@@ -24428,7 +24407,7 @@
   i32.const 1744
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint16Array,u16> (; 382 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint16Array,u16> (; 380 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -24495,7 +24474,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_stream<i32> (; 383 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i32> (; 381 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   i32.const 1
   i32.shl
@@ -24537,7 +24516,7 @@
   end
   local.get $2
  )
- (func $~lib/util/string/joinIntegerArray<i32> (; 384 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i32> (; 382 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24660,7 +24639,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Int32Array#join (; 385 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#join (; 383 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1744
   call $~lib/rt/pure/__retain
   drop
@@ -24672,7 +24651,7 @@
   i32.const 1744
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int32Array,i32> (; 386 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int32Array,i32> (; 384 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -24739,7 +24718,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa_stream<u32> (; 387 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u32> (; 385 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $1
   i32.const 1
   i32.shl
@@ -24763,7 +24742,7 @@
   call $~lib/util/number/utoa_simple<u32>
   local.get $0
  )
- (func $~lib/util/string/joinIntegerArray<u32> (; 388 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u32> (; 386 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -24886,7 +24865,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Uint32Array#join (; 389 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#join (; 387 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1744
   call $~lib/rt/pure/__retain
   drop
@@ -24898,7 +24877,7 @@
   i32.const 1744
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint32Array,u32> (; 390 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint32Array,u32> (; 388 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -24965,7 +24944,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/decimalCount64 (; 391 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64 (; 389 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   i32.const 10
   i32.const 11
   i32.const 12
@@ -25018,7 +24997,7 @@
   i64.lt_u
   select
  )
- (func $~lib/util/number/utoa_simple<u64> (; 392 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/util/number/utoa_simple<u64> (; 390 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   loop $continue|0
    local.get $1
@@ -25048,7 +25027,7 @@
    br_if $continue|0
   end
  )
- (func $~lib/util/number/itoa64 (; 393 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa64 (; 391 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -25114,7 +25093,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<i64> (; 394 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<i64> (; 392 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   local.get $1
@@ -25176,7 +25155,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<i64> (; 395 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i64> (; 393 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -25299,7 +25278,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Int64Array#join (; 396 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#join (; 394 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1744
   call $~lib/rt/pure/__retain
   drop
@@ -25311,7 +25290,7 @@
   i32.const 1744
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int64Array,i64> (; 397 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int64Array,i64> (; 395 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -25378,7 +25357,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/utoa64 (; 398 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/utoa64 (; 396 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -25423,7 +25402,7 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa_stream<u64> (; 399 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<u64> (; 397 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 1
@@ -25464,7 +25443,7 @@
   end
   local.get $1
  )
- (func $~lib/util/string/joinIntegerArray<u64> (; 400 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u64> (; 398 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -25587,7 +25566,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Uint64Array#join (; 401 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#join (; 399 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1744
   call $~lib/rt/pure/__retain
   drop
@@ -25599,7 +25578,7 @@
   i32.const 1744
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint64Array,u64> (; 402 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint64Array,u64> (; 400 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -25666,14 +25645,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/number/isFinite<f64> (; 403 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.sub
-  f64.const 0
-  f64.eq
- )
- (func $~lib/util/number/genDigits (; 404 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (; 401 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i32)
   (local $9 i64)
@@ -26072,7 +26044,7 @@
    local.get $6
   end
  )
- (func $~lib/util/number/prettify (; 405 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (; 402 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   i32.eqz
@@ -26319,7 +26291,7 @@
    end
   end
  )
- (func $~lib/util/number/dtoa_core (; 406 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (; 403 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i64)
@@ -26607,7 +26579,7 @@
   local.get $10
   i32.add
  )
- (func $~lib/util/number/dtoa (; 407 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+ (func $~lib/util/number/dtoa (; 404 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -26619,11 +26591,14 @@
    return
   end
   local.get $0
-  call $~lib/number/isFinite<f64>
-  i32.eqz
+  local.get $0
+  f64.sub
+  f64.const 0
+  f64.ne
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.get $0
+   f64.ne
    if
     i32.const 1832
     call $~lib/rt/pure/__retain
@@ -26658,7 +26633,7 @@
   local.get $1
   call $~lib/rt/tlsf/__free
  )
- (func $~lib/util/number/dtoa_stream (; 408 ;) (type $FUNCSIG$iiid) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
+ (func $~lib/util/number/dtoa_stream (; 405 ;) (type $FUNCSIG$iiid) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
   (local $3 i32)
   local.get $1
   i32.const 1
@@ -26683,11 +26658,14 @@
    return
   end
   local.get $2
-  call $~lib/number/isFinite<f64>
-  i32.eqz
+  local.get $2
+  f64.sub
+  f64.const 0
+  f64.ne
   if
    local.get $2
-   call $~lib/number/isNaN<f64>
+   local.get $2
+   f64.ne
    if
     local.get $0
     i32.const 78
@@ -26726,7 +26704,7 @@
   local.get $2
   call $~lib/util/number/dtoa_core
  )
- (func $~lib/util/string/joinFloatArray<f32> (; 409 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinFloatArray<f32> (; 406 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -26852,7 +26830,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Float32Array#join (; 410 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#join (; 407 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1744
   call $~lib/rt/pure/__retain
   drop
@@ -26864,7 +26842,7 @@
   i32.const 1744
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float32Array,f32> (; 411 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float32Array,f32> (; 408 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -26931,7 +26909,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/string/joinFloatArray<f64> (; 412 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/util/string/joinFloatArray<f64> (; 409 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -27054,7 +27032,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Float64Array#join (; 413 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#join (; 410 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   i32.const 1744
   call $~lib/rt/pure/__retain
   drop
@@ -27066,7 +27044,7 @@
   i32.const 1744
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float64Array,f64> (; 414 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float64Array,f64> (; 411 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -27133,13 +27111,13 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (; 415 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (; 412 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
   i32.load offset=12
  )
- (func $~lib/arraybuffer/ArrayBuffer#slice (; 416 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#slice (; 413 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
@@ -27207,7 +27185,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/typedarray/Int8Array.wrap (; 417 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array.wrap (; 414 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -27300,7 +27278,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int8Array,i8> (; 418 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int8Array,i8> (; 415 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -27410,7 +27388,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array.wrap (; 419 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array.wrap (; 416 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -27503,7 +27481,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8Array,u8> (; 420 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8Array,u8> (; 417 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -27611,7 +27589,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray.wrap (; 421 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray.wrap (; 418 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -27704,7 +27682,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8ClampedArray,u8> (; 422 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8ClampedArray,u8> (; 419 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -27812,7 +27790,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array.wrap (; 423 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array.wrap (; 420 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -27908,7 +27886,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int16Array,i16> (; 424 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int16Array,i16> (; 421 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -28018,7 +27996,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array.wrap (; 425 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array.wrap (; 422 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -28114,7 +28092,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint16Array,u16> (; 426 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint16Array,u16> (; 423 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -28222,7 +28200,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array.wrap (; 427 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array.wrap (; 424 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -28318,7 +28296,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int32Array,i32> (; 428 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int32Array,i32> (; 425 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -28424,7 +28402,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array.wrap (; 429 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array.wrap (; 426 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -28520,7 +28498,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint32Array,u32> (; 430 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint32Array,u32> (; 427 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -28626,7 +28604,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array.wrap (; 431 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array.wrap (; 428 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -28722,7 +28700,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int64Array,i64> (; 432 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int64Array,i64> (; 429 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -28829,7 +28807,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array.wrap (; 433 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array.wrap (; 430 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -28925,7 +28903,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint64Array,u64> (; 434 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint64Array,u64> (; 431 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -29032,7 +29010,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array.wrap (; 435 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array.wrap (; 432 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -29128,7 +29106,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Float32Array,f32> (; 436 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Float32Array,f32> (; 433 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -29233,7 +29211,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array.wrap (; 437 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array.wrap (; 434 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -29329,7 +29307,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Float64Array,f64> (; 438 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Float64Array,f64> (; 435 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -29434,7 +29412,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $start:std/typedarray (; 439 ;) (type $FUNCSIG$v)
+ (func $start:std/typedarray (; 436 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -31335,7 +31313,7 @@
   call $std/typedarray/testArrayWrap<~lib/typedarray/Float32Array,f32>
   call $std/typedarray/testArrayWrap<~lib/typedarray/Float64Array,f64>
  )
- (func $start (; 440 ;) (type $FUNCSIG$v)
+ (func $start (; 437 ;) (type $FUNCSIG$v)
   global.get $~lib/started
   if
    return
@@ -31345,7 +31323,7 @@
   end
   call $start:std/typedarray
  )
- (func $~lib/rt/pure/__visit (; 441 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 438 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   i32.const 3276
   i32.lt_u
@@ -31455,7 +31433,7 @@
    unreachable
   end
  )
- (func $~lib/rt/__visit_members (; 442 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (; 439 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   block $block$4$break
    block $switch$1$default
     block $switch$1$case$2
@@ -31478,7 +31456,7 @@
    call $~lib/rt/pure/__visit
   end
  )
- (func $null (; 443 ;) (type $FUNCSIG$v)
+ (func $null (; 440 ;) (type $FUNCSIG$v)
   nop
  )
 )

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -28,9 +28,7 @@
  (type $FUNCSIG$ifii (func (param f32 i32 i32) (result i32)))
  (type $FUNCSIG$idii (func (param f64 i32 i32) (result i32)))
  (type $FUNCSIG$fff (func (param f32 f32) (result f32)))
- (type $FUNCSIG$if (func (param f32) (result i32)))
  (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))
- (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$vjii (func (param i64 i32 i32)))
  (type $FUNCSIG$vfii (func (param f32 i32 i32)))
  (type $FUNCSIG$vdii (func (param f64 i32 i32)))
@@ -41,6 +39,7 @@
  (type $FUNCSIG$ij (func (param i64) (result i32)))
  (type $FUNCSIG$viji (func (param i32 i64 i32)))
  (type $FUNCSIG$iiij (func (param i32 i32 i64) (result i32)))
+ (type $FUNCSIG$id (func (param f64) (result i32)))
  (type $FUNCSIG$iid (func (param i32 f64) (result i32)))
  (type $FUNCSIG$iijijiji (func (param i32 i64 i32 i64 i32 i64 i32) (result i32)))
  (type $FUNCSIG$iiid (func (param i32 i32 f64) (result i32)))
@@ -18349,12 +18348,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/number/isNaN<f32> (; 358 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)
-  local.get $0
-  local.get $0
-  f32.ne
- )
- (func $~lib/math/NativeMathf.mod (; 359 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
+ (func $~lib/math/NativeMathf.mod (; 358 ;) (type $FUNCSIG$fff) (param $0 f32) (param $1 f32) (result f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -18404,7 +18398,9 @@
    i32.const 1
   else
    local.get $1
-   call $~lib/number/isNaN<f32>
+   local.tee $8
+   local.get $8
+   f32.ne
   end
   if
    local.get $0
@@ -18601,7 +18597,7 @@
   local.get $2
   f32.reinterpret_i32
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 360 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 359 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -18616,7 +18612,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Float32Array#every (; 361 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#every (; 360 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -18682,7 +18678,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|1 (; 362 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32>~anonymous|1 (; 361 ;) (type $FUNCSIG$ifii) (param $0 f32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -18695,7 +18691,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32> (; 363 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float32Array,f32> (; 362 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -18754,12 +18750,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/number/isNaN<f64> (; 364 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.ne
- )
- (func $~lib/math/NativeMath.mod (; 365 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
+ (func $~lib/math/NativeMath.mod (; 363 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)
   (local $2 i64)
   (local $3 i64)
   (local $4 i64)
@@ -18809,7 +18800,9 @@
    i32.const 1
   else
    local.get $1
-   call $~lib/number/isNaN<f64>
+   local.tee $8
+   local.get $8
+   f64.ne
   end
   if
    local.get $0
@@ -19012,7 +19005,7 @@
   local.get $2
   f64.reinterpret_i64
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 366 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 364 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19027,7 +19020,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $~lib/typedarray/Float64Array#every (; 367 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#every (; 365 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -19093,7 +19086,7 @@
    local.get $6
   end
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|1 (; 368 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64>~anonymous|1 (; 366 ;) (type $FUNCSIG$idii) (param $0 f64) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19106,7 +19099,7 @@
   call $~lib/rt/pure/__release
   local.get $3
  )
- (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64> (; 369 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayEvery<~lib/typedarray/Float64Array,f64> (; 367 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -19165,7 +19158,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 370 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8>~anonymous|0 (; 368 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19225,7 +19218,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#forEach (; 371 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int8Array#forEach (; 369 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -19274,7 +19267,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8> (; 372 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int8Array,i8> (; 370 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -19337,7 +19330,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 373 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8>~anonymous|0 (; 371 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19393,7 +19386,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#forEach (; 374 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Uint8Array#forEach (; 372 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -19442,7 +19435,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8> (; 375 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8Array,u8> (; 373 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -19499,7 +19492,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 376 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8>~anonymous|0 (; 374 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19555,7 +19548,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#forEach (; 377 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#forEach (; 375 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -19604,7 +19597,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8> (; 378 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint8ClampedArray,u8> (; 376 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -19661,7 +19654,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 379 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16>~anonymous|0 (; 377 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19721,7 +19714,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#forEach (; 380 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int16Array#forEach (; 378 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -19770,7 +19763,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16> (; 381 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int16Array,i16> (; 379 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -19833,7 +19826,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 382 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16>~anonymous|0 (; 380 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -19889,7 +19882,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#forEach (; 383 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Uint16Array#forEach (; 381 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -19938,7 +19931,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16> (; 384 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint16Array,u16> (; 382 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -19995,7 +19988,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 385 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32>~anonymous|0 (; 383 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -20047,7 +20040,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#forEach (; 386 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int32Array#forEach (; 384 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -20096,7 +20089,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32> (; 387 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int32Array,i32> (; 385 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -20147,7 +20140,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 388 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32>~anonymous|0 (; 386 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -20199,7 +20192,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#forEach (; 389 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Uint32Array#forEach (; 387 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -20248,7 +20241,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32> (; 390 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint32Array,u32> (; 388 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -20299,7 +20292,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 391 ;) (type $FUNCSIG$vjii) (param $0 i64) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64>~anonymous|0 (; 389 ;) (type $FUNCSIG$vjii) (param $0 i64) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -20352,7 +20345,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#forEach (; 392 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int64Array#forEach (; 390 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -20401,7 +20394,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64> (; 393 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Int64Array,i64> (; 391 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -20455,7 +20448,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 394 ;) (type $FUNCSIG$vjii) (param $0 i64) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64>~anonymous|0 (; 392 ;) (type $FUNCSIG$vjii) (param $0 i64) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -20508,7 +20501,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#forEach (; 395 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Uint64Array#forEach (; 393 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -20557,7 +20550,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64> (; 396 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Uint64Array,u64> (; 394 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -20611,7 +20604,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 397 ;) (type $FUNCSIG$vfii) (param $0 f32) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32>~anonymous|0 (; 395 ;) (type $FUNCSIG$vfii) (param $0 f32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -20664,7 +20657,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#forEach (; 398 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Float32Array#forEach (; 396 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -20713,7 +20706,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32> (; 399 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float32Array,f32> (; 397 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -20767,7 +20760,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 400 ;) (type $FUNCSIG$vdii) (param $0 f64) (param $1 i32) (param $2 i32)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64>~anonymous|0 (; 398 ;) (type $FUNCSIG$vdii) (param $0 f64) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $2
   call $~lib/rt/pure/__retain
@@ -20820,7 +20813,7 @@
   local.get $2
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#forEach (; 401 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Float64Array#forEach (; 399 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -20869,7 +20862,7 @@
   local.get $3
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64> (; 402 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayForEach<~lib/typedarray/Float64Array,f64> (; 400 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   i32.const 0
@@ -20923,7 +20916,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#reverse (; 403 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#reverse (; 401 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -20987,7 +20980,7 @@
   end
   local.get $1
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Int8Array,i8> (; 404 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int8Array,i8> (; 402 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -21173,7 +21166,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#reverse (; 405 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#reverse (; 403 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -21237,7 +21230,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Uint8Array#subarray (; 406 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#subarray (; 404 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -21344,7 +21337,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8Array,u8> (; 407 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8Array,u8> (; 405 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -21524,7 +21517,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#reverse (; 408 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#reverse (; 406 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -21588,7 +21581,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Uint8ClampedArray#subarray (; 409 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#subarray (; 407 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -21695,7 +21688,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8ClampedArray,u8> (; 410 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint8ClampedArray,u8> (; 408 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -21875,7 +21868,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#reverse (; 411 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#reverse (; 409 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -21939,7 +21932,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Int16Array#subarray (; 412 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#subarray (; 410 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -22046,7 +22039,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Int16Array,i16> (; 413 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int16Array,i16> (; 411 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -22232,7 +22225,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#reverse (; 414 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#reverse (; 412 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -22296,7 +22289,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Uint16Array#subarray (; 415 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#subarray (; 413 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -22403,7 +22396,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint16Array,u16> (; 416 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint16Array,u16> (; 414 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -22583,7 +22576,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#reverse (; 417 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#reverse (; 415 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -22647,7 +22640,7 @@
   end
   local.get $1
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Int32Array,i32> (; 418 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int32Array,i32> (; 416 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -22821,7 +22814,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#reverse (; 419 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#reverse (; 417 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -22885,7 +22878,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Uint32Array#subarray (; 420 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#subarray (; 418 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -22992,7 +22985,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint32Array,u32> (; 421 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint32Array,u32> (; 419 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -23166,7 +23159,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#reverse (; 422 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#reverse (; 420 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -23230,7 +23223,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Int64Array#subarray (; 423 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#subarray (; 421 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -23337,7 +23330,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Int64Array,i64> (; 424 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Int64Array,i64> (; 422 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -23514,7 +23507,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#reverse (; 425 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#reverse (; 423 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -23578,7 +23571,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Uint64Array#subarray (; 426 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#subarray (; 424 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -23685,7 +23678,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint64Array,u64> (; 427 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Uint64Array,u64> (; 425 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -23862,7 +23855,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#reverse (; 428 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#reverse (; 426 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -23926,7 +23919,7 @@
   end
   local.get $1
  )
- (func $~lib/typedarray/Float32Array#subarray (; 429 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#subarray (; 427 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -24033,7 +24026,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Float32Array,f32> (; 430 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Float32Array,f32> (; 428 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -24210,7 +24203,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#reverse (; 431 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#reverse (; 429 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -24274,7 +24267,7 @@
   end
   local.get $1
  )
- (func $std/typedarray/testArrayReverse<~lib/typedarray/Float64Array,f64> (; 432 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayReverse<~lib/typedarray/Float64Array,f64> (; 430 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -24451,7 +24444,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#indexOf (; 433 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#indexOf (; 431 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -24551,7 +24544,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Int8Array#lastIndexOf (; 434 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#lastIndexOf (; 432 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -24647,7 +24640,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Int8Array#lastIndexOf|trampoline (; 435 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#lastIndexOf|trampoline (; 433 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -24667,7 +24660,7 @@
   local.get $2
   call $~lib/typedarray/Int8Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int8Array,i8> (; 436 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int8Array,i8> (; 434 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -25140,7 +25133,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#indexOf (; 437 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#indexOf (; 435 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -25238,7 +25231,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint8Array#lastIndexOf (; 438 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#lastIndexOf (; 436 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -25332,7 +25325,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint8Array#lastIndexOf|trampoline (; 439 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#lastIndexOf|trampoline (; 437 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -25352,7 +25345,7 @@
   local.get $2
   call $~lib/typedarray/Uint8Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8Array,u8> (; 440 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8Array,u8> (; 438 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -25823,7 +25816,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#indexOf (; 441 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#indexOf (; 439 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -25921,7 +25914,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint8ClampedArray#lastIndexOf (; 442 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#lastIndexOf (; 440 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -26015,7 +26008,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint8ClampedArray#lastIndexOf|trampoline (; 443 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#lastIndexOf|trampoline (; 441 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -26035,7 +26028,7 @@
   local.get $2
   call $~lib/typedarray/Uint8ClampedArray#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8ClampedArray,u8> (; 444 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint8ClampedArray,u8> (; 442 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -26506,7 +26499,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#indexOf (; 445 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#indexOf (; 443 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -26606,7 +26599,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Int16Array#lastIndexOf (; 446 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#lastIndexOf (; 444 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -26702,7 +26695,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Int16Array#lastIndexOf|trampoline (; 447 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#lastIndexOf|trampoline (; 445 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -26722,7 +26715,7 @@
   local.get $2
   call $~lib/typedarray/Int16Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int16Array,i16> (; 448 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int16Array,i16> (; 446 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -27195,7 +27188,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#indexOf (; 449 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#indexOf (; 447 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -27293,7 +27286,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint16Array#lastIndexOf (; 450 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#lastIndexOf (; 448 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -27387,7 +27380,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint16Array#lastIndexOf|trampoline (; 451 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#lastIndexOf|trampoline (; 449 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -27407,7 +27400,7 @@
   local.get $2
   call $~lib/typedarray/Uint16Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint16Array,u16> (; 452 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint16Array,u16> (; 450 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -27878,7 +27871,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#indexOf (; 453 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#indexOf (; 451 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -27974,7 +27967,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Int32Array#lastIndexOf (; 454 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#lastIndexOf (; 452 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -28066,7 +28059,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Int32Array#lastIndexOf|trampoline (; 455 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#lastIndexOf|trampoline (; 453 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -28086,7 +28079,7 @@
   local.get $2
   call $~lib/typedarray/Int32Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int32Array,i32> (; 456 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int32Array,i32> (; 454 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -28555,7 +28548,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#indexOf (; 457 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#indexOf (; 455 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -28651,7 +28644,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint32Array#lastIndexOf (; 458 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#lastIndexOf (; 456 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -28743,7 +28736,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint32Array#lastIndexOf|trampoline (; 459 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#lastIndexOf|trampoline (; 457 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -28763,7 +28756,7 @@
   local.get $2
   call $~lib/typedarray/Uint32Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint32Array,u32> (; 460 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint32Array,u32> (; 458 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -29232,7 +29225,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#indexOf (; 461 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#indexOf (; 459 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -29328,7 +29321,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Int64Array#lastIndexOf (; 462 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#lastIndexOf (; 460 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -29420,7 +29413,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Int64Array#lastIndexOf|trampoline (; 463 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#lastIndexOf|trampoline (; 461 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -29440,7 +29433,7 @@
   local.get $2
   call $~lib/typedarray/Int64Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int64Array,i64> (; 464 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Int64Array,i64> (; 462 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -29910,7 +29903,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#indexOf (; 465 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#indexOf (; 463 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -30006,7 +29999,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint64Array#lastIndexOf (; 466 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#lastIndexOf (; 464 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -30098,7 +30091,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Uint64Array#lastIndexOf|trampoline (; 467 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#lastIndexOf|trampoline (; 465 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -30118,7 +30111,7 @@
   local.get $2
   call $~lib/typedarray/Uint64Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint64Array,u64> (; 468 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Uint64Array,u64> (; 466 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -30588,7 +30581,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#indexOf (; 469 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#indexOf (; 467 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 f32)
   (local $5 i32)
@@ -30684,7 +30677,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Float32Array#lastIndexOf (; 470 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#lastIndexOf (; 468 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 f32)
   (local $5 i32)
@@ -30776,7 +30769,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Float32Array#lastIndexOf|trampoline (; 471 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#lastIndexOf|trampoline (; 469 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -30796,7 +30789,7 @@
   local.get $2
   call $~lib/typedarray/Float32Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float32Array,f32> (; 472 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float32Array,f32> (; 470 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -31266,7 +31259,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#indexOf (; 473 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#indexOf (; 471 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 f64)
   (local $5 i32)
@@ -31362,7 +31355,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Float64Array#lastIndexOf (; 474 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#lastIndexOf (; 472 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 f64)
   (local $5 i32)
@@ -31454,7 +31447,7 @@
    local.get $9
   end
  )
- (func $~lib/typedarray/Float64Array#lastIndexOf|trampoline (; 475 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#lastIndexOf|trampoline (; 473 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -31474,7 +31467,7 @@
   local.get $2
   call $~lib/typedarray/Float64Array#lastIndexOf
  )
- (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float64Array,f64> (; 476 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayIndexOfAndLastIndexOf<~lib/typedarray/Float64Array,f64> (; 474 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -31944,7 +31937,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#includes (; 477 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#includes (; 475 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 f64)
   (local $5 i32)
@@ -31953,6 +31946,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 f64)
+  (local $11 f64)
   block $~lib/typedarray/INCLUDES<~lib/typedarray/Float64Array,f64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -32024,9 +32018,13 @@
       i32.const 1
      else
       local.get $10
-      call $~lib/number/isNaN<f64>
+      local.tee $11
+      local.get $11
+      f64.ne
       local.get $4
-      call $~lib/number/isNaN<f64>
+      local.tee $11
+      local.get $11
+      f64.ne
       i32.and
      end
      if
@@ -32053,7 +32051,7 @@
    br $~lib/typedarray/INCLUDES<~lib/typedarray/Float64Array,f64>|inlined.0
   end
  )
- (func $~lib/typedarray/Float32Array#includes (; 478 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#includes (; 476 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 f32)
   (local $5 i32)
@@ -32062,6 +32060,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 f32)
+  (local $11 f32)
   block $~lib/typedarray/INCLUDES<~lib/typedarray/Float32Array,f32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -32133,9 +32132,13 @@
       i32.const 1
      else
       local.get $10
-      call $~lib/number/isNaN<f32>
+      local.tee $11
+      local.get $11
+      f32.ne
       local.get $4
-      call $~lib/number/isNaN<f32>
+      local.tee $11
+      local.get $11
+      f32.ne
       i32.and
      end
      if
@@ -32162,7 +32165,7 @@
    br $~lib/typedarray/INCLUDES<~lib/typedarray/Float32Array,f32>|inlined.0
   end
  )
- (func $~lib/util/number/decimalCount32 (; 479 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/decimalCount32 (; 477 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   local.get $0
   i32.const 100000
@@ -32228,7 +32231,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/utoa32_lut (; 480 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/util/number/utoa32_lut (; 478 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -32370,7 +32373,7 @@
    i32.store16
   end
  )
- (func $~lib/util/number/itoa32 (; 481 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa32 (; 479 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -32425,7 +32428,7 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<i8> (; 482 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<i8> (; 480 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 24
   i32.shl
@@ -32434,7 +32437,7 @@
   call $~lib/util/number/itoa32
   return
  )
- (func $~lib/string/String#get:length (; 483 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/string/String#get:length (; 481 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
@@ -32442,7 +32445,7 @@
   i32.const 1
   i32.shr_u
  )
- (func $~lib/util/number/itoa_stream<i8> (; 484 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i8> (; 482 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -32515,7 +32518,7 @@
   end
   local.get $3
  )
- (func $~lib/string/String#substring (; 485 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/string/String#substring (; 483 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -32622,7 +32625,7 @@
   local.get $10
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/string/joinIntegerArray<i8> (; 486 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i8> (; 484 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -32770,7 +32773,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int8Array#join (; 487 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#join (; 485 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -32786,7 +32789,7 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/util/string/compareImpl (; 488 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+ (func $~lib/util/string/compareImpl (; 486 ;) (type $FUNCSIG$iiiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -32906,7 +32909,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/string/String.__eq (; 489 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/string/String.__eq (; 487 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -32979,12 +32982,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Int8Array#toString (; 490 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array#toString (; 488 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 2192
   call $~lib/typedarray/Int8Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int8Array,i8> (; 491 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int8Array,i8> (; 489 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -33053,7 +33056,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/utoa32 (; 492 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/utoa32 (; 490 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -33088,14 +33091,14 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<u8> (; 493 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<u8> (; 491 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/util/number/itoa_stream<u8> (; 494 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u8> (; 492 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -33138,7 +33141,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<u8> (; 495 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u8> (; 493 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -33286,7 +33289,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint8Array#join (; 496 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#join (; 494 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -33302,12 +33305,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Uint8Array#toString (; 497 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#toString (; 495 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 2192
   call $~lib/typedarray/Uint8Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint8Array,u8> (; 498 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint8Array,u8> (; 496 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -33376,7 +33379,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#join (; 499 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#join (; 497 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -33392,12 +33395,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Uint8ClampedArray#toString (; 500 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray#toString (; 498 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 2192
   call $~lib/typedarray/Uint8ClampedArray#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint8ClampedArray,u8> (; 501 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint8ClampedArray,u8> (; 499 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -33466,7 +33469,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa<i16> (; 502 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<i16> (; 500 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.shl
@@ -33475,7 +33478,7 @@
   call $~lib/util/number/itoa32
   return
  )
- (func $~lib/util/number/itoa_stream<i16> (; 503 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i16> (; 501 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -33548,7 +33551,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<i16> (; 504 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i16> (; 502 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -33696,7 +33699,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int16Array#join (; 505 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#join (; 503 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -33712,12 +33715,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Int16Array#toString (; 506 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array#toString (; 504 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 2192
   call $~lib/typedarray/Int16Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int16Array,i16> (; 507 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int16Array,i16> (; 505 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -33786,14 +33789,14 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa<u16> (; 508 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<u16> (; 506 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 65535
   i32.and
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/util/number/itoa_stream<u16> (; 509 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u16> (; 507 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -33836,7 +33839,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<u16> (; 510 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u16> (; 508 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -33984,7 +33987,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint16Array#join (; 511 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#join (; 509 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -34000,12 +34003,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Uint16Array#toString (; 512 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array#toString (; 510 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 2192
   call $~lib/typedarray/Uint16Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint16Array,u16> (; 513 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint16Array,u16> (; 511 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -34074,12 +34077,12 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa<i32> (; 514 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<i32> (; 512 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/itoa32
   return
  )
- (func $~lib/util/number/itoa_stream<i32> (; 515 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<i32> (; 513 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -34136,7 +34139,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<i32> (; 516 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i32> (; 514 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -34284,7 +34287,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int32Array#join (; 517 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#join (; 515 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -34300,12 +34303,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Int32Array#toString (; 518 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int32Array#toString (; 516 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 2192
   call $~lib/typedarray/Int32Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int32Array,i32> (; 519 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int32Array,i32> (; 517 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -34374,12 +34377,12 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/itoa<u32> (; 520 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/number/itoa<u32> (; 518 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/util/number/utoa32
   return
  )
- (func $~lib/util/number/itoa_stream<u32> (; 521 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/itoa_stream<u32> (; 519 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -34416,7 +34419,7 @@
   call $~lib/util/number/utoa32_lut
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<u32> (; 522 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u32> (; 520 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -34564,7 +34567,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint32Array#join (; 523 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#join (; 521 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -34580,12 +34583,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Uint32Array#toString (; 524 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array#toString (; 522 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 2192
   call $~lib/typedarray/Uint32Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint32Array,u32> (; 525 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint32Array,u32> (; 523 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -34654,7 +34657,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/decimalCount64 (; 526 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/decimalCount64 (; 524 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   local.get $0
   i64.const 1000000000000000
@@ -34727,7 +34730,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/utoa64_lut (; 527 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/util/number/utoa64_lut (; 525 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   (local $4 i64)
   (local $5 i32)
@@ -34854,7 +34857,7 @@
   local.get $2
   call $~lib/util/number/utoa32_lut
  )
- (func $~lib/util/number/itoa64 (; 528 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa64 (; 526 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -34943,12 +34946,12 @@
   local.get $2
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<i64> (; 529 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa<i64> (; 527 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   local.get $0
   call $~lib/util/number/itoa64
   return
  )
- (func $~lib/util/number/itoa_stream<i64> (; 530 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<i64> (; 528 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -35033,7 +35036,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<i64> (; 531 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<i64> (; 529 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -35181,7 +35184,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Int64Array#join (; 532 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#join (; 530 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -35197,12 +35200,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Int64Array#toString (; 533 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int64Array#toString (; 531 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 2192
   call $~lib/typedarray/Int64Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int64Array,i64> (; 534 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Int64Array,i64> (; 532 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -35271,7 +35274,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/number/utoa64 (; 535 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/utoa64 (; 533 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -35338,12 +35341,12 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $~lib/util/number/itoa<u64> (; 536 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/number/itoa<u64> (; 534 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   local.get $0
   call $~lib/util/number/utoa64
   return
  )
- (func $~lib/util/number/itoa_stream<u64> (; 537 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
+ (func $~lib/util/number/itoa_stream<u64> (; 535 ;) (type $FUNCSIG$iiij) (param $0 i32) (param $1 i32) (param $2 i64) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -35406,7 +35409,7 @@
   end
   local.get $3
  )
- (func $~lib/util/string/joinIntegerArray<u64> (; 538 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinIntegerArray<u64> (; 536 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -35554,7 +35557,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Uint64Array#join (; 539 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#join (; 537 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -35570,12 +35573,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Uint64Array#toString (; 540 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array#toString (; 538 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 2192
   call $~lib/typedarray/Uint64Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint64Array,u64> (; 541 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint64Array,u64> (; 539 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -35644,14 +35647,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/number/isFinite<f64> (; 542 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  local.get $0
-  local.get $0
-  f64.sub
-  f64.const 0
-  f64.eq
- )
- (func $~lib/array/Array<u64>#__unchecked_get (; 543 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__unchecked_get (; 540 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -35660,7 +35656,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<i16>#__unchecked_get (; 544 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__unchecked_get (; 541 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -35669,7 +35665,7 @@
   i32.add
   i32.load16_s
  )
- (func $~lib/util/number/genDigits (; 545 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
+ (func $~lib/util/number/genDigits (; 542 ;) (type $FUNCSIG$iijijiji) (param $0 i32) (param $1 i64) (param $2 i32) (param $3 i64) (param $4 i32) (param $5 i64) (param $6 i32) (result i32)
   (local $7 i32)
   (local $8 i64)
   (local $9 i64)
@@ -36171,7 +36167,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/prettify (; 546 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/number/prettify (; 543 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -36490,7 +36486,7 @@
   end
   unreachable
  )
- (func $~lib/util/number/dtoa_core (; 547 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/util/number/dtoa_core (; 544 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -36912,10 +36908,11 @@
   local.get $2
   i32.add
  )
- (func $~lib/util/number/dtoa (; 548 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  (local $1 i32)
+ (func $~lib/util/number/dtoa (; 545 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
+  (local $1 f64)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   local.get $0
   f64.const 0
   f64.eq
@@ -36925,11 +36922,17 @@
    return
   end
   local.get $0
-  call $~lib/number/isFinite<f64>
+  local.tee $1
+  local.get $1
+  f64.sub
+  f64.const 0
+  f64.eq
   i32.eqz
   if
    local.get $0
-   call $~lib/number/isNaN<f64>
+   local.tee $1
+   local.get $1
+   f64.ne
    if
     i32.const 2280
     call $~lib/rt/pure/__retain
@@ -36949,31 +36952,32 @@
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
-  local.set $1
-  local.get $1
-  local.get $0
-  call $~lib/util/number/dtoa_core
   local.set $2
   local.get $2
+  local.get $0
+  call $~lib/util/number/dtoa_core
+  local.set $3
+  local.get $3
   i32.const 28
   i32.eq
   if
-   local.get $1
+   local.get $2
    call $~lib/rt/pure/__retain
    return
   end
-  local.get $1
-  i32.const 0
   local.get $2
-  call $~lib/string/String#substring
-  local.set $3
-  local.get $1
-  call $~lib/rt/tlsf/__free
+  i32.const 0
   local.get $3
+  call $~lib/string/String#substring
+  local.set $4
+  local.get $2
+  call $~lib/rt/tlsf/__free
+  local.get $4
  )
- (func $~lib/util/number/dtoa_stream (; 549 ;) (type $FUNCSIG$iiid) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
-  (local $3 i32)
+ (func $~lib/util/number/dtoa_stream (; 546 ;) (type $FUNCSIG$iiid) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
+  (local $3 f64)
   (local $4 i32)
+  (local $5 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -36997,11 +37001,17 @@
    return
   end
   local.get $2
-  call $~lib/number/isFinite<f64>
+  local.tee $3
+  local.get $3
+  f64.sub
+  f64.const 0
+  f64.eq
   i32.eqz
   if
    local.get $2
-   call $~lib/number/isNaN<f64>
+   local.tee $3
+   local.get $3
+   f64.ne
    if
     local.get $0
     i32.const 78
@@ -37018,21 +37028,21 @@
     local.get $2
     f64.const 0
     f64.lt
-    local.set $3
-    i32.const 8
-    local.get $3
-    i32.add
     local.set $4
+    i32.const 8
+    local.get $4
+    i32.add
+    local.set $5
     local.get $0
     i32.const 2304
     i32.const 2344
-    local.get $3
-    select
     local.get $4
+    select
+    local.get $5
     i32.const 1
     i32.shl
     call $~lib/memory/memory.copy
-    local.get $4
+    local.get $5
     return
    end
    unreachable
@@ -37041,7 +37051,7 @@
   local.get $2
   call $~lib/util/number/dtoa_core
  )
- (func $~lib/util/string/joinFloatArray<f32> (; 550 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinFloatArray<f32> (; 547 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -37192,7 +37202,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Float32Array#join (; 551 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#join (; 548 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -37208,12 +37218,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Float32Array#toString (; 552 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array#toString (; 549 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 2192
   call $~lib/typedarray/Float32Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float32Array,f32> (; 553 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float32Array,f32> (; 550 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -37282,7 +37292,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/util/string/joinFloatArray<f64> (; 554 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/util/string/joinFloatArray<f64> (; 551 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -37430,7 +37440,7 @@
   call $~lib/rt/pure/__release
   local.get $4
  )
- (func $~lib/typedarray/Float64Array#join (; 555 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#join (; 552 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   call $~lib/rt/pure/__retain
@@ -37446,12 +37456,12 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $~lib/typedarray/Float64Array#toString (; 556 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array#toString (; 553 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 2192
   call $~lib/typedarray/Float64Array#join
  )
- (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float64Array,f64> (; 557 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float64Array,f64> (; 554 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -37520,13 +37530,13 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (; 558 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (; 555 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
   i32.load offset=12
  )
- (func $~lib/arraybuffer/ArrayBuffer#slice (; 559 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#slice (; 556 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -37609,7 +37619,7 @@
   local.get $7
   call $~lib/rt/pure/__retain
  )
- (func $~lib/typedarray/Int8Array.wrap (; 560 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array.wrap (; 557 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -37728,7 +37738,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Int8Array.wrap|trampoline (; 561 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array.wrap|trampoline (; 558 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -37751,7 +37761,7 @@
   local.get $2
   call $~lib/typedarray/Int8Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int8Array,i8> (; 562 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int8Array,i8> (; 559 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -37874,7 +37884,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array.wrap (; 563 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array.wrap (; 560 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -37993,7 +38003,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Uint8Array.wrap|trampoline (; 564 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array.wrap|trampoline (; 561 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -38016,7 +38026,7 @@
   local.get $2
   call $~lib/typedarray/Uint8Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8Array,u8> (; 565 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8Array,u8> (; 562 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -38137,7 +38147,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray.wrap (; 566 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray.wrap (; 563 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -38256,7 +38266,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Uint8ClampedArray.wrap|trampoline (; 567 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray.wrap|trampoline (; 564 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -38279,7 +38289,7 @@
   local.get $2
   call $~lib/typedarray/Uint8ClampedArray.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8ClampedArray,u8> (; 568 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8ClampedArray,u8> (; 565 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -38400,7 +38410,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array.wrap (; 569 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array.wrap (; 566 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -38519,7 +38529,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Int16Array.wrap|trampoline (; 570 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array.wrap|trampoline (; 567 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -38542,7 +38552,7 @@
   local.get $2
   call $~lib/typedarray/Int16Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int16Array,i16> (; 571 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int16Array,i16> (; 568 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -38665,7 +38675,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array.wrap (; 572 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array.wrap (; 569 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -38784,7 +38794,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Uint16Array.wrap|trampoline (; 573 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array.wrap|trampoline (; 570 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -38807,7 +38817,7 @@
   local.get $2
   call $~lib/typedarray/Uint16Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint16Array,u16> (; 574 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint16Array,u16> (; 571 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -38928,7 +38938,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array.wrap (; 575 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array.wrap (; 572 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -39047,7 +39057,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Int32Array.wrap|trampoline (; 576 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array.wrap|trampoline (; 573 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -39070,7 +39080,7 @@
   local.get $2
   call $~lib/typedarray/Int32Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int32Array,i32> (; 577 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int32Array,i32> (; 574 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -39189,7 +39199,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array.wrap (; 578 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array.wrap (; 575 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -39308,7 +39318,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Uint32Array.wrap|trampoline (; 579 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array.wrap|trampoline (; 576 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -39331,7 +39341,7 @@
   local.get $2
   call $~lib/typedarray/Uint32Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint32Array,u32> (; 580 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint32Array,u32> (; 577 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -39450,7 +39460,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array.wrap (; 581 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array.wrap (; 578 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -39569,7 +39579,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Int64Array.wrap|trampoline (; 582 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array.wrap|trampoline (; 579 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -39592,7 +39602,7 @@
   local.get $2
   call $~lib/typedarray/Int64Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int64Array,i64> (; 583 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int64Array,i64> (; 580 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -39712,7 +39722,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array.wrap (; 584 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array.wrap (; 581 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -39831,7 +39841,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Uint64Array.wrap|trampoline (; 585 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array.wrap|trampoline (; 582 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -39854,7 +39864,7 @@
   local.get $2
   call $~lib/typedarray/Uint64Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint64Array,u64> (; 586 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint64Array,u64> (; 583 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -39974,7 +39984,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array.wrap (; 587 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array.wrap (; 584 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -40093,7 +40103,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Float32Array.wrap|trampoline (; 588 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array.wrap|trampoline (; 585 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -40116,7 +40126,7 @@
   local.get $2
   call $~lib/typedarray/Float32Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Float32Array,f32> (; 589 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Float32Array,f32> (; 586 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -40236,7 +40246,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array.wrap (; 590 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array.wrap (; 587 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -40355,7 +40365,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Float64Array.wrap|trampoline (; 591 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array.wrap|trampoline (; 588 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -40378,7 +40388,7 @@
   local.get $2
   call $~lib/typedarray/Float64Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Float64Array,f64> (; 592 ;) (type $FUNCSIG$v)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Float64Array,f64> (; 589 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -40498,7 +40508,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $start:std/typedarray (; 593 ;) (type $FUNCSIG$v)
+ (func $start:std/typedarray (; 590 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -42530,7 +42540,7 @@
   call $std/typedarray/testArrayWrap<~lib/typedarray/Float32Array,f32>
   call $std/typedarray/testArrayWrap<~lib/typedarray/Float64Array,f64>
  )
- (func $start (; 594 ;) (type $FUNCSIG$v)
+ (func $start (; 591 ;) (type $FUNCSIG$v)
   global.get $~lib/started
   if
    return
@@ -42540,22 +42550,22 @@
   end
   call $start:std/typedarray
  )
- (func $~lib/array/Array<i8>#__visit_impl (; 595 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i8>#__visit_impl (; 592 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<i32>#__visit_impl (; 596 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#__visit_impl (; 593 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u32>#__visit_impl (; 597 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u32>#__visit_impl (; 594 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u64>#__visit_impl (; 598 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u64>#__visit_impl (; 595 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<i16>#__visit_impl (; 599 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i16>#__visit_impl (; 596 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/rt/pure/__visit (; 600 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 597 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -42685,7 +42695,7 @@
    end
   end
  )
- (func $~lib/rt/__visit_members (; 601 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (; 598 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $block$4$break
    block $switch$1$default
@@ -42743,6 +42753,6 @@
   end
   return
  )
- (func $null (; 602 ;) (type $FUNCSIG$v)
+ (func $null (; 599 ;) (type $FUNCSIG$v)
  )
 )

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -18398,8 +18398,7 @@
    i32.const 1
   else
    local.get $1
-   local.tee $8
-   local.get $8
+   local.get $1
    f32.ne
   end
   if
@@ -18800,8 +18799,7 @@
    i32.const 1
   else
    local.get $1
-   local.tee $8
-   local.get $8
+   local.get $1
    f64.ne
   end
   if
@@ -31946,7 +31944,6 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 f64)
-  (local $11 f64)
   block $~lib/typedarray/INCLUDES<~lib/typedarray/Float64Array,f64>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -32018,12 +32015,10 @@
       i32.const 1
      else
       local.get $10
-      local.tee $11
-      local.get $11
+      local.get $10
       f64.ne
       local.get $4
-      local.tee $11
-      local.get $11
+      local.get $4
       f64.ne
       i32.and
      end
@@ -32060,7 +32055,6 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 f32)
-  (local $11 f32)
   block $~lib/typedarray/INCLUDES<~lib/typedarray/Float32Array,f32>|inlined.0 (result i32)
    local.get $0
    call $~lib/rt/pure/__retain
@@ -32132,12 +32126,10 @@
       i32.const 1
      else
       local.get $10
-      local.tee $11
-      local.get $11
+      local.get $10
       f32.ne
       local.get $4
-      local.tee $11
-      local.get $11
+      local.get $4
       f32.ne
       i32.and
      end
@@ -36909,10 +36901,9 @@
   i32.add
  )
  (func $~lib/util/number/dtoa (; 545 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)
-  (local $1 f64)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
   local.get $0
   f64.const 0
   f64.eq
@@ -36922,16 +36913,14 @@
    return
   end
   local.get $0
-  local.tee $1
-  local.get $1
+  local.get $0
   f64.sub
   f64.const 0
   f64.eq
   i32.eqz
   if
    local.get $0
-   local.tee $1
-   local.get $1
+   local.get $0
    f64.ne
    if
     i32.const 2280
@@ -36952,32 +36941,31 @@
   i32.shl
   i32.const 1
   call $~lib/rt/tlsf/__alloc
-  local.set $2
-  local.get $2
+  local.set $1
+  local.get $1
   local.get $0
   call $~lib/util/number/dtoa_core
-  local.set $3
-  local.get $3
+  local.set $2
+  local.get $2
   i32.const 28
   i32.eq
   if
-   local.get $2
+   local.get $1
    call $~lib/rt/pure/__retain
    return
   end
-  local.get $2
+  local.get $1
   i32.const 0
-  local.get $3
-  call $~lib/string/String#substring
-  local.set $4
   local.get $2
+  call $~lib/string/String#substring
+  local.set $3
+  local.get $1
   call $~lib/rt/tlsf/__free
-  local.get $4
+  local.get $3
  )
  (func $~lib/util/number/dtoa_stream (; 546 ;) (type $FUNCSIG$iiid) (param $0 i32) (param $1 i32) (param $2 f64) (result i32)
-  (local $3 f64)
+  (local $3 i32)
   (local $4 i32)
-  (local $5 i32)
   local.get $0
   local.get $1
   i32.const 1
@@ -37001,16 +36989,14 @@
    return
   end
   local.get $2
-  local.tee $3
-  local.get $3
+  local.get $2
   f64.sub
   f64.const 0
   f64.eq
   i32.eqz
   if
    local.get $2
-   local.tee $3
-   local.get $3
+   local.get $2
    f64.ne
    if
     local.get $0
@@ -37028,21 +37014,21 @@
     local.get $2
     f64.const 0
     f64.lt
-    local.set $4
+    local.set $3
     i32.const 8
-    local.get $4
+    local.get $3
     i32.add
-    local.set $5
+    local.set $4
     local.get $0
     i32.const 2304
     i32.const 2344
-    local.get $4
+    local.get $3
     select
-    local.get $5
+    local.get $4
     i32.const 1
     i32.shl
     call $~lib/memory/memory.copy
-    local.get $5
+    local.get $4
     return
    end
    unreachable

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -13762,8 +13762,6 @@
   call $~lib/typedarray/Int8Array#some
   local.set $3
   local.get $3
-  i32.const 0
-  i32.ne
   i32.eqz
   i32.eqz
   if
@@ -13916,8 +13914,6 @@
   call $~lib/typedarray/Uint8Array#some
   local.set $3
   local.get $3
-  i32.const 0
-  i32.ne
   i32.eqz
   i32.eqz
   if
@@ -14070,8 +14066,6 @@
   call $~lib/typedarray/Uint8ClampedArray#some
   local.set $3
   local.get $3
-  i32.const 0
-  i32.ne
   i32.eqz
   i32.eqz
   if
@@ -14228,8 +14222,6 @@
   call $~lib/typedarray/Int16Array#some
   local.set $3
   local.get $3
-  i32.const 0
-  i32.ne
   i32.eqz
   i32.eqz
   if
@@ -14382,8 +14374,6 @@
   call $~lib/typedarray/Uint16Array#some
   local.set $3
   local.get $3
-  i32.const 0
-  i32.ne
   i32.eqz
   i32.eqz
   if
@@ -14532,8 +14522,6 @@
   call $~lib/typedarray/Int32Array#some
   local.set $3
   local.get $3
-  i32.const 0
-  i32.ne
   i32.eqz
   i32.eqz
   if
@@ -14682,8 +14670,6 @@
   call $~lib/typedarray/Uint32Array#some
   local.set $3
   local.get $3
-  i32.const 0
-  i32.ne
   i32.eqz
   i32.eqz
   if
@@ -14832,8 +14818,6 @@
   call $~lib/typedarray/Int64Array#some
   local.set $3
   local.get $3
-  i32.const 0
-  i32.ne
   i32.eqz
   i32.eqz
   if
@@ -14982,8 +14966,6 @@
   call $~lib/typedarray/Uint64Array#some
   local.set $3
   local.get $3
-  i32.const 0
-  i32.ne
   i32.eqz
   i32.eqz
   if
@@ -15132,8 +15114,6 @@
   call $~lib/typedarray/Float32Array#some
   local.set $3
   local.get $3
-  i32.const 0
-  i32.ne
   i32.eqz
   i32.eqz
   if
@@ -15282,8 +15262,6 @@
   call $~lib/typedarray/Float64Array#some
   local.set $3
   local.get $3
-  i32.const 0
-  i32.ne
   i32.eqz
   i32.eqz
   if
@@ -17112,8 +17090,6 @@
   call $~lib/typedarray/Int8Array#every
   local.set $3
   local.get $3
-  i32.const 0
-  i32.ne
   i32.eqz
   i32.eqz
   if
@@ -17271,8 +17247,6 @@
   call $~lib/typedarray/Uint8Array#every
   local.set $3
   local.get $3
-  i32.const 0
-  i32.ne
   i32.eqz
   i32.eqz
   if
@@ -17430,8 +17404,6 @@
   call $~lib/typedarray/Uint8ClampedArray#every
   local.set $3
   local.get $3
-  i32.const 0
-  i32.ne
   i32.eqz
   i32.eqz
   if
@@ -17593,8 +17565,6 @@
   call $~lib/typedarray/Int16Array#every
   local.set $3
   local.get $3
-  i32.const 0
-  i32.ne
   i32.eqz
   i32.eqz
   if
@@ -17752,8 +17722,6 @@
   call $~lib/typedarray/Uint16Array#every
   local.set $3
   local.get $3
-  i32.const 0
-  i32.ne
   i32.eqz
   i32.eqz
   if
@@ -17907,8 +17875,6 @@
   call $~lib/typedarray/Int32Array#every
   local.set $3
   local.get $3
-  i32.const 0
-  i32.ne
   i32.eqz
   i32.eqz
   if
@@ -18062,8 +18028,6 @@
   call $~lib/typedarray/Uint32Array#every
   local.set $3
   local.get $3
-  i32.const 0
-  i32.ne
   i32.eqz
   i32.eqz
   if
@@ -18217,8 +18181,6 @@
   call $~lib/typedarray/Int64Array#every
   local.set $3
   local.get $3
-  i32.const 0
-  i32.ne
   i32.eqz
   i32.eqz
   if
@@ -18372,8 +18334,6 @@
   call $~lib/typedarray/Uint64Array#every
   local.set $3
   local.get $3
-  i32.const 0
-  i32.ne
   i32.eqz
   i32.eqz
   if
@@ -18779,8 +18739,6 @@
   call $~lib/typedarray/Float32Array#every
   local.set $3
   local.get $3
-  i32.const 0
-  i32.ne
   i32.eqz
   i32.eqz
   if
@@ -18884,7 +18842,9 @@
    return
   end
   local.get $4
-  i64.eqz
+  i64.const 0
+  i64.ne
+  i32.eqz
   if
    local.get $4
    local.get $2
@@ -18916,7 +18876,9 @@
    local.set $2
   end
   local.get $5
-  i64.eqz
+  i64.const 0
+  i64.ne
+  i32.eqz
   if
    local.get $5
    local.get $3
@@ -19188,8 +19150,6 @@
   call $~lib/typedarray/Float64Array#every
   local.set $3
   local.get $3
-  i32.const 0
-  i32.ne
   i32.eqz
   i32.eqz
   if
@@ -34904,7 +34864,9 @@
   (local $7 i32)
   (local $8 i64)
   local.get $0
-  i64.eqz
+  i64.const 0
+  i64.ne
+  i32.eqz
   if
    i32.const 1720
    call $~lib/rt/pure/__retain
@@ -35001,7 +34963,9 @@
   i32.add
   local.set $0
   local.get $2
-  i64.eqz
+  i64.const 0
+  i64.ne
+  i32.eqz
   if
    local.get $0
    i32.const 48
@@ -35316,7 +35280,9 @@
   (local $6 i32)
   (local $7 i64)
   local.get $0
-  i64.eqz
+  i64.const 0
+  i64.ne
+  i32.eqz
   if
    i32.const 1720
    call $~lib/rt/pure/__retain
@@ -35391,7 +35357,9 @@
   i32.add
   local.set $0
   local.get $2
-  i64.eqz
+  i64.const 0
+  i64.ne
+  i32.eqz
   if
    local.get $0
    i32.const 48

--- a/tests/compiler/unary.optimized.wat
+++ b/tests/compiler/unary.optimized.wat
@@ -94,7 +94,8 @@
   i64.const 2
   global.set $unary/I
   global.get $unary/I
-  i64.eqz
+  i64.const 0
+  i64.eq
   i64.extend_i32_u
   global.set $unary/I
   global.get $unary/I
@@ -150,13 +151,12 @@
   global.get $unary/f
   local.tee $0
   f32.const 0
-  f32.eq
-  local.get $0
-  local.get $0
   f32.ne
-  i32.or
-  i32.const 0
-  i32.ne
+  local.get $0
+  local.get $0
+  f32.eq
+  i32.and
+  i32.eqz
   global.set $unary/i
   global.get $unary/f
   f32.const 1
@@ -207,13 +207,12 @@
   global.get $unary/F
   local.tee $1
   f64.const 0
-  f64.eq
-  local.get $1
-  local.get $1
   f64.ne
-  i32.or
-  i32.const 0
-  i32.ne
+  local.get $1
+  local.get $1
+  f64.eq
+  i32.and
+  i32.eqz
   i64.extend_i32_u
   global.set $unary/I
   global.get $unary/F

--- a/tests/compiler/unary.optimized.wat
+++ b/tests/compiler/unary.optimized.wat
@@ -8,10 +8,10 @@
  (export "memory" (memory $0))
  (start $start)
  (func $start:unary (; 0 ;) (type $FUNCSIG$v)
-  (local $0 i32)
-  (local $1 i64)
-  (local $2 f32)
-  (local $3 f64)
+  (local $0 f32)
+  (local $1 f64)
+  (local $2 i32)
+  (local $3 i64)
   global.get $unary/i
   i32.const 1
   i32.add
@@ -54,18 +54,18 @@
   i32.sub
   global.set $unary/i
   global.get $unary/i
-  local.tee $0
+  local.tee $2
   i32.const 1
   i32.add
   global.set $unary/i
-  local.get $0
+  local.get $2
   global.set $unary/i
   global.get $unary/i
-  local.tee $0
+  local.tee $2
   i32.const 1
   i32.sub
   global.set $unary/i
-  local.get $0
+  local.get $2
   global.set $unary/i
   global.get $unary/I
   i64.const 1
@@ -110,18 +110,18 @@
   i64.sub
   global.set $unary/I
   global.get $unary/I
-  local.tee $1
+  local.tee $3
   i64.const 1
   i64.add
   global.set $unary/I
-  local.get $1
+  local.get $3
   global.set $unary/I
   global.get $unary/I
-  local.tee $1
+  local.tee $3
   i64.const 1
   i64.sub
   global.set $unary/I
-  local.get $1
+  local.get $3
   global.set $unary/I
   global.get $unary/f
   f32.const 1
@@ -148,8 +148,15 @@
   f32.const 1.25
   global.set $unary/f
   global.get $unary/f
+  local.tee $0
   f32.const 0
   f32.eq
+  local.get $0
+  local.get $0
+  f32.ne
+  i32.or
+  i32.const 0
+  i32.ne
   global.set $unary/i
   global.get $unary/f
   f32.const 1
@@ -160,18 +167,18 @@
   f32.sub
   global.set $unary/f
   global.get $unary/f
-  local.tee $2
+  local.tee $0
   f32.const 1
   f32.add
   global.set $unary/f
-  local.get $2
+  local.get $0
   global.set $unary/f
   global.get $unary/f
-  local.tee $2
+  local.tee $0
   f32.const 1
   f32.sub
   global.set $unary/f
-  local.get $2
+  local.get $0
   global.set $unary/f
   global.get $unary/F
   f64.const 1
@@ -198,8 +205,15 @@
   f64.const 1.25
   global.set $unary/F
   global.get $unary/F
+  local.tee $1
   f64.const 0
   f64.eq
+  local.get $1
+  local.get $1
+  f64.ne
+  i32.or
+  i32.const 0
+  i32.ne
   i64.extend_i32_u
   global.set $unary/I
   global.get $unary/F
@@ -211,18 +225,18 @@
   f64.sub
   global.set $unary/F
   global.get $unary/F
-  local.tee $3
+  local.tee $1
   f64.const 1
   f64.add
   global.set $unary/F
-  local.get $3
+  local.get $1
   global.set $unary/F
   global.get $unary/F
-  local.tee $3
+  local.tee $1
   f64.const 1
   f64.sub
   global.set $unary/F
-  local.get $3
+  local.get $1
   global.set $unary/F
  )
  (func $start (; 1 ;) (type $FUNCSIG$v)

--- a/tests/compiler/unary.untouched.wat
+++ b/tests/compiler/unary.untouched.wat
@@ -10,10 +10,10 @@
  (export "memory" (memory $0))
  (start $start)
  (func $start:unary (; 0 ;) (type $FUNCSIG$v)
-  (local $0 i32)
-  (local $1 i64)
-  (local $2 f32)
-  (local $3 f64)
+  (local $0 f64)
+  (local $1 i32)
+  (local $2 i64)
+  (local $3 f32)
   i32.const 1
   drop
   i32.const -1
@@ -30,8 +30,13 @@
   f64.const -1.25
   drop
   f64.const 1.25
+  local.tee $0
   f64.const 0
   f64.eq
+  local.get $0
+  local.get $0
+  f64.ne
+  i32.or
   drop
   global.get $unary/i
   drop
@@ -99,18 +104,18 @@
   global.get $unary/i
   global.set $unary/i
   global.get $unary/i
-  local.tee $0
+  local.tee $1
   i32.const 1
   i32.add
   global.set $unary/i
-  local.get $0
+  local.get $1
   global.set $unary/i
   global.get $unary/i
-  local.tee $0
+  local.tee $1
   i32.const 1
   i32.sub
   global.set $unary/i
-  local.get $0
+  local.get $1
   global.set $unary/i
   global.get $unary/I
   drop
@@ -180,18 +185,18 @@
   global.get $unary/I
   global.set $unary/I
   global.get $unary/I
-  local.tee $1
+  local.tee $2
   i64.const 1
   i64.add
   global.set $unary/I
-  local.get $1
+  local.get $2
   global.set $unary/I
   global.get $unary/I
-  local.tee $1
+  local.tee $2
   i64.const 1
   i64.sub
   global.set $unary/I
-  local.get $1
+  local.get $2
   global.set $unary/I
   global.get $unary/f
   drop
@@ -199,8 +204,13 @@
   f32.neg
   drop
   global.get $unary/f
+  local.tee $3
   f32.const 0
   f32.eq
+  local.get $3
+  local.get $3
+  f32.ne
+  i32.or
   drop
   global.get $unary/f
   f32.const 1
@@ -223,8 +233,15 @@
   f32.const -1.25
   global.set $unary/f
   f64.const 1.25
+  local.tee $0
   f64.const 0
   f64.eq
+  local.get $0
+  local.get $0
+  f64.ne
+  i32.or
+  i32.const 0
+  i32.ne
   global.set $unary/i
   global.get $unary/f
   global.set $unary/f
@@ -232,8 +249,15 @@
   f32.neg
   global.set $unary/f
   global.get $unary/f
+  local.tee $3
   f32.const 0
   f32.eq
+  local.get $3
+  local.get $3
+  f32.ne
+  i32.or
+  i32.const 0
+  i32.ne
   global.set $unary/i
   global.get $unary/f
   f32.const 1
@@ -248,18 +272,18 @@
   global.get $unary/f
   global.set $unary/f
   global.get $unary/f
-  local.tee $2
+  local.tee $3
   f32.const 1
   f32.add
   global.set $unary/f
-  local.get $2
+  local.get $3
   global.set $unary/f
   global.get $unary/f
-  local.tee $2
+  local.tee $3
   f32.const 1
   f32.sub
   global.set $unary/f
-  local.get $2
+  local.get $3
   global.set $unary/f
   global.get $unary/F
   drop
@@ -267,8 +291,13 @@
   f64.neg
   drop
   global.get $unary/F
+  local.tee $0
   f64.const 0
   f64.eq
+  local.get $0
+  local.get $0
+  f64.ne
+  i32.or
   drop
   global.get $unary/F
   f64.const 1
@@ -291,8 +320,15 @@
   f64.const -1.25
   global.set $unary/F
   f64.const 1.25
+  local.tee $0
   f64.const 0
   f64.eq
+  local.get $0
+  local.get $0
+  f64.ne
+  i32.or
+  i32.const 0
+  i32.ne
   i64.extend_i32_u
   global.set $unary/I
   global.get $unary/F
@@ -301,8 +337,15 @@
   f64.neg
   global.set $unary/F
   global.get $unary/F
+  local.tee $0
   f64.const 0
   f64.eq
+  local.get $0
+  local.get $0
+  f64.ne
+  i32.or
+  i32.const 0
+  i32.ne
   i64.extend_i32_u
   global.set $unary/I
   global.get $unary/F
@@ -318,18 +361,18 @@
   global.get $unary/F
   global.set $unary/F
   global.get $unary/F
-  local.tee $3
+  local.tee $0
   f64.const 1
   f64.add
   global.set $unary/F
-  local.get $3
+  local.get $0
   global.set $unary/F
   global.get $unary/F
-  local.tee $3
+  local.tee $0
   f64.const 1
   f64.sub
   global.set $unary/F
-  local.get $3
+  local.get $0
   global.set $unary/F
  )
  (func $start (; 1 ;) (type $FUNCSIG$v)

--- a/tests/compiler/unary.untouched.wat
+++ b/tests/compiler/unary.untouched.wat
@@ -32,11 +32,12 @@
   f64.const 1.25
   local.tee $0
   f64.const 0
-  f64.eq
-  local.get $0
-  local.get $0
   f64.ne
-  i32.or
+  local.get $0
+  local.get $0
+  f64.eq
+  i32.and
+  i32.eqz
   drop
   global.get $unary/i
   drop
@@ -124,7 +125,9 @@
   i64.sub
   drop
   global.get $unary/I
-  i64.eqz
+  i64.const 0
+  i64.ne
+  i32.eqz
   drop
   global.get $unary/I
   i64.const -1
@@ -151,7 +154,9 @@
   i64.const -1
   global.set $unary/I
   i64.const 1
-  i64.eqz
+  i64.const 0
+  i64.ne
+  i32.eqz
   i64.extend_i32_u
   global.set $unary/I
   i64.const 1
@@ -165,7 +170,9 @@
   i64.sub
   global.set $unary/I
   global.get $unary/I
-  i64.eqz
+  i64.const 0
+  i64.ne
+  i32.eqz
   i64.extend_i32_u
   global.set $unary/I
   global.get $unary/I
@@ -206,11 +213,12 @@
   global.get $unary/f
   local.tee $3
   f32.const 0
-  f32.eq
-  local.get $3
-  local.get $3
   f32.ne
-  i32.or
+  local.get $3
+  local.get $3
+  f32.eq
+  i32.and
+  i32.eqz
   drop
   global.get $unary/f
   f32.const 1
@@ -235,13 +243,12 @@
   f64.const 1.25
   local.tee $0
   f64.const 0
-  f64.eq
-  local.get $0
-  local.get $0
   f64.ne
-  i32.or
-  i32.const 0
-  i32.ne
+  local.get $0
+  local.get $0
+  f64.eq
+  i32.and
+  i32.eqz
   global.set $unary/i
   global.get $unary/f
   global.set $unary/f
@@ -251,13 +258,12 @@
   global.get $unary/f
   local.tee $3
   f32.const 0
-  f32.eq
-  local.get $3
-  local.get $3
   f32.ne
-  i32.or
-  i32.const 0
-  i32.ne
+  local.get $3
+  local.get $3
+  f32.eq
+  i32.and
+  i32.eqz
   global.set $unary/i
   global.get $unary/f
   f32.const 1
@@ -293,11 +299,12 @@
   global.get $unary/F
   local.tee $0
   f64.const 0
-  f64.eq
-  local.get $0
-  local.get $0
   f64.ne
-  i32.or
+  local.get $0
+  local.get $0
+  f64.eq
+  i32.and
+  i32.eqz
   drop
   global.get $unary/F
   f64.const 1
@@ -322,13 +329,12 @@
   f64.const 1.25
   local.tee $0
   f64.const 0
-  f64.eq
-  local.get $0
-  local.get $0
   f64.ne
-  i32.or
-  i32.const 0
-  i32.ne
+  local.get $0
+  local.get $0
+  f64.eq
+  i32.and
+  i32.eqz
   i64.extend_i32_u
   global.set $unary/I
   global.get $unary/F
@@ -339,13 +345,12 @@
   global.get $unary/F
   local.tee $0
   f64.const 0
-  f64.eq
-  local.get $0
-  local.get $0
   f64.ne
-  i32.or
-  i32.const 0
-  i32.ne
+  local.get $0
+  local.get $0
+  f64.eq
+  i32.and
+  i32.eqz
   i64.extend_i32_u
   global.set $unary/I
   global.get $unary/F


### PR DESCRIPTION
fixes #770 
fixes #787

This is mostly identical to https://github.com/AssemblyScript/assemblyscript/pull/787 but also removes some internal patterns prone to errors when dealing with temporary locals as it was hard to grasp if code would "just work" otherwise.

In particular, flows had a `getAndFreeTempLocal` helper that immediately free'd a local intended for one-time use, which can lead to subtle errors where sub-expressions might reuse the same local. Hence I decided that even if code looks more cumbersome without it, that it's worth to require holding on to a temp as long as another `make*` function might reuse the same, so it's pretty much guaranteed that even if we update codegen in between a `getTempLocal` and a `freeTempLocal` in the future the resulting code will keep working.

I've also looked over all the occurrences of `makeIsFalseish` and `makeIsTrueish` which all *seem* to be fine, adding the local to the flow being responsible. The notable ones here are those of anything `if`-like where the condition temp locals go to the outer instead of one of the inner flows.

cc @MaxGraey 