### PR TITLE
Allow using a custom analyzer

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -16,6 +16,7 @@ under the licensing terms detailed in LICENSE:
 * Willem Wyndham <willem@cs.umd.edu>
 * Bowen Wang <bowen@nearprotocol.com>
 * Emil Laine <laine.emil@gmail.com>
+* Stephen Paul Weber <stephen.weber@shopify.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -41,7 +41,7 @@ import {
 } from "./util";
 
 /** Walker base class. */
-abstract class ExportsWalker {
+export abstract class ExportsWalker {
 
   /** Program reference. */
   program: Program;


### PR DESCRIPTION
Export ExportsWalker to allow building custom walkers for analysis tools.

Allow an option to asc.main to get called with the Program object to
facilitate building custom CLIs on top of asc that call their own analysis
logic.