### PR TITLE
Use ES2016 as target for src and transforms

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -19,7 +19,7 @@ under the licensing terms detailed in LICENSE:
 * Stephen Paul Weber <stephen.weber@shopify.com>
 * Jay Phelps <hello@jayphelps.com>
 * jhwgh1968 <jhwgh1968@protonmail.com>
-* Jeff Charles <jeff.charles@shopify.com>
+* Jeffrey Charles <jeffreycharles@gmail.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/NOTICE
+++ b/NOTICE
@@ -19,6 +19,7 @@ under the licensing terms detailed in LICENSE:
 * Stephen Paul Weber <stephen.weber@shopify.com>
 * Jay Phelps <hello@jayphelps.com>
 * jhwgh1968 <jhwgh1968@protonmail.com>
+* Jeff Charles <jeff.charles@shopify.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/cli/asc.js
+++ b/cli/asc.js
@@ -219,7 +219,9 @@ exports.main = function main(argv, options, callback) {
     let transformArgs = args.transform;
     for (let i = 0, k = transformArgs.length; i < k; ++i) {
       let filename = transformArgs[i].trim();
-      if (/\.ts$/.test(filename)) require("ts-node").register({ transpileOnly: true, skipProject: true });
+      if (/\.ts$/.test(filename)) {
+        require("ts-node").register({ transpileOnly: true, skipProject: true, compilerOptions: { target: "ES2016" } });
+      }
       try {
         const classOrModule = require(require.resolve(filename, { paths: [baseDir, process.cwd()] }));
         if (typeof classOrModule === "function") {

--- a/cli/asc.js
+++ b/cli/asc.js
@@ -40,7 +40,8 @@ var assemblyscript, isDev = false;
     try { // `asc` on the command line without dist files
       require("ts-node").register({
         project: path.join(__dirname, "..", "src", "tsconfig.json"),
-        skipIgnore: true
+        skipIgnore: true,
+        compilerOptions: { target: "ES2016" }
       });
       require("../src/glue/js");
       assemblyscript = require("../src");

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../out",
     "allowJs": false,
-    "sourceMap": true
+    "sourceMap": true,
+    "target": "ES2016"
   },
   "include": [
     "./**/*.ts"


### PR DESCRIPTION
Fixes #978. src and transforms will now have the same compile target so
transforms can consume classes exported by src.