### PR TITLE
Support anyref variable declartions as Wasm locals

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -17,6 +17,7 @@ under the licensing terms detailed in LICENSE:
 * Bowen Wang <bowen@nearprotocol.com>
 * Emil Laine <laine.emil@gmail.com>
 * Stephen Paul Weber <stephen.weber@shopify.com>
+* Jay Phelps <hello@jayphelps.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -324,6 +324,7 @@ export class Flow {
       case NativeType.F32: { temps = parentFunction.tempF32s; break; }
       case NativeType.F64: { temps = parentFunction.tempF64s; break; }
       case NativeType.V128: { temps = parentFunction.tempV128s; break; }
+      case NativeType.Anyref: { temps = parentFunction.tempAnyrefs; break; }
       default: throw new Error("concrete type expected");
     }
     var local: Local;
@@ -393,6 +394,10 @@ export class Flow {
       }
       case NativeType.V128: {
         temps = parentFunction.tempV128s || (parentFunction.tempV128s = []);
+        break;
+      }
+      case NativeType.Anyref: {
+        temps = parentFunction.tempAnyrefs || (parentFunction.tempAnyrefs = []);
         break;
       }
       default: throw new Error("concrete type expected");

--- a/src/module.ts
+++ b/src/module.ts
@@ -1423,6 +1423,10 @@ export class Module {
             // TODO
             return 0;
           }
+          // Not possible to clone an anyref as it is opaque
+          case NativeType.Anyref: {
+            return 0;
+          }
           default: {
             throw new Error("concrete type expected");
           }

--- a/src/program.ts
+++ b/src/program.ts
@@ -2900,6 +2900,7 @@ export class Function extends TypedElement {
   tempF32s: Local[] | null = null;
   tempF64s: Local[] | null = null;
   tempV128s: Local[] | null = null;
+  tempAnyrefs: Local[] | null = null;
 
   // used by flows to keep track of break labels
   nextBreakId: i32 = 0;

--- a/tests/compiler/features/reference-types.ts
+++ b/tests/compiler/features/reference-types.ts
@@ -3,7 +3,10 @@
 export declare function external(a: anyref): anyref;
 
 export function internal(a: anyref): anyref {
-  return a;
+  const b = external(a);
+  let c = external(b);
+  var d = external(c);
+  return d;
 }
 
 // can use reflection to work with anyref values

--- a/tests/compiler/features/reference-types.untouched.wat
+++ b/tests/compiler/features/reference-types.untouched.wat
@@ -30,7 +30,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 16
+   i32.const 19
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45,7 +45,19 @@
   call $~lib/bindings/console/log
  )
  (func $features/reference-types/internal (; 6 ;) (type $FUNCSIG$aa) (param $0 anyref) (result anyref)
+  (local $1 anyref)
+  (local $2 anyref)
+  (local $3 anyref)
   local.get $0
+  call $features/reference-types/external
+  local.set $1
+  local.get $1
+  call $features/reference-types/external
+  local.set $2
+  local.get $2
+  call $features/reference-types/external
+  local.set $3
+  local.get $3
  )
  (func $start (; 7 ;) (type $FUNCSIG$v)
   call $start:features/reference-types


### PR DESCRIPTION
```ts
declare function external(a: anyref): anyref;

export function internal(a: anyref): anyref {
  // is an anyref
  const b = external(a);
  return b;
}
```

Right now if you try to use an anyref as a variable declaration it barfs with:

```
ERROR: concrete type expected
    at c.getTempLocal
```

This solves it by making the compiler aware that anyrefs can be stored as locals

Keywords: reference types, reference-types, gc