### PR TITLE
WIP: Indirect calls on null trapping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,9 @@ jobs:
       run: npm run clean
     - name: Test experimental features
       env:
-        ASC_FEATURES: mutable-globals,threads,reference-types,bigint-integration
+        ASC_FEATURES: mutable-globals,threads,reference-types,bigint-integration,exception-handling
       run: |
-        npm run test:compiler rt/flags features/js-bigint-integration features/reference-types features/threads
+        npm run test:compiler rt/flags features/js-bigint-integration features/reference-types features/threads features/exception-handling
   test-runtime:
     name: "Test runtimes on node: node"
     runs-on: ubuntu-latest

--- a/examples/game-of-life/build/untouched.wat
+++ b/examples/game-of-life/build/untouched.wat
@@ -60,7 +60,7 @@
        global.get $assembly/config/BGR_DEAD
        i32.const 16777215
        i32.and
-      else       
+      else
        global.get $assembly/config/BGR_ALIVE
        i32.const -16777216
        i32.or
@@ -134,7 +134,7 @@
     i32.eq
     if (result i32)
      local.get $0
-    else     
+    else
      local.get $2
      i32.const 1
      i32.sub
@@ -145,7 +145,7 @@
     i32.eq
     if (result i32)
      i32.const 0
-    else     
+    else
      local.get $2
      i32.const 1
      i32.add
@@ -165,7 +165,7 @@
       i32.eq
       if (result i32)
        local.get $1
-      else       
+      else
        local.get $5
        i32.const 1
        i32.sub
@@ -176,7 +176,7 @@
       i32.eq
       if (result i32)
        i32.const 0
-      else       
+      else
        local.get $5
        i32.const 1
        i32.add
@@ -367,7 +367,7 @@
         i32.shl
         local.get $14
         i32.store
-       else        
+       else
         local.get $5
         local.set $16
         local.get $2
@@ -388,7 +388,7 @@
         local.get $14
         i32.store
        end
-      else       
+      else
        local.get $9
        i32.const 3
        i32.eq
@@ -412,7 +412,7 @@
         i32.shl
         local.get $8
         i32.store
-       else        
+       else
         local.get $5
         local.set $15
         local.get $2
@@ -563,5 +563,6 @@
   end
  )
  (func $null (; 4 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/examples/mandelbrot/build/untouched.wat
+++ b/examples/mandelbrot/build/untouched.wat
@@ -251,5 +251,6 @@
   end
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/examples/n-body/build/untouched.wat
+++ b/examples/n-body/build/untouched.wat
@@ -2225,5 +2225,6 @@
   global.set $~lib/rt/stub/offset
  )
  (func $null (; 24 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/examples/pson/build/untouched.wat
+++ b/examples/pson/build/untouched.wat
@@ -484,5 +484,6 @@
   end
  )
  (func $null (; 18 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/lib/i64/build/untouched.wat
+++ b/lib/i64/build/untouched.wat
@@ -749,5 +749,6 @@
   global.set $assembly/i64/hi
  )
  (func $null (; 31 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/allocators/buddy/untouched.wat
+++ b/tests/allocators/buddy/untouched.wat
@@ -88,7 +88,7 @@
      local.get $1
      i32.const 3
      i32.and
-    else     
+    else
      i32.const 0
     end
     if
@@ -1293,7 +1293,7 @@
    i32.le_u
    if (result i32)
     i32.const 1
-   else    
+   else
     local.get $5
     local.get $3
     i32.add
@@ -1413,7 +1413,7 @@
       end
      end
     end
-   else    
+   else
     local.get $4
     i32.const 7
     i32.and
@@ -1554,7 +1554,7 @@
       local.get $4
       i32.load8_u
       i32.eq
-     else      
+     else
       i32.const 0
      end
      if
@@ -1581,7 +1581,7 @@
     local.get $4
     i32.load8_u
     i32.sub
-   else    
+   else
     i32.const 0
    end
   end
@@ -2019,7 +2019,7 @@
       i32.ne
       if (result i32)
        i32.const 1
-      else       
+      else
        local.get $2
        i32.const 0
        i32.eq
@@ -2060,7 +2060,7 @@
       i32.div_u
       global.get $assembly/buddy/List.SIZE
       i32.add
-     else      
+     else
       local.get $3
      end
      local.set $4
@@ -2164,7 +2164,7 @@
      call $assembly/buddy/parent_is_split
      if (result i32)
       i32.const 1
-     else      
+     else
       local.get $1
       global.get $assembly/buddy/bucket_limit
       i32.eq
@@ -2207,5 +2207,6 @@
   call $start:assembly/index
  )
  (func $null (; 26 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/allocators/rt-full/untouched.wat
+++ b/tests/allocators/rt-full/untouched.wat
@@ -77,7 +77,7 @@
    local.get $3
    i32.const 1073741808
    i32.lt_u
-  else   
+  else
    i32.const 0
   end
   i32.eqz
@@ -99,7 +99,7 @@
    i32.const 4
    i32.shr_u
    local.set $5
-  else   
+  else
    i32.const 31
    local.get $3
    i32.clz
@@ -129,7 +129,7 @@
    local.get $5
    i32.const 16
    i32.lt_u
-  else   
+  else
    i32.const 0
   end
   i32.eqz
@@ -444,7 +444,7 @@
    local.get $8
    i32.const 1073741808
    i32.lt_u
-  else   
+  else
    i32.const 0
   end
   i32.eqz
@@ -487,7 +487,7 @@
    i32.const 4
    i32.shr_u
    local.set $10
-  else   
+  else
    i32.const 31
    local.get $8
    i32.clz
@@ -517,7 +517,7 @@
    local.get $10
    i32.const 16
    i32.lt_u
-  else   
+  else
    i32.const 0
   end
   i32.eqz
@@ -636,7 +636,7 @@
    i32.const 15
    i32.and
    i32.eqz
-  else   
+  else
    i32.const 0
   end
   if (result i32)
@@ -644,7 +644,7 @@
    i32.const 15
    i32.and
    i32.eqz
-  else   
+  else
    i32.const 0
   end
   i32.eqz
@@ -694,10 +694,10 @@
     local.get $4
     i32.load
     local.set $5
-   else    
+   else
     nop
    end
-  else   
+  else
    local.get $1
    local.get $0
    i32.const 1572
@@ -815,7 +815,7 @@
    memory.grow
    i32.const 0
    i32.lt_s
-  else   
+  else
    i32.const 0
   end
   if
@@ -973,7 +973,7 @@
    i32.const 4
    i32.shr_u
    local.set $3
-  else   
+  else
    local.get $1
    i32.const 536870904
    i32.lt_u
@@ -988,7 +988,7 @@
     i32.add
     i32.const 1
     i32.sub
-   else    
+   else
     local.get $1
    end
    local.set $4
@@ -1021,7 +1021,7 @@
    local.get $3
    i32.const 16
    i32.lt_u
-  else   
+  else
    i32.const 0
   end
   i32.eqz
@@ -1073,7 +1073,7 @@
    if
     i32.const 0
     local.set $7
-   else    
+   else
     local.get $5
     i32.ctz
     local.set $2
@@ -1121,7 +1121,7 @@
     end
     local.set $7
    end
-  else   
+  else
    block $~lib/rt/tlsf/GETHEAD|inlined.3 (result i32)
     local.get $0
     local.set $9
@@ -1253,7 +1253,7 @@
    local.get $0
    local.get $5
    call $~lib/rt/tlsf/insertBlock
-  else   
+  else
    local.get $1
    local.get $3
    i32.const 1
@@ -1505,7 +1505,7 @@
      local.get $1
      i32.const 3
      i32.and
-    else     
+    else
      i32.const 0
     end
     if
@@ -2710,7 +2710,7 @@
    i32.le_u
    if (result i32)
     i32.const 1
-   else    
+   else
     local.get $5
     local.get $3
     i32.add
@@ -2830,7 +2830,7 @@
       end
      end
     end
-   else    
+   else
     local.get $4
     i32.const 7
     i32.and
@@ -2931,7 +2931,7 @@
    i32.const 15
    i32.and
    i32.eqz
-  else   
+  else
    i32.const 0
   end
   i32.eqz
@@ -3060,7 +3060,7 @@
     global.get $~lib/rt/tlsf/ROOT
     local.get $0
     call $~lib/rt/tlsf/freeBlock
-   else    
+   else
     local.get $0
     i32.const -2147483648
     i32.const 0
@@ -3069,7 +3069,7 @@
     i32.or
     i32.store offset=4
    end
-  else   
+  else
    local.get $2
    i32.const 0
    i32.gt_u
@@ -3106,7 +3106,7 @@
      local.get $0
      call $~lib/rt/pure/appendRoot
     end
-   else    
+   else
     local.get $0
     local.get $1
     i32.const 268435455
@@ -3195,7 +3195,7 @@
    if
     local.get $0
     call $~lib/rt/pure/scanBlack
-   else    
+   else
     local.get $0
     local.get $1
     i32.const 1879048192
@@ -3228,7 +3228,7 @@
    i32.const -2147483648
    i32.and
    i32.eqz
-  else   
+  else
    i32.const 0
   end
   if
@@ -3292,7 +3292,7 @@
      i32.and
      i32.const 0
      i32.gt_u
-    else     
+    else
      i32.const 0
     end
     if
@@ -3305,7 +3305,7 @@
      i32.const 4
      i32.add
      local.set $1
-    else     
+    else
      local.get $5
      i32.const 1879048192
      i32.and
@@ -3316,14 +3316,14 @@
       i32.const 268435455
       i32.and
       i32.eqz
-     else      
+     else
       i32.const 0
      end
      if
       global.get $~lib/rt/tlsf/ROOT
       local.get $4
       call $~lib/rt/tlsf/freeBlock
-     else      
+     else
       local.get $4
       local.get $5
       i32.const -2147483648
@@ -3474,7 +3474,7 @@
       local.get $4
       i32.load8_u
       i32.eq
-     else      
+     else
       i32.const 0
      end
      if
@@ -3501,7 +3501,7 @@
     local.get $4
     i32.load8_u
     i32.sub
-   else    
+   else
     i32.const 0
    end
   end
@@ -3718,5 +3718,6 @@
   end
  )
  (func $null (; 33 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/allocators/rt-stub/untouched.wat
+++ b/tests/allocators/rt-stub/untouched.wat
@@ -160,7 +160,7 @@
      local.get $1
      i32.const 3
      i32.and
-    else     
+    else
      i32.const 0
     end
     if
@@ -1365,7 +1365,7 @@
    i32.le_u
    if (result i32)
     i32.const 1
-   else    
+   else
     local.get $5
     local.get $3
     i32.add
@@ -1485,7 +1485,7 @@
       end
      end
     end
-   else    
+   else
     local.get $4
     i32.const 7
     i32.and
@@ -1626,7 +1626,7 @@
       local.get $4
       i32.load8_u
       i32.eq
-     else      
+     else
       i32.const 0
      end
      if
@@ -1653,7 +1653,7 @@
     local.get $4
     i32.load8_u
     i32.sub
-   else    
+   else
     i32.const 0
    end
   end
@@ -1678,5 +1678,6 @@
   global.set $~lib/rt/stub/offset
  )
  (func $null (; 14 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/ReturnType.optimized.wat
+++ b/tests/compiler/ReturnType.optimized.wat
@@ -3,6 +3,6 @@
  (memory $0 0)
  (export "memory" (memory $0))
  (func $null (; 0 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/ReturnType.untouched.wat
+++ b/tests/compiler/ReturnType.untouched.wat
@@ -5,5 +5,6 @@
  (elem (i32.const 0) $null)
  (export "memory" (memory $0))
  (func $null (; 0 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/abi.optimized.wat
+++ b/tests/compiler/abi.optimized.wat
@@ -20,6 +20,6 @@
   global.set $abi/y
  )
  (func $null (; 2 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/abi.untouched.wat
+++ b/tests/compiler/abi.untouched.wat
@@ -203,5 +203,6 @@
   call $start:abi
  )
  (func $null (; 7 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/asc-constants.optimized.wat
+++ b/tests/compiler/asc-constants.optimized.wat
@@ -2,7 +2,7 @@
  (type $FUNCSIG$v (func))
  (memory $0 0)
  (export "memory" (memory $0))
- (func $start (; 0 ;) (type $FUNCSIG$v)
-  nop
+ (func $null (; 0 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/asc-constants.untouched.wat
+++ b/tests/compiler/asc-constants.untouched.wat
@@ -53,5 +53,6 @@
   call $start:asc-constants
  )
  (func $null (; 2 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/assert-nonnull.optimized.wat
+++ b/tests/compiler/assert-nonnull.optimized.wat
@@ -186,6 +186,6 @@
   end
  )
  (func $null (; 15 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/assert-nonnull.untouched.wat
+++ b/tests/compiler/assert-nonnull.untouched.wat
@@ -365,5 +365,6 @@
   local.get $2
  )
  (func $null (; 19 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/assert.optimized.wat
+++ b/tests/compiler/assert.optimized.wat
@@ -3,6 +3,6 @@
  (memory $0 0)
  (export "memory" (memory $0))
  (func $null (; 0 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/assert.untouched.wat
+++ b/tests/compiler/assert.untouched.wat
@@ -5,5 +5,6 @@
  (elem (i32.const 0) $null)
  (export "memory" (memory $0))
  (func $null (; 0 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/binary.optimized.wat
+++ b/tests/compiler/binary.optimized.wat
@@ -260,8 +260,7 @@
     return
    end
    local.get $2
-   i64.const 0
-   i64.eq
+   i64.eqz
    if (result i64)
     local.get $1
     i64.const 0
@@ -708,6 +707,6 @@
   call $start:binary
  )
  (func $null (; 6 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/binary.untouched.wat
+++ b/tests/compiler/binary.untouched.wat
@@ -3323,5 +3323,6 @@
   call $start:binary
  )
  (func $null (; 8 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/bool.optimized.wat
+++ b/tests/compiler/bool.optimized.wat
@@ -11,6 +11,6 @@
   call $start:bool
  )
  (func $null (; 2 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/bool.untouched.wat
+++ b/tests/compiler/bool.untouched.wat
@@ -119,5 +119,6 @@
   call $start:bool
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/builtins.optimized.wat
+++ b/tests/compiler/builtins.optimized.wat
@@ -33,7 +33,7 @@
  (data (i32.const 576) "\08\00\00\00\01\00\00\00\01\00\00\00\08\00\00\00v\00o\00i\00d")
  (data (i32.const 600) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00s\00o\00m\00e\00 \00v\00a\00l\00u\00e")
  (table $0 4 funcref)
- (elem (i32.const 0) $start:builtins~anonymous|1 $start:builtins~anonymous|0 $start:builtins~anonymous|1 $start:builtins~anonymous|2)
+ (elem (i32.const 0) $null $start:builtins~anonymous|0 $start:builtins~anonymous|1 $start:builtins~anonymous|2)
  (global $builtins/b (mut i32) (i32.const 0))
  (global $builtins/i (mut i32) (i32.const 0))
  (global $builtins/I (mut i64) (i64.const 0))
@@ -878,5 +878,8 @@
  )
  (func $start (; 10 ;) (type $FUNCSIG$v)
   call $start:builtins
+ )
+ (func $null (; 11 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/builtins.untouched.wat
+++ b/tests/compiler/builtins.untouched.wat
@@ -1883,5 +1883,6 @@
   call $start:builtins
  )
  (func $null (; 14 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/call-inferred.optimized.wat
+++ b/tests/compiler/call-inferred.optimized.wat
@@ -13,6 +13,6 @@
   call $start:call-inferred
  )
  (func $null (; 2 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/call-inferred.untouched.wat
+++ b/tests/compiler/call-inferred.untouched.wat
@@ -99,5 +99,6 @@
   call $start:call-inferred
  )
  (func $null (; 8 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/call-optional.optimized.wat
+++ b/tests/compiler/call-optional.optimized.wat
@@ -136,6 +136,6 @@
   call $start:call-optional
  )
  (func $null (; 5 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/call-optional.untouched.wat
+++ b/tests/compiler/call-optional.untouched.wat
@@ -150,5 +150,6 @@
   call $start:call-optional
  )
  (func $null (; 5 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/call-super.optimized.wat
+++ b/tests/compiler/call-super.optimized.wat
@@ -431,6 +431,6 @@
   call $call-super/test5
  )
  (func $null (; 15 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/call-super.untouched.wat
+++ b/tests/compiler/call-super.untouched.wat
@@ -559,5 +559,6 @@
   call $start:call-super
  )
  (func $null (; 22 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/class-extends.optimized.wat
+++ b/tests/compiler/class-extends.optimized.wat
@@ -19,6 +19,6 @@
   i32.store16 offset=4
  )
  (func $null (; 1 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/class-extends.untouched.wat
+++ b/tests/compiler/class-extends.untouched.wat
@@ -33,5 +33,6 @@
   call $~lib/rt/stub/__release
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/class-overloading.optimized.wat
+++ b/tests/compiler/class-overloading.optimized.wat
@@ -7,7 +7,7 @@
  (func $class-overloading/test (; 0 ;) (type $FUNCSIG$vi) (param $0 i32)
   nop
  )
- (func $start (; 1 ;) (type $FUNCSIG$v)
-  nop
+ (func $null (; 1 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/class-overloading.untouched.wat
+++ b/tests/compiler/class-overloading.untouched.wat
@@ -34,5 +34,6 @@
   call $start:class-overloading
  )
  (func $null (; 6 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/class-static-function.optimized.wat
+++ b/tests/compiler/class-static-function.optimized.wat
@@ -29,6 +29,6 @@
   end
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/class-static-function.untouched.wat
+++ b/tests/compiler/class-static-function.untouched.wat
@@ -39,5 +39,6 @@
   call $start:class-static-function
  )
  (func $null (; 5 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/class.optimized.wat
+++ b/tests/compiler/class.optimized.wat
@@ -25,7 +25,7 @@
   i32.store8 offset=6
   local.get $0
  )
- (func $start (; 1 ;) (type $FUNCSIG$v)
-  nop
+ (func $null (; 1 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/class.untouched.wat
+++ b/tests/compiler/class.untouched.wat
@@ -119,5 +119,6 @@
   call $start:class
  )
  (func $null (; 9 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/closure.untouched.wat
+++ b/tests/compiler/closure.untouched.wat
@@ -5,5 +5,6 @@
  (elem (i32.const 0) $null)
  (export "memory" (memory $0))
  (func $null (; 0 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/comma.optimized.wat
+++ b/tests/compiler/comma.optimized.wat
@@ -159,6 +159,6 @@
   call $start:comma
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/comma.untouched.wat
+++ b/tests/compiler/comma.untouched.wat
@@ -187,5 +187,6 @@
   call $start:comma
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/constructor.optimized.wat
+++ b/tests/compiler/constructor.optimized.wat
@@ -175,6 +175,6 @@
   call $start:constructor
  )
  (func $null (; 4 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/constructor.untouched.wat
+++ b/tests/compiler/constructor.untouched.wat
@@ -324,5 +324,6 @@
   call $start:constructor
  )
  (func $null (; 15 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/continue.optimized.wat
+++ b/tests/compiler/continue.optimized.wat
@@ -31,6 +31,6 @@
   end
  )
  (func $null (; 1 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/continue.untouched.wat
+++ b/tests/compiler/continue.untouched.wat
@@ -38,5 +38,6 @@
   end
  )
  (func $null (; 1 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/declare.optimized.wat
+++ b/tests/compiler/declare.optimized.wat
@@ -40,6 +40,6 @@
   call $start:declare
  )
  (func $null (; 5 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/declare.untouched.wat
+++ b/tests/compiler/declare.untouched.wat
@@ -44,5 +44,6 @@
   call $start:declare
  )
  (func $null (; 5 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/do.optimized.wat
+++ b/tests/compiler/do.optimized.wat
@@ -149,6 +149,6 @@
   call $start:do
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/do.untouched.wat
+++ b/tests/compiler/do.untouched.wat
@@ -166,5 +166,6 @@
   call $start:do
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/empty.optimized.wat
+++ b/tests/compiler/empty.optimized.wat
@@ -3,6 +3,6 @@
  (memory $0 0)
  (export "memory" (memory $0))
  (func $null (; 0 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/empty.untouched.wat
+++ b/tests/compiler/empty.untouched.wat
@@ -5,5 +5,6 @@
  (elem (i32.const 0) $null)
  (export "memory" (memory $0))
  (func $null (; 0 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/enum.optimized.wat
+++ b/tests/compiler/enum.optimized.wat
@@ -68,6 +68,6 @@
   global.set $enum/NonConstant.ONE
  )
  (func $null (; 1 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/enum.untouched.wat
+++ b/tests/compiler/enum.untouched.wat
@@ -84,5 +84,6 @@
   call $start:enum
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/export-default.optimized.wat
+++ b/tests/compiler/export-default.optimized.wat
@@ -7,4 +7,7 @@
  (func $export-default/theDefault (; 0 ;) (type $FUNCSIG$v)
   nop
  )
+ (func $null (; 1 ;) (type $FUNCSIG$v)
+  unreachable
+ )
 )

--- a/tests/compiler/export-default.untouched.wat
+++ b/tests/compiler/export-default.untouched.wat
@@ -10,5 +10,6 @@
   nop
  )
  (func $null (; 1 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/export.optimized.wat
+++ b/tests/compiler/export.optimized.wat
@@ -32,4 +32,7 @@
  (func $export/ns.one (; 3 ;) (type $FUNCSIG$v)
   nop
  )
+ (func $null (; 4 ;) (type $FUNCSIG$v)
+  unreachable
+ )
 )

--- a/tests/compiler/export.untouched.wat
+++ b/tests/compiler/export.untouched.wat
@@ -38,5 +38,6 @@
   nop
  )
  (func $null (; 5 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/exports.optimized.wat
+++ b/tests/compiler/exports.optimized.wat
@@ -148,7 +148,7 @@
   global.set $~lib/rt/stub/offset
  )
  (func $null (; 9 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
  (func $exports/subOpt|trampoline (; 10 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1

--- a/tests/compiler/exports.untouched.wat
+++ b/tests/compiler/exports.untouched.wat
@@ -254,6 +254,7 @@
   global.set $~lib/rt/stub/offset
  )
  (func $null (; 17 ;) (type $FUNCSIG$v)
+  unreachable
  )
  (func $exports/subOpt|trampoline (; 18 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   block $1of1

--- a/tests/compiler/external.optimized.wat
+++ b/tests/compiler/external.optimized.wat
@@ -13,6 +13,6 @@
  (export "three" (func $external/three))
  (export "var_" (global $external/var_))
  (func $null (; 4 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/external.untouched.wat
+++ b/tests/compiler/external.untouched.wat
@@ -15,5 +15,6 @@
  (export "three" (func $external/three))
  (export "var_" (global $external/var_))
  (func $null (; 4 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/features/exception-handling.js
+++ b/tests/compiler/features/exception-handling.js
@@ -1,0 +1,8 @@
+const assert = require('assert');
+
+exports.postInstantiate = function (instance) {
+  const exports = instance.exports;
+  assert.throws(() => {
+    exports.testNullFunction();
+  }, /^RuntimeError: wasm exception$/);
+};

--- a/tests/compiler/features/exception-handling.json
+++ b/tests/compiler/features/exception-handling.json
@@ -1,0 +1,8 @@
+{
+  "features": [
+    "exception-handling"
+  ],
+  "asc_flags": [
+    "--runtime none"
+  ]
+}

--- a/tests/compiler/features/exception-handling.optimized.wat
+++ b/tests/compiler/features/exception-handling.optimized.wat
@@ -1,0 +1,24 @@
+(module
+ (type $FUNCSIG$v (func))
+ (type $NullPointerException (func (param i32)))
+ (memory $0 1)
+ (data (i32.const 8) ",\00\00\00\01\00\00\00\01\00\00\00,\00\00\00n\00u\00l\00l\00 \00i\00s\00 \00n\00o\00t\00 \00a\00 \00f\00u\00n\00c\00t\00i\00o\00n")
+ (table $0 2 funcref)
+ (elem (i32.const 0) $null $features/exception-handling/testNullable~anonymous|0)
+ (global $~lib/argc (mut i32) (i32.const 0))
+ (event $NullPointerException (attr 0) (param i32))
+ (export "memory" (memory $0))
+ (export "testNullFunction" (func $features/exception-handling/testNullFunction))
+ (func $features/exception-handling/testNullable~anonymous|0 (; 0 ;) (type $FUNCSIG$v)
+  nop
+ )
+ (func $features/exception-handling/testNullFunction (; 1 ;) (type $FUNCSIG$v)
+  i32.const 0
+  global.set $~lib/argc
+  call $null
+ )
+ (func $null (; 2 ;) (type $FUNCSIG$v)
+  i32.const 24
+  throw $NullPointerException
+ )
+)

--- a/tests/compiler/features/exception-handling.ts
+++ b/tests/compiler/features/exception-handling.ts
@@ -1,0 +1,12 @@
+function testNullable(b: boolean): (() => void) | null {
+  if (b) {
+    return (): void => { };
+  } else {
+    return null;
+  }
+}
+
+export function testNullFunction(): void {
+  var fn = testNullable(false) as () => void;
+  fn();
+}

--- a/tests/compiler/features/exception-handling.untouched.wat
+++ b/tests/compiler/features/exception-handling.untouched.wat
@@ -1,0 +1,41 @@
+(module
+ (type $FUNCSIG$v (func))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $NullPointerException (func (param i32)))
+ (memory $0 1)
+ (data (i32.const 8) ",\00\00\00\01\00\00\00\01\00\00\00,\00\00\00n\00u\00l\00l\00 \00i\00s\00 \00n\00o\00t\00 \00a\00 \00f\00u\00n\00c\00t\00i\00o\00n\00")
+ (table $0 2 funcref)
+ (elem (i32.const 0) $null $features/exception-handling/testNullable~anonymous|0)
+ (global $~lib/argc (mut i32) (i32.const 0))
+ (event $NullPointerException (attr 0) (param i32))
+ (export "memory" (memory $0))
+ (export "testNullFunction" (func $features/exception-handling/testNullFunction))
+ (func $features/exception-handling/testNullable~anonymous|0 (; 0 ;) (type $FUNCSIG$v)
+  nop
+ )
+ (func $features/exception-handling/testNullable (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  if
+   i32.const 1
+   return
+  else
+   i32.const 0
+   return
+  end
+  unreachable
+ )
+ (func $features/exception-handling/testNullFunction (; 2 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  i32.const 0
+  call $features/exception-handling/testNullable
+  local.set $0
+  i32.const 0
+  global.set $~lib/argc
+  local.get $0
+  call_indirect (type $FUNCSIG$v)
+ )
+ (func $null (; 3 ;) (type $FUNCSIG$v)
+  i32.const 24
+  throw $NullPointerException
+ )
+)

--- a/tests/compiler/features/js-bigint-integration.optimized.wat
+++ b/tests/compiler/features/js-bigint-integration.optimized.wat
@@ -51,6 +51,6 @@
   call $start:features/js-bigint-integration
  )
  (func $null (; 5 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/features/js-bigint-integration.untouched.wat
+++ b/tests/compiler/features/js-bigint-integration.untouched.wat
@@ -55,5 +55,6 @@
   call $start:features/js-bigint-integration
  )
  (func $null (; 5 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/features/mutable-globals.optimized.wat
+++ b/tests/compiler/features/mutable-globals.optimized.wat
@@ -76,6 +76,6 @@
   call $start:features/mutable-globals
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/features/mutable-globals.untouched.wat
+++ b/tests/compiler/features/mutable-globals.untouched.wat
@@ -82,5 +82,6 @@
   call $start:features/mutable-globals
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/features/reference-types.optimized.wat
+++ b/tests/compiler/features/reference-types.optimized.wat
@@ -26,7 +26,7 @@
   if
    i32.const 0
    i32.const 24
-   i32.const 16
+   i32.const 19
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42,11 +42,14 @@
  )
  (func $features/reference-types/internal (; 6 ;) (type $FUNCSIG$aa) (param $0 anyref) (result anyref)
   local.get $0
+  call $features/reference-types/external
+  call $features/reference-types/external
+  call $features/reference-types/external
  )
  (func $start (; 7 ;) (type $FUNCSIG$v)
   call $start:features/reference-types
  )
  (func $null (; 8 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/features/reference-types.untouched.wat
+++ b/tests/compiler/features/reference-types.untouched.wat
@@ -63,5 +63,6 @@
   call $start:features/reference-types
  )
  (func $null (; 8 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/features/simd.untouched.wat
+++ b/tests/compiler/features/simd.untouched.wat
@@ -2299,5 +2299,6 @@
   call $start:features/simd
  )
  (func $null (; 17 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/features/threads.optimized.wat
+++ b/tests/compiler/features/threads.optimized.wat
@@ -537,6 +537,6 @@
   call $features/threads/testAtomicAsm
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/features/threads.untouched.wat
+++ b/tests/compiler/features/threads.untouched.wat
@@ -543,5 +543,6 @@
   call $start:features/threads
  )
  (func $null (; 4 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/for.optimized.wat
+++ b/tests/compiler/for.optimized.wat
@@ -159,6 +159,6 @@
   call $start:for
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/for.untouched.wat
+++ b/tests/compiler/for.untouched.wat
@@ -199,5 +199,6 @@
   call $start:for
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/function-expression.js
+++ b/tests/compiler/function-expression.js
@@ -1,0 +1,6 @@
+const assert = require('assert');
+
+exports.postInstantiate = function (instance) {
+  const exports = instance.exports;
+  assert.throws(exports.testNullFunction, /^RuntimeError: unreachable$/);
+};

--- a/tests/compiler/function-expression.optimized.wat
+++ b/tests/compiler/function-expression.optimized.wat
@@ -8,9 +8,10 @@
  (memory $0 1)
  (data (i32.const 8) ",\00\00\00\01\00\00\00\01\00\00\00,\00\00\00f\00u\00n\00c\00t\00i\00o\00n\00-\00e\00x\00p\00r\00e\00s\00s\00i\00o\00n\00.\00t\00s")
  (table $0 12 funcref)
- (elem (i32.const 0) $start:function-expression~someName $start:function-expression~anonymous|0 $start:function-expression~anonymous|0 $start:function-expression~someName $start:function-expression~anonymous|2 $start:function-expression~anonymous|3 $start:function-expression~anonymous|4 $start:function-expression~anonymous|5 $start:function-expression~anonymous|3 $start:function-expression~anonymous|4 $start:function-expression~anonymous|5 $start:function-expression~anonymous|2)
+ (elem (i32.const 0) $null $start:function-expression~anonymous|0 $start:function-expression~anonymous|0 $start:function-expression~someName $start:function-expression~anonymous|2 $start:function-expression~anonymous|3 $start:function-expression~anonymous|4 $start:function-expression~anonymous|5 $start:function-expression~anonymous|3 $start:function-expression~anonymous|4 $start:function-expression~anonymous|5 $start:function-expression~someName)
  (global $~lib/argc (mut i32) (i32.const 0))
  (export "memory" (memory $0))
+ (export "testNullFunction" (func $function-expression/testNullFunction))
  (start $start)
  (func $start:function-expression~anonymous|0 (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
@@ -167,7 +168,15 @@
    unreachable
   end
  )
- (func $start (; 9 ;) (type $FUNCSIG$v)
+ (func $function-expression/testNullFunction (; 9 ;) (type $FUNCSIG$v)
+  i32.const 0
+  global.set $~lib/argc
+  call $null
+ )
+ (func $start (; 10 ;) (type $FUNCSIG$v)
   call $start:function-expression
+ )
+ (func $null (; 11 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/function-expression.ts
+++ b/tests/compiler/function-expression.ts
@@ -35,11 +35,16 @@ assert(testOmittedReturn1()(1, 2) == 3);
 assert(testOmittedReturn2()(1, 2) == 1);
 assert(testOmittedReturn3()(1, 2) == 42);
 
-function testNullable(b: boolean): (() => i32) | null {
+function testNullable(b: boolean): (() => void) | null {
   if (b) {
-    return (): i32 => 1;
+    return (): void => { };
   } else {
     return null;
   }
 }
 assert(testNullable(false) == null);
+
+export function testNullFunction(): void {
+  var fn = testNullable(false) as () => void;
+  fn();
+}

--- a/tests/compiler/function-expression.untouched.wat
+++ b/tests/compiler/function-expression.untouched.wat
@@ -15,6 +15,7 @@
  (global $function-expression/f3 (mut i32) (i32.const 3))
  (global $function-expression/f4 (mut i32) (i32.const 4))
  (export "memory" (memory $0))
+ (export "testNullFunction" (func $function-expression/testNullFunction))
  (start $start)
  (func $start:function-expression~anonymous|0 (; 1 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
@@ -67,8 +68,8 @@
  (func $function-expression/testOmittedReturn3 (; 14 ;) (type $FUNCSIG$i) (result i32)
   i32.const 10
  )
- (func $function-expression/testNullable~anonymous|0 (; 15 ;) (type $FUNCSIG$i) (result i32)
-  i32.const 1
+ (func $function-expression/testNullable~anonymous|0 (; 15 ;) (type $FUNCSIG$v)
+  nop
  )
  (func $function-expression/testNullable (; 16 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
@@ -237,9 +238,20 @@
    unreachable
   end
  )
- (func $start (; 18 ;) (type $FUNCSIG$v)
+ (func $function-expression/testNullFunction (; 18 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  i32.const 0
+  call $function-expression/testNullable
+  local.set $0
+  i32.const 0
+  global.set $~lib/argc
+  local.get $0
+  call_indirect (type $FUNCSIG$v)
+ )
+ (func $start (; 19 ;) (type $FUNCSIG$v)
   call $start:function-expression
  )
- (func $null (; 19 ;) (type $FUNCSIG$v)
+ (func $null (; 20 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/function-types.optimized.wat
+++ b/tests/compiler/function-types.optimized.wat
@@ -166,6 +166,6 @@
   call $start:function-types
  )
  (func $null (; 7 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/function-types.untouched.wat
+++ b/tests/compiler/function-types.untouched.wat
@@ -225,5 +225,6 @@
   call $start:function-types
  )
  (func $null (; 14 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/function.optimized.wat
+++ b/tests/compiler/function.optimized.wat
@@ -2,7 +2,7 @@
  (type $FUNCSIG$v (func))
  (memory $0 0)
  (export "memory" (memory $0))
- (func $start (; 0 ;) (type $FUNCSIG$v)
-  nop
+ (func $null (; 0 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/function.untouched.wat
+++ b/tests/compiler/function.untouched.wat
@@ -136,5 +136,6 @@
   call $start:function
  )
  (func $null (; 20 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/getter-call.optimized.wat
+++ b/tests/compiler/getter-call.optimized.wat
@@ -97,6 +97,6 @@
   global.set $~lib/rt/stub/offset
  )
  (func $null (; 5 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/getter-call.untouched.wat
+++ b/tests/compiler/getter-call.untouched.wat
@@ -174,5 +174,6 @@
   global.set $~lib/rt/stub/offset
  )
  (func $null (; 9 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/getter-setter.optimized.wat
+++ b/tests/compiler/getter-setter.optimized.wat
@@ -26,6 +26,6 @@
   call $start:getter-setter
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/getter-setter.untouched.wat
+++ b/tests/compiler/getter-setter.untouched.wat
@@ -64,5 +64,6 @@
   call $start:getter-setter
  )
  (func $null (; 5 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/i64-polyfill.optimized.wat
+++ b/tests/compiler/i64-polyfill.optimized.wat
@@ -94,8 +94,7 @@
   i64.const 32
   i64.shl
   i64.or
-  i64.const 0
-  i64.eq
+  i64.eqz
   global.set $../../lib/i64/assembly/i64/lo
   i32.const 0
   global.set $../../lib/i64/assembly/i64/hi
@@ -691,6 +690,6 @@
   global.set $../../lib/i64/assembly/i64/hi
  )
  (func $null (; 31 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/i64-polyfill.untouched.wat
+++ b/tests/compiler/i64-polyfill.untouched.wat
@@ -751,5 +751,6 @@
   global.set $../../lib/i64/assembly/i64/hi
  )
  (func $null (; 31 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/if.optimized.wat
+++ b/tests/compiler/if.optimized.wat
@@ -111,6 +111,6 @@
   call $start:if
  )
  (func $null (; 6 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/if.untouched.wat
+++ b/tests/compiler/if.untouched.wat
@@ -143,5 +143,6 @@
   call $start:if
  )
  (func $null (; 7 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/import.optimized.wat
+++ b/tests/compiler/import.optimized.wat
@@ -2,7 +2,7 @@
  (type $FUNCSIG$v (func))
  (memory $0 0)
  (export "memory" (memory $0))
- (func $start (; 0 ;) (type $FUNCSIG$v)
-  nop
+ (func $null (; 0 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/import.untouched.wat
+++ b/tests/compiler/import.untouched.wat
@@ -64,5 +64,6 @@
   call $start:import
  )
  (func $null (; 7 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/indexof-valueof.optimized.wat
+++ b/tests/compiler/indexof-valueof.optimized.wat
@@ -3,6 +3,6 @@
  (memory $0 0)
  (export "memory" (memory $0))
  (func $null (; 0 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/indexof-valueof.untouched.wat
+++ b/tests/compiler/indexof-valueof.untouched.wat
@@ -5,5 +5,6 @@
  (elem (i32.const 0) $null)
  (export "memory" (memory $0))
  (func $null (; 0 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/infer-generic.optimized.wat
+++ b/tests/compiler/infer-generic.optimized.wat
@@ -76,6 +76,6 @@
   call $~lib/array/Array<f32>#reduce<bool>
  )
  (func $null (; 5 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/infer-generic.untouched.wat
+++ b/tests/compiler/infer-generic.untouched.wat
@@ -168,5 +168,6 @@
   call $start:infer-generic
  )
  (func $null (; 16 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/infer-type.optimized.wat
+++ b/tests/compiler/infer-type.optimized.wat
@@ -34,6 +34,6 @@
   call $start:infer-type
  )
  (func $null (; 2 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/infer-type.untouched.wat
+++ b/tests/compiler/infer-type.untouched.wat
@@ -100,5 +100,6 @@
   call $start:infer-type
  )
  (func $null (; 7 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/inlining-blocklocals.optimized.wat
+++ b/tests/compiler/inlining-blocklocals.optimized.wat
@@ -50,6 +50,6 @@
   call $inlining-blocklocals/test
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/inlining-blocklocals.untouched.wat
+++ b/tests/compiler/inlining-blocklocals.untouched.wat
@@ -100,5 +100,6 @@
   call $start:inlining-blocklocals
  )
  (func $null (; 4 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/inlining-recursive.optimized.wat
+++ b/tests/compiler/inlining-recursive.optimized.wat
@@ -12,6 +12,6 @@
   call $inlining-recursive/baz
  )
  (func $null (; 2 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/inlining-recursive.untouched.wat
+++ b/tests/compiler/inlining-recursive.untouched.wat
@@ -17,5 +17,6 @@
   call $inlining-recursive/baz
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/inlining.optimized.wat
+++ b/tests/compiler/inlining.optimized.wat
@@ -214,6 +214,6 @@
   call $inlining/test_ctor
  )
  (func $null (; 8 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/inlining.untouched.wat
+++ b/tests/compiler/inlining.untouched.wat
@@ -520,5 +520,6 @@
   call $start:inlining
  )
  (func $null (; 11 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/instanceof.optimized.wat
+++ b/tests/compiler/instanceof.optimized.wat
@@ -24,6 +24,6 @@
   call $start:instanceof
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/instanceof.untouched.wat
+++ b/tests/compiler/instanceof.untouched.wat
@@ -134,5 +134,6 @@
   call $start:instanceof
  )
  (func $null (; 9 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/limits.optimized.wat
+++ b/tests/compiler/limits.optimized.wat
@@ -2,7 +2,7 @@
  (type $FUNCSIG$v (func))
  (memory $0 0)
  (export "memory" (memory $0))
- (func $start (; 0 ;) (type $FUNCSIG$v)
-  nop
+ (func $null (; 0 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/limits.untouched.wat
+++ b/tests/compiler/limits.untouched.wat
@@ -89,5 +89,6 @@
   call $start:limits
  )
  (func $null (; 2 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/literals.optimized.wat
+++ b/tests/compiler/literals.optimized.wat
@@ -2,7 +2,7 @@
  (type $FUNCSIG$v (func))
  (memory $0 0)
  (export "memory" (memory $0))
- (func $start (; 0 ;) (type $FUNCSIG$v)
-  nop
+ (func $null (; 0 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/literals.untouched.wat
+++ b/tests/compiler/literals.untouched.wat
@@ -99,5 +99,6 @@
   call $start:literals
  )
  (func $null (; 2 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/logical.optimized.wat
+++ b/tests/compiler/logical.optimized.wat
@@ -98,6 +98,6 @@
   call $start:logical
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/logical.untouched.wat
+++ b/tests/compiler/logical.untouched.wat
@@ -496,5 +496,6 @@
   call $start:logical
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/loop-flow.optimized.wat
+++ b/tests/compiler/loop-flow.optimized.wat
@@ -160,6 +160,6 @@
   call $start:loop-flow
  )
  (func $null (; 11 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/loop-flow.untouched.wat
+++ b/tests/compiler/loop-flow.untouched.wat
@@ -238,5 +238,6 @@
   call $start:loop-flow
  )
  (func $null (; 14 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/loop-wrap.optimized.wat
+++ b/tests/compiler/loop-wrap.optimized.wat
@@ -61,6 +61,6 @@
   end
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/loop-wrap.untouched.wat
+++ b/tests/compiler/loop-wrap.untouched.wat
@@ -79,5 +79,6 @@
   end
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/mandelbrot.optimized.wat
+++ b/tests/compiler/mandelbrot.optimized.wat
@@ -32,8 +32,7 @@
    local.get $2
    i64.const 1
    i64.shl
-   i64.const 0
-   i64.eq
+   i64.eqz
    if
     f64.const -1
     local.get $0
@@ -75,8 +74,7 @@
     local.get $2
     i64.const 32
     i64.shl
-    i64.const 0
-    i64.eq
+    i64.eqz
     i32.const 0
     local.get $1
     i32.const 1072693248
@@ -203,8 +201,7 @@
    local.get $3
    i64.const 1
    i64.shl
-   i64.const 0
-   i64.eq
+   i64.eqz
    if
     f64.const -1
     local.get $0
@@ -246,8 +243,7 @@
     local.get $3
     i64.const 32
     i64.shl
-    i64.const 0
-    i64.eq
+    i64.eqz
     i32.const 0
     local.get $2
     i32.const 1072693248
@@ -575,6 +571,6 @@
   end
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/mandelbrot.untouched.wat
+++ b/tests/compiler/mandelbrot.untouched.wat
@@ -718,5 +718,6 @@
   end
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/many-locals.optimized.wat
+++ b/tests/compiler/many-locals.optimized.wat
@@ -34,6 +34,6 @@
   end
  )
  (func $null (; 4 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/many-locals.untouched.wat
+++ b/tests/compiler/many-locals.untouched.wat
@@ -821,5 +821,6 @@
   call $start:many-locals
  )
  (func $null (; 5 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/memcpy.optimized.wat
+++ b/tests/compiler/memcpy.optimized.wat
@@ -1045,6 +1045,6 @@
   call $start:memcpy
  )
  (func $null (; 4 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/memcpy.untouched.wat
+++ b/tests/compiler/memcpy.untouched.wat
@@ -1255,5 +1255,6 @@
   call $start:memcpy
  )
  (func $null (; 4 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/memmove.optimized.wat
+++ b/tests/compiler/memmove.optimized.wat
@@ -374,6 +374,6 @@
   call $start:memmove
  )
  (func $null (; 4 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/memmove.untouched.wat
+++ b/tests/compiler/memmove.untouched.wat
@@ -421,5 +421,6 @@
   call $start:memmove
  )
  (func $null (; 4 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/memset.optimized.wat
+++ b/tests/compiler/memset.optimized.wat
@@ -329,6 +329,6 @@
   call $start:memset
  )
  (func $null (; 4 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/memset.untouched.wat
+++ b/tests/compiler/memset.untouched.wat
@@ -380,5 +380,6 @@
   call $start:memset
  )
  (func $null (; 4 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/merge.optimized.wat
+++ b/tests/compiler/merge.optimized.wat
@@ -2,7 +2,7 @@
  (type $FUNCSIG$v (func))
  (memory $0 0)
  (export "memory" (memory $0))
- (func $start (; 0 ;) (type $FUNCSIG$v)
-  nop
+ (func $null (; 0 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/merge.untouched.wat
+++ b/tests/compiler/merge.untouched.wat
@@ -93,5 +93,6 @@
   call $start:merge
  )
  (func $null (; 18 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/named-export-default.optimized.wat
+++ b/tests/compiler/named-export-default.optimized.wat
@@ -8,6 +8,6 @@
   i32.const 3
  )
  (func $null (; 1 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/named-export-default.untouched.wat
+++ b/tests/compiler/named-export-default.untouched.wat
@@ -10,5 +10,6 @@
   i32.const 3
  )
  (func $null (; 1 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/named-import-default.optimized.wat
+++ b/tests/compiler/named-import-default.optimized.wat
@@ -8,6 +8,6 @@
   i32.const 3
  )
  (func $null (; 1 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/named-import-default.untouched.wat
+++ b/tests/compiler/named-import-default.untouched.wat
@@ -13,5 +13,6 @@
   call $named-export-default/get3
  )
  (func $null (; 2 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/namespace.optimized.wat
+++ b/tests/compiler/namespace.optimized.wat
@@ -12,6 +12,6 @@
   global.set $namespace/Outer.Inner.evenAnotherVar
  )
  (func $null (; 1 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/namespace.untouched.wat
+++ b/tests/compiler/namespace.untouched.wat
@@ -38,5 +38,6 @@
   call $start:namespace
  )
  (func $null (; 4 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/number.optimized.wat
+++ b/tests/compiler/number.optimized.wat
@@ -2161,6 +2161,6 @@
   call $start:number
  )
  (func $null (; 23 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/number.untouched.wat
+++ b/tests/compiler/number.untouched.wat
@@ -4229,5 +4229,6 @@
   call $start:number
  )
  (func $null (; 31 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/optional-typeparameters.optimized.wat
+++ b/tests/compiler/optional-typeparameters.optimized.wat
@@ -91,6 +91,6 @@
   global.set $optional-typeparameters/tDerived
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/optional-typeparameters.untouched.wat
+++ b/tests/compiler/optional-typeparameters.untouched.wat
@@ -203,5 +203,6 @@
   call $start:optional-typeparameters
  )
  (func $null (; 11 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/overflow.optimized.wat
+++ b/tests/compiler/overflow.optimized.wat
@@ -3,7 +3,7 @@
  (memory $0 1)
  (data (i32.const 8) "\16\00\00\00\01\00\00\00\01\00\00\00\16\00\00\00o\00v\00e\00r\00f\00l\00o\00w\00.\00t\00s")
  (export "memory" (memory $0))
- (func $start (; 0 ;) (type $FUNCSIG$v)
-  nop
+ (func $null (; 0 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/overflow.untouched.wat
+++ b/tests/compiler/overflow.untouched.wat
@@ -733,5 +733,6 @@
   call $start:overflow
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/portable-conversions.optimized.wat
+++ b/tests/compiler/portable-conversions.optimized.wat
@@ -11,6 +11,6 @@
   call $start:portable-conversions
  )
  (func $null (; 2 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/portable-conversions.untouched.wat
+++ b/tests/compiler/portable-conversions.untouched.wat
@@ -638,5 +638,6 @@
   call $start:portable-conversions
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/possibly-null.optimized.wat
+++ b/tests/compiler/possibly-null.optimized.wat
@@ -62,6 +62,6 @@
   nop
  )
  (func $null (; 5 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/possibly-null.untouched.wat
+++ b/tests/compiler/possibly-null.untouched.wat
@@ -416,5 +416,6 @@
   call $~lib/rt/stub/__release
  )
  (func $null (; 21 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/rc/global-init.optimized.wat
+++ b/tests/compiler/rc/global-init.optimized.wat
@@ -1941,6 +1941,6 @@
   unreachable
  )
  (func $null (; 34 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/rc/global-init.untouched.wat
+++ b/tests/compiler/rc/global-init.untouched.wat
@@ -3466,5 +3466,6 @@
   unreachable
  )
  (func $null (; 36 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/rc/local-init.optimized.wat
+++ b/tests/compiler/rc/local-init.optimized.wat
@@ -1918,6 +1918,6 @@
   unreachable
  )
  (func $null (; 33 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/rc/local-init.untouched.wat
+++ b/tests/compiler/rc/local-init.untouched.wat
@@ -3457,5 +3457,6 @@
   unreachable
  )
  (func $null (; 37 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/rc/logical-and-mismatch.optimized.wat
+++ b/tests/compiler/rc/logical-and-mismatch.optimized.wat
@@ -1961,6 +1961,6 @@
   unreachable
  )
  (func $null (; 35 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/rc/logical-and-mismatch.untouched.wat
+++ b/tests/compiler/rc/logical-and-mismatch.untouched.wat
@@ -3495,5 +3495,6 @@
   unreachable
  )
  (func $null (; 37 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/rc/logical-or-mismatch.optimized.wat
+++ b/tests/compiler/rc/logical-or-mismatch.optimized.wat
@@ -1961,6 +1961,6 @@
   unreachable
  )
  (func $null (; 35 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/rc/logical-or-mismatch.untouched.wat
+++ b/tests/compiler/rc/logical-or-mismatch.untouched.wat
@@ -3495,5 +3495,6 @@
   unreachable
  )
  (func $null (; 37 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/rc/rereturn.optimized.wat
+++ b/tests/compiler/rc/rereturn.optimized.wat
@@ -1897,6 +1897,6 @@
   unreachable
  )
  (func $null (; 29 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/rc/rereturn.untouched.wat
+++ b/tests/compiler/rc/rereturn.untouched.wat
@@ -3431,5 +3431,6 @@
   unreachable
  )
  (func $null (; 34 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/rc/ternary-mismatch.optimized.wat
+++ b/tests/compiler/rc/ternary-mismatch.optimized.wat
@@ -1953,6 +1953,6 @@
   unreachable
  )
  (func $null (; 37 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/rc/ternary-mismatch.untouched.wat
+++ b/tests/compiler/rc/ternary-mismatch.untouched.wat
@@ -3479,5 +3479,6 @@
   unreachable
  )
  (func $null (; 39 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/recursive.optimized.wat
+++ b/tests/compiler/recursive.optimized.wat
@@ -23,6 +23,6 @@
   i32.add
  )
  (func $null (; 1 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/recursive.untouched.wat
+++ b/tests/compiler/recursive.untouched.wat
@@ -25,5 +25,6 @@
   i32.add
  )
  (func $null (; 1 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/reexport.optimized.wat
+++ b/tests/compiler/reexport.optimized.wat
@@ -46,4 +46,7 @@
   i32.add
   drop
  )
+ (func $null (; 5 ;) (type $FUNCSIG$v)
+  unreachable
+ )
 )

--- a/tests/compiler/reexport.untouched.wat
+++ b/tests/compiler/reexport.untouched.wat
@@ -55,5 +55,6 @@
   call $start:reexport
  )
  (func $null (; 7 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/rereexport.optimized.wat
+++ b/tests/compiler/rereexport.optimized.wat
@@ -8,7 +8,7 @@
  (export "renamed_a" (global $export/a))
  (export "renamed_b" (global $export/b))
  (export "renamed_renamed_b" (global $export/b))
- (func $start (; 0 ;) (type $FUNCSIG$v)
-  nop
+ (func $null (; 0 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/rereexport.untouched.wat
+++ b/tests/compiler/rereexport.untouched.wat
@@ -40,5 +40,6 @@
   call $start:rereexport
  )
  (func $null (; 5 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/resolve-access.optimized.wat
+++ b/tests/compiler/resolve-access.optimized.wat
@@ -485,8 +485,7 @@
   (local $2 i32)
   (local $3 i32)
   local.get $0
-  i64.const 0
-  i64.eq
+  i64.eqz
   if
    i32.const 152
    return
@@ -588,6 +587,6 @@
   global.set $~lib/rt/stub/offset
  )
  (func $null (; 17 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/resolve-access.untouched.wat
+++ b/tests/compiler/resolve-access.untouched.wat
@@ -2082,5 +2082,6 @@
   global.set $~lib/rt/stub/offset
  )
  (func $null (; 26 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/resolve-binary.optimized.wat
+++ b/tests/compiler/resolve-binary.optimized.wat
@@ -2435,6 +2435,6 @@
   call $start:resolve-binary
  )
  (func $null (; 21 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/resolve-binary.untouched.wat
+++ b/tests/compiler/resolve-binary.untouched.wat
@@ -5807,5 +5807,6 @@
   call $start:resolve-binary
  )
  (func $null (; 46 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/resolve-elementaccess.optimized.wat
+++ b/tests/compiler/resolve-elementaccess.optimized.wat
@@ -1837,6 +1837,6 @@
   call $start:resolve-elementaccess
  )
  (func $null (; 22 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/resolve-elementaccess.untouched.wat
+++ b/tests/compiler/resolve-elementaccess.untouched.wat
@@ -3830,5 +3830,6 @@
   call $start:resolve-elementaccess
  )
  (func $null (; 28 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/resolve-function-expression.optimized.wat
+++ b/tests/compiler/resolve-function-expression.optimized.wat
@@ -404,6 +404,6 @@
   call $start:resolve-function-expression
  )
  (func $null (; 14 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/resolve-function-expression.untouched.wat
+++ b/tests/compiler/resolve-function-expression.untouched.wat
@@ -692,5 +692,6 @@
   call $start:resolve-function-expression
  )
  (func $null (; 18 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/resolve-nested.optimized.wat
+++ b/tests/compiler/resolve-nested.optimized.wat
@@ -22,6 +22,6 @@
   nop
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/resolve-nested.untouched.wat
+++ b/tests/compiler/resolve-nested.untouched.wat
@@ -113,5 +113,6 @@
   call $~lib/rt/stub/__release
  )
  (func $null (; 5 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/resolve-new.optimized.wat
+++ b/tests/compiler/resolve-new.optimized.wat
@@ -88,6 +88,6 @@
   drop
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/resolve-new.untouched.wat
+++ b/tests/compiler/resolve-new.untouched.wat
@@ -166,5 +166,6 @@
   call $start:resolve-new
  )
  (func $null (; 8 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/resolve-propertyaccess.optimized.wat
+++ b/tests/compiler/resolve-propertyaccess.optimized.wat
@@ -495,6 +495,6 @@
   call $start:resolve-propertyaccess
  )
  (func $null (; 11 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/resolve-propertyaccess.untouched.wat
+++ b/tests/compiler/resolve-propertyaccess.untouched.wat
@@ -833,5 +833,6 @@
   call $start:resolve-propertyaccess
  )
  (func $null (; 16 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/resolve-ternary.optimized.wat
+++ b/tests/compiler/resolve-ternary.optimized.wat
@@ -3364,6 +3364,6 @@
   end
  )
  (func $null (; 45 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/resolve-ternary.untouched.wat
+++ b/tests/compiler/resolve-ternary.untouched.wat
@@ -5508,5 +5508,6 @@
   return
  )
  (func $null (; 54 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/resolve-unary.optimized.wat
+++ b/tests/compiler/resolve-unary.optimized.wat
@@ -644,6 +644,6 @@
   call $start:resolve-unary
  )
  (func $null (; 12 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/resolve-unary.untouched.wat
+++ b/tests/compiler/resolve-unary.untouched.wat
@@ -1271,5 +1271,6 @@
   call $start:resolve-unary
  )
  (func $null (; 32 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/retain-i32.optimized.wat
+++ b/tests/compiler/retain-i32.optimized.wat
@@ -70,6 +70,6 @@
   call $start:retain-i32
  )
  (func $null (; 2 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/retain-i32.untouched.wat
+++ b/tests/compiler/retain-i32.untouched.wat
@@ -802,5 +802,6 @@
   call $start:retain-i32
  )
  (func $null (; 5 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/retain-release-sanity.optimized.wat
+++ b/tests/compiler/retain-release-sanity.optimized.wat
@@ -2828,6 +2828,6 @@
   end
  )
  (func $null (; 46 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/retain-release-sanity.untouched.wat
+++ b/tests/compiler/retain-release-sanity.untouched.wat
@@ -4616,5 +4616,6 @@
   return
  )
  (func $null (; 54 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/retain-release.optimized.wat
+++ b/tests/compiler/retain-release.optimized.wat
@@ -10,7 +10,7 @@
  (data (i32.const 8) "\n\00\00\00\01\00\00\00\01\00\00\00\n\00\00\00e\00r\00r\00o\00r")
  (data (i32.const 40) "\"\00\00\00\01\00\00\00\01\00\00\00\"\00\00\00r\00e\00t\00a\00i\00n\00-\00r\00e\00l\00e\00a\00s\00e\00.\00t\00s")
  (table $0 1 funcref)
- (elem (i32.const 0) $retain-release/receiveRef)
+ (elem (i32.const 0) $null)
  (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (global $retain-release/REF (mut i32) (i32.const 0))
@@ -268,5 +268,8 @@
   i32.store
   local.get $0
   global.set $retain-release/TARGET
+ )
+ (func $null (; 18 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/retain-release.untouched.wat
+++ b/tests/compiler/retain-release.untouched.wat
@@ -793,5 +793,6 @@
   call $start:retain-release
  )
  (func $null (; 46 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/rt/flags.untouched.wat
+++ b/tests/compiler/rt/flags.untouched.wat
@@ -1400,5 +1400,6 @@
   call $start:rt/flags
  )
  (func $null (; 63 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/rt/ids.optimized.wat
+++ b/tests/compiler/rt/ids.optimized.wat
@@ -3,6 +3,6 @@
  (memory $0 0)
  (export "memory" (memory $0))
  (func $null (; 0 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/rt/ids.untouched.wat
+++ b/tests/compiler/rt/ids.untouched.wat
@@ -5,5 +5,6 @@
  (elem (i32.const 0) $null)
  (export "memory" (memory $0))
  (func $null (; 0 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/rt/instanceof.optimized.wat
+++ b/tests/compiler/rt/instanceof.optimized.wat
@@ -521,6 +521,6 @@
   call $start:rt/instanceof
  )
  (func $null (; 9 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/rt/instanceof.untouched.wat
+++ b/tests/compiler/rt/instanceof.untouched.wat
@@ -686,5 +686,6 @@
   call $start:rt/instanceof
  )
  (func $null (; 10 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/rt/stub-realloc.optimized.wat
+++ b/tests/compiler/rt/stub-realloc.optimized.wat
@@ -598,4 +598,7 @@
   global.set $~lib/rt/stub/offset
   call $start:rt/stub-realloc
  )
+ (func $null (; 11 ;) (type $FUNCSIG$v)
+  unreachable
+ )
 )

--- a/tests/compiler/rt/stub-realloc.untouched.wat
+++ b/tests/compiler/rt/stub-realloc.untouched.wat
@@ -1735,5 +1735,6 @@
   call $start:rt/stub-realloc
  )
  (func $null (; 12 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/runtime-full.optimized.wat
+++ b/tests/compiler/runtime-full.optimized.wat
@@ -1889,6 +1889,6 @@
   unreachable
  )
  (func $null (; 28 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/runtime-full.untouched.wat
+++ b/tests/compiler/runtime-full.untouched.wat
@@ -3403,5 +3403,6 @@
   unreachable
  )
  (func $null (; 29 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/runtime-half.optimized.wat
+++ b/tests/compiler/runtime-half.optimized.wat
@@ -3,6 +3,6 @@
  (memory $0 0)
  (export "memory" (memory $0))
  (func $null (; 0 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/runtime-half.untouched.wat
+++ b/tests/compiler/runtime-half.untouched.wat
@@ -5,5 +5,6 @@
  (elem (i32.const 0) $null)
  (export "memory" (memory $0))
  (func $null (; 0 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/runtime-none.optimized.wat
+++ b/tests/compiler/runtime-none.optimized.wat
@@ -3,6 +3,6 @@
  (memory $0 0)
  (export "memory" (memory $0))
  (func $null (; 0 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/runtime-none.untouched.wat
+++ b/tests/compiler/runtime-none.untouched.wat
@@ -5,5 +5,6 @@
  (elem (i32.const 0) $null)
  (export "memory" (memory $0))
  (func $null (; 0 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/runtime-stub.optimized.wat
+++ b/tests/compiler/runtime-stub.optimized.wat
@@ -117,4 +117,7 @@
   i32.const 48
   global.set $~lib/rt/stub/offset
  )
+ (func $null (; 6 ;) (type $FUNCSIG$v)
+  unreachable
+ )
 )

--- a/tests/compiler/runtime-stub.untouched.wat
+++ b/tests/compiler/runtime-stub.untouched.wat
@@ -147,5 +147,6 @@
   global.set $~lib/rt/stub/offset
  )
  (func $null (; 6 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/scoped.optimized.wat
+++ b/tests/compiler/scoped.optimized.wat
@@ -36,6 +36,6 @@
   call $start:scoped
  )
  (func $null (; 2 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/scoped.untouched.wat
+++ b/tests/compiler/scoped.untouched.wat
@@ -69,5 +69,6 @@
   call $start:scoped
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/simd.untouched.wat
+++ b/tests/compiler/simd.untouched.wat
@@ -2079,5 +2079,6 @@
   call $start:simd
  )
  (func $null (; 11 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/static-this.optimized.wat
+++ b/tests/compiler/static-this.optimized.wat
@@ -4,6 +4,6 @@
  (data (i32.const 8) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00s\00t\00a\00t\00i\00c\00-\00t\00h\00i\00s\00.\00t\00s")
  (export "memory" (memory $0))
  (func $null (; 0 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/static-this.untouched.wat
+++ b/tests/compiler/static-this.untouched.wat
@@ -31,5 +31,6 @@
   call $start:static-this
  )
  (func $null (; 4 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/array-access.optimized.wat
+++ b/tests/compiler/std/array-access.optimized.wat
@@ -223,6 +223,6 @@
   call $~lib/string/String#startsWith
  )
  (func $null (; 11 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/std/array-access.untouched.wat
+++ b/tests/compiler/std/array-access.untouched.wat
@@ -494,5 +494,6 @@
   local.get $3
  )
  (func $null (; 19 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -2402,6 +2402,6 @@
   end
  )
  (func $null (; 40 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -4097,5 +4097,6 @@
   return
  )
  (func $null (; 50 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -10325,8 +10325,7 @@
   (local $2 i32)
   (local $3 i32)
   local.get $0
-  i64.const 0
-  i64.eq
+  i64.eqz
   if
    i32.const 4768
    call $~lib/rt/pure/__retain
@@ -10374,8 +10373,7 @@
   i32.add
   local.set $0
   local.get $2
-  i64.const 0
-  i64.eq
+  i64.eqz
   if
    local.get $0
    i32.const 48
@@ -10535,8 +10533,7 @@
   (local $3 i32)
   (local $4 i32)
   local.get $0
-  i64.const 0
-  i64.eq
+  i64.eqz
   if
    i32.const 4768
    call $~lib/rt/pure/__retain
@@ -10605,8 +10602,7 @@
   i32.add
   local.set $0
   local.get $2
-  i64.const 0
-  i64.eq
+  i64.eqz
   if
    local.get $0
    i32.const 48
@@ -17823,6 +17819,6 @@
   end
  )
  (func $null (; 210 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -25282,5 +25282,6 @@
   return
  )
  (func $null (; 339 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -2672,6 +2672,6 @@
   end
  )
  (func $null (; 42 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/std/arraybuffer.untouched.wat
+++ b/tests/compiler/std/arraybuffer.untouched.wat
@@ -4572,5 +4572,6 @@
   return
  )
  (func $null (; 55 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/dataview.optimized.wat
+++ b/tests/compiler/std/dataview.optimized.wat
@@ -4278,6 +4278,6 @@
   unreachable
  )
  (func $null (; 65 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/std/dataview.untouched.wat
+++ b/tests/compiler/std/dataview.untouched.wat
@@ -6415,5 +6415,6 @@
   unreachable
  )
  (func $null (; 70 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/date.optimized.wat
+++ b/tests/compiler/std/date.optimized.wat
@@ -97,8 +97,8 @@
   f64.const 0
   call $~lib/bindings/Date/UTC
   i64.trunc_f64_s
-  i64.const 0
-  i64.ne
+  i64.eqz
+  i32.eqz
   if
    i32.const 0
    i32.const 24
@@ -116,8 +116,8 @@
   f64.const 0
   call $~lib/bindings/Date/UTC
   i64.trunc_f64_s
-  i64.const 0
-  i64.ne
+  i64.eqz
+  i32.eqz
   if
    i32.const 0
    i32.const 24
@@ -210,6 +210,6 @@
   call $start:std/date
  )
  (func $null (; 7 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/std/date.untouched.wat
+++ b/tests/compiler/std/date.untouched.wat
@@ -342,5 +342,6 @@
   call $start:std/date
  )
  (func $null (; 11 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/hash.optimized.wat
+++ b/tests/compiler/std/hash.optimized.wat
@@ -206,6 +206,6 @@
   call $start:std/hash
  )
  (func $null (; 5 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/std/hash.untouched.wat
+++ b/tests/compiler/std/hash.untouched.wat
@@ -410,5 +410,6 @@
   call $start:std/hash
  )
  (func $null (; 9 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/libm.optimized.wat
+++ b/tests/compiler/std/libm.optimized.wat
@@ -520,8 +520,7 @@
    local.get $2
    i64.const 1
    i64.shl
-   i64.const 0
-   i64.eq
+   i64.eqz
    if
     f64.const -1
     local.get $0
@@ -563,8 +562,7 @@
     local.get $2
     i64.const 32
     i64.shl
-    i64.const 0
-    i64.eq
+    i64.eqz
     i32.const 0
     local.get $1
     i32.const 1072693248
@@ -2883,8 +2881,7 @@
   local.set $0
   i32.const 1
   local.get $2
-  i64.const 0
-  i64.eq
+  i64.eqz
   local.get $5
   i32.const 2047
   i32.eq
@@ -3066,8 +3063,7 @@
    local.get $3
    i64.const 1
    i64.shl
-   i64.const 0
-   i64.eq
+   i64.eqz
    if
     f64.const -1
     local.get $0
@@ -3109,8 +3105,7 @@
     local.get $3
     i64.const 32
     i64.shl
-    i64.const 0
-    i64.eq
+    i64.eqz
     i32.const 0
     local.get $2
     i32.const 1072693248
@@ -3277,8 +3272,7 @@
    local.get $3
    i64.const 1
    i64.shl
-   i64.const 0
-   i64.eq
+   i64.eqz
    if
     f64.const -1
     local.get $0
@@ -3320,8 +3314,7 @@
     local.get $3
     i64.const 32
     i64.shl
-    i64.const 0
-    i64.eq
+    i64.eqz
     i32.const 0
     local.get $2
     i32.const 1072693248
@@ -9275,6 +9268,6 @@
   f32.trunc
  )
  (func $null (; 120 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/std/libm.untouched.wat
+++ b/tests/compiler/std/libm.untouched.wat
@@ -12541,5 +12541,6 @@
   f32.trunc
  )
  (func $null (; 122 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -8737,6 +8737,6 @@
   call $~lib/rt/pure/__visit
  )
  (func $null (; 107 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -12720,5 +12720,6 @@
   unreachable
  )
  (func $null (; 151 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -1068,8 +1068,7 @@
    local.get $2
    i64.const 1
    i64.shl
-   i64.const 0
-   i64.eq
+   i64.eqz
    if
     f64.const -1
     local.get $0
@@ -1111,8 +1110,7 @@
     local.get $2
     i64.const 32
     i64.shl
-    i64.const 0
-    i64.eq
+    i64.eqz
     i32.const 0
     local.get $1
     i32.const 1072693248
@@ -5321,8 +5319,7 @@
   local.set $0
   i32.const 1
   local.get $2
-  i64.const 0
-  i64.eq
+  i64.eqz
   local.get $5
   i32.const 2047
   i32.eq
@@ -5613,8 +5610,7 @@
    local.get $3
    i64.const 1
    i64.shl
-   i64.const 0
-   i64.eq
+   i64.eqz
    if
     f64.const -1
     local.get $0
@@ -5656,8 +5652,7 @@
     local.get $3
     i64.const 32
     i64.shl
-    i64.const 0
-    i64.eq
+    i64.eqz
     i32.const 0
     local.get $2
     i32.const 1072693248
@@ -6020,8 +6015,7 @@
    local.get $3
    i64.const 1
    i64.shl
-   i64.const 0
-   i64.eq
+   i64.eqz
    if
     f64.const -1
     local.get $0
@@ -6063,8 +6057,7 @@
     local.get $3
     i64.const 32
     i64.shl
-    i64.const 0
-    i64.eq
+    i64.eqz
     i32.const 0
     local.get $2
     i32.const 1072693248
@@ -6446,8 +6439,7 @@
   i64.const 1
   i64.shl
   local.tee $6
-  i64.const 0
-  i64.eq
+  i64.eqz
   if (result i32)
    i32.const 1
   else
@@ -6487,8 +6479,7 @@
     return
    end
    local.get $4
-   i64.const 0
-   i64.eq
+   i64.eqz
    if (result i64)
     local.get $2
     i64.const 0
@@ -6512,8 +6503,7 @@
    end
    local.set $2
    local.get $5
-   i64.const 0
-   i64.eq
+   i64.eqz
    if (result i64)
     local.get $3
     i64.const 0
@@ -8846,8 +8836,7 @@
   local.get $4
   i64.const 1
   i64.shl
-  i64.const 0
-  i64.eq
+  i64.eqz
   select
   select
   if
@@ -8862,15 +8851,13 @@
   local.get $2
   i64.const 1
   i64.shl
-  i64.const 0
-  i64.eq
+  i64.eqz
   if
    local.get $0
    return
   end
   local.get $3
-  i64.const 0
-  i64.eq
+  i64.eqz
   if (result i64)
    local.get $2
    i64.const 0
@@ -8894,8 +8881,7 @@
   end
   local.set $2
   local.get $6
-  i64.const 0
-  i64.eq
+  i64.eqz
   if (result i64)
    local.get $4
    i64.const 0
@@ -8980,8 +8966,7 @@
     local.set $5
    end
    local.get $2
-   i64.const 0
-   i64.eq
+   i64.eqz
    if
     i64.const -60
     local.set $3
@@ -45417,8 +45402,8 @@
   i64.const 0
   i32.const 1
   call $~lib/math/ipow64
-  i64.const 0
-  i64.ne
+  i64.eqz
+  i32.eqz
   if
    i32.const 0
    i32.const 24
@@ -45430,8 +45415,8 @@
   i64.const 0
   i32.const 2
   call $~lib/math/ipow64
-  i64.const 0
-  i64.ne
+  i64.eqz
+  i32.eqz
   if
    i32.const 0
    i32.const 24
@@ -45443,8 +45428,8 @@
   i64.const 0
   i32.const 3
   call $~lib/math/ipow64
-  i64.const 0
-  i64.ne
+  i64.eqz
+  i32.eqz
   if
    i32.const 0
    i32.const 24
@@ -46196,6 +46181,6 @@
   call $start:std/math
  )
  (func $null (; 173 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -54554,5 +54554,6 @@
   call $start:std/math
  )
  (func $null (; 175 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/mod.optimized.wat
+++ b/tests/compiler/std/mod.optimized.wat
@@ -46,8 +46,7 @@
   i64.const 1
   i64.shl
   local.tee $6
-  i64.const 0
-  i64.eq
+  i64.eqz
   if (result i32)
    i32.const 1
   else
@@ -87,8 +86,7 @@
     return
    end
    local.get $4
-   i64.const 0
-   i64.eq
+   i64.eqz
    if (result i64)
     local.get $2
     i64.const 0
@@ -112,8 +110,7 @@
    end
    local.set $2
    local.get $5
-   i64.const 0
-   i64.eq
+   i64.eqz
    if (result i64)
     local.get $3
     i64.const 0
@@ -2250,6 +2247,6 @@
   call $start:std/mod
  )
  (func $null (; 10 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/std/mod.untouched.wat
+++ b/tests/compiler/std/mod.untouched.wat
@@ -2365,5 +2365,6 @@
   call $start:std/mod
  )
  (func $null (; 10 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/new.optimized.wat
+++ b/tests/compiler/std/new.optimized.wat
@@ -106,6 +106,6 @@
   global.set $std/new/aClass
  )
  (func $null (; 4 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/std/new.untouched.wat
+++ b/tests/compiler/std/new.untouched.wat
@@ -171,5 +171,6 @@
   call $start:std/new
  )
  (func $null (; 6 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/object-literal.optimized.wat
+++ b/tests/compiler/std/object-literal.optimized.wat
@@ -300,6 +300,6 @@
   call $start:std/object-literal
  )
  (func $null (; 9 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/std/object-literal.untouched.wat
+++ b/tests/compiler/std/object-literal.untouched.wat
@@ -457,5 +457,6 @@
   call $start:std/object-literal
  )
  (func $null (; 13 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/object.optimized.wat
+++ b/tests/compiler/std/object.optimized.wat
@@ -672,6 +672,6 @@
   call $start:std/object
  )
  (func $null (; 11 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/std/object.untouched.wat
+++ b/tests/compiler/std/object.untouched.wat
@@ -889,5 +889,6 @@
   call $start:std/object
  )
  (func $null (; 15 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/operator-overloading.optimized.wat
+++ b/tests/compiler/std/operator-overloading.optimized.wat
@@ -2385,6 +2385,6 @@
   call $start:std/operator-overloading
  )
  (func $null (; 13 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/std/operator-overloading.untouched.wat
+++ b/tests/compiler/std/operator-overloading.untouched.wat
@@ -3293,5 +3293,6 @@
   call $start:std/operator-overloading
  )
  (func $null (; 38 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/pointer.optimized.wat
+++ b/tests/compiler/std/pointer.optimized.wat
@@ -611,6 +611,6 @@
   call $start:std/pointer
  )
  (func $null (; 5 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/std/pointer.untouched.wat
+++ b/tests/compiler/std/pointer.untouched.wat
@@ -2211,5 +2211,6 @@
   call $start:std/pointer
  )
  (func $null (; 8 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/polyfills.optimized.wat
+++ b/tests/compiler/std/polyfills.optimized.wat
@@ -3,7 +3,7 @@
  (memory $0 1)
  (data (i32.const 8) " \00\00\00\01\00\00\00\01\00\00\00 \00\00\00s\00t\00d\00/\00p\00o\00l\00y\00f\00i\00l\00l\00s\00.\00t\00s")
  (export "memory" (memory $0))
- (func $start (; 0 ;) (type $FUNCSIG$v)
-  nop
+ (func $null (; 0 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/polyfills.untouched.wat
+++ b/tests/compiler/std/polyfills.untouched.wat
@@ -494,5 +494,6 @@
   call $start:std/polyfills
  )
  (func $null (; 19 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -7632,6 +7632,6 @@
   call $~lib/rt/pure/__visit
  )
  (func $null (; 99 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -11432,5 +11432,6 @@
   unreachable
  )
  (func $null (; 141 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/simd.optimized.wat
+++ b/tests/compiler/std/simd.optimized.wat
@@ -3,6 +3,6 @@
  (memory $0 0)
  (export "memory" (memory $0))
  (func $null (; 0 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/std/simd.untouched.wat
+++ b/tests/compiler/std/simd.untouched.wat
@@ -6,5 +6,6 @@
  (global $~lib/ASC_FEATURE_SIMD i32 (i32.const 0))
  (export "memory" (memory $0))
  (func $null (; 0 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/static-array.optimized.wat
+++ b/tests/compiler/std/static-array.optimized.wat
@@ -1029,6 +1029,6 @@
   call $start:std/static-array
  )
  (func $null (; 17 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/std/static-array.untouched.wat
+++ b/tests/compiler/std/static-array.untouched.wat
@@ -2369,5 +2369,6 @@
   call $start:std/static-array
  )
  (func $null (; 31 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/string-encoding.optimized.wat
+++ b/tests/compiler/std/string-encoding.optimized.wat
@@ -3925,6 +3925,6 @@
   unreachable
  )
  (func $null (; 58 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/std/string-encoding.untouched.wat
+++ b/tests/compiler/std/string-encoding.untouched.wat
@@ -5664,5 +5664,6 @@
   unreachable
  )
  (func $null (; 60 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -4366,8 +4366,7 @@
     i32.const -342
     i32.lt_s
     local.get $2
-    i64.const 0
-    i64.eq
+    i64.eqz
     select
     if
      br $~lib/util/string/scientific|inlined.0
@@ -6503,8 +6502,7 @@
   (local $2 i32)
   (local $3 i32)
   local.get $0
-  i64.const 0
-  i64.eq
+  i64.eqz
   if
    i32.const 1192
    call $~lib/rt/pure/__retain
@@ -6549,8 +6547,7 @@
   (local $3 i32)
   (local $4 i32)
   local.get $0
-  i64.const 0
-  i64.eq
+  i64.eqz
   if
    i32.const 1192
    call $~lib/rt/pure/__retain
@@ -14758,6 +14755,6 @@
   end
  )
  (func $null (; 95 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -18533,5 +18533,6 @@
   return
  )
  (func $null (; 109 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/symbol.optimized.wat
+++ b/tests/compiler/std/symbol.optimized.wat
@@ -1716,6 +1716,6 @@
   call $start:std/symbol
  )
  (func $null (; 31 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/std/symbol.untouched.wat
+++ b/tests/compiler/std/symbol.untouched.wat
@@ -3621,5 +3621,6 @@
   call $start:std/symbol
  )
  (func $null (; 36 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/trace.optimized.wat
+++ b/tests/compiler/std/trace.optimized.wat
@@ -91,6 +91,6 @@
   call $start:std/trace
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/std/trace.untouched.wat
+++ b/tests/compiler/std/trace.untouched.wat
@@ -93,5 +93,6 @@
   call $start:std/trace
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -10598,8 +10598,7 @@
   local.get $2
   call $~lib/rt/pure/__release
   local.get $0
-  i64.const 0
-  i64.eq
+  i64.eqz
  )
  (func $std/typedarray/testArraySome<~lib/typedarray/Int64Array,i64> (; 209 ;) (type $FUNCSIG$v)
   (local $0 i32)
@@ -12619,8 +12618,7 @@
   local.get $0
   i64.const 2
   i64.rem_s
-  i64.const 0
-  i64.eq
+  i64.eqz
   local.get $2
   call $~lib/rt/pure/__release
  )
@@ -12730,8 +12728,7 @@
   local.get $0
   i64.const 2
   i64.rem_u
-  i64.const 0
-  i64.eq
+  i64.eqz
   local.get $2
   call $~lib/rt/pure/__release
  )
@@ -13088,8 +13085,7 @@
     return
    end
    local.get $2
-   i64.const 0
-   i64.eq
+   i64.eqz
    if (result i64)
     local.get $1
     i64.const 0
@@ -25033,8 +25029,7 @@
   (local $3 i32)
   (local $4 i32)
   local.get $0
-  i64.const 0
-  i64.eq
+  i64.eqz
   if
    i32.const 1720
    call $~lib/rt/pure/__retain
@@ -25103,8 +25098,7 @@
   i32.add
   local.set $0
   local.get $2
-  i64.const 0
-  i64.eq
+  i64.eqz
   if
    local.get $0
    i32.const 48
@@ -25362,8 +25356,7 @@
   (local $2 i32)
   (local $3 i32)
   local.get $0
-  i64.const 0
-  i64.eq
+  i64.eqz
   if
    i32.const 1720
    call $~lib/rt/pure/__retain
@@ -25411,8 +25404,7 @@
   i32.add
   local.set $0
   local.get $2
-  i64.const 0
-  i64.eq
+  i64.eqz
   if
    local.get $0
    i32.const 48
@@ -31457,6 +31449,6 @@
   end
  )
  (func $null (; 440 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -42740,5 +42740,6 @@
   return
  )
  (func $null (; 599 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/switch.optimized.wat
+++ b/tests/compiler/switch.optimized.wat
@@ -398,6 +398,6 @@
   call $start:switch
  )
  (func $null (; 7 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/switch.untouched.wat
+++ b/tests/compiler/switch.untouched.wat
@@ -553,5 +553,6 @@
   call $start:switch
  )
  (func $null (; 10 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/ternary.optimized.wat
+++ b/tests/compiler/ternary.optimized.wat
@@ -13,6 +13,6 @@
   global.set $ternary/a
  )
  (func $null (; 1 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/ternary.untouched.wat
+++ b/tests/compiler/ternary.untouched.wat
@@ -24,5 +24,6 @@
   call $start:ternary
  )
  (func $null (; 2 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/typealias.optimized.wat
+++ b/tests/compiler/typealias.optimized.wat
@@ -8,6 +8,6 @@
   local.get $0
  )
  (func $null (; 1 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/typealias.untouched.wat
+++ b/tests/compiler/typealias.untouched.wat
@@ -10,5 +10,6 @@
   local.get $0
  )
  (func $null (; 1 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/typeof.optimized.wat
+++ b/tests/compiler/typeof.optimized.wat
@@ -508,4 +508,7 @@
   end
   call $start:typeof
  )
+ (func $null (; 9 ;) (type $FUNCSIG$v)
+  unreachable
+ )
 )

--- a/tests/compiler/typeof.untouched.wat
+++ b/tests/compiler/typeof.untouched.wat
@@ -664,5 +664,6 @@
   call $start:typeof
  )
  (func $null (; 12 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/unary.optimized.wat
+++ b/tests/compiler/unary.optimized.wat
@@ -94,8 +94,7 @@
   i64.const 2
   global.set $unary/I
   global.get $unary/I
-  i64.const 0
-  i64.eq
+  i64.eqz
   i64.extend_i32_u
   global.set $unary/I
   global.get $unary/I
@@ -242,6 +241,6 @@
   call $start:unary
  )
  (func $null (; 2 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/unary.untouched.wat
+++ b/tests/compiler/unary.untouched.wat
@@ -384,5 +384,6 @@
   call $start:unary
  )
  (func $null (; 2 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/void.optimized.wat
+++ b/tests/compiler/void.optimized.wat
@@ -2,7 +2,7 @@
  (type $FUNCSIG$v (func))
  (memory $0 0)
  (export "memory" (memory $0))
- (func $start (; 0 ;) (type $FUNCSIG$v)
-  nop
+ (func $null (; 0 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/void.untouched.wat
+++ b/tests/compiler/void.untouched.wat
@@ -25,5 +25,6 @@
   call $start:void
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/wasi.optimized.wat
+++ b/tests/compiler/wasi.optimized.wat
@@ -9,6 +9,6 @@
   global.set $wasi/sig
  )
  (func $null (; 1 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/wasi.untouched.wat
+++ b/tests/compiler/wasi.untouched.wat
@@ -18,5 +18,6 @@
   call $start:wasi
  )
  (func $null (; 2 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/while.optimized.wat
+++ b/tests/compiler/while.optimized.wat
@@ -175,6 +175,6 @@
   call $start:while
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
-  nop
+  unreachable
  )
 )

--- a/tests/compiler/while.untouched.wat
+++ b/tests/compiler/while.untouched.wat
@@ -209,5 +209,6 @@
   call $start:while
  )
  (func $null (; 3 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/wildcard-export.optimized.wat
+++ b/tests/compiler/wildcard-export.optimized.wat
@@ -8,7 +8,7 @@
  (export "renamed_a" (global $export/a))
  (export "renamed_b" (global $export/b))
  (export "renamed_renamed_b" (global $export/b))
- (func $start (; 0 ;) (type $FUNCSIG$v)
-  nop
+ (func $null (; 0 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/compiler/wildcard-export.untouched.wat
+++ b/tests/compiler/wildcard-export.untouched.wat
@@ -43,5 +43,6 @@
   call $start:wildcard-export
  )
  (func $null (; 6 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )

--- a/tests/features.json
+++ b/tests/features.json
@@ -29,5 +29,13 @@
     "v8_flags": [
       "--experimental-wasm-bigint"
     ]
+  },
+  "exception-handling": {
+    "asc_flags": [
+      "--enable exception-handling"
+    ],
+    "v8_flags": [
+      "--experimental-wasm-eh"
+    ]
   }
 }

--- a/tests/runtime/untouched.wat
+++ b/tests/runtime/untouched.wat
@@ -70,7 +70,7 @@
    local.get $3
    i32.const 1073741808
    i32.lt_u
-  else   
+  else
    i32.const 0
   end
   i32.eqz
@@ -92,7 +92,7 @@
    i32.const 4
    i32.shr_u
    local.set $5
-  else   
+  else
    i32.const 31
    local.get $3
    i32.clz
@@ -122,7 +122,7 @@
    local.get $5
    i32.const 16
    i32.lt_u
-  else   
+  else
    i32.const 0
   end
   i32.eqz
@@ -437,7 +437,7 @@
    local.get $8
    i32.const 1073741808
    i32.lt_u
-  else   
+  else
    i32.const 0
   end
   i32.eqz
@@ -480,7 +480,7 @@
    i32.const 4
    i32.shr_u
    local.set $10
-  else   
+  else
    i32.const 31
    local.get $8
    i32.clz
@@ -510,7 +510,7 @@
    local.get $10
    i32.const 16
    i32.lt_u
-  else   
+  else
    i32.const 0
   end
   i32.eqz
@@ -629,7 +629,7 @@
    i32.const 15
    i32.and
    i32.eqz
-  else   
+  else
    i32.const 0
   end
   if (result i32)
@@ -637,7 +637,7 @@
    i32.const 15
    i32.and
    i32.eqz
-  else   
+  else
    i32.const 0
   end
   i32.eqz
@@ -687,10 +687,10 @@
     local.get $4
     i32.load
     local.set $5
-   else    
+   else
     nop
    end
-  else   
+  else
    local.get $1
    local.get $0
    i32.const 1572
@@ -808,7 +808,7 @@
    memory.grow
    i32.const 0
    i32.lt_s
-  else   
+  else
    i32.const 0
   end
   if
@@ -966,7 +966,7 @@
    i32.const 4
    i32.shr_u
    local.set $3
-  else   
+  else
    local.get $1
    i32.const 536870904
    i32.lt_u
@@ -981,7 +981,7 @@
     i32.add
     i32.const 1
     i32.sub
-   else    
+   else
     local.get $1
    end
    local.set $4
@@ -1014,7 +1014,7 @@
    local.get $3
    i32.const 16
    i32.lt_u
-  else   
+  else
    i32.const 0
   end
   i32.eqz
@@ -1066,7 +1066,7 @@
    if
     i32.const 0
     local.set $7
-   else    
+   else
     local.get $5
     i32.ctz
     local.set $2
@@ -1114,7 +1114,7 @@
     end
     local.set $7
    end
-  else   
+  else
    block $~lib/rt/tlsf/GETHEAD|inlined.3 (result i32)
     local.get $0
     local.set $9
@@ -1246,7 +1246,7 @@
    local.get $0
    local.get $5
    call $~lib/rt/tlsf/insertBlock
-  else   
+  else
    local.get $1
    local.get $3
    i32.const 1
@@ -1498,7 +1498,7 @@
      local.get $1
      i32.const 3
      i32.and
-    else     
+    else
      i32.const 0
     end
     if
@@ -2703,7 +2703,7 @@
    i32.le_u
    if (result i32)
     i32.const 1
-   else    
+   else
     local.get $5
     local.get $3
     i32.add
@@ -2823,7 +2823,7 @@
       end
      end
     end
-   else    
+   else
     local.get $4
     i32.const 7
     i32.and
@@ -2924,7 +2924,7 @@
    i32.const 15
    i32.and
    i32.eqz
-  else   
+  else
    i32.const 0
   end
   i32.eqz
@@ -3053,7 +3053,7 @@
     global.get $~lib/rt/tlsf/ROOT
     local.get $0
     call $~lib/rt/tlsf/freeBlock
-   else    
+   else
     local.get $0
     i32.const -2147483648
     i32.const 0
@@ -3062,7 +3062,7 @@
     i32.or
     i32.store offset=4
    end
-  else   
+  else
    local.get $2
    i32.const 0
    i32.gt_u
@@ -3099,7 +3099,7 @@
      local.get $0
      call $~lib/rt/pure/appendRoot
     end
-   else    
+   else
     local.get $0
     local.get $1
     i32.const 268435455
@@ -3188,7 +3188,7 @@
    if
     local.get $0
     call $~lib/rt/pure/scanBlack
-   else    
+   else
     local.get $0
     local.get $1
     i32.const 1879048192
@@ -3221,7 +3221,7 @@
    i32.const -2147483648
    i32.and
    i32.eqz
-  else   
+  else
    i32.const 0
   end
   if
@@ -3285,7 +3285,7 @@
      i32.and
      i32.const 0
      i32.gt_u
-    else     
+    else
      i32.const 0
     end
     if
@@ -3298,7 +3298,7 @@
      i32.const 4
      i32.add
      local.set $1
-    else     
+    else
      local.get $5
      i32.const 1879048192
      i32.and
@@ -3309,14 +3309,14 @@
       i32.const 268435455
       i32.and
       i32.eqz
-     else      
+     else
       i32.const 0
      end
      if
       global.get $~lib/rt/tlsf/ROOT
       local.get $4
       call $~lib/rt/tlsf/freeBlock
-     else      
+     else
       local.get $4
       local.get $5
       i32.const -2147483648
@@ -3604,5 +3604,6 @@
   end
  )
  (func $null (; 29 ;) (type $FUNCSIG$v)
+  unreachable
  )
 )


### PR DESCRIPTION
WIP: This PR makes indirect calls on null either trap with `unreachable` or, if exception-handling is enabled, throws a Wasm exception.

***

I'm not sure if this is the right approach right now, since AS currently fakes exceptions using an extern call to abort() (which requires people to provide a JS implementation as an import) then uses `unreachable`.

I started to do that at first, but worry that it means everyone now needs to include an abort() implementation. I considered disabling it if they use --noAssert but then again, it seems like this should be an exception and it seemed weird that --noAssert would disable that.

Then I noticed that AS actually already wraps Binaryen's exception-handling support even though it's not yet used anywhere, so I figured I'd give that a shot for fun and use this as a discussion point on whether this is instead the more correct direction?

***

~~One note: I'm using `let message = this.ensureStaticString("null is not a function");` to generate an interned string for the exception, however it doesn't seem to be working. The string doesn't seem to show up in the Wasm file (no data section at all, in fact). Did I do something wrong?~~ We solved the issue.