### PR TITLE
Publish preparations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
 jobs:
   check:
     name: "Check preconditions"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,76 @@
+name: Publish
+on:
+  schedule:
+  - cron: '0 5 * * *'
+jobs:
+  publish:
+    name: "Publish packages"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        ref: release
+    - name: Merge master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        git config user.name "GitHub Actions"
+        git config user.email "actions@github.com"
+        git remote set-url origin "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        git fetch origin
+        git merge origin/master
+    - uses: actions/setup-node@v1
+    - name: Install dependencies
+      run: npm ci
+    - name: Build distribution files
+      run: |
+        npm run clean
+        npm run build
+    - name: Test distribution files
+      run: npm test
+    - name: Set up version
+      run: |
+        VERSION=$(node -e "console.log(require('./package.json').version)")
+        git add --force dist/*
+        if git rev-parse v$VERSION >/dev/null 2>&1; then
+          VERSION=$VERSION-nightly.$(date "+%Y%m%d")
+          if git rev-parse v$VERSION >/dev/null 2>&1; then
+            echo "Nightly $VERSION does already exist."
+            exit 1
+          fi
+          echo ::set-env name=CHANNEL::nightly
+          echo "Committing nightly ($VERSION) ..."
+          git commit -m "Nightly v$VERSION"
+          npm version $VERSION --no-git-tag-version --force
+        else
+          echo ::set-env name=CHANNEL::latest
+          echo "Committing release ($VERSION) ..."
+          git commit --allow-empty -m "Release v$VERSION"
+        fi
+        echo ::set-env name=VERSION::$VERSION
+    - name: Create tag and push distribution files
+      run: |
+        git tag v$VERSION
+        git push origin release
+        git push origin v$VERSION
+    # - name: Publish to npm
+    #   env:
+    #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    #   run: |
+    #     echo "npm publish --tag $CHANNEL"
+    #     cd ./lib/loader
+    #     npm version $VERSION --no-git-tag-version --force
+    #     echo "npm publish --tag $CHANNEL"
+    #     cd ../..
+    # - uses: actions/setup-node@v1
+    #   with:
+    #     registry-url: 'https://npm.pkg.github.com'
+    #     scope: '@AssemblyScript'
+    # - name: Publish to gpr
+    #   env:
+    #     NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   run: |
+    #     echo "npm publish --tag $CHANNEL"
+    #     cd ./lib/loader
+    #     echo "npm publish --tag $CHANNEL"
+    #     cd ../..

--- a/lib/loader/package.json
+++ b/lib/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assemblyscript/loader",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assemblyscript",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "author": "Daniel Wirtz <dcode+assemblyscript@dcode.io>",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This PR contains the initial preparation work to start publishing to npm. Idea is:

* Create a `release` branch that is always up to date with the tip of our releases
* Once a day
  * Merge `master` into `release`
  * Build and commit dist files
  * Obtain the current version from `package.json`
  * Check if the respective tag (with a prepended "v") does exist
    * If it exists, make a nightly of the form `v$VERSION-nightly.YYYYMMDD`
    * If it does not exist, make a release of the form `v$VERSION`
  * Push dist files back to `release` and create the tag
  * Publish to npm (not yet enabled)
  * Publish to GH package registry (not yet enabled)

This gives us:

* To bump the version, all we have to do is edit `package.json`
* If the dist files at the tip of our releases are the same as those we just built, the job fails (commit is empty) so we don't publish unnecessary duplicates.

With caveats being:

* Publishing happens exactly once a day, so it might take a while till these end up on npm etc.
* Installing `AssemblyScript/assemblyscript` via npm will no longer work once dist files are removed from master (currently still there)