### PR TITLE
Temporarily pin node-v8 to last known good build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,8 @@ jobs:
     - uses: dcodeIO/setup-node-nvm@v1.0.0
       with:
         node-mirror: https://nodejs.org/download/v8-canary/
+        # FIXME: newer node-v8 builds are currently broken
+        node-version: "14.0.0-v8-canary201911242015a12d82"
     - name: Install dependencies
       run: npm ci --no-audit
     - name: Clean distribution files


### PR DESCRIPTION
see: https://github.com/AssemblyScript/assemblyscript/issues/989