### PR TITLE
Remove @types/webassembly-js-api from loader

### DIFF
--- a/lib/loader/index.d.ts
+++ b/lib/loader/index.d.ts
@@ -1,7 +1,5 @@
 /// <reference lib="esnext.bigint" />
 
-import "@types/webassembly-js-api";
-
 /** WebAssembly imports with two levels of nesting. */
 interface ImportsObject extends Record<string, any> {
   env?: {

--- a/lib/loader/package.json
+++ b/lib/loader/package.json
@@ -4,6 +4,8 @@
   "keywords": [
     "assemblyscript",
     "loader",
+    "glue",
+    "interop",
     "webassembly",
     "wasm"
   ],

--- a/lib/loader/package.json
+++ b/lib/loader/package.json
@@ -30,8 +30,5 @@
     "index.js",
     "package.json",
     "README.md"
-  ],
-  "dependencies": {
-    "@types/webassembly-js-api": "0.0.1"
-  }
+  ]
 }


### PR DESCRIPTION
"@types/webassembly-js-api" deprecated and cause to conflicts since TS provide own webassembly api definitions.