### PR TITLE
Emit an error on not implemented closure

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -7251,6 +7251,15 @@ export class Compiler extends DiagnosticEmitter {
     switch (target.kind) {
       case ElementKind.LOCAL: {
         let type = (<Local>target).type;
+        if (target.parent != flow.parentFunction) {
+          // Closures are not yet supported
+          this.error(
+            DiagnosticCode.Not_implemented,
+            expression.range
+          );
+          this.currentType = type;
+          return module.unreachable();
+        }
         assert(type != Type.void);
         if ((<Local>target).is(CommonFlags.INLINED)) {
           return this.compileInlineConstant(<Local>target, contextualType, constraints);

--- a/tests/compiler/closure.json
+++ b/tests/compiler/closure.json
@@ -1,5 +1,9 @@
 {
   "asc_flags": [
     "--runtime none"
+  ],
+  "stderr": [
+    "AS100: Not implemented.",
+    "EOF"
   ]
 }

--- a/tests/compiler/closure.optimized.wat
+++ b/tests/compiler/closure.optimized.wat
@@ -1,8 +1,0 @@
-(module
- (type $FUNCSIG$v (func))
- (memory $0 0)
- (export "memory" (memory $0))
- (func $null (; 0 ;) (type $FUNCSIG$v)
-  nop
- )
-)

--- a/tests/compiler/closure.ts
+++ b/tests/compiler/closure.ts
@@ -1,16 +1,8 @@
-// TODO
+function test($local0: i32, $local1: i32): (value: i32) => i32 {
+  return function inner(value: i32) {
+    return $local1; // closure
+  };
+}
 
-// export function outer(): () => () => i32 {
-//   var inner: i32 = 42; // should become a global right away
-//   return function a(): () => i32 {
-//     return function b(): i32 {
-//       return inner++;
-//     };
-//   };
-// }
-
-// var fnA = outer();
-// var fnB = fnA();
-
-// assert(fnB() == 42);
-// assert(fnB() == 43);
+test(1, 2);
+ERROR("EOF");


### PR DESCRIPTION
As pointed out in https://github.com/AssemblyScript/assemblyscript/issues/954, while closed-over locals can be properly resolved meanwhile, we were missing an error when we see one. Still not great, but it really shouldn't yield a validation error.