### PR TITLE
CI: run compiler tests on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,31 @@ jobs:
       run: npm run build
     - name: Test distribution
       run: npm test
+  test-windows:
+    name: "Test compiler on Windows with node: node"
+    runs-on: windows-latest
+    needs: check
+    steps:
+    - uses: actions/checkout@v1.0.0
+      with:
+        node-mirror: https://nodejs.org/download/v8-canary/
+    - name: Install node via nvm-windows
+      run: |
+        Invoke-WebRequest -Uri https://github.com/coreybutler/nvm-windows/releases/download/1.1.7/nvm-noinstall.zip -OutFile nvm.zip
+        Expand-Archive nvm.zip -DestinationPath nvm
+        nvm/nvm install node
+        nvm/nvm use node
+        npm -g install npm@latest
+    - name: Install dependencies
+      run: npm ci --no-audit
+    - name: Clean distribution files
+      run: npm run clean
+    - name: Test sources
+      run: npm test
+    - name: Build distribution files
+      run: npm run build
+    - name: Test distribution
+      run: npm test
   test-canary:
     name: "Test features on node: v8-canary"
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,6 @@ jobs:
     needs: check
     steps:
     - uses: actions/checkout@v1.0.0
-      with:
-        node-mirror: https://nodejs.org/download/v8-canary/
     - name: Install node via nvm-windows
       run: |
         Invoke-WebRequest -Uri https://github.com/coreybutler/nvm-windows/releases/download/1.1.7/nvm-noinstall.zip -OutFile nvm.zip

--- a/NOTICE
+++ b/NOTICE
@@ -18,6 +18,7 @@ under the licensing terms detailed in LICENSE:
 * Emil Laine <laine.emil@gmail.com>
 * Stephen Paul Weber <stephen.weber@shopify.com>
 * Jay Phelps <hello@jayphelps.com>
+* jhwgh1968 <jhwgh1968@protonmail.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:


### PR DESCRIPTION
Tests the compiler on Windows as a separate CI job. This is designed to catch "bash-isms" that could otherwise sneak in, rather than provide full Windows coverage. Thus it only tests the stable node version.

On Linux, nvm is used to determine the current stable version. Since that does not work on Windows, the job uses [nvm-windows](https://github.com/coreybutler/nvm-windows) as a substitute. That project is written in Golang, so a pre-compiled binary is downloaded and invoked directly.