### PR TITLE
Even more publish fixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish
 on:
   schedule:
-  - cron: '0 4 * * *'
+  - cron: '0 0 * * *'
 jobs:
   publish:
     name: "Publish packages"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,7 +75,7 @@ jobs:
         NPM_REGISTRY: "npm.pkg.github.com"
         NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        npm config set "//${NPM_REGISTRY}/:_authToken=${NPM_AUTH_TOKEN}""
+        npm config set "//${NPM_REGISTRY}/:_authToken=${NPM_AUTH_TOKEN}"
         sed -i 's/"assemblyscript"/"@assemblyscript\/assemblyscript"/' package.json
         sed -i 's/"assemblyscript"/"@assemblyscript\/assemblyscript"/' package-lock.json
         npm publish --registry=https://${NPM_REGISTRY}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![](https://avatars1.githubusercontent.com/u/28916798?s=64) AssemblyScript
 =================
 
-[![Actions Status](https://github.com/AssemblyScript/assemblyscript/workflows/CI/badge.svg)](https://github.com/AssemblyScript/assemblyscript/actions) [![npm](https://img.shields.io/npm/v/assemblyscript.svg?color=0074C1)](https://www.npmjs.com/package/assemblyscript) [![npm (tag)](https://img.shields.io/npm/v/assemblyscript/nightly.svg?color=0074C1)](https://www.npmjs.com/package/assemblyscript)
+[![Actions Status](https://github.com/AssemblyScript/assemblyscript/workflows/CI/badge.svg)](https://github.com/AssemblyScript/assemblyscript/actions) [![npm](https://img.shields.io/npm/v/assemblyscript.svg?color=0074C1)](https://www.npmjs.com/package/assemblyscript) [![npm@nightly](https://img.shields.io/npm/v/assemblyscript/nightly.svg?color=0074C1)](https://www.npmjs.com/package/assemblyscript)
 
 **AssemblyScript** compiles a strict subset of [TypeScript](http://www.typescriptlang.org) (basically JavaScript with types) to [WebAssembly](http://webassembly.org) using [Binaryen](https://github.com/WebAssembly/binaryen). It generates lean and mean WebAssembly modules while being just an `npm install` away.
 
@@ -9,7 +9,7 @@ Check out the [documentation](https://docs.assemblyscript.org) or try it out in 
 
 ---
 
-<h3 align="center">Our Sponsors</h2>
+<h3 align="center">Our Sponsors</h3>
 <p align="center">
   <a href="https://opencollective.com/assemblyscript/tiers/sponsor/0/website" target="_blank"><img src="https://opencollective.com/assemblyscript/tiers/sponsor/0/avatar.svg"></a>
   <a href="https://opencollective.com/assemblyscript/tiers/sponsor/1/website" target="_blank"><img src="https://opencollective.com/assemblyscript/tiers/sponsor/1/avatar.svg"></a>
@@ -23,7 +23,7 @@ Check out the [documentation](https://docs.assemblyscript.org) or try it out in 
   <a href="https://opencollective.com/assemblyscript/tiers/sponsor/9/website" target="_blank"><img src="https://opencollective.com/assemblyscript/tiers/sponsor/9/avatar.svg"></a>
 </p>
 <br />
-<h3 align="center">Our Backers</h2>
+<h3 align="center">Our Backers</h3>
 <p align="center">
   <a href="https://opencollective.com/assemblyscript#backers" target="_blank"><img src="https://opencollective.com/assemblyscript/backer.svg?avatarHeight=44" /></a>
 </p>

--- a/cli/asc.js
+++ b/cli/asc.js
@@ -37,7 +37,10 @@ var assemblyscript, isDev = false;
     assemblyscript = require("../dist/assemblyscript.js");
   } catch (e) {
     try { // `asc` on the command line without dist files
-      require("ts-node").register({ project: path.join(__dirname, "..", "src", "tsconfig.json") });
+      require("ts-node").register({
+        project: path.join(__dirname, "..", "src", "tsconfig.json"),
+        skipIgnore: true
+      });
       require("../src/glue/js");
       assemblyscript = require("../src");
       isDev = true;

--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
-require("ts-node").register({ project: path.join(__dirname, "src", "tsconfig.json") });
+require("ts-node").register({
+  project: require("path").join(__dirname, "src", "tsconfig.json"),
+  skipIgnore: true
+});
 require("./src/glue/js");
 module.exports = require("./src");

--- a/lib/loader/README.md
+++ b/lib/loader/README.md
@@ -1,4 +1,4 @@
-![AS](https://avatars1.githubusercontent.com/u/28916798?s=48) loader
+![AS](https://avatars1.githubusercontent.com/u/28916798?s=48) AssemblyScript Loader
 ======================
 
 A convenient loader for AssemblyScript modules. Demangles module exports to a friendly object structure compatible with WebIDL and TypeScript definitions and provides some useful utility to read/write data from/to memory.
@@ -7,7 +7,7 @@ Usage
 -----
 
 ```js
-const loader = require("assemblyscript/lib/loader");
+const loader = require("@assemblyscript/loader");
 ...
 ```
 

--- a/lib/loader/package.json
+++ b/lib/loader/package.json
@@ -1,11 +1,20 @@
 {
   "name": "@assemblyscript/loader",
+  "description": "A convenient loader for AssemblyScript modules.",
+  "keywords": [
+    "assemblyscript",
+    "loader",
+    "webassembly",
+    "wasm"
+  ],
   "version": "0.0.0",
   "author": "Daniel Wirtz <dcode+assemblyscript@dcode.io>",
   "license": "Apache-2.0",
+  "homepage": "https://assemblyscript.org",
   "repository": {
     "type": "git",
-    "url": "https://github.com/AssemblyScript/assemblyscript.git"
+    "url": "https://github.com/AssemblyScript/assemblyscript.git",
+    "directory": "lib/loader"
   },
   "bugs": {
     "url": "https://github.com/AssemblyScript/assemblyscript/issues"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "glob": "^7.1.5",
     "long": "^4.0.0",
     "source-map-support": "^0.5.16",
-    "ts-node": "^6.2.0"
+    "ts-node": "^6.2.0",
+    "typescript": "^3.7.2"
   },
   "devDependencies": {
     "@types/node": "^12.12.6",
@@ -24,10 +25,8 @@
     "diff": "^4.0.1",
     "physical-cpu-count": "^2.0.0",
     "ts-loader": "^6.2.1",
-    "ts-node": "^6.2.0",
     "tslint": "^5.20.1",
     "typedoc-plugin-external-module-name": "^2.1.0",
-    "typescript": "^3.7.2",
     "webpack": "^4.41.2",
     "webpack-cli": "^3.3.10"
   },

--- a/package.json
+++ b/package.json
@@ -1,8 +1,17 @@
 {
   "name": "assemblyscript",
+  "description": "A TypeScript to WebAssembly compiler.",
+  "keywords": [
+    "typescript",
+    "webassembly",
+    "compiler",
+    "assemblyscript",
+    "wasm"
+  ],
   "version": "0.8.0",
   "author": "Daniel Wirtz <dcode+assemblyscript@dcode.io>",
   "license": "Apache-2.0",
+  "homepage": "https://assemblyscript.org",
   "repository": {
     "type": "git",
     "url": "https://github.com/AssemblyScript/assemblyscript.git"
@@ -35,9 +44,6 @@
   "bin": {
     "asc": "bin/asc",
     "asinit": "bin/asinit"
-  },
-  "engines": {
-    "node": ">=8"
   },
   "scripts": {
     "build": "npm run build:bundle && npm run build:dts",

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -6,6 +6,7 @@ const pkg = require("../package.json");
 
 console.log("Updating package.json ...");
 delete pkg.dependencies["ts-node"]; // doesn't need ts-node
+delete pkg.dependencies.typescript; // or typescript
 delete pkg.devDependencies;         // or development dependencies
 delete pkg.scripts;                 // or scripts
 pkg.files = pkg["files.release"];   // but specifies files


### PR DESCRIPTION
* Fixes classic misplaced quote
* Specifies `skipIgnore` to ts-node in case the compiler lives inside of `node_modules`
* Makes TypeScript a normal dependency along ts-node for master where there are no dist files