### PR TITLE
[math] sync with latest musl updates

### DIFF
--- a/std/assembly/math.ts
+++ b/std/assembly/math.ts
@@ -1210,7 +1210,7 @@ export namespace NativeMath {
         let kcond = k > 20;
         let offset = select<i32>(52, 20, kcond) - k;
         let Ly = select<i32>(ly, iy, kcond);
-        let jj = Ly >> offset;
+        let jj = Ly >>> offset;
         if ((jj << offset) == Ly) yisint = 2 - (jj & 1);
       }
     }
@@ -2206,6 +2206,7 @@ export namespace NativeMathf {
     var sign_ = <i32>(hx >> 31);
     hx &= 0x7FFFFFFF;
     if (hx >= 0x42AEAC50) {
+      if (hx > 0x7F800000) return x; // NaN
       if (hx >= 0x42B17218) {
         if (!sign_) return x * Ox1p127f;
         else if (hx >= 0x42CFF1B5) return 0;

--- a/std/assembly/math.ts
+++ b/std/assembly/math.ts
@@ -1207,10 +1207,9 @@ export namespace NativeMath {
       if (iy >= 0x43400000) yisint = 2;
       else if (iy >= 0x3FF00000) {
         k = (iy >> 20) - 0x3FF;
-        let kcond = k > 20;
-        let offset = select<i32>(52, 20, kcond) - k;
-        let Ly = select<i32>(ly, iy, kcond);
-        let jj = Ly >>> offset;
+        let offset = select<u32>(52, 20, k > 20) - k;
+        let Ly = select<u32>(ly, iy, k > 20);
+        let jj = Ly >> offset;
         if ((jj << offset) == Ly) yisint = 2 - (jj & 1);
       }
     }

--- a/tests/compiler/binary.untouched.wat
+++ b/tests/compiler/binary.untouched.wat
@@ -120,7 +120,7 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
-  (local $14 i32)
+  (local $14 f64)
   (local $15 f64)
   (local $16 f64)
   (local $17 f64)
@@ -133,9 +133,9 @@
   (local $24 f64)
   (local $25 f64)
   (local $26 f64)
-  (local $27 f64)
+  (local $27 i32)
   (local $28 i32)
-  (local $29 i32)
+  (local $29 f64)
   (local $30 f64)
   (local $31 f64)
   (local $32 f64)
@@ -146,8 +146,7 @@
   (local $37 f64)
   (local $38 f64)
   (local $39 f64)
-  (local $40 f64)
-  (local $41 i32)
+  (local $40 i32)
   local.get $0
   i64.reinterpret_f64
   local.set $2
@@ -254,34 +253,34 @@
      i32.const 1023
      i32.sub
      local.set $10
+     i32.const 52
+     i32.const 20
      local.get $10
      i32.const 20
      i32.gt_s
-     local.set $11
-     i32.const 52
-     i32.const 20
-     local.get $11
      select
      local.get $10
      i32.sub
-     local.set $12
+     local.set $11
      local.get $6
      local.get $8
-     local.get $11
+     local.get $10
+     i32.const 20
+     i32.gt_s
      select
+     local.set $12
+     local.get $12
+     local.get $11
+     i32.shr_u
      local.set $13
      local.get $13
-     local.get $12
-     i32.shr_u
-     local.set $14
-     local.get $14
-     local.get $12
+     local.get $11
      i32.shl
-     local.get $13
+     local.get $12
      i32.eq
      if
       i32.const 2
-      local.get $14
+      local.get $13
       i32.const 1
       i32.and
       i32.sub
@@ -379,7 +378,7 @@
   end
   local.get $0
   f64.abs
-  local.set $15
+  local.set $14
   local.get $4
   i32.const 0
   i32.eq
@@ -402,16 +401,16 @@
     i32.eq
    end
    if
-    local.get $15
-    local.set $16
+    local.get $14
+    local.set $15
     local.get $5
     i32.const 0
     i32.lt_s
     if
      f64.const 1
-     local.get $16
+     local.get $15
      f64.div
-     local.set $16
+     local.set $15
     end
     local.get $3
     i32.const 0
@@ -425,31 +424,31 @@
      i32.const 0
      i32.eq
      if
-      local.get $16
-      local.get $16
+      local.get $15
+      local.get $15
       f64.sub
-      local.set $17
-      local.get $17
-      local.get $17
-      f64.div
       local.set $16
+      local.get $16
+      local.get $16
+      f64.div
+      local.set $15
      else
       local.get $9
       i32.const 1
       i32.eq
       if
-       local.get $16
+       local.get $15
        f64.neg
-       local.set $16
+       local.set $15
       end
      end
     end
-    local.get $16
+    local.get $15
     return
    end
   end
   f64.const 1
-  local.set $18
+  local.set $17
   local.get $3
   i32.const 0
   i32.lt_s
@@ -461,9 +460,9 @@
     local.get $0
     local.get $0
     f64.sub
-    local.set $17
-    local.get $17
-    local.get $17
+    local.set $16
+    local.get $16
+    local.get $16
     f64.div
     return
    end
@@ -472,7 +471,7 @@
    i32.eq
    if
     f64.const -1
-    local.set $18
+    local.set $17
    end
   end
   local.get $8
@@ -528,13 +527,13 @@
     i32.const 0
     i32.lt_s
     if (result f64)
-     local.get $18
+     local.get $17
      f64.const 1.e+300
      f64.mul
      f64.const 1.e+300
      f64.mul
     else
-     local.get $18
+     local.get $17
      f64.const 1e-300
      f64.mul
      f64.const 1e-300
@@ -550,13 +549,13 @@
     i32.const 0
     i32.gt_s
     if (result f64)
-     local.get $18
+     local.get $17
      f64.const 1.e+300
      f64.mul
      f64.const 1.e+300
      f64.mul
     else
-     local.get $18
+     local.get $17
      f64.const 1e-300
      f64.mul
      f64.const 1e-300
@@ -564,98 +563,98 @@
     end
     return
    end
-   local.get $15
+   local.get $14
    f64.const 1
    f64.sub
-   local.set $24
-   local.get $24
-   local.get $24
+   local.set $23
+   local.get $23
+   local.get $23
    f64.mul
    f64.const 0.5
-   local.get $24
+   local.get $23
    f64.const 0.3333333333333333
-   local.get $24
+   local.get $23
    f64.const 0.25
    f64.mul
    f64.sub
    f64.mul
    f64.sub
    f64.mul
-   local.set $27
+   local.set $26
    f64.const 1.4426950216293335
-   local.get $24
+   local.get $23
    f64.mul
-   local.set $25
-   local.get $24
+   local.set $24
+   local.get $23
    f64.const 1.9259629911266175e-08
    f64.mul
-   local.get $27
+   local.get $26
    f64.const 1.4426950408889634
    f64.mul
    f64.sub
-   local.set $26
+   local.set $25
+   local.get $24
    local.get $25
-   local.get $26
    f64.add
-   local.set $19
-   local.get $19
+   local.set $18
+   local.get $18
    i64.reinterpret_f64
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $19
-   local.get $26
-   local.get $19
+   local.set $18
    local.get $25
+   local.get $18
+   local.get $24
    f64.sub
    f64.sub
-   local.set $20
+   local.set $19
   else
    i32.const 0
-   local.set $29
+   local.set $28
    local.get $7
    i32.const 1048576
    i32.lt_s
    if
-    local.get $15
+    local.get $14
     f64.const 9007199254740992
     f64.mul
-    local.set $15
-    local.get $29
+    local.set $14
+    local.get $28
     i32.const 53
     i32.sub
-    local.set $29
-    local.get $15
+    local.set $28
+    local.get $14
     i64.reinterpret_f64
     i64.const 32
     i64.shr_u
     i32.wrap_i64
     local.set $7
    end
-   local.get $29
+   local.get $28
    local.get $7
    i32.const 20
    i32.shr_s
    i32.const 1023
    i32.sub
    i32.add
-   local.set $29
+   local.set $28
    local.get $7
    i32.const 1048575
    i32.and
-   local.set $28
-   local.get $28
+   local.set $27
+   local.get $27
    i32.const 1072693248
    i32.or
    local.set $7
-   local.get $28
+   local.get $27
    i32.const 235662
    i32.le_s
    if
     i32.const 0
     local.set $10
    else
-    local.get $28
+    local.get $27
     i32.const 767610
     i32.lt_s
     if
@@ -664,17 +663,17 @@
     else
      i32.const 0
      local.set $10
-     local.get $29
+     local.get $28
      i32.const 1
      i32.add
-     local.set $29
+     local.set $28
      local.get $7
      i32.const 1048576
      i32.sub
      local.set $7
     end
    end
-   local.get $15
+   local.get $14
    i64.reinterpret_f64
    i64.const 4294967295
    i64.and
@@ -684,34 +683,34 @@
    i64.shl
    i64.or
    f64.reinterpret_i64
-   local.set $15
+   local.set $14
    f64.const 1.5
    f64.const 1
    local.get $10
    select
-   local.set $35
-   local.get $15
-   local.get $35
+   local.set $34
+   local.get $14
+   local.get $34
    f64.sub
-   local.set $25
+   local.set $24
    f64.const 1
-   local.get $15
-   local.get $35
+   local.get $14
+   local.get $34
    f64.add
    f64.div
-   local.set $26
+   local.set $25
+   local.get $24
    local.get $25
-   local.get $26
    f64.mul
-   local.set $17
-   local.get $17
-   local.set $31
-   local.get $31
+   local.set $16
+   local.get $16
+   local.set $30
+   local.get $30
    i64.reinterpret_f64
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $31
+   local.set $30
    local.get $7
    i32.const 1
    i32.shr_s
@@ -727,42 +726,42 @@
    i64.const 32
    i64.shl
    f64.reinterpret_i64
-   local.set $33
-   local.get $15
-   local.get $33
-   local.get $35
-   f64.sub
-   f64.sub
-   local.set $34
-   local.get $26
-   local.get $25
-   local.get $31
-   local.get $33
-   f64.mul
-   f64.sub
-   local.get $31
-   local.get $34
-   f64.mul
-   f64.sub
-   f64.mul
    local.set $32
-   local.get $17
-   local.get $17
+   local.get $14
+   local.get $32
+   local.get $34
+   f64.sub
+   f64.sub
+   local.set $33
+   local.get $25
+   local.get $24
+   local.get $30
+   local.get $32
    f64.mul
-   local.set $30
+   f64.sub
    local.get $30
-   local.get $30
+   local.get $33
+   f64.mul
+   f64.sub
+   f64.mul
+   local.set $31
+   local.get $16
+   local.get $16
+   f64.mul
+   local.set $29
+   local.get $29
+   local.get $29
    f64.mul
    f64.const 0.5999999999999946
-   local.get $30
+   local.get $29
    f64.const 0.4285714285785502
-   local.get $30
+   local.get $29
    f64.const 0.33333332981837743
-   local.get $30
+   local.get $29
    f64.const 0.272728123808534
-   local.get $30
+   local.get $29
    f64.const 0.23066074577556175
-   local.get $30
+   local.get $29
    f64.const 0.20697501780033842
    f64.mul
    f64.add
@@ -775,184 +774,184 @@
    f64.mul
    f64.add
    f64.mul
-   local.set $23
-   local.get $23
-   local.get $32
-   local.get $31
-   local.get $17
-   f64.add
-   f64.mul
-   f64.add
-   local.set $23
-   local.get $31
-   local.get $31
-   f64.mul
-   local.set $30
-   f64.const 3
-   local.get $30
-   f64.add
-   local.get $23
-   f64.add
-   local.set $33
-   local.get $33
-   i64.reinterpret_f64
-   i64.const -4294967296
-   i64.and
-   f64.reinterpret_i64
-   local.set $33
-   local.get $23
-   local.get $33
-   f64.const 3
-   f64.sub
-   local.get $30
-   f64.sub
-   f64.sub
-   local.set $34
-   local.get $31
-   local.get $33
-   f64.mul
-   local.set $25
-   local.get $32
-   local.get $33
-   f64.mul
-   local.get $34
-   local.get $17
-   f64.mul
-   f64.add
-   local.set $26
-   local.get $25
-   local.get $26
-   f64.add
-   local.set $21
-   local.get $21
-   i64.reinterpret_f64
-   i64.const -4294967296
-   i64.and
-   f64.reinterpret_i64
-   local.set $21
-   local.get $26
-   local.get $21
-   local.get $25
-   f64.sub
-   f64.sub
    local.set $22
-   f64.const 0.9617967009544373
-   local.get $21
+   local.get $22
+   local.get $31
+   local.get $30
+   local.get $16
+   f64.add
    f64.mul
-   local.set $36
+   f64.add
+   local.set $22
+   local.get $30
+   local.get $30
+   f64.mul
+   local.set $29
+   f64.const 3
+   local.get $29
+   f64.add
+   local.get $22
+   f64.add
+   local.set $32
+   local.get $32
+   i64.reinterpret_f64
+   i64.const -4294967296
+   i64.and
+   f64.reinterpret_i64
+   local.set $32
+   local.get $22
+   local.get $32
+   f64.const 3
+   f64.sub
+   local.get $29
+   f64.sub
+   f64.sub
+   local.set $33
+   local.get $30
+   local.get $32
+   f64.mul
+   local.set $24
+   local.get $31
+   local.get $32
+   f64.mul
+   local.get $33
+   local.get $16
+   f64.mul
+   f64.add
+   local.set $25
+   local.get $24
+   local.get $25
+   f64.add
+   local.set $20
+   local.get $20
+   i64.reinterpret_f64
+   i64.const -4294967296
+   i64.and
+   f64.reinterpret_i64
+   local.set $20
+   local.get $25
+   local.get $20
+   local.get $24
+   f64.sub
+   f64.sub
+   local.set $21
+   f64.const 0.9617967009544373
+   local.get $20
+   f64.mul
+   local.set $35
    f64.const 1.350039202129749e-08
    f64.const 0
    local.get $10
    select
-   local.set $37
+   local.set $36
    f64.const -7.028461650952758e-09
-   local.get $21
+   local.get $20
    f64.mul
-   local.get $22
+   local.get $21
    f64.const 0.9617966939259756
    f64.mul
    f64.add
-   local.get $37
+   local.get $36
    f64.add
-   local.set $38
-   local.get $29
+   local.set $37
+   local.get $28
    f64.convert_i32_s
-   local.set $24
+   local.set $23
    f64.const 0.5849624872207642
    f64.const 0
    local.get $10
    select
-   local.set $39
-   local.get $36
+   local.set $38
+   local.get $35
+   local.get $37
+   f64.add
    local.get $38
    f64.add
-   local.get $39
+   local.get $23
    f64.add
-   local.get $24
-   f64.add
-   local.set $19
-   local.get $19
+   local.set $18
+   local.get $18
    i64.reinterpret_f64
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $19
+   local.set $18
+   local.get $37
+   local.get $18
+   local.get $23
+   f64.sub
    local.get $38
-   local.get $19
-   local.get $24
    f64.sub
-   local.get $39
-   f64.sub
-   local.get $36
+   local.get $35
    f64.sub
    f64.sub
-   local.set $20
+   local.set $19
   end
   local.get $1
-  local.set $40
-  local.get $40
+  local.set $39
+  local.get $39
   i64.reinterpret_f64
   i64.const -4294967296
   i64.and
   f64.reinterpret_i64
-  local.set $40
+  local.set $39
   local.get $1
-  local.get $40
+  local.get $39
   f64.sub
-  local.get $19
+  local.get $18
   f64.mul
   local.get $1
-  local.get $20
-  f64.mul
-  f64.add
-  local.set $22
-  local.get $40
   local.get $19
   f64.mul
-  local.set $21
-  local.get $22
-  local.get $21
   f64.add
-  local.set $16
-  local.get $16
+  local.set $21
+  local.get $39
+  local.get $18
+  f64.mul
+  local.set $20
+  local.get $21
+  local.get $20
+  f64.add
+  local.set $15
+  local.get $15
   i64.reinterpret_f64
   local.set $2
   local.get $2
   i64.const 32
   i64.shr_u
   i32.wrap_i64
-  local.set $28
+  local.set $27
   local.get $2
   i32.wrap_i64
-  local.set $41
-  local.get $28
+  local.set $40
+  local.get $27
   i32.const 1083179008
   i32.ge_s
   if
-   local.get $28
+   local.get $27
    i32.const 1083179008
    i32.sub
-   local.get $41
+   local.get $40
    i32.or
    i32.const 0
    i32.ne
    if
-    local.get $18
+    local.get $17
     f64.const 1.e+300
     f64.mul
     f64.const 1.e+300
     f64.mul
     return
    end
-   local.get $22
+   local.get $21
    f64.const 8.008566259537294e-17
    f64.add
-   local.get $16
-   local.get $21
+   local.get $15
+   local.get $20
    f64.sub
    f64.gt
    if
-    local.get $18
+    local.get $17
     f64.const 1.e+300
     f64.mul
     f64.const 1.e+300
@@ -960,34 +959,34 @@
     return
    end
   else
-   local.get $28
+   local.get $27
    i32.const 2147483647
    i32.and
    i32.const 1083231232
    i32.ge_s
    if
-    local.get $28
+    local.get $27
     i32.const -1064252416
     i32.sub
-    local.get $41
+    local.get $40
     i32.or
     i32.const 0
     i32.ne
     if
-     local.get $18
+     local.get $17
      f64.const 1e-300
      f64.mul
      f64.const 1e-300
      f64.mul
      return
     end
-    local.get $22
-    local.get $16
     local.get $21
+    local.get $15
+    local.get $20
     f64.sub
     f64.le
     if
-     local.get $18
+     local.get $17
      f64.const 1e-300
      f64.mul
      f64.const 1e-300
@@ -996,31 +995,31 @@
     end
    end
   end
-  local.get $28
+  local.get $27
   i32.const 2147483647
   i32.and
-  local.set $41
-  local.get $41
+  local.set $40
+  local.get $40
   i32.const 20
   i32.shr_s
   i32.const 1023
   i32.sub
   local.set $10
   i32.const 0
-  local.set $29
-  local.get $41
+  local.set $28
+  local.get $40
   i32.const 1071644672
   i32.gt_s
   if
-   local.get $28
+   local.get $27
    i32.const 1048576
    local.get $10
    i32.const 1
    i32.add
    i32.shr_s
    i32.add
-   local.set $29
-   local.get $29
+   local.set $28
+   local.get $28
    i32.const 2147483647
    i32.and
    i32.const 20
@@ -1029,8 +1028,8 @@
    i32.sub
    local.set $10
    f64.const 0
-   local.set $24
-   local.get $29
+   local.set $23
+   local.get $28
    i32.const 1048575
    local.get $10
    i32.shr_s
@@ -1041,8 +1040,8 @@
    i64.const 32
    i64.shl
    f64.reinterpret_i64
-   local.set $24
-   local.get $29
+   local.set $23
+   local.get $28
    i32.const 1048575
    i32.and
    i32.const 1048576
@@ -1051,71 +1050,71 @@
    local.get $10
    i32.sub
    i32.shr_s
-   local.set $29
-   local.get $28
+   local.set $28
+   local.get $27
    i32.const 0
    i32.lt_s
    if
     i32.const 0
-    local.get $29
+    local.get $28
     i32.sub
-    local.set $29
+    local.set $28
    end
-   local.get $21
-   local.get $24
+   local.get $20
+   local.get $23
    f64.sub
-   local.set $21
+   local.set $20
   end
-  local.get $22
   local.get $21
+  local.get $20
   f64.add
-  local.set $24
-  local.get $24
+  local.set $23
+  local.get $23
   i64.reinterpret_f64
   i64.const -4294967296
   i64.and
   f64.reinterpret_i64
-  local.set $24
-  local.get $24
+  local.set $23
+  local.get $23
   f64.const 0.6931471824645996
   f64.mul
-  local.set $25
-  local.get $22
-  local.get $24
+  local.set $24
   local.get $21
+  local.get $23
+  local.get $20
   f64.sub
   f64.sub
   f64.const 0.6931471805599453
   f64.mul
-  local.get $24
+  local.get $23
   f64.const -1.904654299957768e-09
   f64.mul
   f64.add
-  local.set $26
+  local.set $25
+  local.get $24
   local.get $25
-  local.get $26
   f64.add
-  local.set $16
-  local.get $26
-  local.get $16
+  local.set $15
   local.get $25
+  local.get $15
+  local.get $24
   f64.sub
   f64.sub
-  local.set $27
-  local.get $16
-  local.get $16
+  local.set $26
+  local.get $15
+  local.get $15
   f64.mul
-  local.set $24
-  local.get $16
-  local.get $24
+  local.set $23
+  local.get $15
+  local.get $23
   f64.const 0.16666666666666602
-  local.get $24
+  local.get $23
   f64.const -2.7777777777015593e-03
-  local.get $24
+  local.get $23
   f64.const 6.613756321437934e-05
-  local.get $24
+  local.get $23
   f64.const -1.6533902205465252e-06
-  local.get $24
+  local.get $23
   f64.const 4.1381367970572385e-08
   f64.mul
   f64.add
@@ -1127,64 +1126,64 @@
   f64.add
   f64.mul
   f64.sub
-  local.set $19
-  local.get $16
-  local.get $19
+  local.set $18
+  local.get $15
+  local.get $18
   f64.mul
-  local.get $19
+  local.get $18
   f64.const 2
   f64.sub
   f64.div
-  local.get $27
-  local.get $16
-  local.get $27
+  local.get $26
+  local.get $15
+  local.get $26
   f64.mul
   f64.add
   f64.sub
-  local.set $23
+  local.set $22
   f64.const 1
-  local.get $23
-  local.get $16
+  local.get $22
+  local.get $15
   f64.sub
   f64.sub
-  local.set $16
-  local.get $16
+  local.set $15
+  local.get $15
   i64.reinterpret_f64
   i64.const 32
   i64.shr_u
   i32.wrap_i64
-  local.set $28
+  local.set $27
+  local.get $27
   local.get $28
-  local.get $29
   i32.const 20
   i32.shl
   i32.add
-  local.set $28
-  local.get $28
+  local.set $27
+  local.get $27
   i32.const 20
   i32.shr_s
   i32.const 0
   i32.le_s
   if
-   local.get $16
-   local.get $29
+   local.get $15
+   local.get $28
    call $~lib/math/NativeMath.scalbn
-   local.set $16
+   local.set $15
   else
-   local.get $16
+   local.get $15
    i64.reinterpret_f64
    i64.const 4294967295
    i64.and
-   local.get $28
+   local.get $27
    i64.extend_i32_s
    i64.const 32
    i64.shl
    i64.or
    f64.reinterpret_i64
-   local.set $16
+   local.set $15
   end
-  local.get $18
-  local.get $16
+  local.get $17
+  local.get $15
   f64.mul
  )
  (func $~lib/number/isNaN<f32> (; 2 ;) (type $FUNCSIG$if) (param $0 f32) (result i32)

--- a/tests/compiler/binary.untouched.wat
+++ b/tests/compiler/binary.untouched.wat
@@ -272,7 +272,7 @@
      local.set $13
      local.get $13
      local.get $12
-     i32.shr_s
+     i32.shr_u
      local.set $14
      local.get $14
      local.get $12

--- a/tests/compiler/resolve-binary.untouched.wat
+++ b/tests/compiler/resolve-binary.untouched.wat
@@ -929,7 +929,7 @@
      local.set $13
      local.get $13
      local.get $12
-     i32.shr_s
+     i32.shr_u
      local.set $14
      local.get $14
      local.get $12

--- a/tests/compiler/resolve-binary.untouched.wat
+++ b/tests/compiler/resolve-binary.untouched.wat
@@ -777,7 +777,7 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
-  (local $14 i32)
+  (local $14 f64)
   (local $15 f64)
   (local $16 f64)
   (local $17 f64)
@@ -790,9 +790,9 @@
   (local $24 f64)
   (local $25 f64)
   (local $26 f64)
-  (local $27 f64)
+  (local $27 i32)
   (local $28 i32)
-  (local $29 i32)
+  (local $29 f64)
   (local $30 f64)
   (local $31 f64)
   (local $32 f64)
@@ -803,8 +803,7 @@
   (local $37 f64)
   (local $38 f64)
   (local $39 f64)
-  (local $40 f64)
-  (local $41 i32)
+  (local $40 i32)
   local.get $0
   i64.reinterpret_f64
   local.set $2
@@ -911,34 +910,34 @@
      i32.const 1023
      i32.sub
      local.set $10
+     i32.const 52
+     i32.const 20
      local.get $10
      i32.const 20
      i32.gt_s
-     local.set $11
-     i32.const 52
-     i32.const 20
-     local.get $11
      select
      local.get $10
      i32.sub
-     local.set $12
+     local.set $11
      local.get $6
      local.get $8
-     local.get $11
+     local.get $10
+     i32.const 20
+     i32.gt_s
      select
+     local.set $12
+     local.get $12
+     local.get $11
+     i32.shr_u
      local.set $13
      local.get $13
-     local.get $12
-     i32.shr_u
-     local.set $14
-     local.get $14
-     local.get $12
+     local.get $11
      i32.shl
-     local.get $13
+     local.get $12
      i32.eq
      if
       i32.const 2
-      local.get $14
+      local.get $13
       i32.const 1
       i32.and
       i32.sub
@@ -1036,7 +1035,7 @@
   end
   local.get $0
   f64.abs
-  local.set $15
+  local.set $14
   local.get $4
   i32.const 0
   i32.eq
@@ -1059,16 +1058,16 @@
     i32.eq
    end
    if
-    local.get $15
-    local.set $16
+    local.get $14
+    local.set $15
     local.get $5
     i32.const 0
     i32.lt_s
     if
      f64.const 1
-     local.get $16
+     local.get $15
      f64.div
-     local.set $16
+     local.set $15
     end
     local.get $3
     i32.const 0
@@ -1082,31 +1081,31 @@
      i32.const 0
      i32.eq
      if
-      local.get $16
-      local.get $16
+      local.get $15
+      local.get $15
       f64.sub
-      local.set $17
-      local.get $17
-      local.get $17
-      f64.div
       local.set $16
+      local.get $16
+      local.get $16
+      f64.div
+      local.set $15
      else
       local.get $9
       i32.const 1
       i32.eq
       if
-       local.get $16
+       local.get $15
        f64.neg
-       local.set $16
+       local.set $15
       end
      end
     end
-    local.get $16
+    local.get $15
     return
    end
   end
   f64.const 1
-  local.set $18
+  local.set $17
   local.get $3
   i32.const 0
   i32.lt_s
@@ -1118,9 +1117,9 @@
     local.get $0
     local.get $0
     f64.sub
-    local.set $17
-    local.get $17
-    local.get $17
+    local.set $16
+    local.get $16
+    local.get $16
     f64.div
     return
    end
@@ -1129,7 +1128,7 @@
    i32.eq
    if
     f64.const -1
-    local.set $18
+    local.set $17
    end
   end
   local.get $8
@@ -1185,13 +1184,13 @@
     i32.const 0
     i32.lt_s
     if (result f64)
-     local.get $18
+     local.get $17
      f64.const 1.e+300
      f64.mul
      f64.const 1.e+300
      f64.mul
     else
-     local.get $18
+     local.get $17
      f64.const 1e-300
      f64.mul
      f64.const 1e-300
@@ -1207,13 +1206,13 @@
     i32.const 0
     i32.gt_s
     if (result f64)
-     local.get $18
+     local.get $17
      f64.const 1.e+300
      f64.mul
      f64.const 1.e+300
      f64.mul
     else
-     local.get $18
+     local.get $17
      f64.const 1e-300
      f64.mul
      f64.const 1e-300
@@ -1221,98 +1220,98 @@
     end
     return
    end
-   local.get $15
+   local.get $14
    f64.const 1
    f64.sub
-   local.set $24
-   local.get $24
-   local.get $24
+   local.set $23
+   local.get $23
+   local.get $23
    f64.mul
    f64.const 0.5
-   local.get $24
+   local.get $23
    f64.const 0.3333333333333333
-   local.get $24
+   local.get $23
    f64.const 0.25
    f64.mul
    f64.sub
    f64.mul
    f64.sub
    f64.mul
-   local.set $27
+   local.set $26
    f64.const 1.4426950216293335
-   local.get $24
+   local.get $23
    f64.mul
-   local.set $25
-   local.get $24
+   local.set $24
+   local.get $23
    f64.const 1.9259629911266175e-08
    f64.mul
-   local.get $27
+   local.get $26
    f64.const 1.4426950408889634
    f64.mul
    f64.sub
-   local.set $26
+   local.set $25
+   local.get $24
    local.get $25
-   local.get $26
    f64.add
-   local.set $19
-   local.get $19
+   local.set $18
+   local.get $18
    i64.reinterpret_f64
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $19
-   local.get $26
-   local.get $19
+   local.set $18
    local.get $25
+   local.get $18
+   local.get $24
    f64.sub
    f64.sub
-   local.set $20
+   local.set $19
   else
    i32.const 0
-   local.set $29
+   local.set $28
    local.get $7
    i32.const 1048576
    i32.lt_s
    if
-    local.get $15
+    local.get $14
     f64.const 9007199254740992
     f64.mul
-    local.set $15
-    local.get $29
+    local.set $14
+    local.get $28
     i32.const 53
     i32.sub
-    local.set $29
-    local.get $15
+    local.set $28
+    local.get $14
     i64.reinterpret_f64
     i64.const 32
     i64.shr_u
     i32.wrap_i64
     local.set $7
    end
-   local.get $29
+   local.get $28
    local.get $7
    i32.const 20
    i32.shr_s
    i32.const 1023
    i32.sub
    i32.add
-   local.set $29
+   local.set $28
    local.get $7
    i32.const 1048575
    i32.and
-   local.set $28
-   local.get $28
+   local.set $27
+   local.get $27
    i32.const 1072693248
    i32.or
    local.set $7
-   local.get $28
+   local.get $27
    i32.const 235662
    i32.le_s
    if
     i32.const 0
     local.set $10
    else
-    local.get $28
+    local.get $27
     i32.const 767610
     i32.lt_s
     if
@@ -1321,17 +1320,17 @@
     else
      i32.const 0
      local.set $10
-     local.get $29
+     local.get $28
      i32.const 1
      i32.add
-     local.set $29
+     local.set $28
      local.get $7
      i32.const 1048576
      i32.sub
      local.set $7
     end
    end
-   local.get $15
+   local.get $14
    i64.reinterpret_f64
    i64.const 4294967295
    i64.and
@@ -1341,34 +1340,34 @@
    i64.shl
    i64.or
    f64.reinterpret_i64
-   local.set $15
+   local.set $14
    f64.const 1.5
    f64.const 1
    local.get $10
    select
-   local.set $35
-   local.get $15
-   local.get $35
+   local.set $34
+   local.get $14
+   local.get $34
    f64.sub
-   local.set $25
+   local.set $24
    f64.const 1
-   local.get $15
-   local.get $35
+   local.get $14
+   local.get $34
    f64.add
    f64.div
-   local.set $26
+   local.set $25
+   local.get $24
    local.get $25
-   local.get $26
    f64.mul
-   local.set $17
-   local.get $17
-   local.set $31
-   local.get $31
+   local.set $16
+   local.get $16
+   local.set $30
+   local.get $30
    i64.reinterpret_f64
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $31
+   local.set $30
    local.get $7
    i32.const 1
    i32.shr_s
@@ -1384,42 +1383,42 @@
    i64.const 32
    i64.shl
    f64.reinterpret_i64
-   local.set $33
-   local.get $15
-   local.get $33
-   local.get $35
-   f64.sub
-   f64.sub
-   local.set $34
-   local.get $26
-   local.get $25
-   local.get $31
-   local.get $33
-   f64.mul
-   f64.sub
-   local.get $31
-   local.get $34
-   f64.mul
-   f64.sub
-   f64.mul
    local.set $32
-   local.get $17
-   local.get $17
+   local.get $14
+   local.get $32
+   local.get $34
+   f64.sub
+   f64.sub
+   local.set $33
+   local.get $25
+   local.get $24
+   local.get $30
+   local.get $32
    f64.mul
-   local.set $30
+   f64.sub
    local.get $30
-   local.get $30
+   local.get $33
+   f64.mul
+   f64.sub
+   f64.mul
+   local.set $31
+   local.get $16
+   local.get $16
+   f64.mul
+   local.set $29
+   local.get $29
+   local.get $29
    f64.mul
    f64.const 0.5999999999999946
-   local.get $30
+   local.get $29
    f64.const 0.4285714285785502
-   local.get $30
+   local.get $29
    f64.const 0.33333332981837743
-   local.get $30
+   local.get $29
    f64.const 0.272728123808534
-   local.get $30
+   local.get $29
    f64.const 0.23066074577556175
-   local.get $30
+   local.get $29
    f64.const 0.20697501780033842
    f64.mul
    f64.add
@@ -1432,184 +1431,184 @@
    f64.mul
    f64.add
    f64.mul
-   local.set $23
-   local.get $23
-   local.get $32
-   local.get $31
-   local.get $17
-   f64.add
-   f64.mul
-   f64.add
-   local.set $23
-   local.get $31
-   local.get $31
-   f64.mul
-   local.set $30
-   f64.const 3
-   local.get $30
-   f64.add
-   local.get $23
-   f64.add
-   local.set $33
-   local.get $33
-   i64.reinterpret_f64
-   i64.const -4294967296
-   i64.and
-   f64.reinterpret_i64
-   local.set $33
-   local.get $23
-   local.get $33
-   f64.const 3
-   f64.sub
-   local.get $30
-   f64.sub
-   f64.sub
-   local.set $34
-   local.get $31
-   local.get $33
-   f64.mul
-   local.set $25
-   local.get $32
-   local.get $33
-   f64.mul
-   local.get $34
-   local.get $17
-   f64.mul
-   f64.add
-   local.set $26
-   local.get $25
-   local.get $26
-   f64.add
-   local.set $21
-   local.get $21
-   i64.reinterpret_f64
-   i64.const -4294967296
-   i64.and
-   f64.reinterpret_i64
-   local.set $21
-   local.get $26
-   local.get $21
-   local.get $25
-   f64.sub
-   f64.sub
    local.set $22
-   f64.const 0.9617967009544373
-   local.get $21
+   local.get $22
+   local.get $31
+   local.get $30
+   local.get $16
+   f64.add
    f64.mul
-   local.set $36
+   f64.add
+   local.set $22
+   local.get $30
+   local.get $30
+   f64.mul
+   local.set $29
+   f64.const 3
+   local.get $29
+   f64.add
+   local.get $22
+   f64.add
+   local.set $32
+   local.get $32
+   i64.reinterpret_f64
+   i64.const -4294967296
+   i64.and
+   f64.reinterpret_i64
+   local.set $32
+   local.get $22
+   local.get $32
+   f64.const 3
+   f64.sub
+   local.get $29
+   f64.sub
+   f64.sub
+   local.set $33
+   local.get $30
+   local.get $32
+   f64.mul
+   local.set $24
+   local.get $31
+   local.get $32
+   f64.mul
+   local.get $33
+   local.get $16
+   f64.mul
+   f64.add
+   local.set $25
+   local.get $24
+   local.get $25
+   f64.add
+   local.set $20
+   local.get $20
+   i64.reinterpret_f64
+   i64.const -4294967296
+   i64.and
+   f64.reinterpret_i64
+   local.set $20
+   local.get $25
+   local.get $20
+   local.get $24
+   f64.sub
+   f64.sub
+   local.set $21
+   f64.const 0.9617967009544373
+   local.get $20
+   f64.mul
+   local.set $35
    f64.const 1.350039202129749e-08
    f64.const 0
    local.get $10
    select
-   local.set $37
+   local.set $36
    f64.const -7.028461650952758e-09
-   local.get $21
+   local.get $20
    f64.mul
-   local.get $22
+   local.get $21
    f64.const 0.9617966939259756
    f64.mul
    f64.add
-   local.get $37
+   local.get $36
    f64.add
-   local.set $38
-   local.get $29
+   local.set $37
+   local.get $28
    f64.convert_i32_s
-   local.set $24
+   local.set $23
    f64.const 0.5849624872207642
    f64.const 0
    local.get $10
    select
-   local.set $39
-   local.get $36
+   local.set $38
+   local.get $35
+   local.get $37
+   f64.add
    local.get $38
    f64.add
-   local.get $39
+   local.get $23
    f64.add
-   local.get $24
-   f64.add
-   local.set $19
-   local.get $19
+   local.set $18
+   local.get $18
    i64.reinterpret_f64
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $19
+   local.set $18
+   local.get $37
+   local.get $18
+   local.get $23
+   f64.sub
    local.get $38
-   local.get $19
-   local.get $24
    f64.sub
-   local.get $39
-   f64.sub
-   local.get $36
+   local.get $35
    f64.sub
    f64.sub
-   local.set $20
+   local.set $19
   end
   local.get $1
-  local.set $40
-  local.get $40
+  local.set $39
+  local.get $39
   i64.reinterpret_f64
   i64.const -4294967296
   i64.and
   f64.reinterpret_i64
-  local.set $40
+  local.set $39
   local.get $1
-  local.get $40
+  local.get $39
   f64.sub
-  local.get $19
+  local.get $18
   f64.mul
   local.get $1
-  local.get $20
-  f64.mul
-  f64.add
-  local.set $22
-  local.get $40
   local.get $19
   f64.mul
-  local.set $21
-  local.get $22
-  local.get $21
   f64.add
-  local.set $16
-  local.get $16
+  local.set $21
+  local.get $39
+  local.get $18
+  f64.mul
+  local.set $20
+  local.get $21
+  local.get $20
+  f64.add
+  local.set $15
+  local.get $15
   i64.reinterpret_f64
   local.set $2
   local.get $2
   i64.const 32
   i64.shr_u
   i32.wrap_i64
-  local.set $28
+  local.set $27
   local.get $2
   i32.wrap_i64
-  local.set $41
-  local.get $28
+  local.set $40
+  local.get $27
   i32.const 1083179008
   i32.ge_s
   if
-   local.get $28
+   local.get $27
    i32.const 1083179008
    i32.sub
-   local.get $41
+   local.get $40
    i32.or
    i32.const 0
    i32.ne
    if
-    local.get $18
+    local.get $17
     f64.const 1.e+300
     f64.mul
     f64.const 1.e+300
     f64.mul
     return
    end
-   local.get $22
+   local.get $21
    f64.const 8.008566259537294e-17
    f64.add
-   local.get $16
-   local.get $21
+   local.get $15
+   local.get $20
    f64.sub
    f64.gt
    if
-    local.get $18
+    local.get $17
     f64.const 1.e+300
     f64.mul
     f64.const 1.e+300
@@ -1617,34 +1616,34 @@
     return
    end
   else
-   local.get $28
+   local.get $27
    i32.const 2147483647
    i32.and
    i32.const 1083231232
    i32.ge_s
    if
-    local.get $28
+    local.get $27
     i32.const -1064252416
     i32.sub
-    local.get $41
+    local.get $40
     i32.or
     i32.const 0
     i32.ne
     if
-     local.get $18
+     local.get $17
      f64.const 1e-300
      f64.mul
      f64.const 1e-300
      f64.mul
      return
     end
-    local.get $22
-    local.get $16
     local.get $21
+    local.get $15
+    local.get $20
     f64.sub
     f64.le
     if
-     local.get $18
+     local.get $17
      f64.const 1e-300
      f64.mul
      f64.const 1e-300
@@ -1653,31 +1652,31 @@
     end
    end
   end
-  local.get $28
+  local.get $27
   i32.const 2147483647
   i32.and
-  local.set $41
-  local.get $41
+  local.set $40
+  local.get $40
   i32.const 20
   i32.shr_s
   i32.const 1023
   i32.sub
   local.set $10
   i32.const 0
-  local.set $29
-  local.get $41
+  local.set $28
+  local.get $40
   i32.const 1071644672
   i32.gt_s
   if
-   local.get $28
+   local.get $27
    i32.const 1048576
    local.get $10
    i32.const 1
    i32.add
    i32.shr_s
    i32.add
-   local.set $29
-   local.get $29
+   local.set $28
+   local.get $28
    i32.const 2147483647
    i32.and
    i32.const 20
@@ -1686,8 +1685,8 @@
    i32.sub
    local.set $10
    f64.const 0
-   local.set $24
-   local.get $29
+   local.set $23
+   local.get $28
    i32.const 1048575
    local.get $10
    i32.shr_s
@@ -1698,8 +1697,8 @@
    i64.const 32
    i64.shl
    f64.reinterpret_i64
-   local.set $24
-   local.get $29
+   local.set $23
+   local.get $28
    i32.const 1048575
    i32.and
    i32.const 1048576
@@ -1708,71 +1707,71 @@
    local.get $10
    i32.sub
    i32.shr_s
-   local.set $29
-   local.get $28
+   local.set $28
+   local.get $27
    i32.const 0
    i32.lt_s
    if
     i32.const 0
-    local.get $29
+    local.get $28
     i32.sub
-    local.set $29
+    local.set $28
    end
-   local.get $21
-   local.get $24
+   local.get $20
+   local.get $23
    f64.sub
-   local.set $21
+   local.set $20
   end
-  local.get $22
   local.get $21
+  local.get $20
   f64.add
-  local.set $24
-  local.get $24
+  local.set $23
+  local.get $23
   i64.reinterpret_f64
   i64.const -4294967296
   i64.and
   f64.reinterpret_i64
-  local.set $24
-  local.get $24
+  local.set $23
+  local.get $23
   f64.const 0.6931471824645996
   f64.mul
-  local.set $25
-  local.get $22
-  local.get $24
+  local.set $24
   local.get $21
+  local.get $23
+  local.get $20
   f64.sub
   f64.sub
   f64.const 0.6931471805599453
   f64.mul
-  local.get $24
+  local.get $23
   f64.const -1.904654299957768e-09
   f64.mul
   f64.add
-  local.set $26
+  local.set $25
+  local.get $24
   local.get $25
-  local.get $26
   f64.add
-  local.set $16
-  local.get $26
-  local.get $16
+  local.set $15
   local.get $25
+  local.get $15
+  local.get $24
   f64.sub
   f64.sub
-  local.set $27
-  local.get $16
-  local.get $16
+  local.set $26
+  local.get $15
+  local.get $15
   f64.mul
-  local.set $24
-  local.get $16
-  local.get $24
+  local.set $23
+  local.get $15
+  local.get $23
   f64.const 0.16666666666666602
-  local.get $24
+  local.get $23
   f64.const -2.7777777777015593e-03
-  local.get $24
+  local.get $23
   f64.const 6.613756321437934e-05
-  local.get $24
+  local.get $23
   f64.const -1.6533902205465252e-06
-  local.get $24
+  local.get $23
   f64.const 4.1381367970572385e-08
   f64.mul
   f64.add
@@ -1784,64 +1783,64 @@
   f64.add
   f64.mul
   f64.sub
-  local.set $19
-  local.get $16
-  local.get $19
+  local.set $18
+  local.get $15
+  local.get $18
   f64.mul
-  local.get $19
+  local.get $18
   f64.const 2
   f64.sub
   f64.div
-  local.get $27
-  local.get $16
-  local.get $27
+  local.get $26
+  local.get $15
+  local.get $26
   f64.mul
   f64.add
   f64.sub
-  local.set $23
+  local.set $22
   f64.const 1
-  local.get $23
-  local.get $16
+  local.get $22
+  local.get $15
   f64.sub
   f64.sub
-  local.set $16
-  local.get $16
+  local.set $15
+  local.get $15
   i64.reinterpret_f64
   i64.const 32
   i64.shr_u
   i32.wrap_i64
-  local.set $28
+  local.set $27
+  local.get $27
   local.get $28
-  local.get $29
   i32.const 20
   i32.shl
   i32.add
-  local.set $28
-  local.get $28
+  local.set $27
+  local.get $27
   i32.const 20
   i32.shr_s
   i32.const 0
   i32.le_s
   if
-   local.get $16
-   local.get $29
+   local.get $15
+   local.get $28
    call $~lib/math/NativeMath.scalbn
-   local.set $16
+   local.set $15
   else
-   local.get $16
+   local.get $15
    i64.reinterpret_f64
    i64.const 4294967295
    i64.and
-   local.get $28
+   local.get $27
    i64.extend_i32_s
    i64.const 32
    i64.shl
    i64.or
    f64.reinterpret_i64
-   local.set $16
+   local.set $15
   end
-  local.get $18
-  local.get $16
+  local.get $17
+  local.get $15
   f64.mul
  )
  (func $~lib/number/isFinite<f64> (; 16 ;) (type $FUNCSIG$id) (param $0 f64) (result i32)

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -4941,7 +4941,7 @@
   if
    i32.const 0
    i32.const 3480
-   i32.const 1369
+   i32.const 1368
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -6444,7 +6444,7 @@
   if
    i32.const 4256
    i32.const 3480
-   i32.const 1376
+   i32.const 1375
    i32.const 24
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -7558,7 +7558,7 @@
   if
    i32.const 0
    i32.const 3480
-   i32.const 1369
+   i32.const 1368
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -9816,7 +9816,7 @@
   if
    i32.const 4256
    i32.const 3480
-   i32.const 1376
+   i32.const 1375
    i32.const 24
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/libm.optimized.wat
+++ b/tests/compiler/std/libm.optimized.wat
@@ -3558,46 +3558,46 @@
     i32.const 1072693248
     i32.ge_s
     if (result i32)
-     local.get $6
-     local.get $8
+     i32.const 52
+     i32.const 20
      local.get $8
      i32.const 20
      i32.shr_s
      i32.const 1023
      i32.sub
-     local.tee $12
+     local.tee $11
      i32.const 20
      i32.gt_s
-     local.tee $13
-     select
      local.tee $5
-     local.get $5
-     i32.const 52
-     i32.const 20
-     local.get $13
      select
-     local.get $12
+     local.get $11
      i32.sub
-     local.tee $13
-     i32.shr_u
+     local.set $12
+     local.get $6
+     local.get $8
+     local.get $5
+     select
      local.tee $5
-     local.get $13
+     local.get $12
+     i32.shr_u
+     local.set $11
+     i32.const 2
+     local.get $11
+     i32.const 1
+     i32.and
+     i32.sub
+     i32.const 0
+     local.get $11
+     local.get $12
      i32.shl
+     local.get $5
      i32.eq
-     if (result i32)
-      i32.const 2
-      local.get $5
-      i32.const 1
-      i32.and
-      i32.sub
-     else
-      i32.const 0
-     end
+     select
     else
      i32.const 0
     end
    end
-   local.set $11
+   local.set $13
   end
   local.get $6
   i32.eqz
@@ -3715,13 +3715,13 @@
      local.get $4
      i32.const 1072693248
      i32.sub
-     local.get $11
+     local.get $13
      i32.or
      if (result f64)
       local.get $3
       f64.neg
       local.get $3
-      local.get $11
+      local.get $13
       i32.const 1
       i32.eq
       select
@@ -3745,7 +3745,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $11
+   local.get $13
    i32.eqz
    if
     local.get $0
@@ -3758,7 +3758,7 @@
    end
    f64.const -1
    f64.const 1
-   local.get $11
+   local.get $13
    i32.const 1
    i32.eq
    select
@@ -4188,7 +4188,7 @@
     local.get $12
     i32.const 2147483647
     i32.and
-    local.tee $13
+    local.tee $11
     i32.const 20
     i32.shr_s
     i32.const 1023
@@ -4196,7 +4196,7 @@
     local.set $5
     i32.const 0
     local.set $6
-    local.get $13
+    local.get $11
     i32.const 1071644672
     i32.gt_s
     if
@@ -4207,7 +4207,7 @@
      i32.shr_s
      local.get $12
      i32.add
-     local.tee $13
+     local.tee $11
      i32.const 2147483647
      i32.and
      i32.const 20
@@ -4220,14 +4220,14 @@
      i32.shr_s
      i32.const -1
      i32.xor
-     local.get $13
+     local.get $11
      i32.and
      i64.extend_i32_s
      i64.const 32
      i64.shl
      f64.reinterpret_i64
      local.set $0
-     local.get $13
+     local.get $11
      i32.const 1048575
      i32.and
      i32.const 1048576

--- a/tests/compiler/std/libm.optimized.wat
+++ b/tests/compiler/std/libm.optimized.wat
@@ -3579,7 +3579,7 @@
      local.get $12
      i32.sub
      local.tee $13
-     i32.shr_s
+     i32.shr_u
      local.tee $5
      local.get $13
      i32.shl
@@ -7121,6 +7121,13 @@
   i32.const 1118743632
   i32.ge_u
   if
+   local.get $1
+   i32.const 2139095040
+   i32.gt_u
+   if
+    local.get $0
+    return
+   end
    local.get $1
    i32.const 1118925336
    i32.ge_u

--- a/tests/compiler/std/libm.untouched.wat
+++ b/tests/compiler/std/libm.untouched.wat
@@ -4540,7 +4540,7 @@
      local.set $13
      local.get $13
      local.get $12
-     i32.shr_s
+     i32.shr_u
      local.set $14
      local.get $14
      local.get $12
@@ -9298,6 +9298,13 @@
   i32.const 1118743632
   i32.ge_u
   if
+   local.get $1
+   i32.const 2139095040
+   i32.gt_u
+   if
+    local.get $0
+    return
+   end
    local.get $1
    i32.const 1118925336
    i32.ge_u

--- a/tests/compiler/std/libm.untouched.wat
+++ b/tests/compiler/std/libm.untouched.wat
@@ -4388,7 +4388,7 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
-  (local $14 i32)
+  (local $14 f64)
   (local $15 f64)
   (local $16 f64)
   (local $17 f64)
@@ -4401,9 +4401,9 @@
   (local $24 f64)
   (local $25 f64)
   (local $26 f64)
-  (local $27 f64)
+  (local $27 i32)
   (local $28 i32)
-  (local $29 i32)
+  (local $29 f64)
   (local $30 f64)
   (local $31 f64)
   (local $32 f64)
@@ -4414,8 +4414,7 @@
   (local $37 f64)
   (local $38 f64)
   (local $39 f64)
-  (local $40 f64)
-  (local $41 i32)
+  (local $40 i32)
   local.get $0
   i64.reinterpret_f64
   local.set $2
@@ -4522,34 +4521,34 @@
      i32.const 1023
      i32.sub
      local.set $10
+     i32.const 52
+     i32.const 20
      local.get $10
      i32.const 20
      i32.gt_s
-     local.set $11
-     i32.const 52
-     i32.const 20
-     local.get $11
      select
      local.get $10
      i32.sub
-     local.set $12
+     local.set $11
      local.get $6
      local.get $8
-     local.get $11
+     local.get $10
+     i32.const 20
+     i32.gt_s
      select
+     local.set $12
+     local.get $12
+     local.get $11
+     i32.shr_u
      local.set $13
      local.get $13
-     local.get $12
-     i32.shr_u
-     local.set $14
-     local.get $14
-     local.get $12
+     local.get $11
      i32.shl
-     local.get $13
+     local.get $12
      i32.eq
      if
       i32.const 2
-      local.get $14
+      local.get $13
       i32.const 1
       i32.and
       i32.sub
@@ -4647,7 +4646,7 @@
   end
   local.get $0
   f64.abs
-  local.set $15
+  local.set $14
   local.get $4
   i32.const 0
   i32.eq
@@ -4670,16 +4669,16 @@
     i32.eq
    end
    if
-    local.get $15
-    local.set $16
+    local.get $14
+    local.set $15
     local.get $5
     i32.const 0
     i32.lt_s
     if
      f64.const 1
-     local.get $16
+     local.get $15
      f64.div
-     local.set $16
+     local.set $15
     end
     local.get $3
     i32.const 0
@@ -4693,31 +4692,31 @@
      i32.const 0
      i32.eq
      if
-      local.get $16
-      local.get $16
+      local.get $15
+      local.get $15
       f64.sub
-      local.set $17
-      local.get $17
-      local.get $17
-      f64.div
       local.set $16
+      local.get $16
+      local.get $16
+      f64.div
+      local.set $15
      else
       local.get $9
       i32.const 1
       i32.eq
       if
-       local.get $16
+       local.get $15
        f64.neg
-       local.set $16
+       local.set $15
       end
      end
     end
-    local.get $16
+    local.get $15
     return
    end
   end
   f64.const 1
-  local.set $18
+  local.set $17
   local.get $3
   i32.const 0
   i32.lt_s
@@ -4729,9 +4728,9 @@
     local.get $0
     local.get $0
     f64.sub
-    local.set $17
-    local.get $17
-    local.get $17
+    local.set $16
+    local.get $16
+    local.get $16
     f64.div
     return
    end
@@ -4740,7 +4739,7 @@
    i32.eq
    if
     f64.const -1
-    local.set $18
+    local.set $17
    end
   end
   local.get $8
@@ -4796,13 +4795,13 @@
     i32.const 0
     i32.lt_s
     if (result f64)
-     local.get $18
+     local.get $17
      f64.const 1.e+300
      f64.mul
      f64.const 1.e+300
      f64.mul
     else
-     local.get $18
+     local.get $17
      f64.const 1e-300
      f64.mul
      f64.const 1e-300
@@ -4818,13 +4817,13 @@
     i32.const 0
     i32.gt_s
     if (result f64)
-     local.get $18
+     local.get $17
      f64.const 1.e+300
      f64.mul
      f64.const 1.e+300
      f64.mul
     else
-     local.get $18
+     local.get $17
      f64.const 1e-300
      f64.mul
      f64.const 1e-300
@@ -4832,98 +4831,98 @@
     end
     return
    end
-   local.get $15
+   local.get $14
    f64.const 1
    f64.sub
-   local.set $24
-   local.get $24
-   local.get $24
+   local.set $23
+   local.get $23
+   local.get $23
    f64.mul
    f64.const 0.5
-   local.get $24
+   local.get $23
    f64.const 0.3333333333333333
-   local.get $24
+   local.get $23
    f64.const 0.25
    f64.mul
    f64.sub
    f64.mul
    f64.sub
    f64.mul
-   local.set $27
+   local.set $26
    f64.const 1.4426950216293335
-   local.get $24
+   local.get $23
    f64.mul
-   local.set $25
-   local.get $24
+   local.set $24
+   local.get $23
    f64.const 1.9259629911266175e-08
    f64.mul
-   local.get $27
+   local.get $26
    f64.const 1.4426950408889634
    f64.mul
    f64.sub
-   local.set $26
+   local.set $25
+   local.get $24
    local.get $25
-   local.get $26
    f64.add
-   local.set $19
-   local.get $19
+   local.set $18
+   local.get $18
    i64.reinterpret_f64
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $19
-   local.get $26
-   local.get $19
+   local.set $18
    local.get $25
+   local.get $18
+   local.get $24
    f64.sub
    f64.sub
-   local.set $20
+   local.set $19
   else
    i32.const 0
-   local.set $29
+   local.set $28
    local.get $7
    i32.const 1048576
    i32.lt_s
    if
-    local.get $15
+    local.get $14
     f64.const 9007199254740992
     f64.mul
-    local.set $15
-    local.get $29
+    local.set $14
+    local.get $28
     i32.const 53
     i32.sub
-    local.set $29
-    local.get $15
+    local.set $28
+    local.get $14
     i64.reinterpret_f64
     i64.const 32
     i64.shr_u
     i32.wrap_i64
     local.set $7
    end
-   local.get $29
+   local.get $28
    local.get $7
    i32.const 20
    i32.shr_s
    i32.const 1023
    i32.sub
    i32.add
-   local.set $29
+   local.set $28
    local.get $7
    i32.const 1048575
    i32.and
-   local.set $28
-   local.get $28
+   local.set $27
+   local.get $27
    i32.const 1072693248
    i32.or
    local.set $7
-   local.get $28
+   local.get $27
    i32.const 235662
    i32.le_s
    if
     i32.const 0
     local.set $10
    else
-    local.get $28
+    local.get $27
     i32.const 767610
     i32.lt_s
     if
@@ -4932,17 +4931,17 @@
     else
      i32.const 0
      local.set $10
-     local.get $29
+     local.get $28
      i32.const 1
      i32.add
-     local.set $29
+     local.set $28
      local.get $7
      i32.const 1048576
      i32.sub
      local.set $7
     end
    end
-   local.get $15
+   local.get $14
    i64.reinterpret_f64
    i64.const 4294967295
    i64.and
@@ -4952,34 +4951,34 @@
    i64.shl
    i64.or
    f64.reinterpret_i64
-   local.set $15
+   local.set $14
    f64.const 1.5
    f64.const 1
    local.get $10
    select
-   local.set $35
-   local.get $15
-   local.get $35
+   local.set $34
+   local.get $14
+   local.get $34
    f64.sub
-   local.set $25
+   local.set $24
    f64.const 1
-   local.get $15
-   local.get $35
+   local.get $14
+   local.get $34
    f64.add
    f64.div
-   local.set $26
+   local.set $25
+   local.get $24
    local.get $25
-   local.get $26
    f64.mul
-   local.set $17
-   local.get $17
-   local.set $31
-   local.get $31
+   local.set $16
+   local.get $16
+   local.set $30
+   local.get $30
    i64.reinterpret_f64
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $31
+   local.set $30
    local.get $7
    i32.const 1
    i32.shr_s
@@ -4995,42 +4994,42 @@
    i64.const 32
    i64.shl
    f64.reinterpret_i64
-   local.set $33
-   local.get $15
-   local.get $33
-   local.get $35
-   f64.sub
-   f64.sub
-   local.set $34
-   local.get $26
-   local.get $25
-   local.get $31
-   local.get $33
-   f64.mul
-   f64.sub
-   local.get $31
-   local.get $34
-   f64.mul
-   f64.sub
-   f64.mul
    local.set $32
-   local.get $17
-   local.get $17
+   local.get $14
+   local.get $32
+   local.get $34
+   f64.sub
+   f64.sub
+   local.set $33
+   local.get $25
+   local.get $24
+   local.get $30
+   local.get $32
    f64.mul
-   local.set $30
+   f64.sub
    local.get $30
-   local.get $30
+   local.get $33
+   f64.mul
+   f64.sub
+   f64.mul
+   local.set $31
+   local.get $16
+   local.get $16
+   f64.mul
+   local.set $29
+   local.get $29
+   local.get $29
    f64.mul
    f64.const 0.5999999999999946
-   local.get $30
+   local.get $29
    f64.const 0.4285714285785502
-   local.get $30
+   local.get $29
    f64.const 0.33333332981837743
-   local.get $30
+   local.get $29
    f64.const 0.272728123808534
-   local.get $30
+   local.get $29
    f64.const 0.23066074577556175
-   local.get $30
+   local.get $29
    f64.const 0.20697501780033842
    f64.mul
    f64.add
@@ -5043,184 +5042,184 @@
    f64.mul
    f64.add
    f64.mul
-   local.set $23
-   local.get $23
-   local.get $32
-   local.get $31
-   local.get $17
-   f64.add
-   f64.mul
-   f64.add
-   local.set $23
-   local.get $31
-   local.get $31
-   f64.mul
-   local.set $30
-   f64.const 3
-   local.get $30
-   f64.add
-   local.get $23
-   f64.add
-   local.set $33
-   local.get $33
-   i64.reinterpret_f64
-   i64.const -4294967296
-   i64.and
-   f64.reinterpret_i64
-   local.set $33
-   local.get $23
-   local.get $33
-   f64.const 3
-   f64.sub
-   local.get $30
-   f64.sub
-   f64.sub
-   local.set $34
-   local.get $31
-   local.get $33
-   f64.mul
-   local.set $25
-   local.get $32
-   local.get $33
-   f64.mul
-   local.get $34
-   local.get $17
-   f64.mul
-   f64.add
-   local.set $26
-   local.get $25
-   local.get $26
-   f64.add
-   local.set $21
-   local.get $21
-   i64.reinterpret_f64
-   i64.const -4294967296
-   i64.and
-   f64.reinterpret_i64
-   local.set $21
-   local.get $26
-   local.get $21
-   local.get $25
-   f64.sub
-   f64.sub
    local.set $22
-   f64.const 0.9617967009544373
-   local.get $21
+   local.get $22
+   local.get $31
+   local.get $30
+   local.get $16
+   f64.add
    f64.mul
-   local.set $36
+   f64.add
+   local.set $22
+   local.get $30
+   local.get $30
+   f64.mul
+   local.set $29
+   f64.const 3
+   local.get $29
+   f64.add
+   local.get $22
+   f64.add
+   local.set $32
+   local.get $32
+   i64.reinterpret_f64
+   i64.const -4294967296
+   i64.and
+   f64.reinterpret_i64
+   local.set $32
+   local.get $22
+   local.get $32
+   f64.const 3
+   f64.sub
+   local.get $29
+   f64.sub
+   f64.sub
+   local.set $33
+   local.get $30
+   local.get $32
+   f64.mul
+   local.set $24
+   local.get $31
+   local.get $32
+   f64.mul
+   local.get $33
+   local.get $16
+   f64.mul
+   f64.add
+   local.set $25
+   local.get $24
+   local.get $25
+   f64.add
+   local.set $20
+   local.get $20
+   i64.reinterpret_f64
+   i64.const -4294967296
+   i64.and
+   f64.reinterpret_i64
+   local.set $20
+   local.get $25
+   local.get $20
+   local.get $24
+   f64.sub
+   f64.sub
+   local.set $21
+   f64.const 0.9617967009544373
+   local.get $20
+   f64.mul
+   local.set $35
    f64.const 1.350039202129749e-08
    f64.const 0
    local.get $10
    select
-   local.set $37
+   local.set $36
    f64.const -7.028461650952758e-09
-   local.get $21
+   local.get $20
    f64.mul
-   local.get $22
+   local.get $21
    f64.const 0.9617966939259756
    f64.mul
    f64.add
-   local.get $37
+   local.get $36
    f64.add
-   local.set $38
-   local.get $29
+   local.set $37
+   local.get $28
    f64.convert_i32_s
-   local.set $24
+   local.set $23
    f64.const 0.5849624872207642
    f64.const 0
    local.get $10
    select
-   local.set $39
-   local.get $36
+   local.set $38
+   local.get $35
+   local.get $37
+   f64.add
    local.get $38
    f64.add
-   local.get $39
+   local.get $23
    f64.add
-   local.get $24
-   f64.add
-   local.set $19
-   local.get $19
+   local.set $18
+   local.get $18
    i64.reinterpret_f64
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $19
+   local.set $18
+   local.get $37
+   local.get $18
+   local.get $23
+   f64.sub
    local.get $38
-   local.get $19
-   local.get $24
    f64.sub
-   local.get $39
-   f64.sub
-   local.get $36
+   local.get $35
    f64.sub
    f64.sub
-   local.set $20
+   local.set $19
   end
   local.get $1
-  local.set $40
-  local.get $40
+  local.set $39
+  local.get $39
   i64.reinterpret_f64
   i64.const -4294967296
   i64.and
   f64.reinterpret_i64
-  local.set $40
+  local.set $39
   local.get $1
-  local.get $40
+  local.get $39
   f64.sub
-  local.get $19
+  local.get $18
   f64.mul
   local.get $1
-  local.get $20
-  f64.mul
-  f64.add
-  local.set $22
-  local.get $40
   local.get $19
   f64.mul
-  local.set $21
-  local.get $22
-  local.get $21
   f64.add
-  local.set $16
-  local.get $16
+  local.set $21
+  local.get $39
+  local.get $18
+  f64.mul
+  local.set $20
+  local.get $21
+  local.get $20
+  f64.add
+  local.set $15
+  local.get $15
   i64.reinterpret_f64
   local.set $2
   local.get $2
   i64.const 32
   i64.shr_u
   i32.wrap_i64
-  local.set $28
+  local.set $27
   local.get $2
   i32.wrap_i64
-  local.set $41
-  local.get $28
+  local.set $40
+  local.get $27
   i32.const 1083179008
   i32.ge_s
   if
-   local.get $28
+   local.get $27
    i32.const 1083179008
    i32.sub
-   local.get $41
+   local.get $40
    i32.or
    i32.const 0
    i32.ne
    if
-    local.get $18
+    local.get $17
     f64.const 1.e+300
     f64.mul
     f64.const 1.e+300
     f64.mul
     return
    end
-   local.get $22
+   local.get $21
    f64.const 8.008566259537294e-17
    f64.add
-   local.get $16
-   local.get $21
+   local.get $15
+   local.get $20
    f64.sub
    f64.gt
    if
-    local.get $18
+    local.get $17
     f64.const 1.e+300
     f64.mul
     f64.const 1.e+300
@@ -5228,34 +5227,34 @@
     return
    end
   else
-   local.get $28
+   local.get $27
    i32.const 2147483647
    i32.and
    i32.const 1083231232
    i32.ge_s
    if
-    local.get $28
+    local.get $27
     i32.const -1064252416
     i32.sub
-    local.get $41
+    local.get $40
     i32.or
     i32.const 0
     i32.ne
     if
-     local.get $18
+     local.get $17
      f64.const 1e-300
      f64.mul
      f64.const 1e-300
      f64.mul
      return
     end
-    local.get $22
-    local.get $16
     local.get $21
+    local.get $15
+    local.get $20
     f64.sub
     f64.le
     if
-     local.get $18
+     local.get $17
      f64.const 1e-300
      f64.mul
      f64.const 1e-300
@@ -5264,31 +5263,31 @@
     end
    end
   end
-  local.get $28
+  local.get $27
   i32.const 2147483647
   i32.and
-  local.set $41
-  local.get $41
+  local.set $40
+  local.get $40
   i32.const 20
   i32.shr_s
   i32.const 1023
   i32.sub
   local.set $10
   i32.const 0
-  local.set $29
-  local.get $41
+  local.set $28
+  local.get $40
   i32.const 1071644672
   i32.gt_s
   if
-   local.get $28
+   local.get $27
    i32.const 1048576
    local.get $10
    i32.const 1
    i32.add
    i32.shr_s
    i32.add
-   local.set $29
-   local.get $29
+   local.set $28
+   local.get $28
    i32.const 2147483647
    i32.and
    i32.const 20
@@ -5297,8 +5296,8 @@
    i32.sub
    local.set $10
    f64.const 0
-   local.set $24
-   local.get $29
+   local.set $23
+   local.get $28
    i32.const 1048575
    local.get $10
    i32.shr_s
@@ -5309,8 +5308,8 @@
    i64.const 32
    i64.shl
    f64.reinterpret_i64
-   local.set $24
-   local.get $29
+   local.set $23
+   local.get $28
    i32.const 1048575
    i32.and
    i32.const 1048576
@@ -5319,71 +5318,71 @@
    local.get $10
    i32.sub
    i32.shr_s
-   local.set $29
-   local.get $28
+   local.set $28
+   local.get $27
    i32.const 0
    i32.lt_s
    if
     i32.const 0
-    local.get $29
+    local.get $28
     i32.sub
-    local.set $29
+    local.set $28
    end
-   local.get $21
-   local.get $24
+   local.get $20
+   local.get $23
    f64.sub
-   local.set $21
+   local.set $20
   end
-  local.get $22
   local.get $21
+  local.get $20
   f64.add
-  local.set $24
-  local.get $24
+  local.set $23
+  local.get $23
   i64.reinterpret_f64
   i64.const -4294967296
   i64.and
   f64.reinterpret_i64
-  local.set $24
-  local.get $24
+  local.set $23
+  local.get $23
   f64.const 0.6931471824645996
   f64.mul
-  local.set $25
-  local.get $22
-  local.get $24
+  local.set $24
   local.get $21
+  local.get $23
+  local.get $20
   f64.sub
   f64.sub
   f64.const 0.6931471805599453
   f64.mul
-  local.get $24
+  local.get $23
   f64.const -1.904654299957768e-09
   f64.mul
   f64.add
-  local.set $26
+  local.set $25
+  local.get $24
   local.get $25
-  local.get $26
   f64.add
-  local.set $16
-  local.get $26
-  local.get $16
+  local.set $15
   local.get $25
+  local.get $15
+  local.get $24
   f64.sub
   f64.sub
-  local.set $27
-  local.get $16
-  local.get $16
+  local.set $26
+  local.get $15
+  local.get $15
   f64.mul
-  local.set $24
-  local.get $16
-  local.get $24
+  local.set $23
+  local.get $15
+  local.get $23
   f64.const 0.16666666666666602
-  local.get $24
+  local.get $23
   f64.const -2.7777777777015593e-03
-  local.get $24
+  local.get $23
   f64.const 6.613756321437934e-05
-  local.get $24
+  local.get $23
   f64.const -1.6533902205465252e-06
-  local.get $24
+  local.get $23
   f64.const 4.1381367970572385e-08
   f64.mul
   f64.add
@@ -5395,64 +5394,64 @@
   f64.add
   f64.mul
   f64.sub
-  local.set $19
-  local.get $16
-  local.get $19
+  local.set $18
+  local.get $15
+  local.get $18
   f64.mul
-  local.get $19
+  local.get $18
   f64.const 2
   f64.sub
   f64.div
-  local.get $27
-  local.get $16
-  local.get $27
+  local.get $26
+  local.get $15
+  local.get $26
   f64.mul
   f64.add
   f64.sub
-  local.set $23
+  local.set $22
   f64.const 1
-  local.get $23
-  local.get $16
+  local.get $22
+  local.get $15
   f64.sub
   f64.sub
-  local.set $16
-  local.get $16
+  local.set $15
+  local.get $15
   i64.reinterpret_f64
   i64.const 32
   i64.shr_u
   i32.wrap_i64
-  local.set $28
+  local.set $27
+  local.get $27
   local.get $28
-  local.get $29
   i32.const 20
   i32.shl
   i32.add
-  local.set $28
-  local.get $28
+  local.set $27
+  local.get $27
   i32.const 20
   i32.shr_s
   i32.const 0
   i32.le_s
   if
-   local.get $16
-   local.get $29
+   local.get $15
+   local.get $28
    call $~lib/math/NativeMath.scalbn
-   local.set $16
+   local.set $15
   else
-   local.get $16
+   local.get $15
    i64.reinterpret_f64
    i64.const 4294967295
    i64.and
-   local.get $28
+   local.get $27
    i64.extend_i32_s
    i64.const 32
    i64.shl
    i64.or
    f64.reinterpret_i64
-   local.set $16
+   local.set $15
   end
-  local.get $18
-  local.get $16
+  local.get $17
+  local.get $15
   f64.mul
  )
  (func $../../lib/libm/assembly/libm/pow (; 51 ;) (type $FUNCSIG$ddd) (param $0 f64) (param $1 f64) (result f64)

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -6946,46 +6946,46 @@
     i32.const 1072693248
     i32.ge_s
     if (result i32)
-     local.get $6
-     local.get $8
+     i32.const 52
+     i32.const 20
      local.get $8
      i32.const 20
      i32.shr_s
      i32.const 1023
      i32.sub
-     local.tee $12
+     local.tee $11
      i32.const 20
      i32.gt_s
-     local.tee $13
-     select
      local.tee $5
-     local.get $5
-     i32.const 52
-     i32.const 20
-     local.get $13
      select
-     local.get $12
+     local.get $11
      i32.sub
-     local.tee $13
-     i32.shr_u
+     local.set $12
+     local.get $6
+     local.get $8
+     local.get $5
+     select
      local.tee $5
-     local.get $13
+     local.get $12
+     i32.shr_u
+     local.set $11
+     i32.const 2
+     local.get $11
+     i32.const 1
+     i32.and
+     i32.sub
+     i32.const 0
+     local.get $11
+     local.get $12
      i32.shl
+     local.get $5
      i32.eq
-     if (result i32)
-      i32.const 2
-      local.get $5
-      i32.const 1
-      i32.and
-      i32.sub
-     else
-      i32.const 0
-     end
+     select
     else
      i32.const 0
     end
    end
-   local.set $11
+   local.set $13
   end
   local.get $6
   i32.eqz
@@ -7103,13 +7103,13 @@
      local.get $4
      i32.const 1072693248
      i32.sub
-     local.get $11
+     local.get $13
      i32.or
      if (result f64)
       local.get $3
       f64.neg
       local.get $3
-      local.get $11
+      local.get $13
       i32.const 1
       i32.eq
       select
@@ -7133,7 +7133,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $11
+   local.get $13
    i32.eqz
    if
     local.get $0
@@ -7146,7 +7146,7 @@
    end
    f64.const -1
    f64.const 1
-   local.get $11
+   local.get $13
    i32.const 1
    i32.eq
    select
@@ -7576,7 +7576,7 @@
     local.get $12
     i32.const 2147483647
     i32.and
-    local.tee $13
+    local.tee $11
     i32.const 20
     i32.shr_s
     i32.const 1023
@@ -7584,7 +7584,7 @@
     local.set $5
     i32.const 0
     local.set $6
-    local.get $13
+    local.get $11
     i32.const 1071644672
     i32.gt_s
     if
@@ -7595,7 +7595,7 @@
      i32.shr_s
      local.get $12
      i32.add
-     local.tee $13
+     local.tee $11
      i32.const 2147483647
      i32.and
      i32.const 20
@@ -7608,14 +7608,14 @@
      i32.shr_s
      i32.const -1
      i32.xor
-     local.get $13
+     local.get $11
      i32.and
      i64.extend_i32_s
      i64.const 32
      i64.shl
      f64.reinterpret_i64
      local.set $0
-     local.get $13
+     local.get $11
      i32.const 1048575
      i32.and
      i32.const 1048576
@@ -8660,7 +8660,7 @@
   if
    i32.const 0
    i32.const 384
-   i32.const 1369
+   i32.const 1368
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -8674,7 +8674,7 @@
   if
    i32.const 424
    i32.const 384
-   i32.const 1376
+   i32.const 1375
    i32.const 24
    call $~lib/builtins/abort
    unreachable
@@ -8718,7 +8718,7 @@
   if
    i32.const 424
    i32.const 384
-   i32.const 2725
+   i32.const 2724
    i32.const 24
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -5033,6 +5033,13 @@
   i32.ge_u
   if
    local.get $1
+   i32.const 2139095040
+   i32.gt_u
+   if
+    local.get $0
+    return
+   end
+   local.get $1
    i32.const 1118925336
    i32.ge_u
    if
@@ -6960,7 +6967,7 @@
      local.get $12
      i32.sub
      local.tee $13
-     i32.shr_s
+     i32.shr_u
      local.tee $5
      local.get $13
      i32.shl
@@ -8711,7 +8718,7 @@
   if
    i32.const 424
    i32.const 384
-   i32.const 2724
+   i32.const 2725
    i32.const 24
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -6551,6 +6551,13 @@
   i32.ge_u
   if
    local.get $1
+   i32.const 2139095040
+   i32.gt_u
+   if
+    local.get $0
+    return
+   end
+   local.get $1
    i32.const 1118925336
    i32.ge_u
    if
@@ -9013,7 +9020,7 @@
      local.set $13
      local.get $13
      local.get $12
-     i32.shr_s
+     i32.shr_u
      local.set $14
      local.get $14
      local.get $12
@@ -11077,7 +11084,7 @@
   if
    i32.const 424
    i32.const 384
-   i32.const 2724
+   i32.const 2725
    i32.const 24
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -8868,7 +8868,7 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
-  (local $14 i32)
+  (local $14 f64)
   (local $15 f64)
   (local $16 f64)
   (local $17 f64)
@@ -8881,9 +8881,9 @@
   (local $24 f64)
   (local $25 f64)
   (local $26 f64)
-  (local $27 f64)
+  (local $27 i32)
   (local $28 i32)
-  (local $29 i32)
+  (local $29 f64)
   (local $30 f64)
   (local $31 f64)
   (local $32 f64)
@@ -8894,8 +8894,7 @@
   (local $37 f64)
   (local $38 f64)
   (local $39 f64)
-  (local $40 f64)
-  (local $41 i32)
+  (local $40 i32)
   local.get $0
   i64.reinterpret_f64
   local.set $2
@@ -9002,34 +9001,34 @@
      i32.const 1023
      i32.sub
      local.set $10
+     i32.const 52
+     i32.const 20
      local.get $10
      i32.const 20
      i32.gt_s
-     local.set $11
-     i32.const 52
-     i32.const 20
-     local.get $11
      select
      local.get $10
      i32.sub
-     local.set $12
+     local.set $11
      local.get $6
      local.get $8
-     local.get $11
+     local.get $10
+     i32.const 20
+     i32.gt_s
      select
+     local.set $12
+     local.get $12
+     local.get $11
+     i32.shr_u
      local.set $13
      local.get $13
-     local.get $12
-     i32.shr_u
-     local.set $14
-     local.get $14
-     local.get $12
+     local.get $11
      i32.shl
-     local.get $13
+     local.get $12
      i32.eq
      if
       i32.const 2
-      local.get $14
+      local.get $13
       i32.const 1
       i32.and
       i32.sub
@@ -9127,7 +9126,7 @@
   end
   local.get $0
   f64.abs
-  local.set $15
+  local.set $14
   local.get $4
   i32.const 0
   i32.eq
@@ -9150,16 +9149,16 @@
     i32.eq
    end
    if
-    local.get $15
-    local.set $16
+    local.get $14
+    local.set $15
     local.get $5
     i32.const 0
     i32.lt_s
     if
      f64.const 1
-     local.get $16
+     local.get $15
      f64.div
-     local.set $16
+     local.set $15
     end
     local.get $3
     i32.const 0
@@ -9173,31 +9172,31 @@
      i32.const 0
      i32.eq
      if
-      local.get $16
-      local.get $16
+      local.get $15
+      local.get $15
       f64.sub
-      local.set $17
-      local.get $17
-      local.get $17
-      f64.div
       local.set $16
+      local.get $16
+      local.get $16
+      f64.div
+      local.set $15
      else
       local.get $9
       i32.const 1
       i32.eq
       if
-       local.get $16
+       local.get $15
        f64.neg
-       local.set $16
+       local.set $15
       end
      end
     end
-    local.get $16
+    local.get $15
     return
    end
   end
   f64.const 1
-  local.set $18
+  local.set $17
   local.get $3
   i32.const 0
   i32.lt_s
@@ -9209,9 +9208,9 @@
     local.get $0
     local.get $0
     f64.sub
-    local.set $17
-    local.get $17
-    local.get $17
+    local.set $16
+    local.get $16
+    local.get $16
     f64.div
     return
    end
@@ -9220,7 +9219,7 @@
    i32.eq
    if
     f64.const -1
-    local.set $18
+    local.set $17
    end
   end
   local.get $8
@@ -9276,13 +9275,13 @@
     i32.const 0
     i32.lt_s
     if (result f64)
-     local.get $18
+     local.get $17
      f64.const 1.e+300
      f64.mul
      f64.const 1.e+300
      f64.mul
     else
-     local.get $18
+     local.get $17
      f64.const 1e-300
      f64.mul
      f64.const 1e-300
@@ -9298,13 +9297,13 @@
     i32.const 0
     i32.gt_s
     if (result f64)
-     local.get $18
+     local.get $17
      f64.const 1.e+300
      f64.mul
      f64.const 1.e+300
      f64.mul
     else
-     local.get $18
+     local.get $17
      f64.const 1e-300
      f64.mul
      f64.const 1e-300
@@ -9312,98 +9311,98 @@
     end
     return
    end
-   local.get $15
+   local.get $14
    f64.const 1
    f64.sub
-   local.set $24
-   local.get $24
-   local.get $24
+   local.set $23
+   local.get $23
+   local.get $23
    f64.mul
    f64.const 0.5
-   local.get $24
+   local.get $23
    f64.const 0.3333333333333333
-   local.get $24
+   local.get $23
    f64.const 0.25
    f64.mul
    f64.sub
    f64.mul
    f64.sub
    f64.mul
-   local.set $27
+   local.set $26
    f64.const 1.4426950216293335
-   local.get $24
+   local.get $23
    f64.mul
-   local.set $25
-   local.get $24
+   local.set $24
+   local.get $23
    f64.const 1.9259629911266175e-08
    f64.mul
-   local.get $27
+   local.get $26
    f64.const 1.4426950408889634
    f64.mul
    f64.sub
-   local.set $26
+   local.set $25
+   local.get $24
    local.get $25
-   local.get $26
    f64.add
-   local.set $19
-   local.get $19
+   local.set $18
+   local.get $18
    i64.reinterpret_f64
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $19
-   local.get $26
-   local.get $19
+   local.set $18
    local.get $25
+   local.get $18
+   local.get $24
    f64.sub
    f64.sub
-   local.set $20
+   local.set $19
   else
    i32.const 0
-   local.set $29
+   local.set $28
    local.get $7
    i32.const 1048576
    i32.lt_s
    if
-    local.get $15
+    local.get $14
     f64.const 9007199254740992
     f64.mul
-    local.set $15
-    local.get $29
+    local.set $14
+    local.get $28
     i32.const 53
     i32.sub
-    local.set $29
-    local.get $15
+    local.set $28
+    local.get $14
     i64.reinterpret_f64
     i64.const 32
     i64.shr_u
     i32.wrap_i64
     local.set $7
    end
-   local.get $29
+   local.get $28
    local.get $7
    i32.const 20
    i32.shr_s
    i32.const 1023
    i32.sub
    i32.add
-   local.set $29
+   local.set $28
    local.get $7
    i32.const 1048575
    i32.and
-   local.set $28
-   local.get $28
+   local.set $27
+   local.get $27
    i32.const 1072693248
    i32.or
    local.set $7
-   local.get $28
+   local.get $27
    i32.const 235662
    i32.le_s
    if
     i32.const 0
     local.set $10
    else
-    local.get $28
+    local.get $27
     i32.const 767610
     i32.lt_s
     if
@@ -9412,17 +9411,17 @@
     else
      i32.const 0
      local.set $10
-     local.get $29
+     local.get $28
      i32.const 1
      i32.add
-     local.set $29
+     local.set $28
      local.get $7
      i32.const 1048576
      i32.sub
      local.set $7
     end
    end
-   local.get $15
+   local.get $14
    i64.reinterpret_f64
    i64.const 4294967295
    i64.and
@@ -9432,34 +9431,34 @@
    i64.shl
    i64.or
    f64.reinterpret_i64
-   local.set $15
+   local.set $14
    f64.const 1.5
    f64.const 1
    local.get $10
    select
-   local.set $35
-   local.get $15
-   local.get $35
+   local.set $34
+   local.get $14
+   local.get $34
    f64.sub
-   local.set $25
+   local.set $24
    f64.const 1
-   local.get $15
-   local.get $35
+   local.get $14
+   local.get $34
    f64.add
    f64.div
-   local.set $26
+   local.set $25
+   local.get $24
    local.get $25
-   local.get $26
    f64.mul
-   local.set $17
-   local.get $17
-   local.set $31
-   local.get $31
+   local.set $16
+   local.get $16
+   local.set $30
+   local.get $30
    i64.reinterpret_f64
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $31
+   local.set $30
    local.get $7
    i32.const 1
    i32.shr_s
@@ -9475,42 +9474,42 @@
    i64.const 32
    i64.shl
    f64.reinterpret_i64
-   local.set $33
-   local.get $15
-   local.get $33
-   local.get $35
-   f64.sub
-   f64.sub
-   local.set $34
-   local.get $26
-   local.get $25
-   local.get $31
-   local.get $33
-   f64.mul
-   f64.sub
-   local.get $31
-   local.get $34
-   f64.mul
-   f64.sub
-   f64.mul
    local.set $32
-   local.get $17
-   local.get $17
+   local.get $14
+   local.get $32
+   local.get $34
+   f64.sub
+   f64.sub
+   local.set $33
+   local.get $25
+   local.get $24
+   local.get $30
+   local.get $32
    f64.mul
-   local.set $30
+   f64.sub
    local.get $30
-   local.get $30
+   local.get $33
+   f64.mul
+   f64.sub
+   f64.mul
+   local.set $31
+   local.get $16
+   local.get $16
+   f64.mul
+   local.set $29
+   local.get $29
+   local.get $29
    f64.mul
    f64.const 0.5999999999999946
-   local.get $30
+   local.get $29
    f64.const 0.4285714285785502
-   local.get $30
+   local.get $29
    f64.const 0.33333332981837743
-   local.get $30
+   local.get $29
    f64.const 0.272728123808534
-   local.get $30
+   local.get $29
    f64.const 0.23066074577556175
-   local.get $30
+   local.get $29
    f64.const 0.20697501780033842
    f64.mul
    f64.add
@@ -9523,184 +9522,184 @@
    f64.mul
    f64.add
    f64.mul
-   local.set $23
-   local.get $23
-   local.get $32
-   local.get $31
-   local.get $17
-   f64.add
-   f64.mul
-   f64.add
-   local.set $23
-   local.get $31
-   local.get $31
-   f64.mul
-   local.set $30
-   f64.const 3
-   local.get $30
-   f64.add
-   local.get $23
-   f64.add
-   local.set $33
-   local.get $33
-   i64.reinterpret_f64
-   i64.const -4294967296
-   i64.and
-   f64.reinterpret_i64
-   local.set $33
-   local.get $23
-   local.get $33
-   f64.const 3
-   f64.sub
-   local.get $30
-   f64.sub
-   f64.sub
-   local.set $34
-   local.get $31
-   local.get $33
-   f64.mul
-   local.set $25
-   local.get $32
-   local.get $33
-   f64.mul
-   local.get $34
-   local.get $17
-   f64.mul
-   f64.add
-   local.set $26
-   local.get $25
-   local.get $26
-   f64.add
-   local.set $21
-   local.get $21
-   i64.reinterpret_f64
-   i64.const -4294967296
-   i64.and
-   f64.reinterpret_i64
-   local.set $21
-   local.get $26
-   local.get $21
-   local.get $25
-   f64.sub
-   f64.sub
    local.set $22
-   f64.const 0.9617967009544373
-   local.get $21
+   local.get $22
+   local.get $31
+   local.get $30
+   local.get $16
+   f64.add
    f64.mul
-   local.set $36
+   f64.add
+   local.set $22
+   local.get $30
+   local.get $30
+   f64.mul
+   local.set $29
+   f64.const 3
+   local.get $29
+   f64.add
+   local.get $22
+   f64.add
+   local.set $32
+   local.get $32
+   i64.reinterpret_f64
+   i64.const -4294967296
+   i64.and
+   f64.reinterpret_i64
+   local.set $32
+   local.get $22
+   local.get $32
+   f64.const 3
+   f64.sub
+   local.get $29
+   f64.sub
+   f64.sub
+   local.set $33
+   local.get $30
+   local.get $32
+   f64.mul
+   local.set $24
+   local.get $31
+   local.get $32
+   f64.mul
+   local.get $33
+   local.get $16
+   f64.mul
+   f64.add
+   local.set $25
+   local.get $24
+   local.get $25
+   f64.add
+   local.set $20
+   local.get $20
+   i64.reinterpret_f64
+   i64.const -4294967296
+   i64.and
+   f64.reinterpret_i64
+   local.set $20
+   local.get $25
+   local.get $20
+   local.get $24
+   f64.sub
+   f64.sub
+   local.set $21
+   f64.const 0.9617967009544373
+   local.get $20
+   f64.mul
+   local.set $35
    f64.const 1.350039202129749e-08
    f64.const 0
    local.get $10
    select
-   local.set $37
+   local.set $36
    f64.const -7.028461650952758e-09
-   local.get $21
+   local.get $20
    f64.mul
-   local.get $22
+   local.get $21
    f64.const 0.9617966939259756
    f64.mul
    f64.add
-   local.get $37
+   local.get $36
    f64.add
-   local.set $38
-   local.get $29
+   local.set $37
+   local.get $28
    f64.convert_i32_s
-   local.set $24
+   local.set $23
    f64.const 0.5849624872207642
    f64.const 0
    local.get $10
    select
-   local.set $39
-   local.get $36
+   local.set $38
+   local.get $35
+   local.get $37
+   f64.add
    local.get $38
    f64.add
-   local.get $39
+   local.get $23
    f64.add
-   local.get $24
-   f64.add
-   local.set $19
-   local.get $19
+   local.set $18
+   local.get $18
    i64.reinterpret_f64
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $19
+   local.set $18
+   local.get $37
+   local.get $18
+   local.get $23
+   f64.sub
    local.get $38
-   local.get $19
-   local.get $24
    f64.sub
-   local.get $39
-   f64.sub
-   local.get $36
+   local.get $35
    f64.sub
    f64.sub
-   local.set $20
+   local.set $19
   end
   local.get $1
-  local.set $40
-  local.get $40
+  local.set $39
+  local.get $39
   i64.reinterpret_f64
   i64.const -4294967296
   i64.and
   f64.reinterpret_i64
-  local.set $40
+  local.set $39
   local.get $1
-  local.get $40
+  local.get $39
   f64.sub
-  local.get $19
+  local.get $18
   f64.mul
   local.get $1
-  local.get $20
-  f64.mul
-  f64.add
-  local.set $22
-  local.get $40
   local.get $19
   f64.mul
-  local.set $21
-  local.get $22
-  local.get $21
   f64.add
-  local.set $16
-  local.get $16
+  local.set $21
+  local.get $39
+  local.get $18
+  f64.mul
+  local.set $20
+  local.get $21
+  local.get $20
+  f64.add
+  local.set $15
+  local.get $15
   i64.reinterpret_f64
   local.set $2
   local.get $2
   i64.const 32
   i64.shr_u
   i32.wrap_i64
-  local.set $28
+  local.set $27
   local.get $2
   i32.wrap_i64
-  local.set $41
-  local.get $28
+  local.set $40
+  local.get $27
   i32.const 1083179008
   i32.ge_s
   if
-   local.get $28
+   local.get $27
    i32.const 1083179008
    i32.sub
-   local.get $41
+   local.get $40
    i32.or
    i32.const 0
    i32.ne
    if
-    local.get $18
+    local.get $17
     f64.const 1.e+300
     f64.mul
     f64.const 1.e+300
     f64.mul
     return
    end
-   local.get $22
+   local.get $21
    f64.const 8.008566259537294e-17
    f64.add
-   local.get $16
-   local.get $21
+   local.get $15
+   local.get $20
    f64.sub
    f64.gt
    if
-    local.get $18
+    local.get $17
     f64.const 1.e+300
     f64.mul
     f64.const 1.e+300
@@ -9708,34 +9707,34 @@
     return
    end
   else
-   local.get $28
+   local.get $27
    i32.const 2147483647
    i32.and
    i32.const 1083231232
    i32.ge_s
    if
-    local.get $28
+    local.get $27
     i32.const -1064252416
     i32.sub
-    local.get $41
+    local.get $40
     i32.or
     i32.const 0
     i32.ne
     if
-     local.get $18
+     local.get $17
      f64.const 1e-300
      f64.mul
      f64.const 1e-300
      f64.mul
      return
     end
-    local.get $22
-    local.get $16
     local.get $21
+    local.get $15
+    local.get $20
     f64.sub
     f64.le
     if
-     local.get $18
+     local.get $17
      f64.const 1e-300
      f64.mul
      f64.const 1e-300
@@ -9744,31 +9743,31 @@
     end
    end
   end
-  local.get $28
+  local.get $27
   i32.const 2147483647
   i32.and
-  local.set $41
-  local.get $41
+  local.set $40
+  local.get $40
   i32.const 20
   i32.shr_s
   i32.const 1023
   i32.sub
   local.set $10
   i32.const 0
-  local.set $29
-  local.get $41
+  local.set $28
+  local.get $40
   i32.const 1071644672
   i32.gt_s
   if
-   local.get $28
+   local.get $27
    i32.const 1048576
    local.get $10
    i32.const 1
    i32.add
    i32.shr_s
    i32.add
-   local.set $29
-   local.get $29
+   local.set $28
+   local.get $28
    i32.const 2147483647
    i32.and
    i32.const 20
@@ -9777,8 +9776,8 @@
    i32.sub
    local.set $10
    f64.const 0
-   local.set $24
-   local.get $29
+   local.set $23
+   local.get $28
    i32.const 1048575
    local.get $10
    i32.shr_s
@@ -9789,8 +9788,8 @@
    i64.const 32
    i64.shl
    f64.reinterpret_i64
-   local.set $24
-   local.get $29
+   local.set $23
+   local.get $28
    i32.const 1048575
    i32.and
    i32.const 1048576
@@ -9799,71 +9798,71 @@
    local.get $10
    i32.sub
    i32.shr_s
-   local.set $29
-   local.get $28
+   local.set $28
+   local.get $27
    i32.const 0
    i32.lt_s
    if
     i32.const 0
-    local.get $29
+    local.get $28
     i32.sub
-    local.set $29
+    local.set $28
    end
-   local.get $21
-   local.get $24
+   local.get $20
+   local.get $23
    f64.sub
-   local.set $21
+   local.set $20
   end
-  local.get $22
   local.get $21
+  local.get $20
   f64.add
-  local.set $24
-  local.get $24
+  local.set $23
+  local.get $23
   i64.reinterpret_f64
   i64.const -4294967296
   i64.and
   f64.reinterpret_i64
-  local.set $24
-  local.get $24
+  local.set $23
+  local.get $23
   f64.const 0.6931471824645996
   f64.mul
-  local.set $25
-  local.get $22
-  local.get $24
+  local.set $24
   local.get $21
+  local.get $23
+  local.get $20
   f64.sub
   f64.sub
   f64.const 0.6931471805599453
   f64.mul
-  local.get $24
+  local.get $23
   f64.const -1.904654299957768e-09
   f64.mul
   f64.add
-  local.set $26
+  local.set $25
+  local.get $24
   local.get $25
-  local.get $26
   f64.add
-  local.set $16
-  local.get $26
-  local.get $16
+  local.set $15
   local.get $25
+  local.get $15
+  local.get $24
   f64.sub
   f64.sub
-  local.set $27
-  local.get $16
-  local.get $16
+  local.set $26
+  local.get $15
+  local.get $15
   f64.mul
-  local.set $24
-  local.get $16
-  local.get $24
+  local.set $23
+  local.get $15
+  local.get $23
   f64.const 0.16666666666666602
-  local.get $24
+  local.get $23
   f64.const -2.7777777777015593e-03
-  local.get $24
+  local.get $23
   f64.const 6.613756321437934e-05
-  local.get $24
+  local.get $23
   f64.const -1.6533902205465252e-06
-  local.get $24
+  local.get $23
   f64.const 4.1381367970572385e-08
   f64.mul
   f64.add
@@ -9875,64 +9874,64 @@
   f64.add
   f64.mul
   f64.sub
-  local.set $19
-  local.get $16
-  local.get $19
+  local.set $18
+  local.get $15
+  local.get $18
   f64.mul
-  local.get $19
+  local.get $18
   f64.const 2
   f64.sub
   f64.div
-  local.get $27
-  local.get $16
-  local.get $27
+  local.get $26
+  local.get $15
+  local.get $26
   f64.mul
   f64.add
   f64.sub
-  local.set $23
+  local.set $22
   f64.const 1
-  local.get $23
-  local.get $16
+  local.get $22
+  local.get $15
   f64.sub
   f64.sub
-  local.set $16
-  local.get $16
+  local.set $15
+  local.get $15
   i64.reinterpret_f64
   i64.const 32
   i64.shr_u
   i32.wrap_i64
-  local.set $28
+  local.set $27
+  local.get $27
   local.get $28
-  local.get $29
   i32.const 20
   i32.shl
   i32.add
-  local.set $28
-  local.get $28
+  local.set $27
+  local.get $27
   i32.const 20
   i32.shr_s
   i32.const 0
   i32.le_s
   if
-   local.get $16
-   local.get $29
+   local.get $15
+   local.get $28
    call $~lib/math/NativeMath.scalbn
-   local.set $16
+   local.set $15
   else
-   local.get $16
+   local.get $15
    i64.reinterpret_f64
    i64.const 4294967295
    i64.and
-   local.get $28
+   local.get $27
    i64.extend_i32_s
    i64.const 32
    i64.shl
    i64.or
    f64.reinterpret_i64
-   local.set $16
+   local.set $15
   end
-  local.get $18
-  local.get $16
+  local.get $17
+  local.get $15
   f64.mul
  )
  (func $std/math/test_pow (; 132 ;) (type $FUNCSIG$iddddi) (param $0 f64) (param $1 f64) (param $2 f64) (param $3 f64) (param $4 i32) (result i32)
@@ -11014,7 +11013,7 @@
   if
    i32.const 0
    i32.const 384
-   i32.const 1369
+   i32.const 1368
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -11029,7 +11028,7 @@
   if
    i32.const 424
    i32.const 384
-   i32.const 1376
+   i32.const 1375
    i32.const 24
    call $~lib/builtins/abort
    unreachable
@@ -11084,7 +11083,7 @@
   if
    i32.const 424
    i32.const 384
-   i32.const 2725
+   i32.const 2724
    i32.const 24
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/operator-overloading.optimized.wat
+++ b/tests/compiler/std/operator-overloading.optimized.wat
@@ -334,46 +334,46 @@
     i32.const 1072693248
     i32.ge_s
     if (result i32)
-     local.get $6
-     local.get $8
+     i32.const 52
+     i32.const 20
      local.get $8
      i32.const 20
      i32.shr_s
      i32.const 1023
      i32.sub
-     local.tee $12
+     local.tee $11
      i32.const 20
      i32.gt_s
-     local.tee $13
-     select
      local.tee $5
-     local.get $5
-     i32.const 52
-     i32.const 20
-     local.get $13
      select
-     local.get $12
+     local.get $11
      i32.sub
-     local.tee $13
-     i32.shr_u
+     local.set $12
+     local.get $6
+     local.get $8
+     local.get $5
+     select
      local.tee $5
-     local.get $13
+     local.get $12
+     i32.shr_u
+     local.set $11
+     i32.const 2
+     local.get $11
+     i32.const 1
+     i32.and
+     i32.sub
+     i32.const 0
+     local.get $11
+     local.get $12
      i32.shl
+     local.get $5
      i32.eq
-     if (result i32)
-      i32.const 2
-      local.get $5
-      i32.const 1
-      i32.and
-      i32.sub
-     else
-      i32.const 0
-     end
+     select
     else
      i32.const 0
     end
    end
-   local.set $11
+   local.set $13
   end
   local.get $6
   i32.eqz
@@ -491,13 +491,13 @@
      local.get $4
      i32.const 1072693248
      i32.sub
-     local.get $11
+     local.get $13
      i32.or
      if (result f64)
       local.get $3
       f64.neg
       local.get $3
-      local.get $11
+      local.get $13
       i32.const 1
       i32.eq
       select
@@ -521,7 +521,7 @@
   i32.const 0
   i32.lt_s
   if
-   local.get $11
+   local.get $13
    i32.eqz
    if
     local.get $0
@@ -534,7 +534,7 @@
    end
    f64.const -1
    f64.const 1
-   local.get $11
+   local.get $13
    i32.const 1
    i32.eq
    select
@@ -964,7 +964,7 @@
     local.get $12
     i32.const 2147483647
     i32.and
-    local.tee $13
+    local.tee $11
     i32.const 20
     i32.shr_s
     i32.const 1023
@@ -972,7 +972,7 @@
     local.set $5
     i32.const 0
     local.set $6
-    local.get $13
+    local.get $11
     i32.const 1071644672
     i32.gt_s
     if
@@ -983,7 +983,7 @@
      i32.shr_s
      local.get $12
      i32.add
-     local.tee $13
+     local.tee $11
      i32.const 2147483647
      i32.and
      i32.const 20
@@ -996,14 +996,14 @@
      i32.shr_s
      i32.const -1
      i32.xor
-     local.get $13
+     local.get $11
      i32.and
      i64.extend_i32_s
      i64.const 32
      i64.shl
      f64.reinterpret_i64
      local.set $0
-     local.get $13
+     local.get $11
      i32.const 1048575
      i32.and
      i32.const 1048576

--- a/tests/compiler/std/operator-overloading.optimized.wat
+++ b/tests/compiler/std/operator-overloading.optimized.wat
@@ -355,7 +355,7 @@
      local.get $12
      i32.sub
      local.tee $13
-     i32.shr_s
+     i32.shr_u
      local.tee $5
      local.get $13
      i32.shl

--- a/tests/compiler/std/operator-overloading.untouched.wat
+++ b/tests/compiler/std/operator-overloading.untouched.wat
@@ -606,7 +606,7 @@
      local.set $13
      local.get $13
      local.get $12
-     i32.shr_s
+     i32.shr_u
      local.set $14
      local.get $14
      local.get $12

--- a/tests/compiler/std/operator-overloading.untouched.wat
+++ b/tests/compiler/std/operator-overloading.untouched.wat
@@ -454,7 +454,7 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
-  (local $14 i32)
+  (local $14 f64)
   (local $15 f64)
   (local $16 f64)
   (local $17 f64)
@@ -467,9 +467,9 @@
   (local $24 f64)
   (local $25 f64)
   (local $26 f64)
-  (local $27 f64)
+  (local $27 i32)
   (local $28 i32)
-  (local $29 i32)
+  (local $29 f64)
   (local $30 f64)
   (local $31 f64)
   (local $32 f64)
@@ -480,8 +480,7 @@
   (local $37 f64)
   (local $38 f64)
   (local $39 f64)
-  (local $40 f64)
-  (local $41 i32)
+  (local $40 i32)
   local.get $0
   i64.reinterpret_f64
   local.set $2
@@ -588,34 +587,34 @@
      i32.const 1023
      i32.sub
      local.set $10
+     i32.const 52
+     i32.const 20
      local.get $10
      i32.const 20
      i32.gt_s
-     local.set $11
-     i32.const 52
-     i32.const 20
-     local.get $11
      select
      local.get $10
      i32.sub
-     local.set $12
+     local.set $11
      local.get $6
      local.get $8
-     local.get $11
+     local.get $10
+     i32.const 20
+     i32.gt_s
      select
+     local.set $12
+     local.get $12
+     local.get $11
+     i32.shr_u
      local.set $13
      local.get $13
-     local.get $12
-     i32.shr_u
-     local.set $14
-     local.get $14
-     local.get $12
+     local.get $11
      i32.shl
-     local.get $13
+     local.get $12
      i32.eq
      if
       i32.const 2
-      local.get $14
+      local.get $13
       i32.const 1
       i32.and
       i32.sub
@@ -713,7 +712,7 @@
   end
   local.get $0
   f64.abs
-  local.set $15
+  local.set $14
   local.get $4
   i32.const 0
   i32.eq
@@ -736,16 +735,16 @@
     i32.eq
    end
    if
-    local.get $15
-    local.set $16
+    local.get $14
+    local.set $15
     local.get $5
     i32.const 0
     i32.lt_s
     if
      f64.const 1
-     local.get $16
+     local.get $15
      f64.div
-     local.set $16
+     local.set $15
     end
     local.get $3
     i32.const 0
@@ -759,31 +758,31 @@
      i32.const 0
      i32.eq
      if
-      local.get $16
-      local.get $16
+      local.get $15
+      local.get $15
       f64.sub
-      local.set $17
-      local.get $17
-      local.get $17
-      f64.div
       local.set $16
+      local.get $16
+      local.get $16
+      f64.div
+      local.set $15
      else
       local.get $9
       i32.const 1
       i32.eq
       if
-       local.get $16
+       local.get $15
        f64.neg
-       local.set $16
+       local.set $15
       end
      end
     end
-    local.get $16
+    local.get $15
     return
    end
   end
   f64.const 1
-  local.set $18
+  local.set $17
   local.get $3
   i32.const 0
   i32.lt_s
@@ -795,9 +794,9 @@
     local.get $0
     local.get $0
     f64.sub
-    local.set $17
-    local.get $17
-    local.get $17
+    local.set $16
+    local.get $16
+    local.get $16
     f64.div
     return
    end
@@ -806,7 +805,7 @@
    i32.eq
    if
     f64.const -1
-    local.set $18
+    local.set $17
    end
   end
   local.get $8
@@ -862,13 +861,13 @@
     i32.const 0
     i32.lt_s
     if (result f64)
-     local.get $18
+     local.get $17
      f64.const 1.e+300
      f64.mul
      f64.const 1.e+300
      f64.mul
     else
-     local.get $18
+     local.get $17
      f64.const 1e-300
      f64.mul
      f64.const 1e-300
@@ -884,13 +883,13 @@
     i32.const 0
     i32.gt_s
     if (result f64)
-     local.get $18
+     local.get $17
      f64.const 1.e+300
      f64.mul
      f64.const 1.e+300
      f64.mul
     else
-     local.get $18
+     local.get $17
      f64.const 1e-300
      f64.mul
      f64.const 1e-300
@@ -898,98 +897,98 @@
     end
     return
    end
-   local.get $15
+   local.get $14
    f64.const 1
    f64.sub
-   local.set $24
-   local.get $24
-   local.get $24
+   local.set $23
+   local.get $23
+   local.get $23
    f64.mul
    f64.const 0.5
-   local.get $24
+   local.get $23
    f64.const 0.3333333333333333
-   local.get $24
+   local.get $23
    f64.const 0.25
    f64.mul
    f64.sub
    f64.mul
    f64.sub
    f64.mul
-   local.set $27
+   local.set $26
    f64.const 1.4426950216293335
-   local.get $24
+   local.get $23
    f64.mul
-   local.set $25
-   local.get $24
+   local.set $24
+   local.get $23
    f64.const 1.9259629911266175e-08
    f64.mul
-   local.get $27
+   local.get $26
    f64.const 1.4426950408889634
    f64.mul
    f64.sub
-   local.set $26
+   local.set $25
+   local.get $24
    local.get $25
-   local.get $26
    f64.add
-   local.set $19
-   local.get $19
+   local.set $18
+   local.get $18
    i64.reinterpret_f64
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $19
-   local.get $26
-   local.get $19
+   local.set $18
    local.get $25
+   local.get $18
+   local.get $24
    f64.sub
    f64.sub
-   local.set $20
+   local.set $19
   else
    i32.const 0
-   local.set $29
+   local.set $28
    local.get $7
    i32.const 1048576
    i32.lt_s
    if
-    local.get $15
+    local.get $14
     f64.const 9007199254740992
     f64.mul
-    local.set $15
-    local.get $29
+    local.set $14
+    local.get $28
     i32.const 53
     i32.sub
-    local.set $29
-    local.get $15
+    local.set $28
+    local.get $14
     i64.reinterpret_f64
     i64.const 32
     i64.shr_u
     i32.wrap_i64
     local.set $7
    end
-   local.get $29
+   local.get $28
    local.get $7
    i32.const 20
    i32.shr_s
    i32.const 1023
    i32.sub
    i32.add
-   local.set $29
+   local.set $28
    local.get $7
    i32.const 1048575
    i32.and
-   local.set $28
-   local.get $28
+   local.set $27
+   local.get $27
    i32.const 1072693248
    i32.or
    local.set $7
-   local.get $28
+   local.get $27
    i32.const 235662
    i32.le_s
    if
     i32.const 0
     local.set $10
    else
-    local.get $28
+    local.get $27
     i32.const 767610
     i32.lt_s
     if
@@ -998,17 +997,17 @@
     else
      i32.const 0
      local.set $10
-     local.get $29
+     local.get $28
      i32.const 1
      i32.add
-     local.set $29
+     local.set $28
      local.get $7
      i32.const 1048576
      i32.sub
      local.set $7
     end
    end
-   local.get $15
+   local.get $14
    i64.reinterpret_f64
    i64.const 4294967295
    i64.and
@@ -1018,34 +1017,34 @@
    i64.shl
    i64.or
    f64.reinterpret_i64
-   local.set $15
+   local.set $14
    f64.const 1.5
    f64.const 1
    local.get $10
    select
-   local.set $35
-   local.get $15
-   local.get $35
+   local.set $34
+   local.get $14
+   local.get $34
    f64.sub
-   local.set $25
+   local.set $24
    f64.const 1
-   local.get $15
-   local.get $35
+   local.get $14
+   local.get $34
    f64.add
    f64.div
-   local.set $26
+   local.set $25
+   local.get $24
    local.get $25
-   local.get $26
    f64.mul
-   local.set $17
-   local.get $17
-   local.set $31
-   local.get $31
+   local.set $16
+   local.get $16
+   local.set $30
+   local.get $30
    i64.reinterpret_f64
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $31
+   local.set $30
    local.get $7
    i32.const 1
    i32.shr_s
@@ -1061,42 +1060,42 @@
    i64.const 32
    i64.shl
    f64.reinterpret_i64
-   local.set $33
-   local.get $15
-   local.get $33
-   local.get $35
-   f64.sub
-   f64.sub
-   local.set $34
-   local.get $26
-   local.get $25
-   local.get $31
-   local.get $33
-   f64.mul
-   f64.sub
-   local.get $31
-   local.get $34
-   f64.mul
-   f64.sub
-   f64.mul
    local.set $32
-   local.get $17
-   local.get $17
+   local.get $14
+   local.get $32
+   local.get $34
+   f64.sub
+   f64.sub
+   local.set $33
+   local.get $25
+   local.get $24
+   local.get $30
+   local.get $32
    f64.mul
-   local.set $30
+   f64.sub
    local.get $30
-   local.get $30
+   local.get $33
+   f64.mul
+   f64.sub
+   f64.mul
+   local.set $31
+   local.get $16
+   local.get $16
+   f64.mul
+   local.set $29
+   local.get $29
+   local.get $29
    f64.mul
    f64.const 0.5999999999999946
-   local.get $30
+   local.get $29
    f64.const 0.4285714285785502
-   local.get $30
+   local.get $29
    f64.const 0.33333332981837743
-   local.get $30
+   local.get $29
    f64.const 0.272728123808534
-   local.get $30
+   local.get $29
    f64.const 0.23066074577556175
-   local.get $30
+   local.get $29
    f64.const 0.20697501780033842
    f64.mul
    f64.add
@@ -1109,184 +1108,184 @@
    f64.mul
    f64.add
    f64.mul
-   local.set $23
-   local.get $23
-   local.get $32
-   local.get $31
-   local.get $17
-   f64.add
-   f64.mul
-   f64.add
-   local.set $23
-   local.get $31
-   local.get $31
-   f64.mul
-   local.set $30
-   f64.const 3
-   local.get $30
-   f64.add
-   local.get $23
-   f64.add
-   local.set $33
-   local.get $33
-   i64.reinterpret_f64
-   i64.const -4294967296
-   i64.and
-   f64.reinterpret_i64
-   local.set $33
-   local.get $23
-   local.get $33
-   f64.const 3
-   f64.sub
-   local.get $30
-   f64.sub
-   f64.sub
-   local.set $34
-   local.get $31
-   local.get $33
-   f64.mul
-   local.set $25
-   local.get $32
-   local.get $33
-   f64.mul
-   local.get $34
-   local.get $17
-   f64.mul
-   f64.add
-   local.set $26
-   local.get $25
-   local.get $26
-   f64.add
-   local.set $21
-   local.get $21
-   i64.reinterpret_f64
-   i64.const -4294967296
-   i64.and
-   f64.reinterpret_i64
-   local.set $21
-   local.get $26
-   local.get $21
-   local.get $25
-   f64.sub
-   f64.sub
    local.set $22
-   f64.const 0.9617967009544373
-   local.get $21
+   local.get $22
+   local.get $31
+   local.get $30
+   local.get $16
+   f64.add
    f64.mul
-   local.set $36
+   f64.add
+   local.set $22
+   local.get $30
+   local.get $30
+   f64.mul
+   local.set $29
+   f64.const 3
+   local.get $29
+   f64.add
+   local.get $22
+   f64.add
+   local.set $32
+   local.get $32
+   i64.reinterpret_f64
+   i64.const -4294967296
+   i64.and
+   f64.reinterpret_i64
+   local.set $32
+   local.get $22
+   local.get $32
+   f64.const 3
+   f64.sub
+   local.get $29
+   f64.sub
+   f64.sub
+   local.set $33
+   local.get $30
+   local.get $32
+   f64.mul
+   local.set $24
+   local.get $31
+   local.get $32
+   f64.mul
+   local.get $33
+   local.get $16
+   f64.mul
+   f64.add
+   local.set $25
+   local.get $24
+   local.get $25
+   f64.add
+   local.set $20
+   local.get $20
+   i64.reinterpret_f64
+   i64.const -4294967296
+   i64.and
+   f64.reinterpret_i64
+   local.set $20
+   local.get $25
+   local.get $20
+   local.get $24
+   f64.sub
+   f64.sub
+   local.set $21
+   f64.const 0.9617967009544373
+   local.get $20
+   f64.mul
+   local.set $35
    f64.const 1.350039202129749e-08
    f64.const 0
    local.get $10
    select
-   local.set $37
+   local.set $36
    f64.const -7.028461650952758e-09
-   local.get $21
+   local.get $20
    f64.mul
-   local.get $22
+   local.get $21
    f64.const 0.9617966939259756
    f64.mul
    f64.add
-   local.get $37
+   local.get $36
    f64.add
-   local.set $38
-   local.get $29
+   local.set $37
+   local.get $28
    f64.convert_i32_s
-   local.set $24
+   local.set $23
    f64.const 0.5849624872207642
    f64.const 0
    local.get $10
    select
-   local.set $39
-   local.get $36
+   local.set $38
+   local.get $35
+   local.get $37
+   f64.add
    local.get $38
    f64.add
-   local.get $39
+   local.get $23
    f64.add
-   local.get $24
-   f64.add
-   local.set $19
-   local.get $19
+   local.set $18
+   local.get $18
    i64.reinterpret_f64
    i64.const -4294967296
    i64.and
    f64.reinterpret_i64
-   local.set $19
+   local.set $18
+   local.get $37
+   local.get $18
+   local.get $23
+   f64.sub
    local.get $38
-   local.get $19
-   local.get $24
    f64.sub
-   local.get $39
-   f64.sub
-   local.get $36
+   local.get $35
    f64.sub
    f64.sub
-   local.set $20
+   local.set $19
   end
   local.get $1
-  local.set $40
-  local.get $40
+  local.set $39
+  local.get $39
   i64.reinterpret_f64
   i64.const -4294967296
   i64.and
   f64.reinterpret_i64
-  local.set $40
+  local.set $39
   local.get $1
-  local.get $40
+  local.get $39
   f64.sub
-  local.get $19
+  local.get $18
   f64.mul
   local.get $1
-  local.get $20
-  f64.mul
-  f64.add
-  local.set $22
-  local.get $40
   local.get $19
   f64.mul
-  local.set $21
-  local.get $22
-  local.get $21
   f64.add
-  local.set $16
-  local.get $16
+  local.set $21
+  local.get $39
+  local.get $18
+  f64.mul
+  local.set $20
+  local.get $21
+  local.get $20
+  f64.add
+  local.set $15
+  local.get $15
   i64.reinterpret_f64
   local.set $2
   local.get $2
   i64.const 32
   i64.shr_u
   i32.wrap_i64
-  local.set $28
+  local.set $27
   local.get $2
   i32.wrap_i64
-  local.set $41
-  local.get $28
+  local.set $40
+  local.get $27
   i32.const 1083179008
   i32.ge_s
   if
-   local.get $28
+   local.get $27
    i32.const 1083179008
    i32.sub
-   local.get $41
+   local.get $40
    i32.or
    i32.const 0
    i32.ne
    if
-    local.get $18
+    local.get $17
     f64.const 1.e+300
     f64.mul
     f64.const 1.e+300
     f64.mul
     return
    end
-   local.get $22
+   local.get $21
    f64.const 8.008566259537294e-17
    f64.add
-   local.get $16
-   local.get $21
+   local.get $15
+   local.get $20
    f64.sub
    f64.gt
    if
-    local.get $18
+    local.get $17
     f64.const 1.e+300
     f64.mul
     f64.const 1.e+300
@@ -1294,34 +1293,34 @@
     return
    end
   else
-   local.get $28
+   local.get $27
    i32.const 2147483647
    i32.and
    i32.const 1083231232
    i32.ge_s
    if
-    local.get $28
+    local.get $27
     i32.const -1064252416
     i32.sub
-    local.get $41
+    local.get $40
     i32.or
     i32.const 0
     i32.ne
     if
-     local.get $18
+     local.get $17
      f64.const 1e-300
      f64.mul
      f64.const 1e-300
      f64.mul
      return
     end
-    local.get $22
-    local.get $16
     local.get $21
+    local.get $15
+    local.get $20
     f64.sub
     f64.le
     if
-     local.get $18
+     local.get $17
      f64.const 1e-300
      f64.mul
      f64.const 1e-300
@@ -1330,31 +1329,31 @@
     end
    end
   end
-  local.get $28
+  local.get $27
   i32.const 2147483647
   i32.and
-  local.set $41
-  local.get $41
+  local.set $40
+  local.get $40
   i32.const 20
   i32.shr_s
   i32.const 1023
   i32.sub
   local.set $10
   i32.const 0
-  local.set $29
-  local.get $41
+  local.set $28
+  local.get $40
   i32.const 1071644672
   i32.gt_s
   if
-   local.get $28
+   local.get $27
    i32.const 1048576
    local.get $10
    i32.const 1
    i32.add
    i32.shr_s
    i32.add
-   local.set $29
-   local.get $29
+   local.set $28
+   local.get $28
    i32.const 2147483647
    i32.and
    i32.const 20
@@ -1363,8 +1362,8 @@
    i32.sub
    local.set $10
    f64.const 0
-   local.set $24
-   local.get $29
+   local.set $23
+   local.get $28
    i32.const 1048575
    local.get $10
    i32.shr_s
@@ -1375,8 +1374,8 @@
    i64.const 32
    i64.shl
    f64.reinterpret_i64
-   local.set $24
-   local.get $29
+   local.set $23
+   local.get $28
    i32.const 1048575
    i32.and
    i32.const 1048576
@@ -1385,71 +1384,71 @@
    local.get $10
    i32.sub
    i32.shr_s
-   local.set $29
-   local.get $28
+   local.set $28
+   local.get $27
    i32.const 0
    i32.lt_s
    if
     i32.const 0
-    local.get $29
+    local.get $28
     i32.sub
-    local.set $29
+    local.set $28
    end
-   local.get $21
-   local.get $24
+   local.get $20
+   local.get $23
    f64.sub
-   local.set $21
+   local.set $20
   end
-  local.get $22
   local.get $21
+  local.get $20
   f64.add
-  local.set $24
-  local.get $24
+  local.set $23
+  local.get $23
   i64.reinterpret_f64
   i64.const -4294967296
   i64.and
   f64.reinterpret_i64
-  local.set $24
-  local.get $24
+  local.set $23
+  local.get $23
   f64.const 0.6931471824645996
   f64.mul
-  local.set $25
-  local.get $22
-  local.get $24
+  local.set $24
   local.get $21
+  local.get $23
+  local.get $20
   f64.sub
   f64.sub
   f64.const 0.6931471805599453
   f64.mul
-  local.get $24
+  local.get $23
   f64.const -1.904654299957768e-09
   f64.mul
   f64.add
-  local.set $26
+  local.set $25
+  local.get $24
   local.get $25
-  local.get $26
   f64.add
-  local.set $16
-  local.get $26
-  local.get $16
+  local.set $15
   local.get $25
+  local.get $15
+  local.get $24
   f64.sub
   f64.sub
-  local.set $27
-  local.get $16
-  local.get $16
+  local.set $26
+  local.get $15
+  local.get $15
   f64.mul
-  local.set $24
-  local.get $16
-  local.get $24
+  local.set $23
+  local.get $15
+  local.get $23
   f64.const 0.16666666666666602
-  local.get $24
+  local.get $23
   f64.const -2.7777777777015593e-03
-  local.get $24
+  local.get $23
   f64.const 6.613756321437934e-05
-  local.get $24
+  local.get $23
   f64.const -1.6533902205465252e-06
-  local.get $24
+  local.get $23
   f64.const 4.1381367970572385e-08
   f64.mul
   f64.add
@@ -1461,64 +1460,64 @@
   f64.add
   f64.mul
   f64.sub
-  local.set $19
-  local.get $16
-  local.get $19
+  local.set $18
+  local.get $15
+  local.get $18
   f64.mul
-  local.get $19
+  local.get $18
   f64.const 2
   f64.sub
   f64.div
-  local.get $27
-  local.get $16
-  local.get $27
+  local.get $26
+  local.get $15
+  local.get $26
   f64.mul
   f64.add
   f64.sub
-  local.set $23
+  local.set $22
   f64.const 1
-  local.get $23
-  local.get $16
+  local.get $22
+  local.get $15
   f64.sub
   f64.sub
-  local.set $16
-  local.get $16
+  local.set $15
+  local.get $15
   i64.reinterpret_f64
   i64.const 32
   i64.shr_u
   i32.wrap_i64
-  local.set $28
+  local.set $27
+  local.get $27
   local.get $28
-  local.get $29
   i32.const 20
   i32.shl
   i32.add
-  local.set $28
-  local.get $28
+  local.set $27
+  local.get $27
   i32.const 20
   i32.shr_s
   i32.const 0
   i32.le_s
   if
-   local.get $16
-   local.get $29
+   local.get $15
+   local.get $28
    call $~lib/math/NativeMath.scalbn
-   local.set $16
+   local.set $15
   else
-   local.get $16
+   local.get $15
    i64.reinterpret_f64
    i64.const 4294967295
    i64.and
-   local.get $28
+   local.get $27
    i64.extend_i32_s
    i64.const 32
    i64.shl
    i64.or
    f64.reinterpret_i64
-   local.set $16
+   local.set $15
   end
-  local.get $18
-  local.get $16
+  local.get $17
+  local.get $15
   f64.mul
  )
  (func $std/operator-overloading/Tester.pow (; 13 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)


### PR DESCRIPTION
See
https://git.musl-libc.org/cgit/musl/commit/?id=688d3da0f1730daddbc954bbc2d27cc96ceee04c
https://git.musl-libc.org/cgit/musl/commit/?id=b023c03b574acdfd73418314a5dcaa83e5cea5a0

Before:
`Mathf.exp(-NaN) == 0`

With fixes:
`Mathf.exp(-NaN) == -NaN`