### PR TITLE
[Bug fix] Fix the bug about map.keys and map.values

### DIFF
--- a/std/assembly/map.ts
+++ b/std/assembly/map.ts
@@ -210,8 +210,7 @@ export class Map<K,V> {
     for (let i = 0; i < size; ++i) {
       let entry = changetype<MapEntry<K,V>>(start + <usize>i * ENTRY_SIZE<K,V>());
       if (!(entry.taggedNext & EMPTY)) {
-        keys[length] = entry.key;
-        ++length;
+        keys[length++] = entry.key;
       }
     }
     keys.length = length;
@@ -227,8 +226,7 @@ export class Map<K,V> {
     for (let i = 0; i < size; ++i) {
       let entry = changetype<MapEntry<K,V>>(start + <usize>i * ENTRY_SIZE<K,V>());
       if (!(entry.taggedNext & EMPTY)) {
-        values[length] = entry.value;
-        ++length;
+        values[length++] = entry.value;
       }
     }
     values.length = length;

--- a/std/assembly/map.ts
+++ b/std/assembly/map.ts
@@ -210,7 +210,7 @@ export class Map<K,V> {
     for (let i = 0; i < size; ++i) {
       let entry = changetype<MapEntry<K,V>>(start + <usize>i * ENTRY_SIZE<K,V>());
       if (!(entry.taggedNext & EMPTY)) {
-        keys.push(entry.key);
+        keys[length] = entry.key;
         ++length;
       }
     }
@@ -227,7 +227,7 @@ export class Map<K,V> {
     for (let i = 0; i < size; ++i) {
       let entry = changetype<MapEntry<K,V>>(start + <usize>i * ENTRY_SIZE<K,V>());
       if (!(entry.taggedNext & EMPTY)) {
-        values.push(entry.value);
+        values[length] = entry.value;
         ++length;
       }
     }

--- a/std/assembly/set.ts
+++ b/std/assembly/set.ts
@@ -187,11 +187,9 @@ export class Set<T> {
     for (let i = 0; i < size; ++i) {
       let entry = changetype<SetEntry<T>>(start + <usize>i * ENTRY_SIZE<T>());
       if (!(entry.taggedNext & EMPTY)) {
-        values.push(entry.key);
-        ++length;
+        values[length++] = entry.key;
       }
     }
-    values.length = length;
     return values;
   }
 

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -2813,29 +2813,43 @@
   i32.store offset=12
   local.get $1
  )
- (func $~lib/array/Array<i32>#push (; 48 ;) (param $0 i32) (param $1 i32)
-  (local $2 i32)
+ (func $~lib/array/Array<i32>#__set (; 48 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
-  local.get $0
+  local.get $1
   local.get $0
   i32.load offset=12
-  local.tee $2
-  i32.const 1
-  i32.add
-  local.tee $3
-  i32.const 2
-  call $~lib/array/ensureSize
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 512
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   i32.const 2
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $3
+   i32.store offset=12
+  end
   local.get $0
   i32.load offset=4
-  local.get $2
+  local.get $1
   i32.const 2
   i32.shl
   i32.add
-  local.get $1
+  local.get $2
   i32.store
-  local.get $0
-  local.get $3
-  i32.store offset=12
  )
  (func $~lib/array/Array<i32>#set:length (; 49 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
@@ -2867,11 +2881,11 @@
   local.set $0
   loop $loop|0
    block $break|0
-    local.get $0
+    local.get $1
     local.get $4
     i32.ge_s
     br_if $break|0
-    local.get $0
+    local.get $1
     i32.const 12
     i32.mul
     local.get $3
@@ -2883,23 +2897,24 @@
     i32.eqz
     if
      local.get $2
+     local.get $0
      local.get $5
      i32.load offset=4
-     call $~lib/array/Array<i32>#push
-     local.get $1
+     call $~lib/array/Array<i32>#__set
+     local.get $0
      i32.const 1
      i32.add
-     local.set $1
+     local.set $0
     end
-    local.get $0
+    local.get $1
     i32.const 1
     i32.add
-    local.set $0
+    local.set $1
     br $loop|0
    end
   end
   local.get $2
-  local.get $1
+  local.get $0
   call $~lib/array/Array<i32>#set:length
   local.get $2
  )
@@ -7694,45 +7709,7 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/array/Array<i32>#__set (; 108 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
-  local.get $1
-  local.get $0
-  i32.load offset=12
-  i32.ge_u
-  if
-   local.get $1
-   i32.const 0
-   i32.lt_s
-   if
-    i32.const 280
-    i32.const 512
-    i32.const 109
-    i32.const 21
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $0
-   local.get $1
-   i32.const 1
-   i32.add
-   local.tee $3
-   i32.const 2
-   call $~lib/array/ensureSize
-   local.get $0
-   local.get $3
-   i32.store offset=12
-  end
-  local.get $0
-  i32.load offset=4
-  local.get $1
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $2
-  i32.store
- )
- (func $~lib/map/Map<i32,i32>#keys (; 109 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#keys (; 108 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -7787,7 +7764,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $2
  )
- (func $~lib/map/Map<i32,i32>#delete (; 110 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i32,i32>#delete (; 109 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -7846,7 +7823,7 @@
    call $~lib/map/Map<i32,i32>#rehash
   end
  )
- (func $std/map/testNumeric<i32,i32> (; 111 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<i32,i32> (; 110 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -8273,7 +8250,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u32,i32>#constructor (; 112 ;) (result i32)
+ (func $~lib/map/Map<u32,i32>#constructor (; 111 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 17
@@ -8301,7 +8278,7 @@
   call $~lib/map/Map<i8,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u32,i32>#keys (; 113 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#keys (; 112 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -8366,7 +8343,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $1
  )
- (func $~lib/map/Map<u32,u32>#constructor (; 114 ;) (result i32)
+ (func $~lib/map/Map<u32,u32>#constructor (; 113 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 19
@@ -8394,7 +8371,7 @@
   call $~lib/map/Map<i8,i32>#clear
   local.get $0
  )
- (func $std/map/testNumeric<u32,i32> (; 115 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<u32,i32> (; 114 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -8821,7 +8798,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i64,i32>#clear (; 116 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<i64,i32>#clear (; 115 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   i32.const 16
   call $~lib/arraybuffer/ArrayBuffer#constructor
@@ -8854,7 +8831,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i64,i32>#constructor (; 117 ;) (result i32)
+ (func $~lib/map/Map<i64,i32>#constructor (; 116 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 20
@@ -8882,7 +8859,7 @@
   call $~lib/map/Map<i64,i32>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash64 (; 118 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/hash/hash64 (; 117 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   local.get $0
   i32.wrap_i64
@@ -8948,7 +8925,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/map/Map<i64,i32>#find (; 119 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#find (; 118 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -8991,7 +8968,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i64,i32>#has (; 120 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<i64,i32>#has (; 119 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -9000,7 +8977,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i64,i32>#rehash (; 121 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i64,i32>#rehash (; 120 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9132,7 +9109,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i64,i32>#set (; 122 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/map/Map<i64,i32>#set (; 121 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9222,7 +9199,7 @@
    i32.store
   end
  )
- (func $~lib/map/Map<i64,i32>#get (; 123 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<i64,i32>#get (; 122 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -9241,7 +9218,7 @@
   local.get $0
   i32.load offset=8
  )
- (func $~lib/array/Array<i64>#__set (; 124 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<i64>#__set (; 123 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -9279,7 +9256,7 @@
   local.get $2
   i64.store
  )
- (func $~lib/array/Array<i64>#set:length (; 125 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i64>#set:length (; 124 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   i32.load offset=12
   drop
@@ -9291,7 +9268,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<i64,i32>#keys (; 126 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#keys (; 125 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9356,7 +9333,7 @@
   call $~lib/array/Array<i64>#set:length
   local.get $1
  )
- (func $~lib/map/Map<i64,i32>#values (; 127 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#values (; 126 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9374,11 +9351,11 @@
   local.set $0
   loop $loop|0
    block $break|0
-    local.get $0
+    local.get $1
     local.get $4
     i32.ge_s
     br_if $break|0
-    local.get $0
+    local.get $1
     i32.const 4
     i32.shl
     local.get $3
@@ -9390,27 +9367,28 @@
     i32.eqz
     if
      local.get $2
+     local.get $0
      local.get $5
      i32.load offset=8
-     call $~lib/array/Array<i32>#push
-     local.get $1
+     call $~lib/array/Array<i32>#__set
+     local.get $0
      i32.const 1
      i32.add
-     local.set $1
+     local.set $0
     end
-    local.get $0
+    local.get $1
     i32.const 1
     i32.add
-    local.set $0
+    local.set $1
     br $loop|0
    end
   end
   local.get $2
-  local.get $1
+  local.get $0
   call $~lib/array/Array<i32>#set:length
   local.get $2
  )
- (func $~lib/map/Map<i64,i64>#clear (; 128 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<i64,i64>#clear (; 127 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   i32.const 16
   call $~lib/arraybuffer/ArrayBuffer#constructor
@@ -9443,7 +9421,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i64,i64>#constructor (; 129 ;) (result i32)
+ (func $~lib/map/Map<i64,i64>#constructor (; 128 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 22
@@ -9471,7 +9449,7 @@
   call $~lib/map/Map<i64,i64>#clear
   local.get $0
  )
- (func $~lib/array/Array<i64>#__get (; 130 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<i64>#__get (; 129 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -9492,7 +9470,7 @@
   i32.add
   i64.load
  )
- (func $~lib/map/Map<i64,i64>#find (; 131 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i64,i64>#find (; 130 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -9535,7 +9513,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i64,i64>#rehash (; 132 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i64,i64>#rehash (; 131 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9667,7 +9645,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i64,i64>#set (; 133 ;) (type $FUNCSIG$vijj) (param $0 i32) (param $1 i64) (param $2 i64)
+ (func $~lib/map/Map<i64,i64>#set (; 132 ;) (type $FUNCSIG$vijj) (param $0 i32) (param $1 i64) (param $2 i64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9757,7 +9735,7 @@
    i32.store
   end
  )
- (func $~lib/map/Map<i64,i32>#delete (; 134 ;) (param $0 i32) (param $1 i64)
+ (func $~lib/map/Map<i64,i32>#delete (; 133 ;) (param $0 i32) (param $1 i64)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -9817,7 +9795,7 @@
    call $~lib/map/Map<i64,i32>#rehash
   end
  )
- (func $std/map/testNumeric<i64,i32> (; 135 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<i64,i32> (; 134 ;) (type $FUNCSIG$v)
   (local $0 i64)
   (local $1 i32)
   (local $2 i32)
@@ -10250,7 +10228,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u64,i32>#constructor (; 136 ;) (result i32)
+ (func $~lib/map/Map<u64,i32>#constructor (; 135 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 23
@@ -10278,7 +10256,7 @@
   call $~lib/map/Map<i64,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u64,i32>#keys (; 137 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#keys (; 136 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -10343,7 +10321,7 @@
   call $~lib/array/Array<i64>#set:length
   local.get $1
  )
- (func $~lib/map/Map<u64,u64>#constructor (; 138 ;) (result i32)
+ (func $~lib/map/Map<u64,u64>#constructor (; 137 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 25
@@ -10371,7 +10349,7 @@
   call $~lib/map/Map<i64,i64>#clear
   local.get $0
  )
- (func $std/map/testNumeric<u64,i32> (; 139 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<u64,i32> (; 138 ;) (type $FUNCSIG$v)
   (local $0 i64)
   (local $1 i32)
   (local $2 i32)
@@ -10804,7 +10782,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f32,i32>#constructor (; 140 ;) (result i32)
+ (func $~lib/map/Map<f32,i32>#constructor (; 139 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 26
@@ -10832,7 +10810,7 @@
   call $~lib/map/Map<i8,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<f32,i32>#find (; 141 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#find (; 140 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -10875,7 +10853,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f32,i32>#has (; 142 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/map/Map<f32,i32>#has (; 141 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -10885,7 +10863,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<f32,i32>#rehash (; 143 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f32,i32>#rehash (; 142 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11018,7 +10996,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f32,i32>#set (; 144 ;) (type $FUNCSIG$vifi) (param $0 i32) (param $1 f32) (param $2 i32)
+ (func $~lib/map/Map<f32,i32>#set (; 143 ;) (type $FUNCSIG$vifi) (param $0 i32) (param $1 f32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -11109,7 +11087,7 @@
    i32.store
   end
  )
- (func $~lib/map/Map<f32,i32>#get (; 145 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/map/Map<f32,i32>#get (; 144 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -11129,7 +11107,7 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/array/Array<f32>#__set (; 146 ;) (type $FUNCSIG$viif) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/array/Array<f32>#__set (; 145 ;) (type $FUNCSIG$viif) (param $0 i32) (param $1 i32) (param $2 f32)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -11167,7 +11145,7 @@
   local.get $2
   f32.store
  )
- (func $~lib/map/Map<f32,i32>#keys (; 147 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#keys (; 146 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -11232,7 +11210,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $1
  )
- (func $~lib/map/Map<f32,f32>#constructor (; 148 ;) (result i32)
+ (func $~lib/map/Map<f32,f32>#constructor (; 147 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 28
@@ -11260,7 +11238,7 @@
   call $~lib/map/Map<i8,i32>#clear
   local.get $0
  )
- (func $~lib/array/Array<f32>#__get (; 149 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__get (; 148 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -11281,7 +11259,7 @@
   i32.add
   f32.load
  )
- (func $~lib/map/Map<f32,f32>#rehash (; 150 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f32,f32>#rehash (; 149 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11414,7 +11392,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f32,f32>#set (; 151 ;) (type $FUNCSIG$viff) (param $0 i32) (param $1 f32) (param $2 f32)
+ (func $~lib/map/Map<f32,f32>#set (; 150 ;) (type $FUNCSIG$viff) (param $0 i32) (param $1 f32) (param $2 f32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -11505,7 +11483,7 @@
    i32.store
   end
  )
- (func $~lib/map/Map<f32,i32>#delete (; 152 ;) (param $0 i32) (param $1 f32)
+ (func $~lib/map/Map<f32,i32>#delete (; 151 ;) (param $0 i32) (param $1 f32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -11566,7 +11544,7 @@
    call $~lib/map/Map<f32,i32>#rehash
   end
  )
- (func $std/map/testNumeric<f32,i32> (; 153 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<f32,i32> (; 152 ;) (type $FUNCSIG$v)
   (local $0 f32)
   (local $1 i32)
   (local $2 i32)
@@ -11999,7 +11977,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f64,i32>#constructor (; 154 ;) (result i32)
+ (func $~lib/map/Map<f64,i32>#constructor (; 153 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 29
@@ -12027,7 +12005,7 @@
   call $~lib/map/Map<i64,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<f64,i32>#find (; 155 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#find (; 154 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -12070,7 +12048,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f64,i32>#has (; 156 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/map/Map<f64,i32>#has (; 155 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -12080,7 +12058,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<f64,i32>#rehash (; 157 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f64,i32>#rehash (; 156 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12213,7 +12191,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f64,i32>#set (; 158 ;) (type $FUNCSIG$vidi) (param $0 i32) (param $1 f64) (param $2 i32)
+ (func $~lib/map/Map<f64,i32>#set (; 157 ;) (type $FUNCSIG$vidi) (param $0 i32) (param $1 f64) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12304,7 +12282,7 @@
    i32.store
   end
  )
- (func $~lib/map/Map<f64,i32>#get (; 159 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/map/Map<f64,i32>#get (; 158 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -12324,7 +12302,7 @@
   local.get $0
   i32.load offset=8
  )
- (func $~lib/array/Array<f64>#__set (; 160 ;) (type $FUNCSIG$viid) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/array/Array<f64>#__set (; 159 ;) (type $FUNCSIG$viid) (param $0 i32) (param $1 i32) (param $2 f64)
   (local $3 i32)
   local.get $1
   local.get $0
@@ -12362,7 +12340,7 @@
   local.get $2
   f64.store
  )
- (func $~lib/map/Map<f64,i32>#keys (; 161 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#keys (; 160 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -12427,7 +12405,7 @@
   call $~lib/array/Array<i64>#set:length
   local.get $1
  )
- (func $~lib/map/Map<f64,f64>#constructor (; 162 ;) (result i32)
+ (func $~lib/map/Map<f64,f64>#constructor (; 161 ;) (result i32)
   (local $0 i32)
   i32.const 24
   i32.const 31
@@ -12455,7 +12433,7 @@
   call $~lib/map/Map<i64,i64>#clear
   local.get $0
  )
- (func $~lib/array/Array<f64>#__get (; 163 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__get (; 162 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -12476,7 +12454,7 @@
   i32.add
   f64.load
  )
- (func $~lib/map/Map<f64,f64>#find (; 164 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f64,f64>#find (; 163 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -12519,7 +12497,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f64,f64>#rehash (; 165 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f64,f64>#rehash (; 164 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12652,7 +12630,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f64,f64>#set (; 166 ;) (type $FUNCSIG$vidd) (param $0 i32) (param $1 f64) (param $2 f64)
+ (func $~lib/map/Map<f64,f64>#set (; 165 ;) (type $FUNCSIG$vidd) (param $0 i32) (param $1 f64) (param $2 f64)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12743,7 +12721,7 @@
    i32.store
   end
  )
- (func $~lib/map/Map<f64,i32>#delete (; 167 ;) (param $0 i32) (param $1 f64)
+ (func $~lib/map/Map<f64,i32>#delete (; 166 ;) (param $0 i32) (param $1 f64)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -12804,7 +12782,7 @@
    call $~lib/map/Map<f64,i32>#rehash
   end
  )
- (func $std/map/testNumeric<f64,i32> (; 168 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<f64,i32> (; 167 ;) (type $FUNCSIG$v)
   (local $0 f64)
   (local $1 i32)
   (local $2 i32)
@@ -13237,7 +13215,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $start (; 169 ;) (type $FUNCSIG$v)
+ (func $start (; 168 ;) (type $FUNCSIG$v)
   call $std/map/testNumeric<i8,i32>
   call $std/map/testNumeric<u8,i32>
   call $std/map/testNumeric<i16,i32>
@@ -13249,7 +13227,7 @@
   call $std/map/testNumeric<f32,i32>
   call $std/map/testNumeric<f64,i32>
  )
- (func $~lib/rt/pure/__visit (; 170 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 169 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
   i32.const 804
   i32.lt_u
@@ -13359,7 +13337,7 @@
    unreachable
   end
  )
- (func $~lib/rt/__visit_members (; 171 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (; 170 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   block $folding-inner0
    block $block$4$break
     block $switch$1$default
@@ -13393,7 +13371,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $null (; 172 ;) (type $FUNCSIG$v)
+ (func $null (; 171 ;) (type $FUNCSIG$v)
   unreachable
  )
 )

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -2737,6 +2737,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.load offset=8
   local.set $4
@@ -2774,15 +2775,16 @@
     i32.and
     i32.eqz
     if
-     local.get $1
      local.get $0
-     local.get $5
-     i32.load8_s
-     call $~lib/array/Array<i8>#__set
-     local.get $0
+     local.tee $6
      i32.const 1
      i32.add
      local.set $0
+     local.get $1
+     local.get $6
+     local.get $5
+     i32.load8_s
+     call $~lib/array/Array<i8>#__set
     end
     local.get $3
     i32.const 1
@@ -2869,6 +2871,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.load offset=8
   local.set $3
@@ -2896,15 +2899,16 @@
     i32.and
     i32.eqz
     if
-     local.get $2
      local.get $0
-     local.get $5
-     i32.load offset=4
-     call $~lib/array/Array<i32>#__set
-     local.get $0
+     local.tee $6
      i32.const 1
      i32.add
      local.set $0
+     local.get $2
+     local.get $6
+     local.get $5
+     i32.load offset=4
+     call $~lib/array/Array<i32>#__set
     end
     local.get $1
     i32.const 1
@@ -4422,6 +4426,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.load offset=8
   local.set $4
@@ -4459,15 +4464,16 @@
     i32.and
     i32.eqz
     if
-     local.get $1
      local.get $0
-     local.get $5
-     i32.load8_u
-     call $~lib/array/Array<i8>#__set
-     local.get $0
+     local.tee $6
      i32.const 1
      i32.add
      local.set $0
+     local.get $1
+     local.get $6
+     local.get $5
+     i32.load8_u
+     call $~lib/array/Array<i8>#__set
     end
     local.get $3
     i32.const 1
@@ -5660,6 +5666,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.load offset=8
   local.set $4
@@ -5697,15 +5704,16 @@
     i32.and
     i32.eqz
     if
-     local.get $1
      local.get $0
-     local.get $5
-     i32.load16_s
-     call $~lib/array/Array<i16>#__set
-     local.get $0
+     local.tee $6
      i32.const 1
      i32.add
      local.set $0
+     local.get $1
+     local.get $6
+     local.get $5
+     i32.load16_s
+     call $~lib/array/Array<i16>#__set
     end
     local.get $3
     i32.const 1
@@ -6847,6 +6855,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.load offset=8
   local.set $4
@@ -6884,15 +6893,16 @@
     i32.and
     i32.eqz
     if
-     local.get $1
      local.get $0
-     local.get $5
-     i32.load16_u
-     call $~lib/array/Array<i16>#__set
-     local.get $0
+     local.tee $6
      i32.const 1
      i32.add
      local.set $0
+     local.get $1
+     local.get $6
+     local.get $5
+     i32.load16_u
+     call $~lib/array/Array<i16>#__set
     end
     local.get $3
     i32.const 1
@@ -7715,6 +7725,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.load offset=8
   local.set $3
@@ -7742,15 +7753,16 @@
     i32.and
     i32.eqz
     if
-     local.get $2
      local.get $0
-     local.get $5
-     i32.load
-     call $~lib/array/Array<i32>#__set
-     local.get $0
+     local.tee $6
      i32.const 1
      i32.add
      local.set $0
+     local.get $2
+     local.get $6
+     local.get $5
+     i32.load
+     call $~lib/array/Array<i32>#__set
     end
     local.get $1
     i32.const 1
@@ -8284,6 +8296,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.load offset=8
   local.set $4
@@ -8321,15 +8334,16 @@
     i32.and
     i32.eqz
     if
-     local.get $1
      local.get $0
-     local.get $5
-     i32.load
-     call $~lib/array/Array<i32>#__set
-     local.get $0
+     local.tee $6
      i32.const 1
      i32.add
      local.set $0
+     local.get $1
+     local.get $6
+     local.get $5
+     i32.load
+     call $~lib/array/Array<i32>#__set
     end
     local.get $3
     i32.const 1
@@ -9274,6 +9288,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.load offset=8
   local.set $4
@@ -9311,15 +9326,16 @@
     i32.and
     i32.eqz
     if
-     local.get $1
      local.get $0
-     local.get $5
-     i64.load
-     call $~lib/array/Array<i64>#__set
-     local.get $0
+     local.tee $6
      i32.const 1
      i32.add
      local.set $0
+     local.get $1
+     local.get $6
+     local.get $5
+     i64.load
+     call $~lib/array/Array<i64>#__set
     end
     local.get $3
     i32.const 1
@@ -9339,6 +9355,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.load offset=8
   local.set $3
@@ -9366,15 +9383,16 @@
     i32.and
     i32.eqz
     if
-     local.get $2
      local.get $0
-     local.get $5
-     i32.load offset=8
-     call $~lib/array/Array<i32>#__set
-     local.get $0
+     local.tee $6
      i32.const 1
      i32.add
      local.set $0
+     local.get $2
+     local.get $6
+     local.get $5
+     i32.load offset=8
+     call $~lib/array/Array<i32>#__set
     end
     local.get $1
     i32.const 1
@@ -10262,6 +10280,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.load offset=8
   local.set $4
@@ -10299,15 +10318,16 @@
     i32.and
     i32.eqz
     if
-     local.get $1
      local.get $0
-     local.get $5
-     i64.load
-     call $~lib/array/Array<i64>#__set
-     local.get $0
+     local.tee $6
      i32.const 1
      i32.add
      local.set $0
+     local.get $1
+     local.get $6
+     local.get $5
+     i64.load
+     call $~lib/array/Array<i64>#__set
     end
     local.get $3
     i32.const 1
@@ -11151,6 +11171,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.load offset=8
   local.set $4
@@ -11188,15 +11209,16 @@
     i32.and
     i32.eqz
     if
-     local.get $1
      local.get $0
-     local.get $5
-     f32.load
-     call $~lib/array/Array<f32>#__set
-     local.get $0
+     local.tee $6
      i32.const 1
      i32.add
      local.set $0
+     local.get $1
+     local.get $6
+     local.get $5
+     f32.load
+     call $~lib/array/Array<f32>#__set
     end
     local.get $3
     i32.const 1
@@ -12346,6 +12368,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.load offset=8
   local.set $4
@@ -12383,15 +12406,16 @@
     i32.and
     i32.eqz
     if
-     local.get $1
      local.get $0
-     local.get $5
-     f64.load
-     call $~lib/array/Array<f64>#__set
-     local.get $0
+     local.tee $6
      i32.const 1
      i32.add
      local.set $0
+     local.get $1
+     local.get $6
+     local.get $5
+     f64.load
+     call $~lib/array/Array<f64>#__set
     end
     local.get $3
     i32.const 1

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -11,12 +11,21 @@
  (type $FUNCSIG$ij (func (param i64) (result i32)))
  (type $FUNCSIG$iiji (func (param i32 i64 i32) (result i32)))
  (type $FUNCSIG$viji (func (param i32 i64 i32)))
+ (type $FUNCSIG$viij (func (param i32 i32 i64)))
+ (type $FUNCSIG$jii (func (param i32 i32) (result i64)))
+ (type $FUNCSIG$vijj (func (param i32 i64 i64)))
  (type $FUNCSIG$iif (func (param i32 f32) (result i32)))
  (type $FUNCSIG$iifi (func (param i32 f32 i32) (result i32)))
  (type $FUNCSIG$vifi (func (param i32 f32 i32)))
+ (type $FUNCSIG$viif (func (param i32 i32 f32)))
+ (type $FUNCSIG$fii (func (param i32 i32) (result f32)))
+ (type $FUNCSIG$viff (func (param i32 f32 f32)))
  (type $FUNCSIG$iid (func (param i32 f64) (result i32)))
  (type $FUNCSIG$iidi (func (param i32 f64 i32) (result i32)))
  (type $FUNCSIG$vidi (func (param i32 f64 i32)))
+ (type $FUNCSIG$viid (func (param i32 i32 f64)))
+ (type $FUNCSIG$dii (func (param i32 i32) (result f64)))
+ (type $FUNCSIG$vidd (func (param i32 f64 f64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
@@ -33,7 +42,8 @@
  (data (i32.const 360) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00s\00t\00d\00/\00m\00a\00p\00.\00t\00s")
  (data (i32.const 400) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00K\00e\00y\00 \00d\00o\00e\00s\00 \00n\00o\00t\00 \00e\00x\00i\00s\00t")
  (data (i32.const 456) "\16\00\00\00\01\00\00\00\01\00\00\00\16\00\00\00~\00l\00i\00b\00/\00m\00a\00p\00.\00t\00s")
- (data (i32.const 496) "\0d\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\98D\08\00\00\00\00\00\98D\00\00\00\00\00\00\98\84\08\00\00\00\00\00\98\84\00\00\00\00\00\00\98\04\t\00\00\00\00\00\98\04\01\00\00\00\00\00\98\04\n\00\00\00\00\00\98\04\02\00\00\00\00\00\98\04\19\00\00\00\00\00\98\04\1a")
+ (data (i32.const 496) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s")
+ (data (i32.const 544) " \00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\98D\08\00\00\00\00\003\04\00\00\02\00\00\00\93\04\00\00\02\00\00\008D\08\00\00\00\00\00\98\04\t\00\00\00\00\00\98D\00\00\00\00\00\003\00\00\00\02\00\00\008@\00\00\00\00\00\00\98\84\08\00\00\00\00\00S\04\00\00\02\00\00\00X\84\08\00\00\00\00\00\98\84\00\00\00\00\00\00S\00\00\00\02\00\00\00X\80\00\00\00\00\00\00\98\04\01\00\00\00\00\00\93\00\00\00\02\00\00\00\98\00\01\00\00\00\00\00\98\04\n\00\00\00\00\00\13\05\00\00\02\00\00\00\18\05\n\00\00\00\00\00\98\04\02\00\00\00\00\00\13\01\00\00\02\00\00\00\18\01\02\00\00\00\00\00\98\04\19\00\00\00\00\00\93\0c\00\00\02\00\00\00\98\0c\19\00\00\00\00\00\98\04\1a\00\00\00\00\00\13\0d\00\00\02\00\00\00\18\0d\1a")
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
  (global $~lib/rt/pure/ROOTS (mut i32) (i32.const 0))
@@ -626,10 +636,10 @@
   if
    unreachable
   end
-  i32.const 608
+  i32.const 816
   i32.const 0
   i32.store
-  i32.const 2176
+  i32.const 2384
   i32.const 0
   i32.store
   i32.const 0
@@ -643,7 +653,7 @@
     local.get $0
     i32.const 2
     i32.shl
-    i32.const 608
+    i32.const 816
     i32.add
     i32.const 0
     i32.store offset=4
@@ -662,7 +672,7 @@
       i32.add
       i32.const 2
       i32.shl
-      i32.const 608
+      i32.const 816
       i32.add
       i32.const 0
       i32.store offset=96
@@ -680,13 +690,13 @@
     br $loop|0
    end
   end
-  i32.const 608
-  i32.const 2192
+  i32.const 816
+  i32.const 2400
   memory.size
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
-  i32.const 608
+  i32.const 816
   global.set $~lib/rt/tlsf/ROOT
  )
  (func $~lib/rt/tlsf/prepareSize (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
@@ -1378,7 +1388,7 @@
  )
  (func $~lib/rt/pure/__retain (; 22 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
-  i32.const 604
+  i32.const 804
   i32.gt_u
   if
    local.get $0
@@ -1621,7 +1631,7 @@
  )
  (func $~lib/rt/__typeinfo (; 25 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
-  i32.const 496
+  i32.const 544
   i32.load
   i32.gt_u
   if
@@ -1635,7 +1645,7 @@
   local.get $0
   i32.const 3
   i32.shl
-  i32.const 500
+  i32.const 548
   i32.add
   i32.load
  )
@@ -2007,7 +2017,7 @@
  )
  (func $~lib/rt/pure/__release (; 31 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
-  i32.const 604
+  i32.const 804
   i32.gt_u
   if
    local.get $0
@@ -2391,7 +2401,1205 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/map/Map<i8,i32>#delete (; 40 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (; 40 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  local.get $1
+  i32.const 1073741808
+  local.get $2
+  i32.shr_u
+  i32.gt_u
+  if
+   i32.const 176
+   i32.const 224
+   i32.const 23
+   i32.const 56
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $2
+  i32.shl
+  local.tee $3
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.tee $2
+  local.get $3
+  call $~lib/memory/memory.fill
+  local.get $0
+  i32.eqz
+  if
+   i32.const 12
+   i32.const 2
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $2
+  local.set $1
+  local.get $0
+  i32.load
+  local.tee $4
+  local.get $2
+  i32.ne
+  if
+   local.get $1
+   call $~lib/rt/pure/__retain
+   local.set $1
+   local.get $4
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $1
+  i32.store
+  local.get $0
+  local.get $2
+  i32.store offset=4
+  local.get $0
+  local.get $3
+  i32.store offset=8
+  local.get $0
+ )
+ (func $~lib/rt/tlsf/reallocateBlock (; 41 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $2
+  call $~lib/rt/tlsf/prepareSize
+  local.set $3
+  local.get $1
+  i32.load
+  local.tee $4
+  i32.const 1
+  i32.and
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   i32.load offset=4
+   i32.const -268435456
+   i32.and
+   i32.eqz
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 521
+   i32.const 4
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  local.get $4
+  i32.const -4
+  i32.and
+  i32.le_u
+  if
+   local.get $0
+   local.get $1
+   local.get $3
+   call $~lib/rt/tlsf/prepareBlock
+   local.get $1
+   local.get $2
+   i32.store offset=12
+   local.get $1
+   return
+  end
+  local.get $1
+  i32.const 16
+  i32.add
+  local.get $1
+  i32.load
+  i32.const -4
+  i32.and
+  i32.add
+  local.tee $6
+  i32.load
+  local.tee $5
+  i32.const 1
+  i32.and
+  if
+   local.get $4
+   i32.const -4
+   i32.and
+   i32.const 16
+   i32.add
+   local.get $5
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $5
+   local.get $3
+   i32.ge_u
+   if
+    local.get $0
+    local.get $6
+    call $~lib/rt/tlsf/removeBlock
+    local.get $1
+    local.get $4
+    i32.const 3
+    i32.and
+    local.get $5
+    i32.or
+    i32.store
+    local.get $1
+    local.get $2
+    i32.store offset=12
+    local.get $0
+    local.get $1
+    local.get $3
+    call $~lib/rt/tlsf/prepareBlock
+    local.get $1
+    return
+   end
+  end
+  local.get $0
+  local.get $2
+  call $~lib/rt/tlsf/allocateBlock
+  local.tee $3
+  local.get $1
+  i32.load offset=8
+  i32.store offset=8
+  local.get $3
+  i32.const 16
+  i32.add
+  local.get $1
+  i32.const 16
+  i32.add
+  local.get $2
+  call $~lib/memory/memory.copy
+  local.get $1
+  local.get $4
+  i32.const 1
+  i32.or
+  i32.store
+  local.get $0
+  local.get $1
+  call $~lib/rt/tlsf/insertBlock
+  local.get $1
+  call $~lib/rt/rtrace/onfree
+  local.get $3
+ )
+ (func $~lib/rt/tlsf/__realloc (; 42 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  global.get $~lib/rt/tlsf/ROOT
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 585
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 15
+  i32.and
+  i32.eqz
+  i32.const 0
+  local.get $0
+  select
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 586
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/rt/tlsf/ROOT
+  local.get $0
+  i32.const 16
+  i32.sub
+  local.get $1
+  call $~lib/rt/tlsf/reallocateBlock
+  i32.const 16
+  i32.add
+ )
+ (func $~lib/array/ensureSize (; 43 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=8
+  local.tee $3
+  local.get $2
+  i32.shr_u
+  i32.gt_u
+  if
+   local.get $1
+   i32.const 1073741808
+   local.get $2
+   i32.shr_u
+   i32.gt_u
+   if
+    i32.const 176
+    i32.const 512
+    i32.const 14
+    i32.const 47
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   i32.load
+   local.tee $4
+   local.get $1
+   local.get $2
+   i32.shl
+   local.tee $2
+   call $~lib/rt/tlsf/__realloc
+   local.tee $1
+   local.get $3
+   i32.add
+   local.get $2
+   local.get $3
+   i32.sub
+   call $~lib/memory/memory.fill
+   local.get $1
+   local.get $4
+   i32.ne
+   if
+    local.get $0
+    local.get $1
+    call $~lib/rt/pure/__retain
+    i32.store
+    local.get $0
+    local.get $1
+    i32.store offset=4
+   end
+   local.get $0
+   local.get $2
+   i32.store offset=8
+  end
+ )
+ (func $~lib/array/Array<i8>#__set (; 44 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 512
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   i32.const 0
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $3
+   i32.store offset=12
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.add
+  local.get $2
+  i32.store8
+ )
+ (func $~lib/array/Array<i8>#set:length (; 45 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  local.get $0
+  i32.load offset=12
+  drop
+  local.get $0
+  local.get $1
+  i32.const 0
+  call $~lib/array/ensureSize
+  local.get $0
+  local.get $1
+  i32.store offset=12
+ )
+ (func $~lib/map/Map<i8,i32>#keys (; 46 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 16
+  i32.const 4
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.get $2
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $2
+  i32.store offset=12
+  i32.const 0
+  local.set $0
+  loop $loop|0
+   local.get $3
+   local.get $2
+   i32.lt_s
+   if
+    local.get $3
+    i32.const 12
+    i32.mul
+    local.get $4
+    i32.add
+    local.tee $5
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $1
+     local.get $0
+     local.get $5
+     i32.load8_s
+     call $~lib/array/Array<i8>#__set
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $loop|0
+   end
+  end
+  local.get $1
+  local.get $0
+  call $~lib/array/Array<i8>#set:length
+  local.get $1
+ )
+ (func $~lib/array/Array<i32>#constructor (; 47 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  i32.const 16
+  i32.const 5
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.get $0
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $0
+  i32.store offset=12
+  local.get $1
+ )
+ (func $~lib/array/Array<i32>#push (; 48 ;) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  local.get $0
+  i32.load offset=12
+  local.tee $2
+  i32.const 1
+  i32.add
+  local.tee $3
+  i32.const 2
+  call $~lib/array/ensureSize
+  local.get $0
+  i32.load offset=4
+  local.get $2
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $1
+  i32.store
+  local.get $0
+  local.get $3
+  i32.store offset=12
+ )
+ (func $~lib/array/Array<i32>#set:length (; 49 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  local.get $0
+  i32.load offset=12
+  drop
+  local.get $0
+  local.get $1
+  i32.const 2
+  call $~lib/array/ensureSize
+  local.get $0
+  local.get $1
+  i32.store offset=12
+ )
+ (func $~lib/map/Map<i8,i32>#values (; 50 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $3
+  local.get $0
+  i32.load offset=16
+  local.tee $4
+  call $~lib/array/Array<i32>#constructor
+  local.set $2
+  i32.const 0
+  local.set $0
+  loop $loop|0
+   block $break|0
+    local.get $0
+    local.get $4
+    i32.ge_s
+    br_if $break|0
+    local.get $0
+    i32.const 12
+    i32.mul
+    local.get $3
+    i32.add
+    local.tee $5
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $2
+     local.get $5
+     i32.load offset=4
+     call $~lib/array/Array<i32>#push
+     local.get $1
+     i32.const 1
+     i32.add
+     local.set $1
+    end
+    local.get $0
+    i32.const 1
+    i32.add
+    local.set $0
+    br $loop|0
+   end
+  end
+  local.get $2
+  local.get $1
+  call $~lib/array/Array<i32>#set:length
+  local.get $2
+ )
+ (func $~lib/map/Map<i8,i8>#clear (; 51 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $0
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $0
+  local.get $1
+  i32.store
+  local.get $0
+  i32.const 3
+  i32.store offset=4
+  i32.const 32
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $0
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $0
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+ )
+ (func $~lib/map/Map<i8,i8>#constructor (; 52 ;) (result i32)
+  (local $0 i32)
+  i32.const 24
+  i32.const 6
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+  local.get $0
+  call $~lib/map/Map<i8,i8>#clear
+  local.get $0
+ )
+ (func $~lib/map/Map<i32,i32>#constructor (; 53 ;) (result i32)
+  (local $0 i32)
+  i32.const 24
+  i32.const 7
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+  local.get $0
+  call $~lib/map/Map<i8,i32>#clear
+  local.get $0
+ )
+ (func $~lib/array/Array<i8>#__get (; 54 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 512
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.add
+  i32.load8_s
+ )
+ (func $~lib/array/Array<i32>#__get (; 55 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 512
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
+ )
+ (func $~lib/map/Map<i8,i8>#find (; 56 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  local.get $0
+  i32.load
+  local.get $0
+  i32.load offset=4
+  local.get $2
+  i32.and
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
+  local.set $0
+  loop $continue|0
+   local.get $0
+   if
+    local.get $0
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    if (result i32)
+     i32.const 0
+    else
+     local.get $0
+     i32.load8_u
+     local.get $1
+     i32.const 255
+     i32.and
+     i32.eq
+    end
+    if
+     local.get $0
+     return
+    else
+     local.get $0
+     i32.load offset=4
+     i32.const -2
+     i32.and
+     local.set $0
+     br $continue|0
+    end
+    unreachable
+   end
+  end
+  i32.const 0
+ )
+ (func $~lib/map/Map<i8,i8>#rehash (; 57 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $1
+  i32.const 1
+  i32.add
+  local.tee $4
+  i32.const 2
+  i32.shl
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $5
+  local.get $4
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
+  local.tee $6
+  i32.const 3
+  i32.shl
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $4
+  local.get $0
+  i32.load offset=8
+  local.tee $2
+  local.get $0
+  i32.load offset=16
+  i32.const 3
+  i32.shl
+  i32.add
+  local.set $7
+  local.get $4
+  local.set $3
+  loop $continue|0
+   local.get $2
+   local.get $7
+   i32.eq
+   i32.eqz
+   if
+    local.get $2
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $2
+     i32.load8_s
+     i32.store8
+     local.get $3
+     local.get $2
+     i32.load8_s offset=1
+     i32.store8 offset=1
+     local.get $3
+     local.get $2
+     i32.load8_s
+     call $~lib/util/hash/hash8
+     local.get $1
+     i32.and
+     i32.const 2
+     i32.shl
+     local.get $5
+     i32.add
+     local.tee $8
+     i32.load
+     i32.store offset=4
+     local.get $8
+     local.get $3
+     i32.store
+     local.get $3
+     i32.const 8
+     i32.add
+     local.set $3
+    end
+    local.get $2
+    i32.const 8
+    i32.add
+    local.set $2
+    br $continue|0
+   end
+  end
+  local.get $5
+  local.tee $2
+  local.get $0
+  i32.load
+  local.tee $3
+  i32.ne
+  if
+   local.get $2
+   call $~lib/rt/pure/__retain
+   local.set $2
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $2
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $4
+  local.tee $1
+  local.get $0
+  i32.load offset=8
+  local.tee $2
+  i32.ne
+  if
+   local.get $1
+   call $~lib/rt/pure/__retain
+   local.set $1
+   local.get $2
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  local.get $6
+  i32.store offset=12
+  local.get $0
+  local.get $0
+  i32.load offset=20
+  i32.store offset=16
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/map/Map<i8,i8>#set (; 58 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  local.get $1
+  local.get $1
+  i32.const 24
+  i32.shl
+  i32.const 24
+  i32.shr_s
+  call $~lib/util/hash/hash8
+  local.tee $4
+  call $~lib/map/Map<i8,i8>#find
+  local.tee $3
+  if
+   local.get $3
+   local.get $2
+   i32.store8 offset=1
+  else
+   local.get $0
+   i32.load offset=16
+   local.get $0
+   i32.load offset=12
+   i32.eq
+   if
+    local.get $0
+    local.get $0
+    i32.load offset=20
+    local.get $0
+    i32.load offset=12
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
+    i32.lt_s
+    if (result i32)
+     local.get $0
+     i32.load offset=4
+    else
+     local.get $0
+     i32.load offset=4
+     i32.const 1
+     i32.shl
+     i32.const 1
+     i32.or
+    end
+    call $~lib/map/Map<i8,i8>#rehash
+   end
+   local.get $0
+   i32.load offset=8
+   local.set $3
+   local.get $0
+   local.get $0
+   i32.load offset=16
+   local.tee $5
+   i32.const 1
+   i32.add
+   i32.store offset=16
+   local.get $5
+   i32.const 3
+   i32.shl
+   local.get $3
+   i32.add
+   local.tee $3
+   local.get $1
+   i32.store8
+   local.get $3
+   local.get $2
+   i32.store8 offset=1
+   local.get $0
+   local.get $0
+   i32.load offset=20
+   i32.const 1
+   i32.add
+   i32.store offset=20
+   local.get $3
+   local.get $0
+   i32.load
+   local.get $0
+   i32.load offset=4
+   local.get $4
+   i32.and
+   i32.const 2
+   i32.shl
+   i32.add
+   local.tee $0
+   i32.load
+   i32.store offset=4
+   local.get $0
+   local.get $3
+   i32.store
+  end
+ )
+ (func $~lib/util/hash/hash32 (; 59 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.const 255
+  i32.and
+  i32.const -2128831035
+  i32.xor
+  i32.const 16777619
+  i32.mul
+  local.get $0
+  i32.const 8
+  i32.shr_u
+  i32.const 255
+  i32.and
+  i32.xor
+  i32.const 16777619
+  i32.mul
+  local.get $0
+  i32.const 16
+  i32.shr_u
+  i32.const 255
+  i32.and
+  i32.xor
+  i32.const 16777619
+  i32.mul
+  local.get $0
+  i32.const 24
+  i32.shr_u
+  i32.xor
+  i32.const 16777619
+  i32.mul
+ )
+ (func $~lib/map/Map<i32,i32>#find (; 60 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  local.get $0
+  i32.load
+  local.get $0
+  i32.load offset=4
+  local.get $2
+  i32.and
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
+  local.set $0
+  loop $continue|0
+   local.get $0
+   if
+    local.get $0
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    if (result i32)
+     i32.const 0
+    else
+     local.get $0
+     i32.load
+     local.get $1
+     i32.eq
+    end
+    if
+     local.get $0
+     return
+    else
+     local.get $0
+     i32.load offset=8
+     i32.const -2
+     i32.and
+     local.set $0
+     br $continue|0
+    end
+    unreachable
+   end
+  end
+  i32.const 0
+ )
+ (func $~lib/map/Map<i32,i32>#rehash (; 61 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $1
+  i32.const 1
+  i32.add
+  local.tee $4
+  i32.const 2
+  i32.shl
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $5
+  local.get $4
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
+  local.tee $6
+  i32.const 12
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $4
+  local.get $0
+  i32.load offset=8
+  local.tee $2
+  local.get $0
+  i32.load offset=16
+  i32.const 12
+  i32.mul
+  i32.add
+  local.set $7
+  local.get $4
+  local.set $3
+  loop $continue|0
+   local.get $2
+   local.get $7
+   i32.eq
+   i32.eqz
+   if
+    local.get $2
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $2
+     i32.load
+     i32.store
+     local.get $3
+     local.get $2
+     i32.load offset=4
+     i32.store offset=4
+     local.get $3
+     local.get $2
+     i32.load
+     call $~lib/util/hash/hash32
+     local.get $1
+     i32.and
+     i32.const 2
+     i32.shl
+     local.get $5
+     i32.add
+     local.tee $8
+     i32.load
+     i32.store offset=8
+     local.get $8
+     local.get $3
+     i32.store
+     local.get $3
+     i32.const 12
+     i32.add
+     local.set $3
+    end
+    local.get $2
+    i32.const 12
+    i32.add
+    local.set $2
+    br $continue|0
+   end
+  end
+  local.get $5
+  local.tee $2
+  local.get $0
+  i32.load
+  local.tee $3
+  i32.ne
+  if
+   local.get $2
+   call $~lib/rt/pure/__retain
+   local.set $2
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $2
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $4
+  local.tee $1
+  local.get $0
+  i32.load offset=8
+  local.tee $2
+  i32.ne
+  if
+   local.get $1
+   call $~lib/rt/pure/__retain
+   local.set $1
+   local.get $2
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  local.get $6
+  i32.store offset=12
+  local.get $0
+  local.get $0
+  i32.load offset=20
+  i32.store offset=16
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/map/Map<i32,i32>#set (; 62 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  local.get $1
+  local.get $1
+  call $~lib/util/hash/hash32
+  local.tee $4
+  call $~lib/map/Map<i32,i32>#find
+  local.tee $3
+  if
+   local.get $3
+   local.get $2
+   i32.store offset=4
+  else
+   local.get $0
+   i32.load offset=16
+   local.get $0
+   i32.load offset=12
+   i32.eq
+   if
+    local.get $0
+    local.get $0
+    i32.load offset=20
+    local.get $0
+    i32.load offset=12
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
+    i32.lt_s
+    if (result i32)
+     local.get $0
+     i32.load offset=4
+    else
+     local.get $0
+     i32.load offset=4
+     i32.const 1
+     i32.shl
+     i32.const 1
+     i32.or
+    end
+    call $~lib/map/Map<i32,i32>#rehash
+   end
+   local.get $0
+   i32.load offset=8
+   local.set $3
+   local.get $0
+   local.get $0
+   i32.load offset=16
+   local.tee $5
+   i32.const 1
+   i32.add
+   i32.store offset=16
+   local.get $5
+   i32.const 12
+   i32.mul
+   local.get $3
+   i32.add
+   local.tee $3
+   local.get $1
+   i32.store
+   local.get $3
+   local.get $2
+   i32.store offset=4
+   local.get $0
+   local.get $0
+   i32.load offset=20
+   i32.const 1
+   i32.add
+   i32.store offset=20
+   local.get $3
+   local.get $0
+   i32.load
+   local.get $0
+   i32.load offset=4
+   local.get $4
+   i32.and
+   i32.const 2
+   i32.shl
+   i32.add
+   local.tee $0
+   i32.load
+   i32.store offset=8
+   local.get $0
+   local.get $3
+   i32.store
+  end
+ )
+ (func $~lib/map/Map<i8,i32>#delete (; 63 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -2454,9 +3662,15 @@
    call $~lib/map/Map<i8,i32>#rehash
   end
  )
- (func $std/map/testNumeric<i8,i32> (; 41 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<i8,i32> (; 64 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   call $~lib/map/Map<i8,i32>#constructor
   local.set $1
   loop $loop|0
@@ -2637,9 +3851,104 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/map/Map<i8,i32>#keys
+  local.set $3
+  local.get $1
+  call $~lib/map/Map<i8,i32>#values
+  local.set $6
+  call $~lib/map/Map<i8,i8>#constructor
+  local.set $4
+  call $~lib/map/Map<i32,i32>#constructor
+  local.set $5
   i32.const 0
   local.set $0
   loop $loop|2
+   local.get $0
+   local.get $3
+   i32.load offset=12
+   i32.lt_s
+   if
+    local.get $3
+    local.get $0
+    call $~lib/array/Array<i8>#__get
+    local.set $2
+    local.get $6
+    local.get $0
+    call $~lib/array/Array<i32>#__get
+    local.set $7
+    local.get $1
+    local.get $2
+    call $~lib/map/Map<i8,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 31
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $7
+    i32.const 20
+    i32.sub
+    call $~lib/map/Map<i8,i32>#has
+    if
+     local.get $4
+     local.get $2
+     local.get $2
+     call $~lib/map/Map<i8,i8>#set
+     local.get $5
+     local.get $7
+     i32.const 20
+     i32.sub
+     local.tee $2
+     local.get $2
+     call $~lib/map/Map<i32,i32>#set
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+     br $loop|2
+    else
+     i32.const 0
+     i32.const 376
+     i32.const 32
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    unreachable
+   end
+  end
+  local.get $4
+  i32.load offset=20
+  i32.const 100
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 36
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.load offset=20
+  i32.const 100
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 37
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  local.set $0
+  loop $loop|3
    local.get $0
    i32.const 50
    i32.lt_s
@@ -2651,7 +3960,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 25
+     i32.const 41
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -2670,7 +3979,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 26
+     i32.const 42
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -2684,7 +3993,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 28
+     i32.const 44
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -2693,7 +4002,7 @@
      i32.const 1
      i32.add
      local.set $0
-     br $loop|2
+     br $loop|3
     end
     unreachable
    end
@@ -2705,14 +4014,14 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 30
+   i32.const 46
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
   i32.const 0
   local.set $0
-  loop $loop|3
+  loop $loop|4
    local.get $0
    i32.const 50
    i32.lt_s
@@ -2723,7 +4032,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 50
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -2745,7 +4054,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 36
+     i32.const 52
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -2759,7 +4068,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 38
+     i32.const 54
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -2768,7 +4077,7 @@
      i32.const 1
      i32.add
      local.set $0
-     br $loop|3
+     br $loop|4
     end
     unreachable
    end
@@ -2780,7 +4089,7 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 56
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2792,18 +4101,26 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 44
+   i32.const 60
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u8,i32>#constructor (; 42 ;) (result i32)
+ (func $~lib/map/Map<u8,i32>#constructor (; 65 ;) (result i32)
   (local $0 i32)
   i32.const 24
-  i32.const 4
+  i32.const 8
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
@@ -2828,7 +4145,7 @@
   call $~lib/map/Map<i8,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u8,i32>#has (; 43 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#has (; 66 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -2839,7 +4156,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u8,i32>#rehash (; 44 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,i32>#rehash (; 67 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2971,7 +4288,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u8,i32>#set (; 45 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<u8,i32>#set (; 68 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3063,7 +4380,7 @@
    i32.store
   end
  )
- (func $~lib/map/Map<u8,i32>#get (; 46 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#get (; 69 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -3084,7 +4401,343 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/map/Map<u8,i32>#delete (; 47 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,i32>#keys (; 70 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 16
+  i32.const 9
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.get $2
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $2
+  i32.store offset=12
+  i32.const 0
+  local.set $0
+  loop $loop|0
+   local.get $3
+   local.get $2
+   i32.lt_s
+   if
+    local.get $3
+    i32.const 12
+    i32.mul
+    local.get $4
+    i32.add
+    local.tee $5
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $1
+     local.get $0
+     local.get $5
+     i32.load8_u
+     call $~lib/array/Array<i8>#__set
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $loop|0
+   end
+  end
+  local.get $1
+  local.get $0
+  call $~lib/array/Array<i8>#set:length
+  local.get $1
+ )
+ (func $~lib/map/Map<u8,u8>#constructor (; 71 ;) (result i32)
+  (local $0 i32)
+  i32.const 24
+  i32.const 10
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+  local.get $0
+  call $~lib/map/Map<i8,i8>#clear
+  local.get $0
+ )
+ (func $~lib/array/Array<u8>#__get (; 72 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 512
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.add
+  i32.load8_u
+ )
+ (func $~lib/map/Map<u8,u8>#rehash (; 73 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $1
+  i32.const 1
+  i32.add
+  local.tee $4
+  i32.const 2
+  i32.shl
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $5
+  local.get $4
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
+  local.tee $6
+  i32.const 3
+  i32.shl
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $4
+  local.get $0
+  i32.load offset=8
+  local.tee $2
+  local.get $0
+  i32.load offset=16
+  i32.const 3
+  i32.shl
+  i32.add
+  local.set $7
+  local.get $4
+  local.set $3
+  loop $continue|0
+   local.get $2
+   local.get $7
+   i32.eq
+   i32.eqz
+   if
+    local.get $2
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $2
+     i32.load8_u
+     i32.store8
+     local.get $3
+     local.get $2
+     i32.load8_u offset=1
+     i32.store8 offset=1
+     local.get $3
+     local.get $2
+     i32.load8_u
+     call $~lib/util/hash/hash8
+     local.get $1
+     i32.and
+     i32.const 2
+     i32.shl
+     local.get $5
+     i32.add
+     local.tee $8
+     i32.load
+     i32.store offset=4
+     local.get $8
+     local.get $3
+     i32.store
+     local.get $3
+     i32.const 8
+     i32.add
+     local.set $3
+    end
+    local.get $2
+    i32.const 8
+    i32.add
+    local.set $2
+    br $continue|0
+   end
+  end
+  local.get $5
+  local.tee $2
+  local.get $0
+  i32.load
+  local.tee $3
+  i32.ne
+  if
+   local.get $2
+   call $~lib/rt/pure/__retain
+   local.set $2
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $2
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $4
+  local.tee $1
+  local.get $0
+  i32.load offset=8
+  local.tee $2
+  i32.ne
+  if
+   local.get $1
+   call $~lib/rt/pure/__retain
+   local.set $1
+   local.get $2
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  local.get $6
+  i32.store offset=12
+  local.get $0
+  local.get $0
+  i32.load offset=20
+  i32.store offset=16
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/map/Map<u8,u8>#set (; 74 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  local.get $1
+  local.get $1
+  i32.const 255
+  i32.and
+  call $~lib/util/hash/hash8
+  local.tee $4
+  call $~lib/map/Map<i8,i8>#find
+  local.tee $3
+  if
+   local.get $3
+   local.get $2
+   i32.store8 offset=1
+  else
+   local.get $0
+   i32.load offset=16
+   local.get $0
+   i32.load offset=12
+   i32.eq
+   if
+    local.get $0
+    local.get $0
+    i32.load offset=20
+    local.get $0
+    i32.load offset=12
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
+    i32.lt_s
+    if (result i32)
+     local.get $0
+     i32.load offset=4
+    else
+     local.get $0
+     i32.load offset=4
+     i32.const 1
+     i32.shl
+     i32.const 1
+     i32.or
+    end
+    call $~lib/map/Map<u8,u8>#rehash
+   end
+   local.get $0
+   i32.load offset=8
+   local.set $3
+   local.get $0
+   local.get $0
+   i32.load offset=16
+   local.tee $5
+   i32.const 1
+   i32.add
+   i32.store offset=16
+   local.get $5
+   i32.const 3
+   i32.shl
+   local.get $3
+   i32.add
+   local.tee $3
+   local.get $1
+   i32.store8
+   local.get $3
+   local.get $2
+   i32.store8 offset=1
+   local.get $0
+   local.get $0
+   i32.load offset=20
+   i32.const 1
+   i32.add
+   i32.store offset=20
+   local.get $3
+   local.get $0
+   i32.load
+   local.get $0
+   i32.load offset=4
+   local.get $4
+   i32.and
+   i32.const 2
+   i32.shl
+   i32.add
+   local.tee $0
+   i32.load
+   i32.store offset=4
+   local.get $0
+   local.get $3
+   i32.store
+  end
+ )
+ (func $~lib/map/Map<u8,i32>#delete (; 75 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -3145,9 +4798,15 @@
    call $~lib/map/Map<u8,i32>#rehash
   end
  )
- (func $std/map/testNumeric<u8,i32> (; 48 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<u8,i32> (; 76 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   call $~lib/map/Map<u8,i32>#constructor
   local.set $1
   loop $loop|0
@@ -3318,9 +4977,104 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/map/Map<u8,i32>#keys
+  local.set $3
+  local.get $1
+  call $~lib/map/Map<i8,i32>#values
+  local.set $6
+  call $~lib/map/Map<u8,u8>#constructor
+  local.set $4
+  call $~lib/map/Map<i32,i32>#constructor
+  local.set $5
   i32.const 0
   local.set $0
   loop $loop|2
+   local.get $0
+   local.get $3
+   i32.load offset=12
+   i32.lt_s
+   if
+    local.get $3
+    local.get $0
+    call $~lib/array/Array<u8>#__get
+    local.set $2
+    local.get $6
+    local.get $0
+    call $~lib/array/Array<i32>#__get
+    local.set $7
+    local.get $1
+    local.get $2
+    call $~lib/map/Map<u8,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 31
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $7
+    i32.const 20
+    i32.sub
+    call $~lib/map/Map<u8,i32>#has
+    if
+     local.get $4
+     local.get $2
+     local.get $2
+     call $~lib/map/Map<u8,u8>#set
+     local.get $5
+     local.get $7
+     i32.const 20
+     i32.sub
+     local.tee $2
+     local.get $2
+     call $~lib/map/Map<i32,i32>#set
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+     br $loop|2
+    else
+     i32.const 0
+     i32.const 376
+     i32.const 32
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    unreachable
+   end
+  end
+  local.get $4
+  i32.load offset=20
+  i32.const 100
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 36
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.load offset=20
+  i32.const 100
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 37
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  local.set $0
+  loop $loop|3
    local.get $0
    i32.const 50
    i32.lt_u
@@ -3332,7 +5086,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 25
+     i32.const 41
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -3349,7 +5103,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 26
+     i32.const 42
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -3363,80 +5117,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 28
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    else
-     local.get $0
-     i32.const 1
-     i32.add
-     local.set $0
-     br $loop|2
-    end
-    unreachable
-   end
-  end
-  local.get $1
-  i32.load offset=20
-  i32.const 50
-  i32.ne
-  if
-   i32.const 0
-   i32.const 376
-   i32.const 30
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 0
-  local.set $0
-  loop $loop|3
-   local.get $0
-   i32.const 50
-   i32.lt_u
-   if
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<u8,i32>#has
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 34
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    local.get $0
-    i32.const 255
-    i32.and
-    i32.const 10
-    i32.add
-    call $~lib/map/Map<u8,i32>#set
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<u8,i32>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 36
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<u8,i32>#delete
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<u8,i32>#has
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 38
+     i32.const 44
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -3457,7 +5138,80 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 46
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  local.set $0
+  loop $loop|4
+   local.get $0
+   i32.const 50
+   i32.lt_u
+   if
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<u8,i32>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 50
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    local.get $0
+    i32.const 255
+    i32.and
+    i32.const 10
+    i32.add
+    call $~lib/map/Map<u8,i32>#set
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<u8,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 52
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<u8,i32>#delete
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<u8,i32>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 54
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    else
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+     br $loop|4
+    end
+    unreachable
+   end
+  end
+  local.get $1
+  i32.load offset=20
+  i32.const 50
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 56
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3469,18 +5223,26 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 44
+   i32.const 60
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i16,i32>#constructor (; 49 ;) (result i32)
+ (func $~lib/map/Map<i16,i32>#constructor (; 77 ;) (result i32)
   (local $0 i32)
   i32.const 24
-  i32.const 5
+  i32.const 11
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
@@ -3505,7 +5267,7 @@
   call $~lib/map/Map<i8,i32>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash16 (; 50 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash16 (; 78 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -3520,7 +5282,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/map/Map<i16,i32>#find (; 51 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#find (; 79 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -3565,7 +5327,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i16,i32>#has (; 52 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#has (; 80 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -3578,7 +5340,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i16,i32>#rehash (; 53 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i16,i32>#rehash (; 81 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3710,7 +5472,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i16,i32>#set (; 54 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<i16,i32>#set (; 82 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -3804,7 +5566,7 @@
    i32.store
   end
  )
- (func $~lib/map/Map<i16,i32>#get (; 55 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#get (; 83 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -3827,7 +5589,442 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/map/Map<i16,i32>#delete (; 56 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i16>#__set (; 84 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 512
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   i32.const 1
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $3
+   i32.store offset=12
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 1
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store16
+ )
+ (func $~lib/array/Array<i16>#set:length (; 85 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  local.get $0
+  i32.load offset=12
+  drop
+  local.get $0
+  local.get $1
+  i32.const 1
+  call $~lib/array/ensureSize
+  local.get $0
+  local.get $1
+  i32.store offset=12
+ )
+ (func $~lib/map/Map<i16,i32>#keys (; 86 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 16
+  i32.const 12
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.get $2
+  i32.const 1
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $2
+  i32.store offset=12
+  i32.const 0
+  local.set $0
+  loop $loop|0
+   local.get $3
+   local.get $2
+   i32.lt_s
+   if
+    local.get $3
+    i32.const 12
+    i32.mul
+    local.get $4
+    i32.add
+    local.tee $5
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $1
+     local.get $0
+     local.get $5
+     i32.load16_s
+     call $~lib/array/Array<i16>#__set
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $loop|0
+   end
+  end
+  local.get $1
+  local.get $0
+  call $~lib/array/Array<i16>#set:length
+  local.get $1
+ )
+ (func $~lib/map/Map<i16,i16>#constructor (; 87 ;) (result i32)
+  (local $0 i32)
+  i32.const 24
+  i32.const 13
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+  local.get $0
+  call $~lib/map/Map<i8,i8>#clear
+  local.get $0
+ )
+ (func $~lib/array/Array<i16>#__get (; 88 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 512
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 1
+  i32.shl
+  i32.add
+  i32.load16_s
+ )
+ (func $~lib/map/Map<i16,i16>#find (; 89 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  local.get $0
+  i32.load
+  local.get $0
+  i32.load offset=4
+  local.get $2
+  i32.and
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
+  local.set $0
+  loop $continue|0
+   local.get $0
+   if
+    local.get $0
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    if (result i32)
+     i32.const 0
+    else
+     local.get $0
+     i32.load16_u
+     local.get $1
+     i32.const 65535
+     i32.and
+     i32.eq
+    end
+    if
+     local.get $0
+     return
+    else
+     local.get $0
+     i32.load offset=4
+     i32.const -2
+     i32.and
+     local.set $0
+     br $continue|0
+    end
+    unreachable
+   end
+  end
+  i32.const 0
+ )
+ (func $~lib/map/Map<i16,i16>#rehash (; 90 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $1
+  i32.const 1
+  i32.add
+  local.tee $4
+  i32.const 2
+  i32.shl
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $5
+  local.get $4
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
+  local.tee $6
+  i32.const 3
+  i32.shl
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $4
+  local.get $0
+  i32.load offset=8
+  local.tee $2
+  local.get $0
+  i32.load offset=16
+  i32.const 3
+  i32.shl
+  i32.add
+  local.set $7
+  local.get $4
+  local.set $3
+  loop $continue|0
+   local.get $2
+   local.get $7
+   i32.eq
+   i32.eqz
+   if
+    local.get $2
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $2
+     i32.load16_s
+     i32.store16
+     local.get $3
+     local.get $2
+     i32.load16_s offset=2
+     i32.store16 offset=2
+     local.get $3
+     local.get $2
+     i32.load16_s
+     call $~lib/util/hash/hash16
+     local.get $1
+     i32.and
+     i32.const 2
+     i32.shl
+     local.get $5
+     i32.add
+     local.tee $8
+     i32.load
+     i32.store offset=4
+     local.get $8
+     local.get $3
+     i32.store
+     local.get $3
+     i32.const 8
+     i32.add
+     local.set $3
+    end
+    local.get $2
+    i32.const 8
+    i32.add
+    local.set $2
+    br $continue|0
+   end
+  end
+  local.get $5
+  local.tee $2
+  local.get $0
+  i32.load
+  local.tee $3
+  i32.ne
+  if
+   local.get $2
+   call $~lib/rt/pure/__retain
+   local.set $2
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $2
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $4
+  local.tee $1
+  local.get $0
+  i32.load offset=8
+  local.tee $2
+  i32.ne
+  if
+   local.get $1
+   call $~lib/rt/pure/__retain
+   local.set $1
+   local.get $2
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  local.get $6
+  i32.store offset=12
+  local.get $0
+  local.get $0
+  i32.load offset=20
+  i32.store offset=16
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/map/Map<i16,i16>#set (; 91 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  local.get $1
+  local.get $1
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.shr_s
+  call $~lib/util/hash/hash16
+  local.tee $4
+  call $~lib/map/Map<i16,i16>#find
+  local.tee $3
+  if
+   local.get $3
+   local.get $2
+   i32.store16 offset=2
+  else
+   local.get $0
+   i32.load offset=16
+   local.get $0
+   i32.load offset=12
+   i32.eq
+   if
+    local.get $0
+    local.get $0
+    i32.load offset=20
+    local.get $0
+    i32.load offset=12
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
+    i32.lt_s
+    if (result i32)
+     local.get $0
+     i32.load offset=4
+    else
+     local.get $0
+     i32.load offset=4
+     i32.const 1
+     i32.shl
+     i32.const 1
+     i32.or
+    end
+    call $~lib/map/Map<i16,i16>#rehash
+   end
+   local.get $0
+   i32.load offset=8
+   local.set $3
+   local.get $0
+   local.get $0
+   i32.load offset=16
+   local.tee $5
+   i32.const 1
+   i32.add
+   i32.store offset=16
+   local.get $5
+   i32.const 3
+   i32.shl
+   local.get $3
+   i32.add
+   local.tee $3
+   local.get $1
+   i32.store16
+   local.get $3
+   local.get $2
+   i32.store16 offset=2
+   local.get $0
+   local.get $0
+   i32.load offset=20
+   i32.const 1
+   i32.add
+   i32.store offset=20
+   local.get $3
+   local.get $0
+   i32.load
+   local.get $0
+   i32.load offset=4
+   local.get $4
+   i32.and
+   i32.const 2
+   i32.shl
+   i32.add
+   local.tee $0
+   i32.load
+   i32.store offset=4
+   local.get $0
+   local.get $3
+   i32.store
+  end
+ )
+ (func $~lib/map/Map<i16,i32>#delete (; 92 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -3890,9 +6087,15 @@
    call $~lib/map/Map<i16,i32>#rehash
   end
  )
- (func $std/map/testNumeric<i16,i32> (; 57 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<i16,i32> (; 93 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   call $~lib/map/Map<i16,i32>#constructor
   local.set $1
   loop $loop|0
@@ -4073,9 +6276,104 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/map/Map<i16,i32>#keys
+  local.set $3
+  local.get $1
+  call $~lib/map/Map<i8,i32>#values
+  local.set $6
+  call $~lib/map/Map<i16,i16>#constructor
+  local.set $4
+  call $~lib/map/Map<i32,i32>#constructor
+  local.set $5
   i32.const 0
   local.set $0
   loop $loop|2
+   local.get $0
+   local.get $3
+   i32.load offset=12
+   i32.lt_s
+   if
+    local.get $3
+    local.get $0
+    call $~lib/array/Array<i16>#__get
+    local.set $2
+    local.get $6
+    local.get $0
+    call $~lib/array/Array<i32>#__get
+    local.set $7
+    local.get $1
+    local.get $2
+    call $~lib/map/Map<i16,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 31
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $7
+    i32.const 20
+    i32.sub
+    call $~lib/map/Map<i16,i32>#has
+    if
+     local.get $4
+     local.get $2
+     local.get $2
+     call $~lib/map/Map<i16,i16>#set
+     local.get $5
+     local.get $7
+     i32.const 20
+     i32.sub
+     local.tee $2
+     local.get $2
+     call $~lib/map/Map<i32,i32>#set
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+     br $loop|2
+    else
+     i32.const 0
+     i32.const 376
+     i32.const 32
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    unreachable
+   end
+  end
+  local.get $4
+  i32.load offset=20
+  i32.const 100
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 36
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.load offset=20
+  i32.const 100
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 37
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  local.set $0
+  loop $loop|3
    local.get $0
    i32.const 50
    i32.lt_s
@@ -4087,7 +6385,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 25
+     i32.const 41
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -4106,7 +6404,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 26
+     i32.const 42
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -4120,7 +6418,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 28
+     i32.const 44
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -4129,7 +6427,7 @@
      i32.const 1
      i32.add
      local.set $0
-     br $loop|2
+     br $loop|3
     end
     unreachable
    end
@@ -4141,14 +6439,14 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 30
+   i32.const 46
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
   i32.const 0
   local.set $0
-  loop $loop|3
+  loop $loop|4
    local.get $0
    i32.const 50
    i32.lt_s
@@ -4159,7 +6457,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 50
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -4181,7 +6479,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 36
+     i32.const 52
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -4195,7 +6493,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 38
+     i32.const 54
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -4204,7 +6502,7 @@
      i32.const 1
      i32.add
      local.set $0
-     br $loop|3
+     br $loop|4
     end
     unreachable
    end
@@ -4216,7 +6514,7 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 56
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -4228,18 +6526,26 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 44
+   i32.const 60
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u16,i32>#constructor (; 58 ;) (result i32)
+ (func $~lib/map/Map<u16,i32>#constructor (; 94 ;) (result i32)
   (local $0 i32)
   i32.const 24
-  i32.const 6
+  i32.const 14
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
@@ -4264,7 +6570,7 @@
   call $~lib/map/Map<i8,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u16,i32>#has (; 59 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#has (; 95 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -4275,7 +6581,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u16,i32>#rehash (; 60 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,i32>#rehash (; 96 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4407,7 +6713,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u16,i32>#set (; 61 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<u16,i32>#set (; 97 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4499,7 +6805,7 @@
    i32.store
   end
  )
- (func $~lib/map/Map<u16,i32>#get (; 62 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#get (; 98 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -4520,7 +6826,345 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/map/Map<u16,i32>#delete (; 63 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,i32>#keys (; 99 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 16
+  i32.const 15
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.get $2
+  i32.const 1
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $2
+  i32.store offset=12
+  i32.const 0
+  local.set $0
+  loop $loop|0
+   local.get $3
+   local.get $2
+   i32.lt_s
+   if
+    local.get $3
+    i32.const 12
+    i32.mul
+    local.get $4
+    i32.add
+    local.tee $5
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $1
+     local.get $0
+     local.get $5
+     i32.load16_u
+     call $~lib/array/Array<i16>#__set
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $loop|0
+   end
+  end
+  local.get $1
+  local.get $0
+  call $~lib/array/Array<i16>#set:length
+  local.get $1
+ )
+ (func $~lib/map/Map<u16,u16>#constructor (; 100 ;) (result i32)
+  (local $0 i32)
+  i32.const 24
+  i32.const 16
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+  local.get $0
+  call $~lib/map/Map<i8,i8>#clear
+  local.get $0
+ )
+ (func $~lib/array/Array<u16>#__get (; 101 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 512
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 1
+  i32.shl
+  i32.add
+  i32.load16_u
+ )
+ (func $~lib/map/Map<u16,u16>#rehash (; 102 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $1
+  i32.const 1
+  i32.add
+  local.tee $4
+  i32.const 2
+  i32.shl
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $5
+  local.get $4
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
+  local.tee $6
+  i32.const 3
+  i32.shl
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $4
+  local.get $0
+  i32.load offset=8
+  local.tee $2
+  local.get $0
+  i32.load offset=16
+  i32.const 3
+  i32.shl
+  i32.add
+  local.set $7
+  local.get $4
+  local.set $3
+  loop $continue|0
+   local.get $2
+   local.get $7
+   i32.eq
+   i32.eqz
+   if
+    local.get $2
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $2
+     i32.load16_u
+     i32.store16
+     local.get $3
+     local.get $2
+     i32.load16_u offset=2
+     i32.store16 offset=2
+     local.get $3
+     local.get $2
+     i32.load16_u
+     call $~lib/util/hash/hash16
+     local.get $1
+     i32.and
+     i32.const 2
+     i32.shl
+     local.get $5
+     i32.add
+     local.tee $8
+     i32.load
+     i32.store offset=4
+     local.get $8
+     local.get $3
+     i32.store
+     local.get $3
+     i32.const 8
+     i32.add
+     local.set $3
+    end
+    local.get $2
+    i32.const 8
+    i32.add
+    local.set $2
+    br $continue|0
+   end
+  end
+  local.get $5
+  local.tee $2
+  local.get $0
+  i32.load
+  local.tee $3
+  i32.ne
+  if
+   local.get $2
+   call $~lib/rt/pure/__retain
+   local.set $2
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $2
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $4
+  local.tee $1
+  local.get $0
+  i32.load offset=8
+  local.tee $2
+  i32.ne
+  if
+   local.get $1
+   call $~lib/rt/pure/__retain
+   local.set $1
+   local.get $2
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  local.get $6
+  i32.store offset=12
+  local.get $0
+  local.get $0
+  i32.load offset=20
+  i32.store offset=16
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/map/Map<u16,u16>#set (; 103 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  local.get $1
+  local.get $1
+  i32.const 65535
+  i32.and
+  call $~lib/util/hash/hash16
+  local.tee $4
+  call $~lib/map/Map<i16,i16>#find
+  local.tee $3
+  if
+   local.get $3
+   local.get $2
+   i32.store16 offset=2
+  else
+   local.get $0
+   i32.load offset=16
+   local.get $0
+   i32.load offset=12
+   i32.eq
+   if
+    local.get $0
+    local.get $0
+    i32.load offset=20
+    local.get $0
+    i32.load offset=12
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
+    i32.lt_s
+    if (result i32)
+     local.get $0
+     i32.load offset=4
+    else
+     local.get $0
+     i32.load offset=4
+     i32.const 1
+     i32.shl
+     i32.const 1
+     i32.or
+    end
+    call $~lib/map/Map<u16,u16>#rehash
+   end
+   local.get $0
+   i32.load offset=8
+   local.set $3
+   local.get $0
+   local.get $0
+   i32.load offset=16
+   local.tee $5
+   i32.const 1
+   i32.add
+   i32.store offset=16
+   local.get $5
+   i32.const 3
+   i32.shl
+   local.get $3
+   i32.add
+   local.tee $3
+   local.get $1
+   i32.store16
+   local.get $3
+   local.get $2
+   i32.store16 offset=2
+   local.get $0
+   local.get $0
+   i32.load offset=20
+   i32.const 1
+   i32.add
+   i32.store offset=20
+   local.get $3
+   local.get $0
+   i32.load
+   local.get $0
+   i32.load offset=4
+   local.get $4
+   i32.and
+   i32.const 2
+   i32.shl
+   i32.add
+   local.tee $0
+   i32.load
+   i32.store offset=4
+   local.get $0
+   local.get $3
+   i32.store
+  end
+ )
+ (func $~lib/map/Map<u16,i32>#delete (; 104 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -4581,9 +7225,15 @@
    call $~lib/map/Map<u16,i32>#rehash
   end
  )
- (func $std/map/testNumeric<u16,i32> (; 64 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<u16,i32> (; 105 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   call $~lib/map/Map<u16,i32>#constructor
   local.set $1
   loop $loop|0
@@ -4754,9 +7404,104 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/map/Map<u16,i32>#keys
+  local.set $3
+  local.get $1
+  call $~lib/map/Map<i8,i32>#values
+  local.set $6
+  call $~lib/map/Map<u16,u16>#constructor
+  local.set $4
+  call $~lib/map/Map<i32,i32>#constructor
+  local.set $5
   i32.const 0
   local.set $0
   loop $loop|2
+   local.get $0
+   local.get $3
+   i32.load offset=12
+   i32.lt_s
+   if
+    local.get $3
+    local.get $0
+    call $~lib/array/Array<u16>#__get
+    local.set $2
+    local.get $6
+    local.get $0
+    call $~lib/array/Array<i32>#__get
+    local.set $7
+    local.get $1
+    local.get $2
+    call $~lib/map/Map<u16,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 31
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $7
+    i32.const 20
+    i32.sub
+    call $~lib/map/Map<u16,i32>#has
+    if
+     local.get $4
+     local.get $2
+     local.get $2
+     call $~lib/map/Map<u16,u16>#set
+     local.get $5
+     local.get $7
+     i32.const 20
+     i32.sub
+     local.tee $2
+     local.get $2
+     call $~lib/map/Map<i32,i32>#set
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+     br $loop|2
+    else
+     i32.const 0
+     i32.const 376
+     i32.const 32
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    unreachable
+   end
+  end
+  local.get $4
+  i32.load offset=20
+  i32.const 100
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 36
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.load offset=20
+  i32.const 100
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 37
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  local.set $0
+  loop $loop|3
    local.get $0
    i32.const 50
    i32.lt_u
@@ -4768,7 +7513,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 25
+     i32.const 41
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -4785,7 +7530,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 26
+     i32.const 42
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -4799,80 +7544,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 28
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    else
-     local.get $0
-     i32.const 1
-     i32.add
-     local.set $0
-     br $loop|2
-    end
-    unreachable
-   end
-  end
-  local.get $1
-  i32.load offset=20
-  i32.const 50
-  i32.ne
-  if
-   i32.const 0
-   i32.const 376
-   i32.const 30
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 0
-  local.set $0
-  loop $loop|3
-   local.get $0
-   i32.const 50
-   i32.lt_u
-   if
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<u16,i32>#has
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 34
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    local.get $0
-    i32.const 65535
-    i32.and
-    i32.const 10
-    i32.add
-    call $~lib/map/Map<u16,i32>#set
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<u16,i32>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 36
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<u16,i32>#delete
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<u16,i32>#has
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 38
+     i32.const 44
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -4893,7 +7565,80 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 46
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  local.set $0
+  loop $loop|4
+   local.get $0
+   i32.const 50
+   i32.lt_u
+   if
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<u16,i32>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 50
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    local.get $0
+    i32.const 65535
+    i32.and
+    i32.const 10
+    i32.add
+    call $~lib/map/Map<u16,i32>#set
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<u16,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 52
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<u16,i32>#delete
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<u16,i32>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 54
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    else
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+     br $loop|4
+    end
+    unreachable
+   end
+  end
+  local.get $1
+  i32.load offset=20
+  i32.const 50
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 56
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -4905,348 +7650,32 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 44
+   i32.const 60
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $1
+  local.get $3
   call $~lib/rt/pure/__release
- )
- (func $~lib/map/Map<i32,i32>#constructor (; 65 ;) (result i32)
-  (local $0 i32)
-  i32.const 24
-  i32.const 7
-  call $~lib/rt/tlsf/__alloc
-  call $~lib/rt/pure/__retain
-  local.tee $0
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.const 0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=8
-  local.get $0
-  i32.const 0
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<i8,i32>#clear
-  local.get $0
- )
- (func $~lib/util/hash/hash32 (; 66 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  local.get $0
-  i32.const 255
-  i32.and
-  i32.const -2128831035
-  i32.xor
-  i32.const 16777619
-  i32.mul
-  local.get $0
-  i32.const 8
-  i32.shr_u
-  i32.const 255
-  i32.and
-  i32.xor
-  i32.const 16777619
-  i32.mul
-  local.get $0
-  i32.const 16
-  i32.shr_u
-  i32.const 255
-  i32.and
-  i32.xor
-  i32.const 16777619
-  i32.mul
-  local.get $0
-  i32.const 24
-  i32.shr_u
-  i32.xor
-  i32.const 16777619
-  i32.mul
- )
- (func $~lib/map/Map<i32,i32>#find (; 67 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  local.get $0
-  i32.load
-  local.get $0
-  i32.load offset=4
-  local.get $2
-  i32.and
-  i32.const 2
-  i32.shl
-  i32.add
-  i32.load
-  local.set $0
-  loop $continue|0
-   local.get $0
-   if
-    local.get $0
-    i32.load offset=8
-    i32.const 1
-    i32.and
-    if (result i32)
-     i32.const 0
-    else
-     local.get $0
-     i32.load
-     local.get $1
-     i32.eq
-    end
-    if
-     local.get $0
-     return
-    else
-     local.get $0
-     i32.load offset=8
-     i32.const -2
-     i32.and
-     local.set $0
-     br $continue|0
-    end
-    unreachable
-   end
-  end
-  i32.const 0
- )
- (func $~lib/map/Map<i32,i32>#has (; 68 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
-  local.get $0
-  local.get $1
-  local.get $1
-  call $~lib/util/hash/hash32
-  call $~lib/map/Map<i32,i32>#find
-  i32.const 0
-  i32.ne
- )
- (func $~lib/map/Map<i32,i32>#rehash (; 69 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  local.get $1
-  i32.const 1
-  i32.add
-  local.tee $4
-  i32.const 2
-  i32.shl
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $5
-  local.get $4
-  i32.const 3
-  i32.shl
-  i32.const 3
-  i32.div_s
-  local.tee $6
-  i32.const 12
-  i32.mul
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $4
-  local.get $0
-  i32.load offset=8
-  local.tee $2
-  local.get $0
-  i32.load offset=16
-  i32.const 12
-  i32.mul
-  i32.add
-  local.set $7
-  local.get $4
-  local.set $3
-  loop $continue|0
-   local.get $2
-   local.get $7
-   i32.eq
-   i32.eqz
-   if
-    local.get $2
-    i32.load offset=8
-    i32.const 1
-    i32.and
-    i32.eqz
-    if
-     local.get $3
-     local.get $2
-     i32.load
-     i32.store
-     local.get $3
-     local.get $2
-     i32.load offset=4
-     i32.store offset=4
-     local.get $3
-     local.get $2
-     i32.load
-     call $~lib/util/hash/hash32
-     local.get $1
-     i32.and
-     i32.const 2
-     i32.shl
-     local.get $5
-     i32.add
-     local.tee $8
-     i32.load
-     i32.store offset=8
-     local.get $8
-     local.get $3
-     i32.store
-     local.get $3
-     i32.const 12
-     i32.add
-     local.set $3
-    end
-    local.get $2
-    i32.const 12
-    i32.add
-    local.set $2
-    br $continue|0
-   end
-  end
-  local.get $5
-  local.tee $2
-  local.get $0
-  i32.load
-  local.tee $3
-  i32.ne
-  if
-   local.get $2
-   call $~lib/rt/pure/__retain
-   local.set $2
-   local.get $3
-   call $~lib/rt/pure/__release
-  end
-  local.get $0
-  local.get $2
-  i32.store
-  local.get $0
-  local.get $1
-  i32.store offset=4
-  local.get $4
-  local.tee $1
-  local.get $0
-  i32.load offset=8
-  local.tee $2
-  i32.ne
-  if
-   local.get $1
-   call $~lib/rt/pure/__retain
-   local.set $1
-   local.get $2
-   call $~lib/rt/pure/__release
-  end
-  local.get $0
-  local.get $1
-  i32.store offset=8
-  local.get $0
   local.get $6
-  i32.store offset=12
-  local.get $0
-  local.get $0
-  i32.load offset=20
-  i32.store offset=16
-  local.get $5
   call $~lib/rt/pure/__release
   local.get $4
   call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i32,i32>#set (; 70 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
+ (func $~lib/map/Map<i32,i32>#has (; 106 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
   call $~lib/util/hash/hash32
-  local.tee $4
   call $~lib/map/Map<i32,i32>#find
-  local.tee $3
-  if
-   local.get $3
-   local.get $2
-   i32.store offset=4
-  else
-   local.get $0
-   i32.load offset=16
-   local.get $0
-   i32.load offset=12
-   i32.eq
-   if
-    local.get $0
-    local.get $0
-    i32.load offset=20
-    local.get $0
-    i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.const 4
-    i32.div_s
-    i32.lt_s
-    if (result i32)
-     local.get $0
-     i32.load offset=4
-    else
-     local.get $0
-     i32.load offset=4
-     i32.const 1
-     i32.shl
-     i32.const 1
-     i32.or
-    end
-    call $~lib/map/Map<i32,i32>#rehash
-   end
-   local.get $0
-   i32.load offset=8
-   local.set $3
-   local.get $0
-   local.get $0
-   i32.load offset=16
-   local.tee $5
-   i32.const 1
-   i32.add
-   i32.store offset=16
-   local.get $5
-   i32.const 12
-   i32.mul
-   local.get $3
-   i32.add
-   local.tee $3
-   local.get $1
-   i32.store
-   local.get $3
-   local.get $2
-   i32.store offset=4
-   local.get $0
-   local.get $0
-   i32.load offset=20
-   i32.const 1
-   i32.add
-   i32.store offset=20
-   local.get $3
-   local.get $0
-   i32.load
-   local.get $0
-   i32.load offset=4
-   local.get $4
-   i32.and
-   i32.const 2
-   i32.shl
-   i32.add
-   local.tee $0
-   i32.load
-   i32.store offset=8
-   local.get $0
-   local.get $3
-   i32.store
-  end
+  i32.const 0
+  i32.ne
  )
- (func $~lib/map/Map<i32,i32>#get (; 71 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#get (; 107 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -5265,7 +7694,100 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/map/Map<i32,i32>#delete (; 72 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#__set (; 108 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 512
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   i32.const 2
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $3
+   i32.store offset=12
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store
+ )
+ (func $~lib/map/Map<i32,i32>#keys (; 109 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $3
+  local.get $0
+  i32.load offset=16
+  local.tee $4
+  call $~lib/array/Array<i32>#constructor
+  local.set $2
+  i32.const 0
+  local.set $0
+  loop $loop|0
+   block $break|0
+    local.get $1
+    local.get $4
+    i32.ge_s
+    br_if $break|0
+    local.get $1
+    i32.const 12
+    i32.mul
+    local.get $3
+    i32.add
+    local.tee $5
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $2
+     local.get $0
+     local.get $5
+     i32.load
+     call $~lib/array/Array<i32>#__set
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+    end
+    local.get $1
+    i32.const 1
+    i32.add
+    local.set $1
+    br $loop|0
+   end
+  end
+  local.get $2
+  local.get $0
+  call $~lib/array/Array<i32>#set:length
+  local.get $2
+ )
+ (func $~lib/map/Map<i32,i32>#delete (; 110 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -5324,9 +7846,15 @@
    call $~lib/map/Map<i32,i32>#rehash
   end
  )
- (func $std/map/testNumeric<i32,i32> (; 73 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<i32,i32> (; 111 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   call $~lib/map/Map<i32,i32>#constructor
   local.set $1
   loop $loop|0
@@ -5487,71 +8015,97 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/map/Map<i32,i32>#keys
+  local.set $3
+  local.get $1
+  call $~lib/map/Map<i8,i32>#values
+  local.set $6
+  call $~lib/map/Map<i32,i32>#constructor
+  local.set $4
+  call $~lib/map/Map<i32,i32>#constructor
+  local.set $5
   i32.const 0
   local.set $0
   loop $loop|2
    local.get $0
-   i32.const 50
+   local.get $3
+   i32.load offset=12
    i32.lt_s
    if
-    local.get $1
+    local.get $3
     local.get $0
+    call $~lib/array/Array<i32>#__get
+    local.set $2
+    local.get $6
+    local.get $0
+    call $~lib/array/Array<i32>#__get
+    local.set $7
+    local.get $1
+    local.get $2
     call $~lib/map/Map<i32,i32>#has
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 25
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $1
-    local.get $0
-    call $~lib/map/Map<i32,i32>#get
-    local.get $0
+    local.get $7
     i32.const 20
-    i32.add
-    i32.ne
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 26
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<i32,i32>#delete
-    local.get $1
-    local.get $0
+    i32.sub
     call $~lib/map/Map<i32,i32>#has
     if
-     i32.const 0
-     i32.const 376
-     i32.const 28
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    else
+     local.get $4
+     local.get $2
+     local.get $2
+     call $~lib/map/Map<i32,i32>#set
+     local.get $5
+     local.get $7
+     i32.const 20
+     i32.sub
+     local.tee $2
+     local.get $2
+     call $~lib/map/Map<i32,i32>#set
      local.get $0
      i32.const 1
      i32.add
      local.set $0
      br $loop|2
+    else
+     i32.const 0
+     i32.const 376
+     i32.const 32
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
     end
     unreachable
    end
   end
-  local.get $1
+  local.get $4
   i32.load offset=20
-  i32.const 50
+  i32.const 100
   i32.ne
   if
    i32.const 0
    i32.const 376
-   i32.const 30
+   i32.const 36
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.load offset=20
+  i32.const 100
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 37
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -5566,28 +8120,26 @@
     local.get $1
     local.get $0
     call $~lib/map/Map<i32,i32>#has
+    i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 41
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $1
     local.get $0
+    call $~lib/map/Map<i32,i32>#get
     local.get $0
-    i32.const 10
+    i32.const 20
     i32.add
-    call $~lib/map/Map<i32,i32>#set
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<i32,i32>#has
-    i32.eqz
+    i32.ne
     if
      i32.const 0
      i32.const 376
-     i32.const 36
+     i32.const 42
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -5601,7 +8153,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 38
+     i32.const 44
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -5622,7 +8174,78 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 46
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  local.set $0
+  loop $loop|4
+   local.get $0
+   i32.const 50
+   i32.lt_s
+   if
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<i32,i32>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 50
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    local.get $0
+    i32.const 10
+    i32.add
+    call $~lib/map/Map<i32,i32>#set
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<i32,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 52
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<i32,i32>#delete
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<i32,i32>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 54
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    else
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+     br $loop|4
+    end
+    unreachable
+   end
+  end
+  local.get $1
+  i32.load offset=20
+  i32.const 50
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 56
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -5634,18 +8257,26 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 44
+   i32.const 60
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u32,i32>#constructor (; 74 ;) (result i32)
+ (func $~lib/map/Map<u32,i32>#constructor (; 112 ;) (result i32)
   (local $0 i32)
   i32.const 24
-  i32.const 8
+  i32.const 17
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
@@ -5670,9 +8301,108 @@
   call $~lib/map/Map<i8,i32>#clear
   local.get $0
  )
- (func $std/map/testNumeric<u32,i32> (; 75 ;) (type $FUNCSIG$v)
+ (func $~lib/map/Map<u32,i32>#keys (; 113 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 16
+  i32.const 18
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.get $2
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $2
+  i32.store offset=12
+  i32.const 0
+  local.set $0
+  loop $loop|0
+   local.get $3
+   local.get $2
+   i32.lt_s
+   if
+    local.get $3
+    i32.const 12
+    i32.mul
+    local.get $4
+    i32.add
+    local.tee $5
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $1
+     local.get $0
+     local.get $5
+     i32.load
+     call $~lib/array/Array<i32>#__set
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $loop|0
+   end
+  end
+  local.get $1
+  local.get $0
+  call $~lib/array/Array<i32>#set:length
+  local.get $1
+ )
+ (func $~lib/map/Map<u32,u32>#constructor (; 114 ;) (result i32)
+  (local $0 i32)
+  i32.const 24
+  i32.const 19
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+  local.get $0
+  call $~lib/map/Map<i8,i32>#clear
+  local.get $0
+ )
+ (func $std/map/testNumeric<u32,i32> (; 115 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   call $~lib/map/Map<u32,i32>#constructor
   local.set $1
   loop $loop|0
@@ -5833,71 +8563,97 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/map/Map<u32,i32>#keys
+  local.set $3
+  local.get $1
+  call $~lib/map/Map<i8,i32>#values
+  local.set $6
+  call $~lib/map/Map<u32,u32>#constructor
+  local.set $4
+  call $~lib/map/Map<i32,i32>#constructor
+  local.set $5
   i32.const 0
   local.set $0
   loop $loop|2
    local.get $0
-   i32.const 50
-   i32.lt_u
+   local.get $3
+   i32.load offset=12
+   i32.lt_s
    if
-    local.get $1
+    local.get $3
     local.get $0
+    call $~lib/array/Array<i32>#__get
+    local.set $2
+    local.get $6
+    local.get $0
+    call $~lib/array/Array<i32>#__get
+    local.set $7
+    local.get $1
+    local.get $2
     call $~lib/map/Map<i32,i32>#has
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 25
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $1
-    local.get $0
-    call $~lib/map/Map<i32,i32>#get
-    local.get $0
+    local.get $7
     i32.const 20
-    i32.add
-    i32.ne
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 26
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<i32,i32>#delete
-    local.get $1
-    local.get $0
+    i32.sub
     call $~lib/map/Map<i32,i32>#has
     if
-     i32.const 0
-     i32.const 376
-     i32.const 28
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    else
+     local.get $4
+     local.get $2
+     local.get $2
+     call $~lib/map/Map<i32,i32>#set
+     local.get $5
+     local.get $7
+     i32.const 20
+     i32.sub
+     local.tee $2
+     local.get $2
+     call $~lib/map/Map<i32,i32>#set
      local.get $0
      i32.const 1
      i32.add
      local.set $0
      br $loop|2
+    else
+     i32.const 0
+     i32.const 376
+     i32.const 32
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
     end
     unreachable
    end
   end
-  local.get $1
+  local.get $4
   i32.load offset=20
-  i32.const 50
+  i32.const 100
   i32.ne
   if
    i32.const 0
    i32.const 376
-   i32.const 30
+   i32.const 36
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.load offset=20
+  i32.const 100
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 37
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -5912,28 +8668,26 @@
     local.get $1
     local.get $0
     call $~lib/map/Map<i32,i32>#has
+    i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 41
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $1
     local.get $0
+    call $~lib/map/Map<i32,i32>#get
     local.get $0
-    i32.const 10
+    i32.const 20
     i32.add
-    call $~lib/map/Map<i32,i32>#set
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<i32,i32>#has
-    i32.eqz
+    i32.ne
     if
      i32.const 0
      i32.const 376
-     i32.const 36
+     i32.const 42
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -5947,7 +8701,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 38
+     i32.const 44
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -5968,7 +8722,78 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 46
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  local.set $0
+  loop $loop|4
+   local.get $0
+   i32.const 50
+   i32.lt_u
+   if
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<i32,i32>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 50
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    local.get $0
+    i32.const 10
+    i32.add
+    call $~lib/map/Map<i32,i32>#set
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<i32,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 52
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<i32,i32>#delete
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<i32,i32>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 54
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    else
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+     br $loop|4
+    end
+    unreachable
+   end
+  end
+  local.get $1
+  i32.load offset=20
+  i32.const 50
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 56
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -5980,15 +8805,23 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 44
+   i32.const 60
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i64,i32>#clear (; 76 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<i64,i32>#clear (; 116 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   i32.const 16
   call $~lib/arraybuffer/ArrayBuffer#constructor
@@ -6021,10 +8854,10 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i64,i32>#constructor (; 77 ;) (result i32)
+ (func $~lib/map/Map<i64,i32>#constructor (; 117 ;) (result i32)
   (local $0 i32)
   i32.const 24
-  i32.const 9
+  i32.const 20
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
@@ -6049,7 +8882,7 @@
   call $~lib/map/Map<i64,i32>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash64 (; 78 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/hash/hash64 (; 118 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   local.get $0
   i32.wrap_i64
@@ -6115,7 +8948,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/map/Map<i64,i32>#find (; 79 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#find (; 119 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -6158,7 +8991,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i64,i32>#has (; 80 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<i64,i32>#has (; 120 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -6167,7 +9000,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i64,i32>#rehash (; 81 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i64,i32>#rehash (; 121 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6299,7 +9132,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i64,i32>#set (; 82 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/map/Map<i64,i32>#set (; 122 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6389,7 +9222,7 @@
    i32.store
   end
  )
- (func $~lib/map/Map<i64,i32>#get (; 83 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<i64,i32>#get (; 123 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -6408,7 +9241,523 @@
   local.get $0
   i32.load offset=8
  )
- (func $~lib/map/Map<i64,i32>#delete (; 84 ;) (param $0 i32) (param $1 i64)
+ (func $~lib/array/Array<i64>#__set (; 124 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 512
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   i32.const 3
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $3
+   i32.store offset=12
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 3
+  i32.shl
+  i32.add
+  local.get $2
+  i64.store
+ )
+ (func $~lib/array/Array<i64>#set:length (; 125 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  local.get $0
+  i32.load offset=12
+  drop
+  local.get $0
+  local.get $1
+  i32.const 3
+  call $~lib/array/ensureSize
+  local.get $0
+  local.get $1
+  i32.store offset=12
+ )
+ (func $~lib/map/Map<i64,i32>#keys (; 126 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 16
+  i32.const 21
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.get $2
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $2
+  i32.store offset=12
+  i32.const 0
+  local.set $0
+  loop $loop|0
+   local.get $3
+   local.get $2
+   i32.lt_s
+   if
+    local.get $3
+    i32.const 4
+    i32.shl
+    local.get $4
+    i32.add
+    local.tee $5
+    i32.load offset=12
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $1
+     local.get $0
+     local.get $5
+     i64.load
+     call $~lib/array/Array<i64>#__set
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $loop|0
+   end
+  end
+  local.get $1
+  local.get $0
+  call $~lib/array/Array<i64>#set:length
+  local.get $1
+ )
+ (func $~lib/map/Map<i64,i32>#values (; 127 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $3
+  local.get $0
+  i32.load offset=16
+  local.tee $4
+  call $~lib/array/Array<i32>#constructor
+  local.set $2
+  i32.const 0
+  local.set $0
+  loop $loop|0
+   block $break|0
+    local.get $0
+    local.get $4
+    i32.ge_s
+    br_if $break|0
+    local.get $0
+    i32.const 4
+    i32.shl
+    local.get $3
+    i32.add
+    local.tee $5
+    i32.load offset=12
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $2
+     local.get $5
+     i32.load offset=8
+     call $~lib/array/Array<i32>#push
+     local.get $1
+     i32.const 1
+     i32.add
+     local.set $1
+    end
+    local.get $0
+    i32.const 1
+    i32.add
+    local.set $0
+    br $loop|0
+   end
+  end
+  local.get $2
+  local.get $1
+  call $~lib/array/Array<i32>#set:length
+  local.get $2
+ )
+ (func $~lib/map/Map<i64,i64>#clear (; 128 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $0
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $0
+  local.get $1
+  i32.store
+  local.get $0
+  i32.const 3
+  i32.store offset=4
+  i32.const 96
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  local.get $0
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $0
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+ )
+ (func $~lib/map/Map<i64,i64>#constructor (; 129 ;) (result i32)
+  (local $0 i32)
+  i32.const 24
+  i32.const 22
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+  local.get $0
+  call $~lib/map/Map<i64,i64>#clear
+  local.get $0
+ )
+ (func $~lib/array/Array<i64>#__get (; 130 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 512
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 3
+  i32.shl
+  i32.add
+  i64.load
+ )
+ (func $~lib/map/Map<i64,i64>#find (; 131 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+  local.get $0
+  i32.load
+  local.get $0
+  i32.load offset=4
+  local.get $2
+  i32.and
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
+  local.set $0
+  loop $continue|0
+   local.get $0
+   if
+    local.get $0
+    i32.load offset=16
+    i32.const 1
+    i32.and
+    if (result i32)
+     i32.const 0
+    else
+     local.get $0
+     i64.load
+     local.get $1
+     i64.eq
+    end
+    if
+     local.get $0
+     return
+    else
+     local.get $0
+     i32.load offset=16
+     i32.const -2
+     i32.and
+     local.set $0
+     br $continue|0
+    end
+    unreachable
+   end
+  end
+  i32.const 0
+ )
+ (func $~lib/map/Map<i64,i64>#rehash (; 132 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $1
+  i32.const 1
+  i32.add
+  local.tee $4
+  i32.const 2
+  i32.shl
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $5
+  local.get $4
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
+  local.tee $6
+  i32.const 24
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $4
+  local.get $0
+  i32.load offset=8
+  local.tee $2
+  local.get $0
+  i32.load offset=16
+  i32.const 24
+  i32.mul
+  i32.add
+  local.set $7
+  local.get $4
+  local.set $3
+  loop $continue|0
+   local.get $2
+   local.get $7
+   i32.eq
+   i32.eqz
+   if
+    local.get $2
+    i32.load offset=16
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $2
+     i64.load
+     i64.store
+     local.get $3
+     local.get $2
+     i64.load offset=8
+     i64.store offset=8
+     local.get $3
+     local.get $2
+     i64.load
+     call $~lib/util/hash/hash64
+     local.get $1
+     i32.and
+     i32.const 2
+     i32.shl
+     local.get $5
+     i32.add
+     local.tee $8
+     i32.load
+     i32.store offset=16
+     local.get $8
+     local.get $3
+     i32.store
+     local.get $3
+     i32.const 24
+     i32.add
+     local.set $3
+    end
+    local.get $2
+    i32.const 24
+    i32.add
+    local.set $2
+    br $continue|0
+   end
+  end
+  local.get $5
+  local.tee $2
+  local.get $0
+  i32.load
+  local.tee $3
+  i32.ne
+  if
+   local.get $2
+   call $~lib/rt/pure/__retain
+   local.set $2
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $2
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $4
+  local.tee $1
+  local.get $0
+  i32.load offset=8
+  local.tee $2
+  i32.ne
+  if
+   local.get $1
+   call $~lib/rt/pure/__retain
+   local.set $1
+   local.get $2
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  local.get $6
+  i32.store offset=12
+  local.get $0
+  local.get $0
+  i32.load offset=20
+  i32.store offset=16
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/map/Map<i64,i64>#set (; 133 ;) (type $FUNCSIG$vijj) (param $0 i32) (param $1 i64) (param $2 i64)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  local.get $1
+  local.get $1
+  call $~lib/util/hash/hash64
+  local.tee $4
+  call $~lib/map/Map<i64,i64>#find
+  local.tee $3
+  if
+   local.get $3
+   local.get $2
+   i64.store offset=8
+  else
+   local.get $0
+   i32.load offset=16
+   local.get $0
+   i32.load offset=12
+   i32.eq
+   if
+    local.get $0
+    local.get $0
+    i32.load offset=20
+    local.get $0
+    i32.load offset=12
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
+    i32.lt_s
+    if (result i32)
+     local.get $0
+     i32.load offset=4
+    else
+     local.get $0
+     i32.load offset=4
+     i32.const 1
+     i32.shl
+     i32.const 1
+     i32.or
+    end
+    call $~lib/map/Map<i64,i64>#rehash
+   end
+   local.get $0
+   i32.load offset=8
+   local.set $3
+   local.get $0
+   local.get $0
+   i32.load offset=16
+   local.tee $5
+   i32.const 1
+   i32.add
+   i32.store offset=16
+   local.get $5
+   i32.const 24
+   i32.mul
+   local.get $3
+   i32.add
+   local.tee $3
+   local.get $1
+   i64.store
+   local.get $3
+   local.get $2
+   i64.store offset=8
+   local.get $0
+   local.get $0
+   i32.load offset=20
+   i32.const 1
+   i32.add
+   i32.store offset=20
+   local.get $3
+   local.get $0
+   i32.load
+   local.get $0
+   i32.load offset=4
+   local.get $4
+   i32.and
+   i32.const 2
+   i32.shl
+   i32.add
+   local.tee $0
+   i32.load
+   i32.store offset=16
+   local.get $0
+   local.get $3
+   i32.store
+  end
+ )
+ (func $~lib/map/Map<i64,i32>#delete (; 134 ;) (param $0 i32) (param $1 i64)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -6468,9 +9817,15 @@
    call $~lib/map/Map<i64,i32>#rehash
   end
  )
- (func $std/map/testNumeric<i64,i32> (; 85 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<i64,i32> (; 135 ;) (type $FUNCSIG$v)
   (local $0 i64)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   call $~lib/map/Map<i64,i32>#constructor
   local.set $1
   loop $loop|0
@@ -6636,9 +9991,103 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/map/Map<i64,i32>#keys
+  local.set $4
+  local.get $1
+  call $~lib/map/Map<i64,i32>#values
+  local.set $7
+  call $~lib/map/Map<i64,i64>#constructor
+  local.set $5
+  call $~lib/map/Map<i32,i32>#constructor
+  local.set $6
+  loop $loop|2
+   local.get $2
+   local.get $4
+   i32.load offset=12
+   i32.lt_s
+   if
+    local.get $4
+    local.get $2
+    call $~lib/array/Array<i64>#__get
+    local.set $0
+    local.get $7
+    local.get $2
+    call $~lib/array/Array<i32>#__get
+    local.set $3
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<i64,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 31
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $3
+    i32.const 20
+    i32.sub
+    i64.extend_i32_s
+    call $~lib/map/Map<i64,i32>#has
+    if
+     local.get $5
+     local.get $0
+     local.get $0
+     call $~lib/map/Map<i64,i64>#set
+     local.get $6
+     local.get $3
+     i32.const 20
+     i32.sub
+     local.tee $3
+     local.get $3
+     call $~lib/map/Map<i32,i32>#set
+     local.get $2
+     i32.const 1
+     i32.add
+     local.set $2
+     br $loop|2
+    else
+     i32.const 0
+     i32.const 376
+     i32.const 32
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    unreachable
+   end
+  end
+  local.get $5
+  i32.load offset=20
+  i32.const 100
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 36
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $6
+  i32.load offset=20
+  i32.const 100
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 37
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
   i64.const 0
   local.set $0
-  loop $loop|2
+  loop $loop|3
    local.get $0
    i64.const 50
    i64.lt_s
@@ -6650,7 +10099,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 25
+     i32.const 41
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -6666,7 +10115,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 26
+     i32.const 42
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -6680,79 +10129,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 28
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    else
-     local.get $0
-     i64.const 1
-     i64.add
-     local.set $0
-     br $loop|2
-    end
-    unreachable
-   end
-  end
-  local.get $1
-  i32.load offset=20
-  i32.const 50
-  i32.ne
-  if
-   i32.const 0
-   i32.const 376
-   i32.const 30
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 0
-  local.set $0
-  loop $loop|3
-   local.get $0
-   i64.const 50
-   i64.lt_s
-   if
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<i64,i32>#has
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 34
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    local.get $0
-    i32.wrap_i64
-    i32.const 10
-    i32.add
-    call $~lib/map/Map<i64,i32>#set
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<i64,i32>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 36
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<i64,i32>#delete
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<i64,i32>#has
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 38
+     i32.const 44
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -6773,7 +10150,79 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 46
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 0
+  local.set $0
+  loop $loop|4
+   local.get $0
+   i64.const 50
+   i64.lt_s
+   if
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<i64,i32>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 50
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    local.get $0
+    i32.wrap_i64
+    i32.const 10
+    i32.add
+    call $~lib/map/Map<i64,i32>#set
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<i64,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 52
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<i64,i32>#delete
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<i64,i32>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 54
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    else
+     local.get $0
+     i64.const 1
+     i64.add
+     local.set $0
+     br $loop|4
+    end
+    unreachable
+   end
+  end
+  local.get $1
+  i32.load offset=20
+  i32.const 50
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 56
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -6785,18 +10234,26 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 44
+   i32.const 60
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u64,i32>#constructor (; 86 ;) (result i32)
+ (func $~lib/map/Map<u64,i32>#constructor (; 136 ;) (result i32)
   (local $0 i32)
   i32.const 24
-  i32.const 10
+  i32.const 23
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
@@ -6821,9 +10278,108 @@
   call $~lib/map/Map<i64,i32>#clear
   local.get $0
  )
- (func $std/map/testNumeric<u64,i32> (; 87 ;) (type $FUNCSIG$v)
+ (func $~lib/map/Map<u64,i32>#keys (; 137 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 16
+  i32.const 24
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.get $2
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $2
+  i32.store offset=12
+  i32.const 0
+  local.set $0
+  loop $loop|0
+   local.get $3
+   local.get $2
+   i32.lt_s
+   if
+    local.get $3
+    i32.const 4
+    i32.shl
+    local.get $4
+    i32.add
+    local.tee $5
+    i32.load offset=12
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $1
+     local.get $0
+     local.get $5
+     i64.load
+     call $~lib/array/Array<i64>#__set
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $loop|0
+   end
+  end
+  local.get $1
+  local.get $0
+  call $~lib/array/Array<i64>#set:length
+  local.get $1
+ )
+ (func $~lib/map/Map<u64,u64>#constructor (; 138 ;) (result i32)
+  (local $0 i32)
+  i32.const 24
+  i32.const 25
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+  local.get $0
+  call $~lib/map/Map<i64,i64>#clear
+  local.get $0
+ )
+ (func $std/map/testNumeric<u64,i32> (; 139 ;) (type $FUNCSIG$v)
   (local $0 i64)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   call $~lib/map/Map<u64,i32>#constructor
   local.set $1
   loop $loop|0
@@ -6989,9 +10545,103 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/map/Map<u64,i32>#keys
+  local.set $4
+  local.get $1
+  call $~lib/map/Map<i64,i32>#values
+  local.set $7
+  call $~lib/map/Map<u64,u64>#constructor
+  local.set $5
+  call $~lib/map/Map<i32,i32>#constructor
+  local.set $6
+  loop $loop|2
+   local.get $2
+   local.get $4
+   i32.load offset=12
+   i32.lt_s
+   if
+    local.get $4
+    local.get $2
+    call $~lib/array/Array<i64>#__get
+    local.set $0
+    local.get $7
+    local.get $2
+    call $~lib/array/Array<i32>#__get
+    local.set $3
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<i64,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 31
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $3
+    i32.const 20
+    i32.sub
+    i64.extend_i32_s
+    call $~lib/map/Map<i64,i32>#has
+    if
+     local.get $5
+     local.get $0
+     local.get $0
+     call $~lib/map/Map<i64,i64>#set
+     local.get $6
+     local.get $3
+     i32.const 20
+     i32.sub
+     local.tee $3
+     local.get $3
+     call $~lib/map/Map<i32,i32>#set
+     local.get $2
+     i32.const 1
+     i32.add
+     local.set $2
+     br $loop|2
+    else
+     i32.const 0
+     i32.const 376
+     i32.const 32
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    unreachable
+   end
+  end
+  local.get $5
+  i32.load offset=20
+  i32.const 100
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 36
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $6
+  i32.load offset=20
+  i32.const 100
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 37
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
   i64.const 0
   local.set $0
-  loop $loop|2
+  loop $loop|3
    local.get $0
    i64.const 50
    i64.lt_u
@@ -7003,7 +10653,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 25
+     i32.const 41
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -7019,7 +10669,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 26
+     i32.const 42
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -7033,79 +10683,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 28
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    else
-     local.get $0
-     i64.const 1
-     i64.add
-     local.set $0
-     br $loop|2
-    end
-    unreachable
-   end
-  end
-  local.get $1
-  i32.load offset=20
-  i32.const 50
-  i32.ne
-  if
-   i32.const 0
-   i32.const 376
-   i32.const 30
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 0
-  local.set $0
-  loop $loop|3
-   local.get $0
-   i64.const 50
-   i64.lt_u
-   if
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<i64,i32>#has
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 34
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    local.get $0
-    i32.wrap_i64
-    i32.const 10
-    i32.add
-    call $~lib/map/Map<i64,i32>#set
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<i64,i32>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 36
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<i64,i32>#delete
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<i64,i32>#has
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 38
+     i32.const 44
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -7126,7 +10704,79 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 46
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 0
+  local.set $0
+  loop $loop|4
+   local.get $0
+   i64.const 50
+   i64.lt_u
+   if
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<i64,i32>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 50
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    local.get $0
+    i32.wrap_i64
+    i32.const 10
+    i32.add
+    call $~lib/map/Map<i64,i32>#set
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<i64,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 52
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<i64,i32>#delete
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<i64,i32>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 54
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    else
+     local.get $0
+     i64.const 1
+     i64.add
+     local.set $0
+     br $loop|4
+    end
+    unreachable
+   end
+  end
+  local.get $1
+  i32.load offset=20
+  i32.const 50
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 56
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -7138,18 +10788,26 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 44
+   i32.const 60
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f32,i32>#constructor (; 88 ;) (result i32)
+ (func $~lib/map/Map<f32,i32>#constructor (; 140 ;) (result i32)
   (local $0 i32)
   i32.const 24
-  i32.const 11
+  i32.const 26
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
@@ -7174,7 +10832,7 @@
   call $~lib/map/Map<i8,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<f32,i32>#find (; 89 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#find (; 141 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -7217,7 +10875,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f32,i32>#has (; 90 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/map/Map<f32,i32>#has (; 142 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -7227,7 +10885,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<f32,i32>#rehash (; 91 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f32,i32>#rehash (; 143 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7360,7 +11018,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f32,i32>#set (; 92 ;) (type $FUNCSIG$vifi) (param $0 i32) (param $1 f32) (param $2 i32)
+ (func $~lib/map/Map<f32,i32>#set (; 144 ;) (type $FUNCSIG$vifi) (param $0 i32) (param $1 f32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7451,7 +11109,7 @@
    i32.store
   end
  )
- (func $~lib/map/Map<f32,i32>#get (; 93 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/map/Map<f32,i32>#get (; 145 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -7471,7 +11129,383 @@
   local.get $0
   i32.load offset=4
  )
- (func $~lib/map/Map<f32,i32>#delete (; 94 ;) (param $0 i32) (param $1 f32)
+ (func $~lib/array/Array<f32>#__set (; 146 ;) (type $FUNCSIG$viif) (param $0 i32) (param $1 i32) (param $2 f32)
+  (local $3 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 512
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   i32.const 2
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $3
+   i32.store offset=12
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $2
+  f32.store
+ )
+ (func $~lib/map/Map<f32,i32>#keys (; 147 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 16
+  i32.const 27
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.get $2
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $2
+  i32.store offset=12
+  i32.const 0
+  local.set $0
+  loop $loop|0
+   local.get $3
+   local.get $2
+   i32.lt_s
+   if
+    local.get $3
+    i32.const 12
+    i32.mul
+    local.get $4
+    i32.add
+    local.tee $5
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $1
+     local.get $0
+     local.get $5
+     f32.load
+     call $~lib/array/Array<f32>#__set
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $loop|0
+   end
+  end
+  local.get $1
+  local.get $0
+  call $~lib/array/Array<i32>#set:length
+  local.get $1
+ )
+ (func $~lib/map/Map<f32,f32>#constructor (; 148 ;) (result i32)
+  (local $0 i32)
+  i32.const 24
+  i32.const 28
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+  local.get $0
+  call $~lib/map/Map<i8,i32>#clear
+  local.get $0
+ )
+ (func $~lib/array/Array<f32>#__get (; 149 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 512
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  f32.load
+ )
+ (func $~lib/map/Map<f32,f32>#rehash (; 150 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $1
+  i32.const 1
+  i32.add
+  local.tee $4
+  i32.const 2
+  i32.shl
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $5
+  local.get $4
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
+  local.tee $6
+  i32.const 12
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $4
+  local.get $0
+  i32.load offset=8
+  local.tee $2
+  local.get $0
+  i32.load offset=16
+  i32.const 12
+  i32.mul
+  i32.add
+  local.set $7
+  local.get $4
+  local.set $3
+  loop $continue|0
+   local.get $2
+   local.get $7
+   i32.eq
+   i32.eqz
+   if
+    local.get $2
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $2
+     f32.load
+     f32.store
+     local.get $3
+     local.get $2
+     f32.load offset=4
+     f32.store offset=4
+     local.get $3
+     local.get $2
+     f32.load
+     i32.reinterpret_f32
+     call $~lib/util/hash/hash32
+     local.get $1
+     i32.and
+     i32.const 2
+     i32.shl
+     local.get $5
+     i32.add
+     local.tee $8
+     i32.load
+     i32.store offset=8
+     local.get $8
+     local.get $3
+     i32.store
+     local.get $3
+     i32.const 12
+     i32.add
+     local.set $3
+    end
+    local.get $2
+    i32.const 12
+    i32.add
+    local.set $2
+    br $continue|0
+   end
+  end
+  local.get $5
+  local.tee $2
+  local.get $0
+  i32.load
+  local.tee $3
+  i32.ne
+  if
+   local.get $2
+   call $~lib/rt/pure/__retain
+   local.set $2
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $2
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $4
+  local.tee $1
+  local.get $0
+  i32.load offset=8
+  local.tee $2
+  i32.ne
+  if
+   local.get $1
+   call $~lib/rt/pure/__retain
+   local.set $1
+   local.get $2
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  local.get $6
+  i32.store offset=12
+  local.get $0
+  local.get $0
+  i32.load offset=20
+  i32.store offset=16
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/map/Map<f32,f32>#set (; 151 ;) (type $FUNCSIG$viff) (param $0 i32) (param $1 f32) (param $2 f32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  local.get $1
+  local.get $1
+  i32.reinterpret_f32
+  call $~lib/util/hash/hash32
+  local.tee $4
+  call $~lib/map/Map<f32,i32>#find
+  local.tee $3
+  if
+   local.get $3
+   local.get $2
+   f32.store offset=4
+  else
+   local.get $0
+   i32.load offset=16
+   local.get $0
+   i32.load offset=12
+   i32.eq
+   if
+    local.get $0
+    local.get $0
+    i32.load offset=20
+    local.get $0
+    i32.load offset=12
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
+    i32.lt_s
+    if (result i32)
+     local.get $0
+     i32.load offset=4
+    else
+     local.get $0
+     i32.load offset=4
+     i32.const 1
+     i32.shl
+     i32.const 1
+     i32.or
+    end
+    call $~lib/map/Map<f32,f32>#rehash
+   end
+   local.get $0
+   i32.load offset=8
+   local.set $3
+   local.get $0
+   local.get $0
+   i32.load offset=16
+   local.tee $5
+   i32.const 1
+   i32.add
+   i32.store offset=16
+   local.get $5
+   i32.const 12
+   i32.mul
+   local.get $3
+   i32.add
+   local.tee $3
+   local.get $1
+   f32.store
+   local.get $3
+   local.get $2
+   f32.store offset=4
+   local.get $0
+   local.get $0
+   i32.load offset=20
+   i32.const 1
+   i32.add
+   i32.store offset=20
+   local.get $3
+   local.get $0
+   i32.load
+   local.get $0
+   i32.load offset=4
+   local.get $4
+   i32.and
+   i32.const 2
+   i32.shl
+   i32.add
+   local.tee $0
+   i32.load
+   i32.store offset=8
+   local.get $0
+   local.get $3
+   i32.store
+  end
+ )
+ (func $~lib/map/Map<f32,i32>#delete (; 152 ;) (param $0 i32) (param $1 f32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -7532,9 +11566,15 @@
    call $~lib/map/Map<f32,i32>#rehash
   end
  )
- (func $std/map/testNumeric<f32,i32> (; 95 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<f32,i32> (; 153 ;) (type $FUNCSIG$v)
   (local $0 f32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   call $~lib/map/Map<f32,i32>#constructor
   local.set $1
   loop $loop|0
@@ -7700,9 +11740,103 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/map/Map<f32,i32>#keys
+  local.set $4
+  local.get $1
+  call $~lib/map/Map<i8,i32>#values
+  local.set $7
+  call $~lib/map/Map<f32,f32>#constructor
+  local.set $5
+  call $~lib/map/Map<i32,i32>#constructor
+  local.set $6
+  loop $loop|2
+   local.get $2
+   local.get $4
+   i32.load offset=12
+   i32.lt_s
+   if
+    local.get $4
+    local.get $2
+    call $~lib/array/Array<f32>#__get
+    local.set $0
+    local.get $7
+    local.get $2
+    call $~lib/array/Array<i32>#__get
+    local.set $3
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<f32,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 31
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $3
+    i32.const 20
+    i32.sub
+    f32.convert_i32_s
+    call $~lib/map/Map<f32,i32>#has
+    if
+     local.get $5
+     local.get $0
+     local.get $0
+     call $~lib/map/Map<f32,f32>#set
+     local.get $6
+     local.get $3
+     i32.const 20
+     i32.sub
+     local.tee $3
+     local.get $3
+     call $~lib/map/Map<i32,i32>#set
+     local.get $2
+     i32.const 1
+     i32.add
+     local.set $2
+     br $loop|2
+    else
+     i32.const 0
+     i32.const 376
+     i32.const 32
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    unreachable
+   end
+  end
+  local.get $5
+  i32.load offset=20
+  i32.const 100
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 36
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $6
+  i32.load offset=20
+  i32.const 100
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 37
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
   f32.const 0
   local.set $0
-  loop $loop|2
+  loop $loop|3
    local.get $0
    f32.const 50
    f32.lt
@@ -7714,7 +11848,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 25
+     i32.const 41
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -7730,7 +11864,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 26
+     i32.const 42
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -7744,79 +11878,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 28
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    else
-     local.get $0
-     f32.const 1
-     f32.add
-     local.set $0
-     br $loop|2
-    end
-    unreachable
-   end
-  end
-  local.get $1
-  i32.load offset=20
-  i32.const 50
-  i32.ne
-  if
-   i32.const 0
-   i32.const 376
-   i32.const 30
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  local.set $0
-  loop $loop|3
-   local.get $0
-   f32.const 50
-   f32.lt
-   if
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<f32,i32>#has
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 34
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    local.get $0
-    i32.trunc_f32_s
-    i32.const 10
-    i32.add
-    call $~lib/map/Map<f32,i32>#set
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<f32,i32>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 36
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<f32,i32>#delete
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<f32,i32>#has
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 38
+     i32.const 44
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -7837,7 +11899,79 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 46
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  local.set $0
+  loop $loop|4
+   local.get $0
+   f32.const 50
+   f32.lt
+   if
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<f32,i32>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 50
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    local.get $0
+    i32.trunc_f32_s
+    i32.const 10
+    i32.add
+    call $~lib/map/Map<f32,i32>#set
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<f32,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 52
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<f32,i32>#delete
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<f32,i32>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 54
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    else
+     local.get $0
+     f32.const 1
+     f32.add
+     local.set $0
+     br $loop|4
+    end
+    unreachable
+   end
+  end
+  local.get $1
+  i32.load offset=20
+  i32.const 50
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 56
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -7849,18 +11983,26 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 44
+   i32.const 60
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f64,i32>#constructor (; 96 ;) (result i32)
+ (func $~lib/map/Map<f64,i32>#constructor (; 154 ;) (result i32)
   (local $0 i32)
   i32.const 24
-  i32.const 12
+  i32.const 29
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
@@ -7885,7 +12027,7 @@
   call $~lib/map/Map<i64,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<f64,i32>#find (; 97 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#find (; 155 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -7928,7 +12070,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f64,i32>#has (; 98 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/map/Map<f64,i32>#has (; 156 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -7938,7 +12080,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<f64,i32>#rehash (; 99 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f64,i32>#rehash (; 157 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8071,7 +12213,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f64,i32>#set (; 100 ;) (type $FUNCSIG$vidi) (param $0 i32) (param $1 f64) (param $2 i32)
+ (func $~lib/map/Map<f64,i32>#set (; 158 ;) (type $FUNCSIG$vidi) (param $0 i32) (param $1 f64) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8162,7 +12304,7 @@
    i32.store
   end
  )
- (func $~lib/map/Map<f64,i32>#get (; 101 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/map/Map<f64,i32>#get (; 159 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -8182,7 +12324,426 @@
   local.get $0
   i32.load offset=8
  )
- (func $~lib/map/Map<f64,i32>#delete (; 102 ;) (param $0 i32) (param $1 f64)
+ (func $~lib/array/Array<f64>#__set (; 160 ;) (type $FUNCSIG$viid) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 512
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   i32.const 3
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $3
+   i32.store offset=12
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 3
+  i32.shl
+  i32.add
+  local.get $2
+  f64.store
+ )
+ (func $~lib/map/Map<f64,i32>#keys (; 161 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 16
+  i32.const 30
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.get $2
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $1
+  i32.const 0
+  i32.store offset=12
+  local.get $1
+  local.get $2
+  i32.store offset=12
+  i32.const 0
+  local.set $0
+  loop $loop|0
+   local.get $3
+   local.get $2
+   i32.lt_s
+   if
+    local.get $3
+    i32.const 4
+    i32.shl
+    local.get $4
+    i32.add
+    local.tee $5
+    i32.load offset=12
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $1
+     local.get $0
+     local.get $5
+     f64.load
+     call $~lib/array/Array<f64>#__set
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $loop|0
+   end
+  end
+  local.get $1
+  local.get $0
+  call $~lib/array/Array<i64>#set:length
+  local.get $1
+ )
+ (func $~lib/map/Map<f64,f64>#constructor (; 162 ;) (result i32)
+  (local $0 i32)
+  i32.const 24
+  i32.const 31
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.tee $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+  local.get $0
+  call $~lib/map/Map<i64,i64>#clear
+  local.get $0
+ )
+ (func $~lib/array/Array<f64>#__get (; 163 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 512
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 3
+  i32.shl
+  i32.add
+  f64.load
+ )
+ (func $~lib/map/Map<f64,f64>#find (; 164 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+  local.get $0
+  i32.load
+  local.get $0
+  i32.load offset=4
+  local.get $2
+  i32.and
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
+  local.set $0
+  loop $continue|0
+   local.get $0
+   if
+    local.get $0
+    i32.load offset=16
+    i32.const 1
+    i32.and
+    if (result i32)
+     i32.const 0
+    else
+     local.get $0
+     f64.load
+     local.get $1
+     f64.eq
+    end
+    if
+     local.get $0
+     return
+    else
+     local.get $0
+     i32.load offset=16
+     i32.const -2
+     i32.and
+     local.set $0
+     br $continue|0
+    end
+    unreachable
+   end
+  end
+  i32.const 0
+ )
+ (func $~lib/map/Map<f64,f64>#rehash (; 165 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $1
+  i32.const 1
+  i32.add
+  local.tee $4
+  i32.const 2
+  i32.shl
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $5
+  local.get $4
+  i32.const 3
+  i32.shl
+  i32.const 3
+  i32.div_s
+  local.tee $6
+  i32.const 24
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $4
+  local.get $0
+  i32.load offset=8
+  local.tee $2
+  local.get $0
+  i32.load offset=16
+  i32.const 24
+  i32.mul
+  i32.add
+  local.set $7
+  local.get $4
+  local.set $3
+  loop $continue|0
+   local.get $2
+   local.get $7
+   i32.eq
+   i32.eqz
+   if
+    local.get $2
+    i32.load offset=16
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $2
+     f64.load
+     f64.store
+     local.get $3
+     local.get $2
+     f64.load offset=8
+     f64.store offset=8
+     local.get $3
+     local.get $2
+     f64.load
+     i64.reinterpret_f64
+     call $~lib/util/hash/hash64
+     local.get $1
+     i32.and
+     i32.const 2
+     i32.shl
+     local.get $5
+     i32.add
+     local.tee $8
+     i32.load
+     i32.store offset=16
+     local.get $8
+     local.get $3
+     i32.store
+     local.get $3
+     i32.const 24
+     i32.add
+     local.set $3
+    end
+    local.get $2
+    i32.const 24
+    i32.add
+    local.set $2
+    br $continue|0
+   end
+  end
+  local.get $5
+  local.tee $2
+  local.get $0
+  i32.load
+  local.tee $3
+  i32.ne
+  if
+   local.get $2
+   call $~lib/rt/pure/__retain
+   local.set $2
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $2
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $4
+  local.tee $1
+  local.get $0
+  i32.load offset=8
+  local.tee $2
+  i32.ne
+  if
+   local.get $1
+   call $~lib/rt/pure/__retain
+   local.set $1
+   local.get $2
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  local.get $6
+  i32.store offset=12
+  local.get $0
+  local.get $0
+  i32.load offset=20
+  i32.store offset=16
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/map/Map<f64,f64>#set (; 166 ;) (type $FUNCSIG$vidd) (param $0 i32) (param $1 f64) (param $2 f64)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $0
+  local.get $1
+  local.get $1
+  i64.reinterpret_f64
+  call $~lib/util/hash/hash64
+  local.tee $4
+  call $~lib/map/Map<f64,f64>#find
+  local.tee $3
+  if
+   local.get $3
+   local.get $2
+   f64.store offset=8
+  else
+   local.get $0
+   i32.load offset=16
+   local.get $0
+   i32.load offset=12
+   i32.eq
+   if
+    local.get $0
+    local.get $0
+    i32.load offset=20
+    local.get $0
+    i32.load offset=12
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
+    i32.lt_s
+    if (result i32)
+     local.get $0
+     i32.load offset=4
+    else
+     local.get $0
+     i32.load offset=4
+     i32.const 1
+     i32.shl
+     i32.const 1
+     i32.or
+    end
+    call $~lib/map/Map<f64,f64>#rehash
+   end
+   local.get $0
+   i32.load offset=8
+   local.set $3
+   local.get $0
+   local.get $0
+   i32.load offset=16
+   local.tee $5
+   i32.const 1
+   i32.add
+   i32.store offset=16
+   local.get $5
+   i32.const 24
+   i32.mul
+   local.get $3
+   i32.add
+   local.tee $3
+   local.get $1
+   f64.store
+   local.get $3
+   local.get $2
+   f64.store offset=8
+   local.get $0
+   local.get $0
+   i32.load offset=20
+   i32.const 1
+   i32.add
+   i32.store offset=20
+   local.get $3
+   local.get $0
+   i32.load
+   local.get $0
+   i32.load offset=4
+   local.get $4
+   i32.and
+   i32.const 2
+   i32.shl
+   i32.add
+   local.tee $0
+   i32.load
+   i32.store offset=16
+   local.get $0
+   local.get $3
+   i32.store
+  end
+ )
+ (func $~lib/map/Map<f64,i32>#delete (; 167 ;) (param $0 i32) (param $1 f64)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -8243,9 +12804,15 @@
    call $~lib/map/Map<f64,i32>#rehash
   end
  )
- (func $std/map/testNumeric<f64,i32> (; 103 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<f64,i32> (; 168 ;) (type $FUNCSIG$v)
   (local $0 f64)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   call $~lib/map/Map<f64,i32>#constructor
   local.set $1
   loop $loop|0
@@ -8411,9 +12978,103 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/map/Map<f64,i32>#keys
+  local.set $4
+  local.get $1
+  call $~lib/map/Map<i64,i32>#values
+  local.set $7
+  call $~lib/map/Map<f64,f64>#constructor
+  local.set $5
+  call $~lib/map/Map<i32,i32>#constructor
+  local.set $6
+  loop $loop|2
+   local.get $2
+   local.get $4
+   i32.load offset=12
+   i32.lt_s
+   if
+    local.get $4
+    local.get $2
+    call $~lib/array/Array<f64>#__get
+    local.set $0
+    local.get $7
+    local.get $2
+    call $~lib/array/Array<i32>#__get
+    local.set $3
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<f64,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 31
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $3
+    i32.const 20
+    i32.sub
+    f64.convert_i32_s
+    call $~lib/map/Map<f64,i32>#has
+    if
+     local.get $5
+     local.get $0
+     local.get $0
+     call $~lib/map/Map<f64,f64>#set
+     local.get $6
+     local.get $3
+     i32.const 20
+     i32.sub
+     local.tee $3
+     local.get $3
+     call $~lib/map/Map<i32,i32>#set
+     local.get $2
+     i32.const 1
+     i32.add
+     local.set $2
+     br $loop|2
+    else
+     i32.const 0
+     i32.const 376
+     i32.const 32
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    unreachable
+   end
+  end
+  local.get $5
+  i32.load offset=20
+  i32.const 100
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 36
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $6
+  i32.load offset=20
+  i32.const 100
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 37
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
   f64.const 0
   local.set $0
-  loop $loop|2
+  loop $loop|3
    local.get $0
    f64.const 50
    f64.lt
@@ -8425,7 +13086,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 25
+     i32.const 41
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -8441,7 +13102,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 26
+     i32.const 42
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -8455,79 +13116,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 28
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    else
-     local.get $0
-     f64.const 1
-     f64.add
-     local.set $0
-     br $loop|2
-    end
-    unreachable
-   end
-  end
-  local.get $1
-  i32.load offset=20
-  i32.const 50
-  i32.ne
-  if
-   i32.const 0
-   i32.const 376
-   i32.const 30
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  local.set $0
-  loop $loop|3
-   local.get $0
-   f64.const 50
-   f64.lt
-   if
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<f64,i32>#has
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 34
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    local.get $0
-    i32.trunc_f64_s
-    i32.const 10
-    i32.add
-    call $~lib/map/Map<f64,i32>#set
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<f64,i32>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 36
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<f64,i32>#delete
-    local.get $1
-    local.get $0
-    call $~lib/map/Map<f64,i32>#has
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 38
+     i32.const 44
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -8548,7 +13137,79 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 46
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  local.set $0
+  loop $loop|4
+   local.get $0
+   f64.const 50
+   f64.lt
+   if
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<f64,i32>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 50
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    local.get $0
+    i32.trunc_f64_s
+    i32.const 10
+    i32.add
+    call $~lib/map/Map<f64,i32>#set
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<f64,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 52
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<f64,i32>#delete
+    local.get $1
+    local.get $0
+    call $~lib/map/Map<f64,i32>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 54
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    else
+     local.get $0
+     f64.const 1
+     f64.add
+     local.set $0
+     br $loop|4
+    end
+    unreachable
+   end
+  end
+  local.get $1
+  i32.load offset=20
+  i32.const 50
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 56
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -8560,15 +13221,23 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 44
+   i32.const 60
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $6
+  call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $start (; 104 ;) (type $FUNCSIG$v)
+ (func $start (; 169 ;) (type $FUNCSIG$v)
   call $std/map/testNumeric<i8,i32>
   call $std/map/testNumeric<u8,i32>
   call $std/map/testNumeric<i16,i32>
@@ -8580,9 +13249,9 @@
   call $std/map/testNumeric<f32,i32>
   call $std/map/testNumeric<f64,i32>
  )
- (func $~lib/rt/pure/__visit (; 105 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 170 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
-  i32.const 604
+  i32.const 804
   i32.lt_u
   if
    return
@@ -8690,30 +13359,30 @@
    unreachable
   end
  )
- (func $~lib/rt/__visit_members (; 106 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (; 171 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   block $folding-inner0
-   block $switch$1$default
-    block $switch$1$case$4
+   block $block$4$break
+    block $switch$1$default
      block $switch$1$case$2
       local.get $0
       i32.const 8
       i32.sub
       i32.load
-      br_table $switch$1$case$2 $switch$1$case$2 $switch$1$case$4 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $switch$1$default
+      br_table $switch$1$case$2 $switch$1$case$2 $block$4$break $folding-inner0 $block$4$break $block$4$break $folding-inner0 $folding-inner0 $folding-inner0 $block$4$break $folding-inner0 $folding-inner0 $block$4$break $folding-inner0 $folding-inner0 $block$4$break $folding-inner0 $folding-inner0 $block$4$break $folding-inner0 $folding-inner0 $block$4$break $folding-inner0 $folding-inner0 $block$4$break $folding-inner0 $folding-inner0 $block$4$break $folding-inner0 $folding-inner0 $block$4$break $folding-inner0 $switch$1$default
      end
      return
     end
-    local.get $0
-    i32.load
-    local.tee $0
-    if
-     local.get $0
-     local.get $1
-     call $~lib/rt/pure/__visit
-    end
-    return
+    unreachable
    end
-   unreachable
+   local.get $0
+   i32.load
+   local.tee $0
+   if
+    local.get $0
+    local.get $1
+    call $~lib/rt/pure/__visit
+   end
+   return
   end
   local.get $0
   i32.load
@@ -8724,7 +13393,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $null (; 107 ;) (type $FUNCSIG$v)
+ (func $null (; 172 ;) (type $FUNCSIG$v)
   unreachable
  )
 )

--- a/tests/compiler/std/map.ts
+++ b/tests/compiler/std/map.ts
@@ -20,6 +20,22 @@ function testNumeric<K extends number,V extends number>(): void {
   }
   assert(map.size == 100);
 
+  // keys and values
+  let keys = map.keys();
+  let vals = map.values();
+  let keyMap = new Map<K, K>();
+  let valMap = new Map<V, V>();
+  for (let index = 0; index < keys.length; ++index) {
+    let key = keys[index];
+    let value = vals[index];
+    assert(map.has(key));
+    assert(map.has(<K>(value - 20)));
+    keyMap.set(key, key);
+    valMap.set(<V>(value - 20), <V>(value - 20));
+  }
+  assert(keyMap.size == 100);
+  assert(valMap.size == 100);
+
   // delete
   for (let k: K = 0; k < 50; ++k) {
     assert(map.has(k));

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -4502,34 +4502,51 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<i32>#push (; 52 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  local.get $0
-  i32.load offset=12
-  local.set $2
-  local.get $2
-  i32.const 1
-  i32.add
-  local.set $3
-  local.get $0
-  local.get $3
-  i32.const 2
-  call $~lib/array/ensureSize
+ (func $~lib/array/Array<i32>#__unchecked_set (; 52 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
-  local.get $2
+  local.get $1
   i32.const 2
   i32.shl
   i32.add
-  local.get $1
+  local.get $2
   i32.store
-  local.get $0
-  local.get $3
-  i32.store offset=12
-  local.get $3
  )
- (func $~lib/array/Array<i32>#set:length (; 53 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#__set (; 53 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 512
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.const 2
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.store offset=12
+  end
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/array/Array<i32>#__unchecked_set
+ )
+ (func $~lib/array/Array<i32>#set:length (; 54 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -4542,7 +4559,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<i8,i32>#values (; 54 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#values (; 55 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4583,10 +4600,10 @@
     i32.eqz
     if
      local.get $3
+     local.get $4
      local.get $6
      i32.load offset=4
-     call $~lib/array/Array<i32>#push
-     drop
+     call $~lib/array/Array<i32>#__set
      local.get $4
      i32.const 1
      i32.add
@@ -4605,7 +4622,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<i8,i8>#clear (; 55 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<i8,i8>#clear (; 56 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -4645,7 +4662,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i8,i8>#constructor (; 56 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i8,i8>#constructor (; 57 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -4677,7 +4694,7 @@
   call $~lib/map/Map<i8,i8>#clear
   local.get $0
  )
- (func $~lib/map/Map<i32,i32>#clear (; 57 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<i32,i32>#clear (; 58 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -4717,7 +4734,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i32,i32>#constructor (; 58 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#constructor (; 59 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -4749,11 +4766,11 @@
   call $~lib/map/Map<i32,i32>#clear
   local.get $0
  )
- (func $~lib/array/Array<i8>#get:length (; 59 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i8>#get:length (; 60 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i8>#__unchecked_get (; 60 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__unchecked_get (; 61 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -4762,7 +4779,7 @@
   i32.add
   i32.load8_s
  )
- (func $~lib/array/Array<i8>#__get (; 61 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i8>#__get (; 62 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -4782,7 +4799,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/array/Array<i32>#__unchecked_get (; 62 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__unchecked_get (; 63 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -4791,7 +4808,7 @@
   i32.add
   i32.load
  )
- (func $~lib/array/Array<i32>#__get (; 63 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__get (; 64 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -4811,7 +4828,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<i8,i8>#find (; 64 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i8,i8>#find (; 65 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -4863,7 +4880,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i8,i8>#rehash (; 65 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i8,i8>#rehash (; 66 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5020,7 +5037,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i8,i8>#set (; 66 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<i8,i8>#set (; 67 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5127,7 +5144,7 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/util/hash/hash32 (; 67 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash32 (; 68 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   i32.const -2128831035
   local.set $1
@@ -5169,7 +5186,7 @@
   local.set $1
   local.get $1
  )
- (func $~lib/map/Map<i32,i32>#find (; 68 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#find (; 69 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -5217,7 +5234,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i32,i32>#rehash (; 69 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i32,i32>#rehash (; 70 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5374,7 +5391,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i32,i32>#set (; 70 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<i32,i32>#set (; 71 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5477,15 +5494,15 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/map/Map<i8,i8>#get:size (; 71 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i8,i8>#get:size (; 72 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<i32,i32>#get:size (; 72 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#get:size (; 73 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<i8,i32>#delete (; 73 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i8,i32>#delete (; 74 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5561,7 +5578,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<i8,i32> (; 74 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<i8,i32> (; 75 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -6051,7 +6068,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u8,i32>#clear (; 75 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<u8,i32>#clear (; 76 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -6091,7 +6108,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u8,i32>#constructor (; 76 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#constructor (; 77 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -6123,7 +6140,7 @@
   call $~lib/map/Map<u8,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u8,i32>#find (; 77 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#find (; 78 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -6173,7 +6190,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u8,i32>#has (; 78 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#has (; 79 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -6190,7 +6207,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u8,i32>#rehash (; 79 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,i32>#rehash (; 80 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6347,7 +6364,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u8,i32>#set (; 80 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<u8,i32>#set (; 81 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6452,7 +6469,7 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/map/Map<u8,i32>#get (; 81 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#get (; 82 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -6481,11 +6498,11 @@
   local.get $3
   i32.load offset=4
  )
- (func $~lib/map/Map<u8,i32>#get:size (; 82 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#get:size (; 83 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<u8>#constructor (; 83 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#constructor (; 84 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -6507,7 +6524,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<u8>#__unchecked_set (; 84 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u8>#__unchecked_set (; 85 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -6517,7 +6534,7 @@
   local.get $2
   i32.store8
  )
- (func $~lib/array/Array<u8>#__set (; 85 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u8>#__set (; 86 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -6551,7 +6568,7 @@
   local.get $2
   call $~lib/array/Array<u8>#__unchecked_set
  )
- (func $~lib/array/Array<u8>#set:length (; 86 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u8>#set:length (; 87 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -6564,7 +6581,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<u8,i32>#keys (; 87 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#keys (; 88 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6627,7 +6644,7 @@
   call $~lib/array/Array<u8>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u8,i32>#values (; 88 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#values (; 89 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -6668,10 +6685,10 @@
     i32.eqz
     if
      local.get $3
+     local.get $4
      local.get $6
      i32.load offset=4
-     call $~lib/array/Array<i32>#push
-     drop
+     call $~lib/array/Array<i32>#__set
      local.get $4
      i32.const 1
      i32.add
@@ -6690,7 +6707,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u8,u8>#clear (; 89 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<u8,u8>#clear (; 90 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -6730,7 +6747,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u8,u8>#constructor (; 90 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u8,u8>#constructor (; 91 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -6762,11 +6779,11 @@
   call $~lib/map/Map<u8,u8>#clear
   local.get $0
  )
- (func $~lib/array/Array<u8>#get:length (; 91 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u8>#get:length (; 92 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u8>#__unchecked_get (; 92 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__unchecked_get (; 93 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -6775,7 +6792,7 @@
   i32.add
   i32.load8_u
  )
- (func $~lib/array/Array<u8>#__get (; 93 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__get (; 94 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -6795,7 +6812,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<u8,u8>#find (; 94 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u8,u8>#find (; 95 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -6845,7 +6862,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u8,u8>#rehash (; 95 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,u8>#rehash (; 96 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7002,7 +7019,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u8,u8>#set (; 96 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<u8,u8>#set (; 97 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -7107,11 +7124,11 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/map/Map<u8,u8>#get:size (; 97 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u8,u8>#get:size (; 98 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<u8,i32>#delete (; 98 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#delete (; 99 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7185,7 +7202,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<u8,i32> (; 99 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<u8,i32> (; 100 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -7661,7 +7678,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i16,i32>#clear (; 100 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<i16,i32>#clear (; 101 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -7701,7 +7718,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i16,i32>#constructor (; 101 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#constructor (; 102 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -7733,7 +7750,7 @@
   call $~lib/map/Map<i16,i32>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash16 (; 102 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash16 (; 103 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   i32.const -2128831035
   local.set $1
@@ -7755,7 +7772,7 @@
   local.set $1
   local.get $1
  )
- (func $~lib/map/Map<i16,i32>#find (; 103 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#find (; 104 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -7807,7 +7824,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i16,i32>#has (; 104 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#has (; 105 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -7826,7 +7843,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i16,i32>#rehash (; 105 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i16,i32>#rehash (; 106 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7983,7 +8000,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i16,i32>#set (; 106 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<i16,i32>#set (; 107 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8090,7 +8107,7 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/map/Map<i16,i32>#get (; 107 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#get (; 108 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -8121,11 +8138,11 @@
   local.get $3
   i32.load offset=4
  )
- (func $~lib/map/Map<i16,i32>#get:size (; 108 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#get:size (; 109 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<i16>#constructor (; 109 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#constructor (; 110 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -8147,7 +8164,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<i16>#__unchecked_set (; 110 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i16>#__unchecked_set (; 111 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -8157,7 +8174,7 @@
   local.get $2
   i32.store16
  )
- (func $~lib/array/Array<i16>#__set (; 111 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<i16>#__set (; 112 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -8191,7 +8208,7 @@
   local.get $2
   call $~lib/array/Array<i16>#__unchecked_set
  )
- (func $~lib/array/Array<i16>#set:length (; 112 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i16>#set:length (; 113 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -8204,7 +8221,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<i16,i32>#keys (; 113 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#keys (; 114 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -8267,7 +8284,7 @@
   call $~lib/array/Array<i16>#set:length
   local.get $3
  )
- (func $~lib/map/Map<i16,i32>#values (; 114 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#values (; 115 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -8308,10 +8325,10 @@
     i32.eqz
     if
      local.get $3
+     local.get $4
      local.get $6
      i32.load offset=4
-     call $~lib/array/Array<i32>#push
-     drop
+     call $~lib/array/Array<i32>#__set
      local.get $4
      i32.const 1
      i32.add
@@ -8330,7 +8347,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<i16,i16>#clear (; 115 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<i16,i16>#clear (; 116 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -8370,7 +8387,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i16,i16>#constructor (; 116 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i16>#constructor (; 117 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -8402,11 +8419,11 @@
   call $~lib/map/Map<i16,i16>#clear
   local.get $0
  )
- (func $~lib/array/Array<i16>#get:length (; 117 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i16>#get:length (; 118 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i16>#__unchecked_get (; 118 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__unchecked_get (; 119 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -8415,7 +8432,7 @@
   i32.add
   i32.load16_s
  )
- (func $~lib/array/Array<i16>#__get (; 119 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#__get (; 120 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -8435,7 +8452,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<i16,i16>#find (; 120 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i16,i16>#find (; 121 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -8487,7 +8504,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i16,i16>#rehash (; 121 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i16,i16>#rehash (; 122 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8644,7 +8661,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i16,i16>#set (; 122 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<i16,i16>#set (; 123 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8751,11 +8768,11 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/map/Map<i16,i16>#get:size (; 123 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i16>#get:size (; 124 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<i16,i32>#delete (; 124 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#delete (; 125 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8831,7 +8848,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<i16,i32> (; 125 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<i16,i32> (; 126 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -9321,7 +9338,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u16,i32>#clear (; 126 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<u16,i32>#clear (; 127 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -9361,7 +9378,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u16,i32>#constructor (; 127 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#constructor (; 128 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -9393,7 +9410,7 @@
   call $~lib/map/Map<u16,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u16,i32>#find (; 128 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#find (; 129 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -9443,7 +9460,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u16,i32>#has (; 129 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#has (; 130 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -9460,7 +9477,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u16,i32>#rehash (; 130 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,i32>#rehash (; 131 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9617,7 +9634,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u16,i32>#set (; 131 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<u16,i32>#set (; 132 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -9722,7 +9739,7 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/map/Map<u16,i32>#get (; 132 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#get (; 133 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -9751,11 +9768,11 @@
   local.get $3
   i32.load offset=4
  )
- (func $~lib/map/Map<u16,i32>#get:size (; 133 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#get:size (; 134 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<u16>#constructor (; 134 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#constructor (; 135 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -9777,7 +9794,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<u16>#__unchecked_set (; 135 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u16>#__unchecked_set (; 136 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -9787,7 +9804,7 @@
   local.get $2
   i32.store16
  )
- (func $~lib/array/Array<u16>#__set (; 136 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u16>#__set (; 137 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -9821,7 +9838,7 @@
   local.get $2
   call $~lib/array/Array<u16>#__unchecked_set
  )
- (func $~lib/array/Array<u16>#set:length (; 137 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u16>#set:length (; 138 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -9834,7 +9851,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<u16,i32>#keys (; 138 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#keys (; 139 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9897,7 +9914,7 @@
   call $~lib/array/Array<u16>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u16,i32>#values (; 139 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#values (; 140 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9938,10 +9955,10 @@
     i32.eqz
     if
      local.get $3
+     local.get $4
      local.get $6
      i32.load offset=4
-     call $~lib/array/Array<i32>#push
-     drop
+     call $~lib/array/Array<i32>#__set
      local.get $4
      i32.const 1
      i32.add
@@ -9960,7 +9977,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u16,u16>#clear (; 140 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<u16,u16>#clear (; 141 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -10000,7 +10017,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u16,u16>#constructor (; 141 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,u16>#constructor (; 142 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -10032,11 +10049,11 @@
   call $~lib/map/Map<u16,u16>#clear
   local.get $0
  )
- (func $~lib/array/Array<u16>#get:length (; 142 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u16>#get:length (; 143 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u16>#__unchecked_get (; 143 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#__unchecked_get (; 144 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -10045,7 +10062,7 @@
   i32.add
   i32.load16_u
  )
- (func $~lib/array/Array<u16>#__get (; 144 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#__get (; 145 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -10065,7 +10082,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<u16,u16>#find (; 145 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u16,u16>#find (; 146 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -10115,7 +10132,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u16,u16>#rehash (; 146 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,u16>#rehash (; 147 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10272,7 +10289,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u16,u16>#set (; 147 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<u16,u16>#set (; 148 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -10377,11 +10394,11 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/map/Map<u16,u16>#get:size (; 148 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,u16>#get:size (; 149 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<u16,i32>#delete (; 149 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#delete (; 150 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10455,7 +10472,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<u16,i32> (; 150 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<u16,i32> (; 151 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -10931,7 +10948,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i32,i32>#has (; 151 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#has (; 152 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -10946,7 +10963,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i32,i32>#get (; 152 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#get (; 153 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -10973,51 +10990,7 @@
   local.get $3
   i32.load offset=4
  )
- (func $~lib/array/Array<i32>#__unchecked_set (; 153 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
-  local.get $0
-  i32.load offset=4
-  local.get $1
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $2
-  i32.store
- )
- (func $~lib/array/Array<i32>#__set (; 154 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
-  local.get $1
-  local.get $0
-  i32.load offset=12
-  i32.ge_u
-  if
-   local.get $1
-   i32.const 0
-   i32.lt_s
-   if
-    i32.const 280
-    i32.const 512
-    i32.const 109
-    i32.const 21
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $0
-   local.get $1
-   i32.const 1
-   i32.add
-   i32.const 2
-   call $~lib/array/ensureSize
-   local.get $0
-   local.get $1
-   i32.const 1
-   i32.add
-   i32.store offset=12
-  end
-  local.get $0
-  local.get $1
-  local.get $2
-  call $~lib/array/Array<i32>#__unchecked_set
- )
- (func $~lib/map/Map<i32,i32>#keys (; 155 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#keys (; 154 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -11080,7 +11053,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<i32,i32>#values (; 156 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#values (; 155 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -11121,10 +11094,10 @@
     i32.eqz
     if
      local.get $3
+     local.get $4
      local.get $6
      i32.load offset=4
-     call $~lib/array/Array<i32>#push
-     drop
+     call $~lib/array/Array<i32>#__set
      local.get $4
      i32.const 1
      i32.add
@@ -11143,11 +11116,11 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/array/Array<i32>#get:length (; 157 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#get:length (; 156 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/map/Map<i32,i32>#delete (; 158 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#delete (; 157 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11219,7 +11192,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<i32,i32> (; 159 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<i32,i32> (; 158 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -11681,7 +11654,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u32,i32>#clear (; 160 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<u32,i32>#clear (; 159 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -11721,7 +11694,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u32,i32>#constructor (; 161 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#constructor (; 160 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -11753,7 +11726,7 @@
   call $~lib/map/Map<u32,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u32,i32>#find (; 162 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#find (; 161 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -11801,7 +11774,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u32,i32>#has (; 163 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#has (; 162 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -11816,7 +11789,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u32,i32>#rehash (; 164 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u32,i32>#rehash (; 163 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11973,7 +11946,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u32,i32>#set (; 165 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<u32,i32>#set (; 164 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12076,7 +12049,7 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/map/Map<u32,i32>#get (; 166 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#get (; 165 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -12103,11 +12076,11 @@
   local.get $3
   i32.load offset=4
  )
- (func $~lib/map/Map<u32,i32>#get:size (; 167 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#get:size (; 166 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<u32>#constructor (; 168 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#constructor (; 167 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -12129,7 +12102,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<u32>#__unchecked_set (; 169 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u32>#__unchecked_set (; 168 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -12139,7 +12112,7 @@
   local.get $2
   i32.store
  )
- (func $~lib/array/Array<u32>#__set (; 170 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/array/Array<u32>#__set (; 169 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -12173,7 +12146,7 @@
   local.get $2
   call $~lib/array/Array<u32>#__unchecked_set
  )
- (func $~lib/array/Array<u32>#set:length (; 171 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u32>#set:length (; 170 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -12186,7 +12159,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<u32,i32>#keys (; 172 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#keys (; 171 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -12249,7 +12222,7 @@
   call $~lib/array/Array<u32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u32,i32>#values (; 173 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#values (; 172 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -12290,10 +12263,10 @@
     i32.eqz
     if
      local.get $3
+     local.get $4
      local.get $6
      i32.load offset=4
-     call $~lib/array/Array<i32>#push
-     drop
+     call $~lib/array/Array<i32>#__set
      local.get $4
      i32.const 1
      i32.add
@@ -12312,7 +12285,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u32,u32>#clear (; 174 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<u32,u32>#clear (; 173 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -12352,7 +12325,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u32,u32>#constructor (; 175 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,u32>#constructor (; 174 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -12384,11 +12357,11 @@
   call $~lib/map/Map<u32,u32>#clear
   local.get $0
  )
- (func $~lib/array/Array<u32>#get:length (; 176 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u32>#get:length (; 175 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u32>#__unchecked_get (; 177 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#__unchecked_get (; 176 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -12397,7 +12370,7 @@
   i32.add
   i32.load
  )
- (func $~lib/array/Array<u32>#__get (; 178 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#__get (; 177 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $1
   local.get $0
@@ -12417,7 +12390,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<u32,u32>#find (; 179 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u32,u32>#find (; 178 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -12465,7 +12438,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u32,u32>#rehash (; 180 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u32,u32>#rehash (; 179 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12622,7 +12595,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u32,u32>#set (; 181 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<u32,u32>#set (; 180 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -12725,11 +12698,11 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/map/Map<u32,u32>#get:size (; 182 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,u32>#get:size (; 181 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<u32,i32>#delete (; 183 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#delete (; 182 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -12801,7 +12774,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<u32,i32> (; 184 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<u32,i32> (; 183 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -13263,7 +13236,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i64,i32>#clear (; 185 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<i64,i32>#clear (; 184 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -13303,7 +13276,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i64,i32>#constructor (; 186 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#constructor (; 185 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -13335,7 +13308,7 @@
   call $~lib/map/Map<i64,i32>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash64 (; 187 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/hash/hash64 (; 186 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -13423,7 +13396,7 @@
   local.set $3
   local.get $3
  )
- (func $~lib/map/Map<i64,i32>#find (; 188 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#find (; 187 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -13471,7 +13444,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i64,i32>#has (; 189 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<i64,i32>#has (; 188 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   local.get $0
   local.get $1
@@ -13486,7 +13459,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i64,i32>#rehash (; 190 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i64,i32>#rehash (; 189 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -13644,7 +13617,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i64,i32>#set (; 191 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/map/Map<i64,i32>#set (; 190 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -13748,7 +13721,7 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/map/Map<i64,i32>#get (; 192 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<i64,i32>#get (; 191 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   local.get $0
@@ -13775,11 +13748,11 @@
   local.get $3
   i32.load offset=8
  )
- (func $~lib/map/Map<i64,i32>#get:size (; 193 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#get:size (; 192 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<i64>#constructor (; 194 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i64>#constructor (; 193 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -13801,7 +13774,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<i64>#__unchecked_set (; 195 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<i64>#__unchecked_set (; 194 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -13811,7 +13784,7 @@
   local.get $2
   i64.store
  )
- (func $~lib/array/Array<i64>#__set (; 196 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<i64>#__set (; 195 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -13845,7 +13818,7 @@
   local.get $2
   call $~lib/array/Array<i64>#__unchecked_set
  )
- (func $~lib/array/Array<i64>#set:length (; 197 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i64>#set:length (; 196 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -13858,7 +13831,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<i64,i32>#keys (; 198 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#keys (; 197 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -13921,7 +13894,7 @@
   call $~lib/array/Array<i64>#set:length
   local.get $3
  )
- (func $~lib/map/Map<i64,i32>#values (; 199 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#values (; 198 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -13962,10 +13935,10 @@
     i32.eqz
     if
      local.get $3
+     local.get $4
      local.get $6
      i32.load offset=8
-     call $~lib/array/Array<i32>#push
-     drop
+     call $~lib/array/Array<i32>#__set
      local.get $4
      i32.const 1
      i32.add
@@ -13984,7 +13957,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<i64,i64>#clear (; 200 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<i64,i64>#clear (; 199 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -14024,7 +13997,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i64,i64>#constructor (; 201 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i64>#constructor (; 200 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -14056,11 +14029,11 @@
   call $~lib/map/Map<i64,i64>#clear
   local.get $0
  )
- (func $~lib/array/Array<i64>#get:length (; 202 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i64>#get:length (; 201 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i64>#__unchecked_get (; 203 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<i64>#__unchecked_get (; 202 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -14069,7 +14042,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<i64>#__get (; 204 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<i64>#__get (; 203 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i64)
   local.get $1
   local.get $0
@@ -14089,7 +14062,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<i64,i64>#find (; 205 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i64,i64>#find (; 204 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -14137,7 +14110,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i64,i64>#rehash (; 206 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i64,i64>#rehash (; 205 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -14295,7 +14268,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i64,i64>#set (; 207 ;) (type $FUNCSIG$vijj) (param $0 i32) (param $1 i64) (param $2 i64)
+ (func $~lib/map/Map<i64,i64>#set (; 206 ;) (type $FUNCSIG$vijj) (param $0 i32) (param $1 i64) (param $2 i64)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -14399,11 +14372,11 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/map/Map<i64,i64>#get:size (; 208 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i64>#get:size (; 207 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<i64,i32>#delete (; 209 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<i64,i32>#delete (; 208 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -14476,7 +14449,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<i64,i32> (; 210 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<i64,i32> (; 209 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i64)
   (local $2 i32)
@@ -14946,7 +14919,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u64,i32>#clear (; 211 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<u64,i32>#clear (; 210 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -14986,7 +14959,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u64,i32>#constructor (; 212 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#constructor (; 211 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -15018,7 +14991,7 @@
   call $~lib/map/Map<u64,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u64,i32>#find (; 213 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#find (; 212 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -15066,7 +15039,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u64,i32>#has (; 214 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<u64,i32>#has (; 213 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   local.get $0
   local.get $1
@@ -15081,7 +15054,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u64,i32>#rehash (; 215 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u64,i32>#rehash (; 214 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15239,7 +15212,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u64,i32>#set (; 216 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/map/Map<u64,i32>#set (; 215 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -15343,7 +15316,7 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/map/Map<u64,i32>#get (; 217 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<u64,i32>#get (; 216 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   local.get $0
@@ -15370,11 +15343,11 @@
   local.get $3
   i32.load offset=8
  )
- (func $~lib/map/Map<u64,i32>#get:size (; 218 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#get:size (; 217 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<u64>#constructor (; 219 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u64>#constructor (; 218 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -15396,7 +15369,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<u64>#__unchecked_set (; 220 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<u64>#__unchecked_set (; 219 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -15406,7 +15379,7 @@
   local.get $2
   i64.store
  )
- (func $~lib/array/Array<u64>#__set (; 221 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
+ (func $~lib/array/Array<u64>#__set (; 220 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -15440,7 +15413,7 @@
   local.get $2
   call $~lib/array/Array<u64>#__unchecked_set
  )
- (func $~lib/array/Array<u64>#set:length (; 222 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u64>#set:length (; 221 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -15453,7 +15426,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<u64,i32>#keys (; 223 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#keys (; 222 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -15516,7 +15489,7 @@
   call $~lib/array/Array<u64>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u64,i32>#values (; 224 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#values (; 223 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -15557,10 +15530,10 @@
     i32.eqz
     if
      local.get $3
+     local.get $4
      local.get $6
      i32.load offset=8
-     call $~lib/array/Array<i32>#push
-     drop
+     call $~lib/array/Array<i32>#__set
      local.get $4
      i32.const 1
      i32.add
@@ -15579,7 +15552,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<u64,u64>#clear (; 225 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<u64,u64>#clear (; 224 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -15619,7 +15592,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u64,u64>#constructor (; 226 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,u64>#constructor (; 225 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -15651,11 +15624,11 @@
   call $~lib/map/Map<u64,u64>#clear
   local.get $0
  )
- (func $~lib/array/Array<u64>#get:length (; 227 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u64>#get:length (; 226 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u64>#__unchecked_get (; 228 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__unchecked_get (; 227 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -15664,7 +15637,7 @@
   i32.add
   i64.load
  )
- (func $~lib/array/Array<u64>#__get (; 229 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<u64>#__get (; 228 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
   (local $2 i64)
   local.get $1
   local.get $0
@@ -15684,7 +15657,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<u64,u64>#find (; 230 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u64,u64>#find (; 229 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -15732,7 +15705,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u64,u64>#rehash (; 231 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u64,u64>#rehash (; 230 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -15890,7 +15863,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u64,u64>#set (; 232 ;) (type $FUNCSIG$vijj) (param $0 i32) (param $1 i64) (param $2 i64)
+ (func $~lib/map/Map<u64,u64>#set (; 231 ;) (type $FUNCSIG$vijj) (param $0 i32) (param $1 i64) (param $2 i64)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -15994,11 +15967,11 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/map/Map<u64,u64>#get:size (; 233 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,u64>#get:size (; 232 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<u64,i32>#delete (; 234 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<u64,i32>#delete (; 233 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -16071,7 +16044,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<u64,i32> (; 235 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<u64,i32> (; 234 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i64)
   (local $2 i32)
@@ -16541,7 +16514,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f32,i32>#clear (; 236 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<f32,i32>#clear (; 235 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -16581,7 +16554,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<f32,i32>#constructor (; 237 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#constructor (; 236 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -16613,7 +16586,7 @@
   call $~lib/map/Map<f32,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<f32,i32>#find (; 238 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#find (; 237 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -16661,7 +16634,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f32,i32>#has (; 239 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/map/Map<f32,i32>#has (; 238 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
   (local $2 f32)
   local.get $0
   local.get $1
@@ -16677,7 +16650,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<f32,i32>#rehash (; 240 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f32,i32>#rehash (; 239 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -16836,7 +16809,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f32,i32>#set (; 241 ;) (type $FUNCSIG$vifi) (param $0 i32) (param $1 f32) (param $2 i32)
+ (func $~lib/map/Map<f32,i32>#set (; 240 ;) (type $FUNCSIG$vifi) (param $0 i32) (param $1 f32) (param $2 i32)
   (local $3 f32)
   (local $4 i32)
   (local $5 i32)
@@ -16941,7 +16914,7 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/map/Map<f32,i32>#get (; 242 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/map/Map<f32,i32>#get (; 241 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
   (local $2 f32)
   (local $3 i32)
   local.get $0
@@ -16969,11 +16942,11 @@
   local.get $3
   i32.load offset=4
  )
- (func $~lib/map/Map<f32,i32>#get:size (; 243 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#get:size (; 242 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<f32>#constructor (; 244 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f32>#constructor (; 243 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -16995,7 +16968,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<f32>#__unchecked_set (; 245 ;) (type $FUNCSIG$viif) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/array/Array<f32>#__unchecked_set (; 244 ;) (type $FUNCSIG$viif) (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -17005,7 +16978,7 @@
   local.get $2
   f32.store
  )
- (func $~lib/array/Array<f32>#__set (; 246 ;) (type $FUNCSIG$viif) (param $0 i32) (param $1 i32) (param $2 f32)
+ (func $~lib/array/Array<f32>#__set (; 245 ;) (type $FUNCSIG$viif) (param $0 i32) (param $1 i32) (param $2 f32)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -17039,7 +17012,7 @@
   local.get $2
   call $~lib/array/Array<f32>#__unchecked_set
  )
- (func $~lib/array/Array<f32>#set:length (; 247 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f32>#set:length (; 246 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -17052,7 +17025,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<f32,i32>#keys (; 248 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#keys (; 247 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -17115,7 +17088,7 @@
   call $~lib/array/Array<f32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<f32,i32>#values (; 249 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#values (; 248 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -17156,10 +17129,10 @@
     i32.eqz
     if
      local.get $3
+     local.get $4
      local.get $6
      i32.load offset=4
-     call $~lib/array/Array<i32>#push
-     drop
+     call $~lib/array/Array<i32>#__set
      local.get $4
      i32.const 1
      i32.add
@@ -17178,7 +17151,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<f32,f32>#clear (; 250 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<f32,f32>#clear (; 249 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -17218,7 +17191,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<f32,f32>#constructor (; 251 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,f32>#constructor (; 250 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -17250,11 +17223,11 @@
   call $~lib/map/Map<f32,f32>#clear
   local.get $0
  )
- (func $~lib/array/Array<f32>#get:length (; 252 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f32>#get:length (; 251 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<f32>#__unchecked_get (; 253 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__unchecked_get (; 252 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -17263,7 +17236,7 @@
   i32.add
   f32.load
  )
- (func $~lib/array/Array<f32>#__get (; 254 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__get (; 253 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
   (local $2 f32)
   local.get $1
   local.get $0
@@ -17283,7 +17256,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<f32,f32>#find (; 255 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f32,f32>#find (; 254 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -17331,7 +17304,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f32,f32>#rehash (; 256 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f32,f32>#rehash (; 255 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -17490,7 +17463,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f32,f32>#set (; 257 ;) (type $FUNCSIG$viff) (param $0 i32) (param $1 f32) (param $2 f32)
+ (func $~lib/map/Map<f32,f32>#set (; 256 ;) (type $FUNCSIG$viff) (param $0 i32) (param $1 f32) (param $2 f32)
   (local $3 f32)
   (local $4 i32)
   (local $5 i32)
@@ -17595,11 +17568,11 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/map/Map<f32,f32>#get:size (; 258 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,f32>#get:size (; 257 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<f32,i32>#delete (; 259 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/map/Map<f32,i32>#delete (; 258 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
   (local $2 f32)
   (local $3 i32)
   (local $4 i32)
@@ -17673,7 +17646,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<f32,i32> (; 260 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<f32,i32> (; 259 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f32)
   (local $2 i32)
@@ -18143,7 +18116,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f64,i32>#clear (; 261 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<f64,i32>#clear (; 260 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -18183,7 +18156,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<f64,i32>#constructor (; 262 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#constructor (; 261 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -18215,7 +18188,7 @@
   call $~lib/map/Map<f64,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<f64,i32>#find (; 263 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#find (; 262 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -18263,7 +18236,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f64,i32>#has (; 264 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/map/Map<f64,i32>#has (; 263 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 f64)
   local.get $0
   local.get $1
@@ -18279,7 +18252,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<f64,i32>#rehash (; 265 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f64,i32>#rehash (; 264 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -18438,7 +18411,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f64,i32>#set (; 266 ;) (type $FUNCSIG$vidi) (param $0 i32) (param $1 f64) (param $2 i32)
+ (func $~lib/map/Map<f64,i32>#set (; 265 ;) (type $FUNCSIG$vidi) (param $0 i32) (param $1 f64) (param $2 i32)
   (local $3 f64)
   (local $4 i32)
   (local $5 i32)
@@ -18543,7 +18516,7 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/map/Map<f64,i32>#get (; 267 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/map/Map<f64,i32>#get (; 266 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 f64)
   (local $3 i32)
   local.get $0
@@ -18571,11 +18544,11 @@
   local.get $3
   i32.load offset=8
  )
- (func $~lib/map/Map<f64,i32>#get:size (; 268 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#get:size (; 267 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/array/Array<f64>#constructor (; 269 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<f64>#constructor (; 268 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -18597,7 +18570,7 @@
   i32.store offset=12
   local.get $0
  )
- (func $~lib/array/Array<f64>#__unchecked_set (; 270 ;) (type $FUNCSIG$viid) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/array/Array<f64>#__unchecked_set (; 269 ;) (type $FUNCSIG$viid) (param $0 i32) (param $1 i32) (param $2 f64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -18607,7 +18580,7 @@
   local.get $2
   f64.store
  )
- (func $~lib/array/Array<f64>#__set (; 271 ;) (type $FUNCSIG$viid) (param $0 i32) (param $1 i32) (param $2 f64)
+ (func $~lib/array/Array<f64>#__set (; 270 ;) (type $FUNCSIG$viid) (param $0 i32) (param $1 i32) (param $2 f64)
   local.get $1
   local.get $0
   i32.load offset=12
@@ -18641,7 +18614,7 @@
   local.get $2
   call $~lib/array/Array<f64>#__unchecked_set
  )
- (func $~lib/array/Array<f64>#set:length (; 272 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f64>#set:length (; 271 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load offset=12
@@ -18654,7 +18627,7 @@
   local.get $1
   i32.store offset=12
  )
- (func $~lib/map/Map<f64,i32>#keys (; 273 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#keys (; 272 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -18717,7 +18690,7 @@
   call $~lib/array/Array<f64>#set:length
   local.get $3
  )
- (func $~lib/map/Map<f64,i32>#values (; 274 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#values (; 273 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -18758,10 +18731,10 @@
     i32.eqz
     if
      local.get $3
+     local.get $4
      local.get $6
      i32.load offset=8
-     call $~lib/array/Array<i32>#push
-     drop
+     call $~lib/array/Array<i32>#__set
      local.get $4
      i32.const 1
      i32.add
@@ -18780,7 +18753,7 @@
   call $~lib/array/Array<i32>#set:length
   local.get $3
  )
- (func $~lib/map/Map<f64,f64>#clear (; 275 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<f64,f64>#clear (; 274 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -18820,7 +18793,7 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<f64,f64>#constructor (; 276 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,f64>#constructor (; 275 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -18852,11 +18825,11 @@
   call $~lib/map/Map<f64,f64>#clear
   local.get $0
  )
- (func $~lib/array/Array<f64>#get:length (; 277 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f64>#get:length (; 276 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<f64>#__unchecked_get (; 278 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__unchecked_get (; 277 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -18865,7 +18838,7 @@
   i32.add
   f64.load
  )
- (func $~lib/array/Array<f64>#__get (; 279 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__get (; 278 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
   (local $2 f64)
   local.get $1
   local.get $0
@@ -18885,7 +18858,7 @@
   local.set $2
   local.get $2
  )
- (func $~lib/map/Map<f64,f64>#find (; 280 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f64,f64>#find (; 279 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -18933,7 +18906,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f64,f64>#rehash (; 281 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f64,f64>#rehash (; 280 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -19092,7 +19065,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f64,f64>#set (; 282 ;) (type $FUNCSIG$vidd) (param $0 i32) (param $1 f64) (param $2 f64)
+ (func $~lib/map/Map<f64,f64>#set (; 281 ;) (type $FUNCSIG$vidd) (param $0 i32) (param $1 f64) (param $2 f64)
   (local $3 f64)
   (local $4 i32)
   (local $5 i32)
@@ -19197,11 +19170,11 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/map/Map<f64,f64>#get:size (; 283 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,f64>#get:size (; 282 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<f64,i32>#delete (; 284 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/map/Map<f64,i32>#delete (; 283 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
@@ -19275,7 +19248,7 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<f64,i32> (; 285 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<f64,i32> (; 284 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f64)
   (local $2 i32)
@@ -19745,7 +19718,7 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $start:std/map (; 286 ;) (type $FUNCSIG$v)
+ (func $start:std/map (; 285 ;) (type $FUNCSIG$v)
   call $std/map/testNumeric<i8,i32>
   call $std/map/testNumeric<u8,i32>
   call $std/map/testNumeric<i16,i32>
@@ -19757,10 +19730,10 @@
   call $std/map/testNumeric<f32,i32>
   call $std/map/testNumeric<f64,i32>
  )
- (func $start (; 287 ;) (type $FUNCSIG$v)
+ (func $start (; 286 ;) (type $FUNCSIG$v)
   call $start:std/map
  )
- (func $~lib/rt/pure/__visit (; 288 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 287 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -19890,7 +19863,7 @@
    end
   end
  )
- (func $~lib/map/Map<i8,i32>#__visit_impl (; 289 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i8,i32>#__visit_impl (; 288 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19903,13 +19876,13 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<i8>#__visit_impl (; 290 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i8>#__visit_impl (; 289 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<i32>#__visit_impl (; 291 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#__visit_impl (; 290 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/map/Map<i8,i8>#__visit_impl (; 292 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i8,i8>#__visit_impl (; 291 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19922,7 +19895,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<i32,i32>#__visit_impl (; 293 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i32,i32>#__visit_impl (; 292 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19935,7 +19908,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<u8,i32>#__visit_impl (; 294 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,i32>#__visit_impl (; 293 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19948,10 +19921,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u8>#__visit_impl (; 295 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u8>#__visit_impl (; 294 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/map/Map<u8,u8>#__visit_impl (; 296 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,u8>#__visit_impl (; 295 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19964,7 +19937,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<i16,i32>#__visit_impl (; 297 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i16,i32>#__visit_impl (; 296 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19977,10 +19950,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<i16>#__visit_impl (; 298 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i16>#__visit_impl (; 297 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/map/Map<i16,i16>#__visit_impl (; 299 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i16,i16>#__visit_impl (; 298 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -19993,7 +19966,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<u16,i32>#__visit_impl (; 300 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,i32>#__visit_impl (; 299 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -20006,10 +19979,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u16>#__visit_impl (; 301 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u16>#__visit_impl (; 300 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/map/Map<u16,u16>#__visit_impl (; 302 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,u16>#__visit_impl (; 301 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -20022,7 +19995,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<u32,i32>#__visit_impl (; 303 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u32,i32>#__visit_impl (; 302 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -20035,10 +20008,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u32>#__visit_impl (; 304 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u32>#__visit_impl (; 303 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/map/Map<u32,u32>#__visit_impl (; 305 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u32,u32>#__visit_impl (; 304 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -20051,7 +20024,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<i64,i32>#__visit_impl (; 306 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i64,i32>#__visit_impl (; 305 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -20064,10 +20037,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<i64>#__visit_impl (; 307 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i64>#__visit_impl (; 306 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/map/Map<i64,i64>#__visit_impl (; 308 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i64,i64>#__visit_impl (; 307 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -20080,7 +20053,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<u64,i32>#__visit_impl (; 309 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u64,i32>#__visit_impl (; 308 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -20093,10 +20066,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<u64>#__visit_impl (; 310 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u64>#__visit_impl (; 309 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/map/Map<u64,u64>#__visit_impl (; 311 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u64,u64>#__visit_impl (; 310 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -20109,7 +20082,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<f32,i32>#__visit_impl (; 312 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f32,i32>#__visit_impl (; 311 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -20122,10 +20095,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<f32>#__visit_impl (; 313 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f32>#__visit_impl (; 312 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/map/Map<f32,f32>#__visit_impl (; 314 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f32,f32>#__visit_impl (; 313 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -20138,7 +20111,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<f64,i32>#__visit_impl (; 315 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f64,i32>#__visit_impl (; 314 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -20151,10 +20124,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/array/Array<f64>#__visit_impl (; 316 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f64>#__visit_impl (; 315 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/map/Map<f64,f64>#__visit_impl (; 317 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f64,f64>#__visit_impl (; 316 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -20167,7 +20140,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/rt/__visit_members (; 318 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (; 317 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $block$4$break
    block $switch$1$default
@@ -20369,7 +20342,7 @@
   end
   return
  )
- (func $null (; 319 ;) (type $FUNCSIG$v)
+ (func $null (; 318 ;) (type $FUNCSIG$v)
   unreachable
  )
 )

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -11,12 +11,21 @@
  (type $FUNCSIG$ij (func (param i64) (result i32)))
  (type $FUNCSIG$iiji (func (param i32 i64 i32) (result i32)))
  (type $FUNCSIG$viji (func (param i32 i64 i32)))
+ (type $FUNCSIG$viij (func (param i32 i32 i64)))
+ (type $FUNCSIG$jii (func (param i32 i32) (result i64)))
+ (type $FUNCSIG$vijj (func (param i32 i64 i64)))
  (type $FUNCSIG$iif (func (param i32 f32) (result i32)))
  (type $FUNCSIG$iifi (func (param i32 f32 i32) (result i32)))
  (type $FUNCSIG$vifi (func (param i32 f32 i32)))
+ (type $FUNCSIG$viif (func (param i32 i32 f32)))
+ (type $FUNCSIG$fii (func (param i32 i32) (result f32)))
+ (type $FUNCSIG$viff (func (param i32 f32 f32)))
  (type $FUNCSIG$iid (func (param i32 f64) (result i32)))
  (type $FUNCSIG$iidi (func (param i32 f64 i32) (result i32)))
  (type $FUNCSIG$vidi (func (param i32 f64 i32)))
+ (type $FUNCSIG$viid (func (param i32 i32 f64)))
+ (type $FUNCSIG$dii (func (param i32 i32) (result f64)))
+ (type $FUNCSIG$vidd (func (param i32 f64 f64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
@@ -33,7 +42,8 @@
  (data (i32.const 360) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00s\00t\00d\00/\00m\00a\00p\00.\00t\00s\00")
  (data (i32.const 400) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00K\00e\00y\00 \00d\00o\00e\00s\00 \00n\00o\00t\00 \00e\00x\00i\00s\00t\00")
  (data (i32.const 456) "\16\00\00\00\01\00\00\00\01\00\00\00\16\00\00\00~\00l\00i\00b\00/\00m\00a\00p\00.\00t\00s\00")
- (data (i32.const 496) "\0d\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\98D\08\00\00\00\00\00\98D\00\00\00\00\00\00\98\84\08\00\00\00\00\00\98\84\00\00\00\00\00\00\98\04\t\00\00\00\00\00\98\04\01\00\00\00\00\00\98\04\n\00\00\00\00\00\98\04\02\00\00\00\00\00\98\04\19\00\00\00\00\00\98\04\1a\00\00\00\00\00")
+ (data (i32.const 496) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s\00")
+ (data (i32.const 544) " \00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\98D\08\00\00\00\00\003\04\00\00\02\00\00\00\93\04\00\00\02\00\00\008D\08\00\00\00\00\00\98\04\t\00\00\00\00\00\98D\00\00\00\00\00\003\00\00\00\02\00\00\008@\00\00\00\00\00\00\98\84\08\00\00\00\00\00S\04\00\00\02\00\00\00X\84\08\00\00\00\00\00\98\84\00\00\00\00\00\00S\00\00\00\02\00\00\00X\80\00\00\00\00\00\00\98\04\01\00\00\00\00\00\93\00\00\00\02\00\00\00\98\00\01\00\00\00\00\00\98\04\n\00\00\00\00\00\13\05\00\00\02\00\00\00\18\05\n\00\00\00\00\00\98\04\02\00\00\00\00\00\13\01\00\00\02\00\00\00\18\01\02\00\00\00\00\00\98\04\19\00\00\00\00\00\93\0c\00\00\02\00\00\00\98\0c\19\00\00\00\00\00\98\04\1a\00\00\00\00\00\13\0d\00\00\02\00\00\00\18\0d\1a\00\00\00\00\00")
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
@@ -43,8 +53,8 @@
  (global $~lib/rt/pure/CUR (mut i32) (i32.const 0))
  (global $~lib/ASC_SHRINK_LEVEL i32 (i32.const 0))
  (global $~lib/rt/pure/END (mut i32) (i32.const 0))
- (global $~lib/rt/__rtti_base i32 (i32.const 496))
- (global $~lib/heap/__heap_base i32 (i32.const 604))
+ (global $~lib/rt/__rtti_base i32 (i32.const 544))
+ (global $~lib/heap/__heap_base i32 (i32.const 804))
  (export "memory" (memory $0))
  (start $start)
  (func $~lib/rt/tlsf/removeBlock (; 5 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
@@ -4015,14 +4025,1474 @@
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<i8,i32>#delete (; 42 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (; 42 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $1
+  i32.const 1073741808
+  local.get $2
+  i32.shr_u
+  i32.gt_u
+  if
+   i32.const 176
+   i32.const 224
+   i32.const 23
+   i32.const 56
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $2
+  i32.shl
+  local.tee $1
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.set $3
+  local.get $3
+  i32.const 0
+  local.get $1
+  call $~lib/memory/memory.fill
+  local.get $0
+  i32.eqz
+  if
+   i32.const 12
+   i32.const 2
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  local.tee $4
+  local.get $3
+  local.tee $5
+  local.get $4
+  i32.load
+  local.tee $6
+  i32.ne
+  if
+   local.get $5
+   call $~lib/rt/pure/__retain
+   local.set $5
+   local.get $6
+   call $~lib/rt/pure/__release
+  end
+  local.get $5
+  i32.store
+  local.get $0
+  local.get $3
+  i32.store offset=4
+  local.get $0
+  local.get $1
+  i32.store offset=8
+  local.get $0
+ )
+ (func $~lib/array/Array<i8>#constructor (; 43 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  if (result i32)
+   local.get $0
+  else
+   i32.const 16
+   i32.const 4
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+  end
+  local.get $1
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  local.get $1
+  i32.store offset=12
+  local.get $0
+ )
+ (func $~lib/rt/tlsf/reallocateBlock (; 44 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $2
+  call $~lib/rt/tlsf/prepareSize
+  local.set $3
+  local.get $1
+  i32.load
+  local.set $4
+  local.get $4
+  i32.const 1
+  i32.and
+  i32.eqz
+  if (result i32)
+   local.get $1
+   i32.load offset=4
+   i32.const -268435456
+   i32.and
+   i32.eqz
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 521
+   i32.const 4
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  local.get $4
+  i32.const -4
+  i32.and
+  i32.le_u
+  if
+   local.get $0
+   local.get $1
+   local.get $3
+   call $~lib/rt/tlsf/prepareBlock
+   local.get $1
+   local.get $2
+   i32.store offset=12
+   local.get $1
+   return
+  end
+  local.get $1
+  local.set $5
+  local.get $5
+  i32.const 16
+  i32.add
+  local.get $5
+  i32.load
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+  i32.add
+  local.set $6
+  local.get $6
+  i32.load
+  local.set $7
+  local.get $7
+  i32.const 1
+  i32.and
+  if
+   local.get $4
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $5
+   local.get $5
+   local.get $3
+   i32.ge_u
+   if
+    local.get $0
+    local.get $6
+    call $~lib/rt/tlsf/removeBlock
+    local.get $1
+    local.get $4
+    i32.const 3
+    i32.and
+    local.get $5
+    i32.or
+    i32.store
+    local.get $1
+    local.get $2
+    i32.store offset=12
+    local.get $0
+    local.get $1
+    local.get $3
+    call $~lib/rt/tlsf/prepareBlock
+    local.get $1
+    return
+   end
+  end
+  local.get $0
+  local.get $2
+  call $~lib/rt/tlsf/allocateBlock
+  local.set $8
+  local.get $8
+  local.get $1
+  i32.load offset=8
+  i32.store offset=8
+  local.get $8
+  i32.const 16
+  i32.add
+  local.get $1
+  i32.const 16
+  i32.add
+  local.get $2
+  call $~lib/memory/memory.copy
+  local.get $1
+  local.get $4
+  i32.const 1
+  i32.or
+  i32.store
+  local.get $0
+  local.get $1
+  call $~lib/rt/tlsf/insertBlock
+  local.get $1
+  call $~lib/rt/rtrace/onfree
+  local.get $8
+ )
+ (func $~lib/rt/tlsf/__realloc (; 45 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  global.get $~lib/rt/tlsf/ROOT
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 585
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 0
+  i32.ne
+  if (result i32)
+   local.get $0
+   i32.const 15
+   i32.and
+   i32.eqz
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 586
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/rt/tlsf/ROOT
+  local.get $0
+  i32.const 16
+  i32.sub
+  local.get $1
+  call $~lib/rt/tlsf/reallocateBlock
+  i32.const 16
+  i32.add
+ )
+ (func $~lib/array/ensureSize (; 46 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $3
+  local.get $1
+  local.get $3
+  local.get $2
+  i32.shr_u
+  i32.gt_u
+  if
+   local.get $1
+   i32.const 1073741808
+   local.get $2
+   i32.shr_u
+   i32.gt_u
+   if
+    i32.const 176
+    i32.const 512
+    i32.const 14
+    i32.const 47
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   i32.load
+   local.set $4
+   local.get $1
+   local.get $2
+   i32.shl
+   local.set $5
+   local.get $4
+   local.get $5
+   call $~lib/rt/tlsf/__realloc
+   local.set $6
+   local.get $6
+   local.get $3
+   i32.add
+   i32.const 0
+   local.get $5
+   local.get $3
+   i32.sub
+   call $~lib/memory/memory.fill
+   local.get $6
+   local.get $4
+   i32.ne
+   if
+    local.get $0
+    local.get $6
+    call $~lib/rt/pure/__retain
+    i32.store
+    local.get $0
+    local.get $6
+    i32.store offset=4
+   end
+   local.get $0
+   local.get $5
+   i32.store offset=8
+  end
+ )
+ (func $~lib/array/Array<i8>#__unchecked_set (; 47 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 0
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store8
+ )
+ (func $~lib/array/Array<i8>#__set (; 48 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 512
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.const 0
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.store offset=12
+  end
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/array/Array<i8>#__unchecked_set
+ )
+ (func $~lib/array/Array<i8>#set:length (; 49 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load offset=12
+  local.set $2
+  local.get $0
+  local.get $1
+  i32.const 0
+  call $~lib/array/ensureSize
+  local.get $0
+  local.get $1
+  i32.store offset=12
+ )
+ (func $~lib/map/Map<i8,i32>#keys (; 50 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<i8>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 12
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $4
+     local.get $6
+     i32.load8_s
+     call $~lib/array/Array<i8>#__set
+     local.get $4
+     i32.const 1
+     i32.add
+     local.set $4
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+  local.get $4
+  call $~lib/array/Array<i8>#set:length
+  local.get $3
+ )
+ (func $~lib/array/Array<i32>#constructor (; 51 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  if (result i32)
+   local.get $0
+  else
+   i32.const 16
+   i32.const 5
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+  end
+  local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  local.get $1
+  i32.store offset=12
+  local.get $0
+ )
+ (func $~lib/array/Array<i32>#push (; 52 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  i32.load offset=12
+  local.set $2
+  local.get $2
+  i32.const 1
+  i32.add
+  local.set $3
+  local.get $0
+  local.get $3
+  i32.const 2
+  call $~lib/array/ensureSize
+  local.get $0
+  i32.load offset=4
+  local.get $2
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $1
+  i32.store
+  local.get $0
+  local.get $3
+  i32.store offset=12
+  local.get $3
+ )
+ (func $~lib/array/Array<i32>#set:length (; 53 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load offset=12
+  local.set $2
+  local.get $0
+  local.get $1
+  i32.const 2
+  call $~lib/array/ensureSize
+  local.get $0
+  local.get $1
+  i32.store offset=12
+ )
+ (func $~lib/map/Map<i8,i32>#values (; 54 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<i32>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 12
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $6
+     i32.load offset=4
+     call $~lib/array/Array<i32>#push
+     drop
+     local.get $4
+     i32.const 1
+     i32.add
+     local.set $4
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+  local.get $4
+  call $~lib/array/Array<i32>#set:length
+  local.get $3
+ )
+ (func $~lib/map/Map<i8,i8>#clear (; 55 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 32
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+ )
+ (func $~lib/map/Map<i8,i8>#constructor (; 56 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 24
+   i32.const 6
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+  local.get $0
+  call $~lib/map/Map<i8,i8>#clear
+  local.get $0
+ )
+ (func $~lib/map/Map<i32,i32>#clear (; 57 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 48
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+ )
+ (func $~lib/map/Map<i32,i32>#constructor (; 58 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 24
+   i32.const 7
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+  local.get $0
+  call $~lib/map/Map<i32,i32>#clear
+  local.get $0
+ )
+ (func $~lib/array/Array<i8>#get:length (; 59 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=12
+ )
+ (func $~lib/array/Array<i8>#__unchecked_get (; 60 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 0
+  i32.shl
+  i32.add
+  i32.load8_s
+ )
+ (func $~lib/array/Array<i8>#__get (; 61 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 512
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<i8>#__unchecked_get
+  local.set $2
+  local.get $2
+ )
+ (func $~lib/array/Array<i32>#__unchecked_get (; 62 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
+ )
+ (func $~lib/array/Array<i32>#__get (; 63 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 512
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<i32>#__unchecked_get
+  local.set $2
+  local.get $2
+ )
+ (func $~lib/map/Map<i8,i8>#find (; 64 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  local.get $0
+  i32.load
+  local.get $2
+  local.get $0
+  i32.load offset=4
+  i32.and
+  i32.const 4
+  i32.mul
+  i32.add
+  i32.load
+  local.set $3
+  block $break|0
+   loop $continue|0
+    local.get $3
+    i32.eqz
+    br_if $break|0
+    local.get $3
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if (result i32)
+     local.get $3
+     i32.load8_s
+     local.get $1
+     i32.const 24
+     i32.shl
+     i32.const 24
+     i32.shr_s
+     i32.eq
+    else
+     i32.const 0
+    end
+    if
+     local.get $3
+     return
+    end
+    local.get $3
+    i32.load offset=4
+    i32.const 1
+    i32.const -1
+    i32.xor
+    i32.and
+    local.set $3
+    br $continue|0
+   end
+   unreachable
+  end
+  i32.const 0
+ )
+ (func $~lib/map/Map<i8,i8>#rehash (; 65 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  i32.const 1
+  i32.add
+  local.set $2
+  i32.const 0
+  local.get $2
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $3
+  local.get $2
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
+  local.set $4
+  i32.const 0
+  local.get $4
+  i32.const 8
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $5
+  local.get $0
+  i32.load offset=8
+  local.set $6
+  local.get $6
+  local.get $0
+  i32.load offset=16
+  i32.const 8
+  i32.mul
+  i32.add
+  local.set $7
+  local.get $5
+  local.set $8
+  block $break|0
+   loop $continue|0
+    local.get $6
+    local.get $7
+    i32.ne
+    i32.eqz
+    br_if $break|0
+    local.get $6
+    local.set $9
+    local.get $9
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $8
+     local.set $10
+     local.get $10
+     local.get $9
+     i32.load8_s
+     i32.store8
+     local.get $10
+     local.get $9
+     i32.load8_s offset=1
+     i32.store8 offset=1
+     block $~lib/util/hash/HASH<i8>|inlined.5 (result i32)
+      local.get $9
+      i32.load8_s
+      local.set $11
+      local.get $11
+      call $~lib/util/hash/hash8
+      br $~lib/util/hash/HASH<i8>|inlined.5
+     end
+     local.get $1
+     i32.and
+     local.set $11
+     local.get $3
+     local.get $11
+     i32.const 4
+     i32.mul
+     i32.add
+     local.set $12
+     local.get $10
+     local.get $12
+     i32.load
+     i32.store offset=4
+     local.get $12
+     local.get $8
+     i32.store
+     local.get $8
+     i32.const 8
+     i32.add
+     local.set $8
+    end
+    local.get $6
+    i32.const 8
+    i32.add
+    local.set $6
+    br $continue|0
+   end
+   unreachable
+  end
+  local.get $0
+  local.tee $9
+  local.get $3
+  local.tee $10
+  local.get $9
+  i32.load
+  local.tee $12
+  i32.ne
+  if
+   local.get $10
+   call $~lib/rt/pure/__retain
+   local.set $10
+   local.get $12
+   call $~lib/rt/pure/__release
+  end
+  local.get $10
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $0
+  local.tee $9
+  local.get $5
+  local.tee $11
+  local.get $9
+  i32.load offset=8
+  local.tee $10
+  i32.ne
+  if
+   local.get $11
+   call $~lib/rt/pure/__retain
+   local.set $11
+   local.get $10
+   call $~lib/rt/pure/__release
+  end
+  local.get $11
+  i32.store offset=8
+  local.get $0
+  local.get $4
+  i32.store offset=12
+  local.get $0
+  local.get $0
+  i32.load offset=20
+  i32.store offset=16
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/map/Map<i8,i8>#set (; 66 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  block $~lib/util/hash/HASH<i8>|inlined.4 (result i32)
+   local.get $1
+   local.set $3
+   local.get $3
+   i32.const 24
+   i32.shl
+   i32.const 24
+   i32.shr_s
+   call $~lib/util/hash/hash8
+   br $~lib/util/hash/HASH<i8>|inlined.4
+  end
+  local.set $4
+  local.get $0
+  local.get $1
+  local.get $4
+  call $~lib/map/Map<i8,i8>#find
+  local.set $5
+  local.get $5
+  if
+   local.get $5
+   local.get $2
+   i32.store8 offset=1
+  else
+   local.get $0
+   i32.load offset=16
+   local.get $0
+   i32.load offset=12
+   i32.eq
+   if
+    local.get $0
+    local.get $0
+    i32.load offset=20
+    local.get $0
+    i32.load offset=12
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
+    i32.lt_s
+    if (result i32)
+     local.get $0
+     i32.load offset=4
+    else
+     local.get $0
+     i32.load offset=4
+     i32.const 1
+     i32.shl
+     i32.const 1
+     i32.or
+    end
+    call $~lib/map/Map<i8,i8>#rehash
+   end
+   local.get $0
+   i32.load offset=8
+   call $~lib/rt/pure/__retain
+   local.set $3
+   local.get $3
+   local.get $0
+   local.get $0
+   i32.load offset=16
+   local.tee $6
+   i32.const 1
+   i32.add
+   i32.store offset=16
+   local.get $6
+   i32.const 8
+   i32.mul
+   i32.add
+   local.set $5
+   local.get $5
+   local.get $1
+   i32.store8
+   local.get $5
+   local.get $2
+   i32.store8 offset=1
+   local.get $0
+   local.get $0
+   i32.load offset=20
+   i32.const 1
+   i32.add
+   i32.store offset=20
+   local.get $0
+   i32.load
+   local.get $4
+   local.get $0
+   i32.load offset=4
+   i32.and
+   i32.const 4
+   i32.mul
+   i32.add
+   local.set $6
+   local.get $5
+   local.get $6
+   i32.load
+   i32.store offset=4
+   local.get $6
+   local.get $5
+   i32.store
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+ )
+ (func $~lib/util/hash/hash32 (; 67 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  i32.const -2128831035
+  local.set $1
+  local.get $1
+  local.get $0
+  i32.const 255
+  i32.and
+  i32.xor
+  i32.const 16777619
+  i32.mul
+  local.set $1
+  local.get $1
+  local.get $0
+  i32.const 8
+  i32.shr_u
+  i32.const 255
+  i32.and
+  i32.xor
+  i32.const 16777619
+  i32.mul
+  local.set $1
+  local.get $1
+  local.get $0
+  i32.const 16
+  i32.shr_u
+  i32.const 255
+  i32.and
+  i32.xor
+  i32.const 16777619
+  i32.mul
+  local.set $1
+  local.get $1
+  local.get $0
+  i32.const 24
+  i32.shr_u
+  i32.xor
+  i32.const 16777619
+  i32.mul
+  local.set $1
+  local.get $1
+ )
+ (func $~lib/map/Map<i32,i32>#find (; 68 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  local.get $0
+  i32.load
+  local.get $2
+  local.get $0
+  i32.load offset=4
+  i32.and
+  i32.const 4
+  i32.mul
+  i32.add
+  i32.load
+  local.set $3
+  block $break|0
+   loop $continue|0
+    local.get $3
+    i32.eqz
+    br_if $break|0
+    local.get $3
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if (result i32)
+     local.get $3
+     i32.load
+     local.get $1
+     i32.eq
+    else
+     i32.const 0
+    end
+    if
+     local.get $3
+     return
+    end
+    local.get $3
+    i32.load offset=8
+    i32.const 1
+    i32.const -1
+    i32.xor
+    i32.and
+    local.set $3
+    br $continue|0
+   end
+   unreachable
+  end
+  i32.const 0
+ )
+ (func $~lib/map/Map<i32,i32>#rehash (; 69 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  i32.const 1
+  i32.add
+  local.set $2
+  i32.const 0
+  local.get $2
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $3
+  local.get $2
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
+  local.set $4
+  i32.const 0
+  local.get $4
+  i32.const 12
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $5
+  local.get $0
+  i32.load offset=8
+  local.set $6
+  local.get $6
+  local.get $0
+  i32.load offset=16
+  i32.const 12
+  i32.mul
+  i32.add
+  local.set $7
+  local.get $5
+  local.set $8
+  block $break|0
+   loop $continue|0
+    local.get $6
+    local.get $7
+    i32.ne
+    i32.eqz
+    br_if $break|0
+    local.get $6
+    local.set $9
+    local.get $9
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $8
+     local.set $10
+     local.get $10
+     local.get $9
+     i32.load
+     i32.store
+     local.get $10
+     local.get $9
+     i32.load offset=4
+     i32.store offset=4
+     block $~lib/util/hash/HASH<i32>|inlined.1 (result i32)
+      local.get $9
+      i32.load
+      local.set $11
+      local.get $11
+      call $~lib/util/hash/hash32
+      br $~lib/util/hash/HASH<i32>|inlined.1
+     end
+     local.get $1
+     i32.and
+     local.set $11
+     local.get $3
+     local.get $11
+     i32.const 4
+     i32.mul
+     i32.add
+     local.set $12
+     local.get $10
+     local.get $12
+     i32.load
+     i32.store offset=8
+     local.get $12
+     local.get $8
+     i32.store
+     local.get $8
+     i32.const 12
+     i32.add
+     local.set $8
+    end
+    local.get $6
+    i32.const 12
+    i32.add
+    local.set $6
+    br $continue|0
+   end
+   unreachable
+  end
+  local.get $0
+  local.tee $9
+  local.get $3
+  local.tee $10
+  local.get $9
+  i32.load
+  local.tee $12
+  i32.ne
+  if
+   local.get $10
+   call $~lib/rt/pure/__retain
+   local.set $10
+   local.get $12
+   call $~lib/rt/pure/__release
+  end
+  local.get $10
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $0
+  local.tee $9
+  local.get $5
+  local.tee $11
+  local.get $9
+  i32.load offset=8
+  local.tee $10
+  i32.ne
+  if
+   local.get $11
+   call $~lib/rt/pure/__retain
+   local.set $11
+   local.get $10
+   call $~lib/rt/pure/__release
+  end
+  local.get $11
+  i32.store offset=8
+  local.get $0
+  local.get $4
+  i32.store offset=12
+  local.get $0
+  local.get $0
+  i32.load offset=20
+  i32.store offset=16
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/map/Map<i32,i32>#set (; 70 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  block $~lib/util/hash/HASH<i32>|inlined.0 (result i32)
+   local.get $1
+   local.set $3
+   local.get $3
+   call $~lib/util/hash/hash32
+   br $~lib/util/hash/HASH<i32>|inlined.0
+  end
+  local.set $4
+  local.get $0
+  local.get $1
+  local.get $4
+  call $~lib/map/Map<i32,i32>#find
+  local.set $5
+  local.get $5
+  if
+   local.get $5
+   local.get $2
+   i32.store offset=4
+  else
+   local.get $0
+   i32.load offset=16
+   local.get $0
+   i32.load offset=12
+   i32.eq
+   if
+    local.get $0
+    local.get $0
+    i32.load offset=20
+    local.get $0
+    i32.load offset=12
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
+    i32.lt_s
+    if (result i32)
+     local.get $0
+     i32.load offset=4
+    else
+     local.get $0
+     i32.load offset=4
+     i32.const 1
+     i32.shl
+     i32.const 1
+     i32.or
+    end
+    call $~lib/map/Map<i32,i32>#rehash
+   end
+   local.get $0
+   i32.load offset=8
+   call $~lib/rt/pure/__retain
+   local.set $3
+   local.get $3
+   local.get $0
+   local.get $0
+   i32.load offset=16
+   local.tee $6
+   i32.const 1
+   i32.add
+   i32.store offset=16
+   local.get $6
+   i32.const 12
+   i32.mul
+   i32.add
+   local.set $5
+   local.get $5
+   local.get $1
+   i32.store
+   local.get $5
+   local.get $2
+   i32.store offset=4
+   local.get $0
+   local.get $0
+   i32.load offset=20
+   i32.const 1
+   i32.add
+   i32.store offset=20
+   local.get $0
+   i32.load
+   local.get $4
+   local.get $0
+   i32.load offset=4
+   i32.and
+   i32.const 4
+   i32.mul
+   i32.add
+   local.set $6
+   local.get $5
+   local.get $6
+   i32.load
+   i32.store offset=8
+   local.get $6
+   local.get $5
+   i32.store
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+ )
+ (func $~lib/map/Map<i8,i8>#get:size (; 71 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=20
+ )
+ (func $~lib/map/Map<i32,i32>#get:size (; 72 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=20
+ )
+ (func $~lib/map/Map<i8,i32>#delete (; 73 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   local.get $0
   local.get $1
-  block $~lib/util/hash/HASH<i8>|inlined.4 (result i32)
+  block $~lib/util/hash/HASH<i8>|inlined.6 (result i32)
    local.get $1
    local.set $2
    local.get $2
@@ -4031,7 +5501,7 @@
    i32.const 24
    i32.shr_s
    call $~lib/util/hash/hash8
-   br $~lib/util/hash/HASH<i8>|inlined.4
+   br $~lib/util/hash/HASH<i8>|inlined.6
   end
   call $~lib/map/Map<i8,i32>#find
   local.set $3
@@ -4091,9 +5561,15 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<i8,i32> (; 43 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<i8,i32> (; 74 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   i32.const 0
   call $~lib/map/Map<i8,i32>#constructor
   local.set $0
@@ -4286,32 +5762,134 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
+  call $~lib/map/Map<i8,i32>#keys
+  local.set $1
+  local.get $0
+  call $~lib/map/Map<i8,i32>#values
+  local.set $2
+  i32.const 0
+  call $~lib/map/Map<i8,i8>#constructor
+  local.set $3
+  i32.const 0
+  call $~lib/map/Map<i32,i32>#constructor
+  local.set $4
   block $break|2
    i32.const 0
-   local.set $1
+   local.set $5
    loop $loop|2
+    local.get $5
     local.get $1
-    i32.const 50
+    call $~lib/array/Array<i8>#get:length
     i32.lt_s
     i32.eqz
     br_if $break|2
-    local.get $0
     local.get $1
+    local.get $5
+    call $~lib/array/Array<i8>#__get
+    local.set $6
+    local.get $2
+    local.get $5
+    call $~lib/array/Array<i32>#__get
+    local.set $7
+    local.get $0
+    local.get $6
     call $~lib/map/Map<i8,i32>#has
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 25
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $0
-    local.get $1
+    local.get $7
+    i32.const 20
+    i32.sub
+    call $~lib/map/Map<i8,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 32
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $3
+    local.get $6
+    local.get $6
+    call $~lib/map/Map<i8,i8>#set
+    local.get $4
+    local.get $7
+    i32.const 20
+    i32.sub
+    local.get $7
+    i32.const 20
+    i32.sub
+    call $~lib/map/Map<i32,i32>#set
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|2
+   end
+   unreachable
+  end
+  local.get $3
+  call $~lib/map/Map<i8,i8>#get:size
+  i32.const 100
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 36
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $4
+  call $~lib/map/Map<i32,i32>#get:size
+  i32.const 100
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 37
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $break|3
+   i32.const 0
+   local.set $5
+   loop $loop|3
+    local.get $5
+    i32.const 50
+    i32.lt_s
+    i32.eqz
+    br_if $break|3
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<i8,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 41
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $5
     call $~lib/map/Map<i8,i32>#get
     i32.const 20
-    local.get $1
+    local.get $5
     i32.const 24
     i32.shl
     i32.const 24
@@ -4322,114 +5900,32 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 26
+     i32.const 42
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $0
-    local.get $1
+    local.get $5
     call $~lib/map/Map<i8,i32>#delete
     drop
     local.get $0
-    local.get $1
+    local.get $5
     call $~lib/map/Map<i8,i32>#has
     i32.eqz
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 28
+     i32.const 44
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $5
     i32.const 1
     i32.add
-    local.set $1
-    br $loop|2
-   end
-   unreachable
-  end
-  local.get $0
-  call $~lib/map/Map<i8,i32>#get:size
-  i32.const 50
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 376
-   i32.const 30
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  block $break|3
-   i32.const 0
-   local.set $1
-   loop $loop|3
-    local.get $1
-    i32.const 50
-    i32.lt_s
-    i32.eqz
-    br_if $break|3
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<i8,i32>#has
-    i32.eqz
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 34
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    i32.const 10
-    local.get $1
-    i32.const 24
-    i32.shl
-    i32.const 24
-    i32.shr_s
-    i32.add
-    call $~lib/map/Map<i8,i32>#set
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<i8,i32>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 36
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<i8,i32>#delete
-    drop
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<i8,i32>#has
-    i32.eqz
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 38
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    i32.const 1
-    i32.add
-    local.set $1
+    local.set $5
     br $loop|3
    end
    unreachable
@@ -4442,7 +5938,89 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 46
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $break|4
+   i32.const 0
+   local.set $5
+   loop $loop|4
+    local.get $5
+    i32.const 50
+    i32.lt_s
+    i32.eqz
+    br_if $break|4
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<i8,i32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 50
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $5
+    i32.const 10
+    local.get $5
+    i32.const 24
+    i32.shl
+    i32.const 24
+    i32.shr_s
+    i32.add
+    call $~lib/map/Map<i8,i32>#set
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<i8,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 52
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<i8,i32>#delete
+    drop
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<i8,i32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 54
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|4
+   end
+   unreachable
+  end
+  local.get $0
+  call $~lib/map/Map<i8,i32>#get:size
+  i32.const 50
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 56
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -4457,15 +6035,23 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 44
+   i32.const 60
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u8,i32>#clear (; 44 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<u8,i32>#clear (; 75 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -4505,12 +6091,12 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u8,i32>#constructor (; 45 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#constructor (; 76 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
    i32.const 24
-   i32.const 4
+   i32.const 8
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
    local.set $0
@@ -4537,7 +6123,7 @@
   call $~lib/map/Map<u8,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u8,i32>#find (; 46 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#find (; 77 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -4587,7 +6173,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u8,i32>#has (; 47 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#has (; 78 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -4604,7 +6190,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u8,i32>#rehash (; 48 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,i32>#rehash (; 79 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4761,7 +6347,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u8,i32>#set (; 49 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<u8,i32>#set (; 80 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4866,7 +6452,7 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/map/Map<u8,i32>#get (; 50 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#get (; 81 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -4895,25 +6481,651 @@
   local.get $3
   i32.load offset=4
  )
- (func $~lib/map/Map<u8,i32>#get:size (; 51 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u8,i32>#get:size (; 82 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<u8,i32>#delete (; 52 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#constructor (; 83 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  if (result i32)
+   local.get $0
+  else
+   i32.const 16
+   i32.const 9
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+  end
+  local.get $1
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  local.get $1
+  i32.store offset=12
+  local.get $0
+ )
+ (func $~lib/array/Array<u8>#__unchecked_set (; 84 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 0
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store8
+ )
+ (func $~lib/array/Array<u8>#__set (; 85 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 512
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.const 0
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.store offset=12
+  end
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/array/Array<u8>#__unchecked_set
+ )
+ (func $~lib/array/Array<u8>#set:length (; 86 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load offset=12
+  local.set $2
+  local.get $0
+  local.get $1
+  i32.const 0
+  call $~lib/array/ensureSize
+  local.get $0
+  local.get $1
+  i32.store offset=12
+ )
+ (func $~lib/map/Map<u8,i32>#keys (; 87 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<u8>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 12
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $4
+     local.get $6
+     i32.load8_u
+     call $~lib/array/Array<u8>#__set
+     local.get $4
+     i32.const 1
+     i32.add
+     local.set $4
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+  local.get $4
+  call $~lib/array/Array<u8>#set:length
+  local.get $3
+ )
+ (func $~lib/map/Map<u8,i32>#values (; 88 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<i32>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 12
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $6
+     i32.load offset=4
+     call $~lib/array/Array<i32>#push
+     drop
+     local.get $4
+     i32.const 1
+     i32.add
+     local.set $4
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+  local.get $4
+  call $~lib/array/Array<i32>#set:length
+  local.get $3
+ )
+ (func $~lib/map/Map<u8,u8>#clear (; 89 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 32
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+ )
+ (func $~lib/map/Map<u8,u8>#constructor (; 90 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 24
+   i32.const 10
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+  local.get $0
+  call $~lib/map/Map<u8,u8>#clear
+  local.get $0
+ )
+ (func $~lib/array/Array<u8>#get:length (; 91 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=12
+ )
+ (func $~lib/array/Array<u8>#__unchecked_get (; 92 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 0
+  i32.shl
+  i32.add
+  i32.load8_u
+ )
+ (func $~lib/array/Array<u8>#__get (; 93 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 512
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<u8>#__unchecked_get
+  local.set $2
+  local.get $2
+ )
+ (func $~lib/map/Map<u8,u8>#find (; 94 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  local.get $0
+  i32.load
+  local.get $2
+  local.get $0
+  i32.load offset=4
+  i32.and
+  i32.const 4
+  i32.mul
+  i32.add
+  i32.load
+  local.set $3
+  block $break|0
+   loop $continue|0
+    local.get $3
+    i32.eqz
+    br_if $break|0
+    local.get $3
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if (result i32)
+     local.get $3
+     i32.load8_u
+     local.get $1
+     i32.const 255
+     i32.and
+     i32.eq
+    else
+     i32.const 0
+    end
+    if
+     local.get $3
+     return
+    end
+    local.get $3
+    i32.load offset=4
+    i32.const 1
+    i32.const -1
+    i32.xor
+    i32.and
+    local.set $3
+    br $continue|0
+   end
+   unreachable
+  end
+  i32.const 0
+ )
+ (func $~lib/map/Map<u8,u8>#rehash (; 95 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  i32.const 1
+  i32.add
+  local.set $2
+  i32.const 0
+  local.get $2
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $3
+  local.get $2
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
+  local.set $4
+  i32.const 0
+  local.get $4
+  i32.const 8
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $5
+  local.get $0
+  i32.load offset=8
+  local.set $6
+  local.get $6
+  local.get $0
+  i32.load offset=16
+  i32.const 8
+  i32.mul
+  i32.add
+  local.set $7
+  local.get $5
+  local.set $8
+  block $break|0
+   loop $continue|0
+    local.get $6
+    local.get $7
+    i32.ne
+    i32.eqz
+    br_if $break|0
+    local.get $6
+    local.set $9
+    local.get $9
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $8
+     local.set $10
+     local.get $10
+     local.get $9
+     i32.load8_u
+     i32.store8
+     local.get $10
+     local.get $9
+     i32.load8_u offset=1
+     i32.store8 offset=1
+     block $~lib/util/hash/HASH<u8>|inlined.5 (result i32)
+      local.get $9
+      i32.load8_u
+      local.set $11
+      local.get $11
+      call $~lib/util/hash/hash8
+      br $~lib/util/hash/HASH<u8>|inlined.5
+     end
+     local.get $1
+     i32.and
+     local.set $11
+     local.get $3
+     local.get $11
+     i32.const 4
+     i32.mul
+     i32.add
+     local.set $12
+     local.get $10
+     local.get $12
+     i32.load
+     i32.store offset=4
+     local.get $12
+     local.get $8
+     i32.store
+     local.get $8
+     i32.const 8
+     i32.add
+     local.set $8
+    end
+    local.get $6
+    i32.const 8
+    i32.add
+    local.set $6
+    br $continue|0
+   end
+   unreachable
+  end
+  local.get $0
+  local.tee $9
+  local.get $3
+  local.tee $10
+  local.get $9
+  i32.load
+  local.tee $12
+  i32.ne
+  if
+   local.get $10
+   call $~lib/rt/pure/__retain
+   local.set $10
+   local.get $12
+   call $~lib/rt/pure/__release
+  end
+  local.get $10
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $0
+  local.tee $9
+  local.get $5
+  local.tee $11
+  local.get $9
+  i32.load offset=8
+  local.tee $10
+  i32.ne
+  if
+   local.get $11
+   call $~lib/rt/pure/__retain
+   local.set $11
+   local.get $10
+   call $~lib/rt/pure/__release
+  end
+  local.get $11
+  i32.store offset=8
+  local.get $0
+  local.get $4
+  i32.store offset=12
+  local.get $0
+  local.get $0
+  i32.load offset=20
+  i32.store offset=16
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/map/Map<u8,u8>#set (; 96 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  block $~lib/util/hash/HASH<u8>|inlined.4 (result i32)
+   local.get $1
+   local.set $3
+   local.get $3
+   i32.const 255
+   i32.and
+   call $~lib/util/hash/hash8
+   br $~lib/util/hash/HASH<u8>|inlined.4
+  end
+  local.set $4
+  local.get $0
+  local.get $1
+  local.get $4
+  call $~lib/map/Map<u8,u8>#find
+  local.set $5
+  local.get $5
+  if
+   local.get $5
+   local.get $2
+   i32.store8 offset=1
+  else
+   local.get $0
+   i32.load offset=16
+   local.get $0
+   i32.load offset=12
+   i32.eq
+   if
+    local.get $0
+    local.get $0
+    i32.load offset=20
+    local.get $0
+    i32.load offset=12
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
+    i32.lt_s
+    if (result i32)
+     local.get $0
+     i32.load offset=4
+    else
+     local.get $0
+     i32.load offset=4
+     i32.const 1
+     i32.shl
+     i32.const 1
+     i32.or
+    end
+    call $~lib/map/Map<u8,u8>#rehash
+   end
+   local.get $0
+   i32.load offset=8
+   call $~lib/rt/pure/__retain
+   local.set $3
+   local.get $3
+   local.get $0
+   local.get $0
+   i32.load offset=16
+   local.tee $6
+   i32.const 1
+   i32.add
+   i32.store offset=16
+   local.get $6
+   i32.const 8
+   i32.mul
+   i32.add
+   local.set $5
+   local.get $5
+   local.get $1
+   i32.store8
+   local.get $5
+   local.get $2
+   i32.store8 offset=1
+   local.get $0
+   local.get $0
+   i32.load offset=20
+   i32.const 1
+   i32.add
+   i32.store offset=20
+   local.get $0
+   i32.load
+   local.get $4
+   local.get $0
+   i32.load offset=4
+   i32.and
+   i32.const 4
+   i32.mul
+   i32.add
+   local.set $6
+   local.get $5
+   local.get $6
+   i32.load
+   i32.store offset=4
+   local.get $6
+   local.get $5
+   i32.store
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+ )
+ (func $~lib/map/Map<u8,u8>#get:size (; 97 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=20
+ )
+ (func $~lib/map/Map<u8,i32>#delete (; 98 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   local.get $0
   local.get $1
-  block $~lib/util/hash/HASH<u8>|inlined.4 (result i32)
+  block $~lib/util/hash/HASH<u8>|inlined.6 (result i32)
    local.get $1
    local.set $2
    local.get $2
    i32.const 255
    i32.and
    call $~lib/util/hash/hash8
-   br $~lib/util/hash/HASH<u8>|inlined.4
+   br $~lib/util/hash/HASH<u8>|inlined.6
   end
   call $~lib/map/Map<u8,i32>#find
   local.set $3
@@ -4973,9 +7185,15 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<u8,i32> (; 53 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<u8,i32> (; 99 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   i32.const 0
   call $~lib/map/Map<u8,i32>#constructor
   local.set $0
@@ -5158,32 +7376,134 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
+  call $~lib/map/Map<u8,i32>#keys
+  local.set $1
+  local.get $0
+  call $~lib/map/Map<u8,i32>#values
+  local.set $2
+  i32.const 0
+  call $~lib/map/Map<u8,u8>#constructor
+  local.set $3
+  i32.const 0
+  call $~lib/map/Map<i32,i32>#constructor
+  local.set $4
   block $break|2
    i32.const 0
-   local.set $1
+   local.set $5
    loop $loop|2
+    local.get $5
     local.get $1
-    i32.const 50
-    i32.lt_u
+    call $~lib/array/Array<u8>#get:length
+    i32.lt_s
     i32.eqz
     br_if $break|2
-    local.get $0
     local.get $1
+    local.get $5
+    call $~lib/array/Array<u8>#__get
+    local.set $6
+    local.get $2
+    local.get $5
+    call $~lib/array/Array<i32>#__get
+    local.set $7
+    local.get $0
+    local.get $6
     call $~lib/map/Map<u8,i32>#has
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 25
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $0
-    local.get $1
+    local.get $7
+    i32.const 20
+    i32.sub
+    call $~lib/map/Map<u8,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 32
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $3
+    local.get $6
+    local.get $6
+    call $~lib/map/Map<u8,u8>#set
+    local.get $4
+    local.get $7
+    i32.const 20
+    i32.sub
+    local.get $7
+    i32.const 20
+    i32.sub
+    call $~lib/map/Map<i32,i32>#set
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|2
+   end
+   unreachable
+  end
+  local.get $3
+  call $~lib/map/Map<u8,u8>#get:size
+  i32.const 100
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 36
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $4
+  call $~lib/map/Map<i32,i32>#get:size
+  i32.const 100
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 37
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $break|3
+   i32.const 0
+   local.set $5
+   loop $loop|3
+    local.get $5
+    i32.const 50
+    i32.lt_u
+    i32.eqz
+    br_if $break|3
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<u8,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 41
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $5
     call $~lib/map/Map<u8,i32>#get
     i32.const 20
-    local.get $1
+    local.get $5
     i32.const 255
     i32.and
     i32.add
@@ -5192,112 +7512,32 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 26
+     i32.const 42
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $0
-    local.get $1
+    local.get $5
     call $~lib/map/Map<u8,i32>#delete
     drop
     local.get $0
-    local.get $1
+    local.get $5
     call $~lib/map/Map<u8,i32>#has
     i32.eqz
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 28
+     i32.const 44
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $5
     i32.const 1
     i32.add
-    local.set $1
-    br $loop|2
-   end
-   unreachable
-  end
-  local.get $0
-  call $~lib/map/Map<u8,i32>#get:size
-  i32.const 50
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 376
-   i32.const 30
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  block $break|3
-   i32.const 0
-   local.set $1
-   loop $loop|3
-    local.get $1
-    i32.const 50
-    i32.lt_u
-    i32.eqz
-    br_if $break|3
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<u8,i32>#has
-    i32.eqz
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 34
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    i32.const 10
-    local.get $1
-    i32.const 255
-    i32.and
-    i32.add
-    call $~lib/map/Map<u8,i32>#set
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<u8,i32>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 36
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<u8,i32>#delete
-    drop
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<u8,i32>#has
-    i32.eqz
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 38
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    i32.const 1
-    i32.add
-    local.set $1
+    local.set $5
     br $loop|3
    end
    unreachable
@@ -5310,7 +7550,87 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 46
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $break|4
+   i32.const 0
+   local.set $5
+   loop $loop|4
+    local.get $5
+    i32.const 50
+    i32.lt_u
+    i32.eqz
+    br_if $break|4
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<u8,i32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 50
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $5
+    i32.const 10
+    local.get $5
+    i32.const 255
+    i32.and
+    i32.add
+    call $~lib/map/Map<u8,i32>#set
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<u8,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 52
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<u8,i32>#delete
+    drop
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<u8,i32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 54
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|4
+   end
+   unreachable
+  end
+  local.get $0
+  call $~lib/map/Map<u8,i32>#get:size
+  i32.const 50
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 56
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -5325,15 +7645,23 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 44
+   i32.const 60
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i16,i32>#clear (; 54 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<i16,i32>#clear (; 100 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -5373,12 +7701,12 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i16,i32>#constructor (; 55 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#constructor (; 101 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
    i32.const 24
-   i32.const 5
+   i32.const 11
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
    local.set $0
@@ -5405,7 +7733,7 @@
   call $~lib/map/Map<i16,i32>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash16 (; 56 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash16 (; 102 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   i32.const -2128831035
   local.set $1
@@ -5427,7 +7755,7 @@
   local.set $1
   local.get $1
  )
- (func $~lib/map/Map<i16,i32>#find (; 57 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#find (; 103 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -5479,7 +7807,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i16,i32>#has (; 58 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#has (; 104 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -5498,7 +7826,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i16,i32>#rehash (; 59 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i16,i32>#rehash (; 105 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5655,7 +7983,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i16,i32>#set (; 60 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<i16,i32>#set (; 106 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -5762,7 +8090,7 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/map/Map<i16,i32>#get (; 61 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#get (; 107 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -5793,18 +8121,648 @@
   local.get $3
   i32.load offset=4
  )
- (func $~lib/map/Map<i16,i32>#get:size (; 62 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i16,i32>#get:size (; 108 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<i16,i32>#delete (; 63 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#constructor (; 109 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  if (result i32)
+   local.get $0
+  else
+   i32.const 16
+   i32.const 12
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+  end
+  local.get $1
+  i32.const 1
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  local.get $1
+  i32.store offset=12
+  local.get $0
+ )
+ (func $~lib/array/Array<i16>#__unchecked_set (; 110 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 1
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store16
+ )
+ (func $~lib/array/Array<i16>#__set (; 111 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 512
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.const 1
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.store offset=12
+  end
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/array/Array<i16>#__unchecked_set
+ )
+ (func $~lib/array/Array<i16>#set:length (; 112 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load offset=12
+  local.set $2
+  local.get $0
+  local.get $1
+  i32.const 1
+  call $~lib/array/ensureSize
+  local.get $0
+  local.get $1
+  i32.store offset=12
+ )
+ (func $~lib/map/Map<i16,i32>#keys (; 113 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<i16>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 12
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $4
+     local.get $6
+     i32.load16_s
+     call $~lib/array/Array<i16>#__set
+     local.get $4
+     i32.const 1
+     i32.add
+     local.set $4
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+  local.get $4
+  call $~lib/array/Array<i16>#set:length
+  local.get $3
+ )
+ (func $~lib/map/Map<i16,i32>#values (; 114 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<i32>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 12
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $6
+     i32.load offset=4
+     call $~lib/array/Array<i32>#push
+     drop
+     local.get $4
+     i32.const 1
+     i32.add
+     local.set $4
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+  local.get $4
+  call $~lib/array/Array<i32>#set:length
+  local.get $3
+ )
+ (func $~lib/map/Map<i16,i16>#clear (; 115 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 32
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+ )
+ (func $~lib/map/Map<i16,i16>#constructor (; 116 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 24
+   i32.const 13
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+  local.get $0
+  call $~lib/map/Map<i16,i16>#clear
+  local.get $0
+ )
+ (func $~lib/array/Array<i16>#get:length (; 117 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=12
+ )
+ (func $~lib/array/Array<i16>#__unchecked_get (; 118 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 1
+  i32.shl
+  i32.add
+  i32.load16_s
+ )
+ (func $~lib/array/Array<i16>#__get (; 119 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 512
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<i16>#__unchecked_get
+  local.set $2
+  local.get $2
+ )
+ (func $~lib/map/Map<i16,i16>#find (; 120 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  local.get $0
+  i32.load
+  local.get $2
+  local.get $0
+  i32.load offset=4
+  i32.and
+  i32.const 4
+  i32.mul
+  i32.add
+  i32.load
+  local.set $3
+  block $break|0
+   loop $continue|0
+    local.get $3
+    i32.eqz
+    br_if $break|0
+    local.get $3
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if (result i32)
+     local.get $3
+     i32.load16_s
+     local.get $1
+     i32.const 16
+     i32.shl
+     i32.const 16
+     i32.shr_s
+     i32.eq
+    else
+     i32.const 0
+    end
+    if
+     local.get $3
+     return
+    end
+    local.get $3
+    i32.load offset=4
+    i32.const 1
+    i32.const -1
+    i32.xor
+    i32.and
+    local.set $3
+    br $continue|0
+   end
+   unreachable
+  end
+  i32.const 0
+ )
+ (func $~lib/map/Map<i16,i16>#rehash (; 121 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  i32.const 1
+  i32.add
+  local.set $2
+  i32.const 0
+  local.get $2
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $3
+  local.get $2
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
+  local.set $4
+  i32.const 0
+  local.get $4
+  i32.const 8
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $5
+  local.get $0
+  i32.load offset=8
+  local.set $6
+  local.get $6
+  local.get $0
+  i32.load offset=16
+  i32.const 8
+  i32.mul
+  i32.add
+  local.set $7
+  local.get $5
+  local.set $8
+  block $break|0
+   loop $continue|0
+    local.get $6
+    local.get $7
+    i32.ne
+    i32.eqz
+    br_if $break|0
+    local.get $6
+    local.set $9
+    local.get $9
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $8
+     local.set $10
+     local.get $10
+     local.get $9
+     i32.load16_s
+     i32.store16
+     local.get $10
+     local.get $9
+     i32.load16_s offset=2
+     i32.store16 offset=2
+     block $~lib/util/hash/HASH<i16>|inlined.5 (result i32)
+      local.get $9
+      i32.load16_s
+      local.set $11
+      local.get $11
+      call $~lib/util/hash/hash16
+      br $~lib/util/hash/HASH<i16>|inlined.5
+     end
+     local.get $1
+     i32.and
+     local.set $11
+     local.get $3
+     local.get $11
+     i32.const 4
+     i32.mul
+     i32.add
+     local.set $12
+     local.get $10
+     local.get $12
+     i32.load
+     i32.store offset=4
+     local.get $12
+     local.get $8
+     i32.store
+     local.get $8
+     i32.const 8
+     i32.add
+     local.set $8
+    end
+    local.get $6
+    i32.const 8
+    i32.add
+    local.set $6
+    br $continue|0
+   end
+   unreachable
+  end
+  local.get $0
+  local.tee $9
+  local.get $3
+  local.tee $10
+  local.get $9
+  i32.load
+  local.tee $12
+  i32.ne
+  if
+   local.get $10
+   call $~lib/rt/pure/__retain
+   local.set $10
+   local.get $12
+   call $~lib/rt/pure/__release
+  end
+  local.get $10
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $0
+  local.tee $9
+  local.get $5
+  local.tee $11
+  local.get $9
+  i32.load offset=8
+  local.tee $10
+  i32.ne
+  if
+   local.get $11
+   call $~lib/rt/pure/__retain
+   local.set $11
+   local.get $10
+   call $~lib/rt/pure/__release
+  end
+  local.get $11
+  i32.store offset=8
+  local.get $0
+  local.get $4
+  i32.store offset=12
+  local.get $0
+  local.get $0
+  i32.load offset=20
+  i32.store offset=16
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/map/Map<i16,i16>#set (; 122 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  block $~lib/util/hash/HASH<i16>|inlined.4 (result i32)
+   local.get $1
+   local.set $3
+   local.get $3
+   i32.const 16
+   i32.shl
+   i32.const 16
+   i32.shr_s
+   call $~lib/util/hash/hash16
+   br $~lib/util/hash/HASH<i16>|inlined.4
+  end
+  local.set $4
+  local.get $0
+  local.get $1
+  local.get $4
+  call $~lib/map/Map<i16,i16>#find
+  local.set $5
+  local.get $5
+  if
+   local.get $5
+   local.get $2
+   i32.store16 offset=2
+  else
+   local.get $0
+   i32.load offset=16
+   local.get $0
+   i32.load offset=12
+   i32.eq
+   if
+    local.get $0
+    local.get $0
+    i32.load offset=20
+    local.get $0
+    i32.load offset=12
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
+    i32.lt_s
+    if (result i32)
+     local.get $0
+     i32.load offset=4
+    else
+     local.get $0
+     i32.load offset=4
+     i32.const 1
+     i32.shl
+     i32.const 1
+     i32.or
+    end
+    call $~lib/map/Map<i16,i16>#rehash
+   end
+   local.get $0
+   i32.load offset=8
+   call $~lib/rt/pure/__retain
+   local.set $3
+   local.get $3
+   local.get $0
+   local.get $0
+   i32.load offset=16
+   local.tee $6
+   i32.const 1
+   i32.add
+   i32.store offset=16
+   local.get $6
+   i32.const 8
+   i32.mul
+   i32.add
+   local.set $5
+   local.get $5
+   local.get $1
+   i32.store16
+   local.get $5
+   local.get $2
+   i32.store16 offset=2
+   local.get $0
+   local.get $0
+   i32.load offset=20
+   i32.const 1
+   i32.add
+   i32.store offset=20
+   local.get $0
+   i32.load
+   local.get $4
+   local.get $0
+   i32.load offset=4
+   i32.and
+   i32.const 4
+   i32.mul
+   i32.add
+   local.set $6
+   local.get $5
+   local.get $6
+   i32.load
+   i32.store offset=4
+   local.get $6
+   local.get $5
+   i32.store
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+ )
+ (func $~lib/map/Map<i16,i16>#get:size (; 123 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=20
+ )
+ (func $~lib/map/Map<i16,i32>#delete (; 124 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   local.get $0
   local.get $1
-  block $~lib/util/hash/HASH<i16>|inlined.4 (result i32)
+  block $~lib/util/hash/HASH<i16>|inlined.6 (result i32)
    local.get $1
    local.set $2
    local.get $2
@@ -5813,7 +8771,7 @@
    i32.const 16
    i32.shr_s
    call $~lib/util/hash/hash16
-   br $~lib/util/hash/HASH<i16>|inlined.4
+   br $~lib/util/hash/HASH<i16>|inlined.6
   end
   call $~lib/map/Map<i16,i32>#find
   local.set $3
@@ -5873,9 +8831,15 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<i16,i32> (; 64 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<i16,i32> (; 125 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   i32.const 0
   call $~lib/map/Map<i16,i32>#constructor
   local.set $0
@@ -6068,32 +9032,134 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
+  call $~lib/map/Map<i16,i32>#keys
+  local.set $1
+  local.get $0
+  call $~lib/map/Map<i16,i32>#values
+  local.set $2
+  i32.const 0
+  call $~lib/map/Map<i16,i16>#constructor
+  local.set $3
+  i32.const 0
+  call $~lib/map/Map<i32,i32>#constructor
+  local.set $4
   block $break|2
    i32.const 0
-   local.set $1
+   local.set $5
    loop $loop|2
+    local.get $5
     local.get $1
-    i32.const 50
+    call $~lib/array/Array<i16>#get:length
     i32.lt_s
     i32.eqz
     br_if $break|2
-    local.get $0
     local.get $1
+    local.get $5
+    call $~lib/array/Array<i16>#__get
+    local.set $6
+    local.get $2
+    local.get $5
+    call $~lib/array/Array<i32>#__get
+    local.set $7
+    local.get $0
+    local.get $6
     call $~lib/map/Map<i16,i32>#has
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 25
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $0
-    local.get $1
+    local.get $7
+    i32.const 20
+    i32.sub
+    call $~lib/map/Map<i16,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 32
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $3
+    local.get $6
+    local.get $6
+    call $~lib/map/Map<i16,i16>#set
+    local.get $4
+    local.get $7
+    i32.const 20
+    i32.sub
+    local.get $7
+    i32.const 20
+    i32.sub
+    call $~lib/map/Map<i32,i32>#set
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|2
+   end
+   unreachable
+  end
+  local.get $3
+  call $~lib/map/Map<i16,i16>#get:size
+  i32.const 100
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 36
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $4
+  call $~lib/map/Map<i32,i32>#get:size
+  i32.const 100
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 37
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $break|3
+   i32.const 0
+   local.set $5
+   loop $loop|3
+    local.get $5
+    i32.const 50
+    i32.lt_s
+    i32.eqz
+    br_if $break|3
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<i16,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 41
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $5
     call $~lib/map/Map<i16,i32>#get
     i32.const 20
-    local.get $1
+    local.get $5
     i32.const 16
     i32.shl
     i32.const 16
@@ -6104,114 +9170,32 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 26
+     i32.const 42
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $0
-    local.get $1
+    local.get $5
     call $~lib/map/Map<i16,i32>#delete
     drop
     local.get $0
-    local.get $1
+    local.get $5
     call $~lib/map/Map<i16,i32>#has
     i32.eqz
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 28
+     i32.const 44
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $5
     i32.const 1
     i32.add
-    local.set $1
-    br $loop|2
-   end
-   unreachable
-  end
-  local.get $0
-  call $~lib/map/Map<i16,i32>#get:size
-  i32.const 50
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 376
-   i32.const 30
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  block $break|3
-   i32.const 0
-   local.set $1
-   loop $loop|3
-    local.get $1
-    i32.const 50
-    i32.lt_s
-    i32.eqz
-    br_if $break|3
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<i16,i32>#has
-    i32.eqz
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 34
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    i32.const 10
-    local.get $1
-    i32.const 16
-    i32.shl
-    i32.const 16
-    i32.shr_s
-    i32.add
-    call $~lib/map/Map<i16,i32>#set
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<i16,i32>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 36
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<i16,i32>#delete
-    drop
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<i16,i32>#has
-    i32.eqz
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 38
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    i32.const 1
-    i32.add
-    local.set $1
+    local.set $5
     br $loop|3
    end
    unreachable
@@ -6224,7 +9208,89 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 46
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $break|4
+   i32.const 0
+   local.set $5
+   loop $loop|4
+    local.get $5
+    i32.const 50
+    i32.lt_s
+    i32.eqz
+    br_if $break|4
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<i16,i32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 50
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $5
+    i32.const 10
+    local.get $5
+    i32.const 16
+    i32.shl
+    i32.const 16
+    i32.shr_s
+    i32.add
+    call $~lib/map/Map<i16,i32>#set
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<i16,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 52
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<i16,i32>#delete
+    drop
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<i16,i32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 54
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|4
+   end
+   unreachable
+  end
+  local.get $0
+  call $~lib/map/Map<i16,i32>#get:size
+  i32.const 50
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 56
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -6239,15 +9305,23 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 44
+   i32.const 60
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u16,i32>#clear (; 65 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<u16,i32>#clear (; 126 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -6287,12 +9361,12 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u16,i32>#constructor (; 66 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#constructor (; 127 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
    i32.const 24
-   i32.const 6
+   i32.const 14
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
    local.set $0
@@ -6319,7 +9393,7 @@
   call $~lib/map/Map<u16,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u16,i32>#find (; 67 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#find (; 128 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -6369,7 +9443,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u16,i32>#has (; 68 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#has (; 129 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -6386,7 +9460,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u16,i32>#rehash (; 69 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,i32>#rehash (; 130 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6543,7 +9617,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u16,i32>#set (; 70 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<u16,i32>#set (; 131 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -6648,7 +9722,7 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/map/Map<u16,i32>#get (; 71 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#get (; 132 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -6677,25 +9751,651 @@
   local.get $3
   i32.load offset=4
  )
- (func $~lib/map/Map<u16,i32>#get:size (; 72 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u16,i32>#get:size (; 133 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<u16,i32>#delete (; 73 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#constructor (; 134 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  if (result i32)
+   local.get $0
+  else
+   i32.const 16
+   i32.const 15
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+  end
+  local.get $1
+  i32.const 1
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  local.get $1
+  i32.store offset=12
+  local.get $0
+ )
+ (func $~lib/array/Array<u16>#__unchecked_set (; 135 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 1
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store16
+ )
+ (func $~lib/array/Array<u16>#__set (; 136 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 512
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.const 1
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.store offset=12
+  end
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/array/Array<u16>#__unchecked_set
+ )
+ (func $~lib/array/Array<u16>#set:length (; 137 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load offset=12
+  local.set $2
+  local.get $0
+  local.get $1
+  i32.const 1
+  call $~lib/array/ensureSize
+  local.get $0
+  local.get $1
+  i32.store offset=12
+ )
+ (func $~lib/map/Map<u16,i32>#keys (; 138 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<u16>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 12
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $4
+     local.get $6
+     i32.load16_u
+     call $~lib/array/Array<u16>#__set
+     local.get $4
+     i32.const 1
+     i32.add
+     local.set $4
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+  local.get $4
+  call $~lib/array/Array<u16>#set:length
+  local.get $3
+ )
+ (func $~lib/map/Map<u16,i32>#values (; 139 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<i32>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 12
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $6
+     i32.load offset=4
+     call $~lib/array/Array<i32>#push
+     drop
+     local.get $4
+     i32.const 1
+     i32.add
+     local.set $4
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+  local.get $4
+  call $~lib/array/Array<i32>#set:length
+  local.get $3
+ )
+ (func $~lib/map/Map<u16,u16>#clear (; 140 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 32
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+ )
+ (func $~lib/map/Map<u16,u16>#constructor (; 141 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 24
+   i32.const 16
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+  local.get $0
+  call $~lib/map/Map<u16,u16>#clear
+  local.get $0
+ )
+ (func $~lib/array/Array<u16>#get:length (; 142 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=12
+ )
+ (func $~lib/array/Array<u16>#__unchecked_get (; 143 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 1
+  i32.shl
+  i32.add
+  i32.load16_u
+ )
+ (func $~lib/array/Array<u16>#__get (; 144 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 512
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<u16>#__unchecked_get
+  local.set $2
+  local.get $2
+ )
+ (func $~lib/map/Map<u16,u16>#find (; 145 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  local.get $0
+  i32.load
+  local.get $2
+  local.get $0
+  i32.load offset=4
+  i32.and
+  i32.const 4
+  i32.mul
+  i32.add
+  i32.load
+  local.set $3
+  block $break|0
+   loop $continue|0
+    local.get $3
+    i32.eqz
+    br_if $break|0
+    local.get $3
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if (result i32)
+     local.get $3
+     i32.load16_u
+     local.get $1
+     i32.const 65535
+     i32.and
+     i32.eq
+    else
+     i32.const 0
+    end
+    if
+     local.get $3
+     return
+    end
+    local.get $3
+    i32.load offset=4
+    i32.const 1
+    i32.const -1
+    i32.xor
+    i32.and
+    local.set $3
+    br $continue|0
+   end
+   unreachable
+  end
+  i32.const 0
+ )
+ (func $~lib/map/Map<u16,u16>#rehash (; 146 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  i32.const 1
+  i32.add
+  local.set $2
+  i32.const 0
+  local.get $2
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $3
+  local.get $2
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
+  local.set $4
+  i32.const 0
+  local.get $4
+  i32.const 8
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $5
+  local.get $0
+  i32.load offset=8
+  local.set $6
+  local.get $6
+  local.get $0
+  i32.load offset=16
+  i32.const 8
+  i32.mul
+  i32.add
+  local.set $7
+  local.get $5
+  local.set $8
+  block $break|0
+   loop $continue|0
+    local.get $6
+    local.get $7
+    i32.ne
+    i32.eqz
+    br_if $break|0
+    local.get $6
+    local.set $9
+    local.get $9
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $8
+     local.set $10
+     local.get $10
+     local.get $9
+     i32.load16_u
+     i32.store16
+     local.get $10
+     local.get $9
+     i32.load16_u offset=2
+     i32.store16 offset=2
+     block $~lib/util/hash/HASH<u16>|inlined.5 (result i32)
+      local.get $9
+      i32.load16_u
+      local.set $11
+      local.get $11
+      call $~lib/util/hash/hash16
+      br $~lib/util/hash/HASH<u16>|inlined.5
+     end
+     local.get $1
+     i32.and
+     local.set $11
+     local.get $3
+     local.get $11
+     i32.const 4
+     i32.mul
+     i32.add
+     local.set $12
+     local.get $10
+     local.get $12
+     i32.load
+     i32.store offset=4
+     local.get $12
+     local.get $8
+     i32.store
+     local.get $8
+     i32.const 8
+     i32.add
+     local.set $8
+    end
+    local.get $6
+    i32.const 8
+    i32.add
+    local.set $6
+    br $continue|0
+   end
+   unreachable
+  end
+  local.get $0
+  local.tee $9
+  local.get $3
+  local.tee $10
+  local.get $9
+  i32.load
+  local.tee $12
+  i32.ne
+  if
+   local.get $10
+   call $~lib/rt/pure/__retain
+   local.set $10
+   local.get $12
+   call $~lib/rt/pure/__release
+  end
+  local.get $10
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $0
+  local.tee $9
+  local.get $5
+  local.tee $11
+  local.get $9
+  i32.load offset=8
+  local.tee $10
+  i32.ne
+  if
+   local.get $11
+   call $~lib/rt/pure/__retain
+   local.set $11
+   local.get $10
+   call $~lib/rt/pure/__release
+  end
+  local.get $11
+  i32.store offset=8
+  local.get $0
+  local.get $4
+  i32.store offset=12
+  local.get $0
+  local.get $0
+  i32.load offset=20
+  i32.store offset=16
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/map/Map<u16,u16>#set (; 147 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  block $~lib/util/hash/HASH<u16>|inlined.4 (result i32)
+   local.get $1
+   local.set $3
+   local.get $3
+   i32.const 65535
+   i32.and
+   call $~lib/util/hash/hash16
+   br $~lib/util/hash/HASH<u16>|inlined.4
+  end
+  local.set $4
+  local.get $0
+  local.get $1
+  local.get $4
+  call $~lib/map/Map<u16,u16>#find
+  local.set $5
+  local.get $5
+  if
+   local.get $5
+   local.get $2
+   i32.store16 offset=2
+  else
+   local.get $0
+   i32.load offset=16
+   local.get $0
+   i32.load offset=12
+   i32.eq
+   if
+    local.get $0
+    local.get $0
+    i32.load offset=20
+    local.get $0
+    i32.load offset=12
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
+    i32.lt_s
+    if (result i32)
+     local.get $0
+     i32.load offset=4
+    else
+     local.get $0
+     i32.load offset=4
+     i32.const 1
+     i32.shl
+     i32.const 1
+     i32.or
+    end
+    call $~lib/map/Map<u16,u16>#rehash
+   end
+   local.get $0
+   i32.load offset=8
+   call $~lib/rt/pure/__retain
+   local.set $3
+   local.get $3
+   local.get $0
+   local.get $0
+   i32.load offset=16
+   local.tee $6
+   i32.const 1
+   i32.add
+   i32.store offset=16
+   local.get $6
+   i32.const 8
+   i32.mul
+   i32.add
+   local.set $5
+   local.get $5
+   local.get $1
+   i32.store16
+   local.get $5
+   local.get $2
+   i32.store16 offset=2
+   local.get $0
+   local.get $0
+   i32.load offset=20
+   i32.const 1
+   i32.add
+   i32.store offset=20
+   local.get $0
+   i32.load
+   local.get $4
+   local.get $0
+   i32.load offset=4
+   i32.and
+   i32.const 4
+   i32.mul
+   i32.add
+   local.set $6
+   local.get $5
+   local.get $6
+   i32.load
+   i32.store offset=4
+   local.get $6
+   local.get $5
+   i32.store
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+ )
+ (func $~lib/map/Map<u16,u16>#get:size (; 148 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=20
+ )
+ (func $~lib/map/Map<u16,i32>#delete (; 149 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   local.get $0
   local.get $1
-  block $~lib/util/hash/HASH<u16>|inlined.4 (result i32)
+  block $~lib/util/hash/HASH<u16>|inlined.6 (result i32)
    local.get $1
    local.set $2
    local.get $2
    i32.const 65535
    i32.and
    call $~lib/util/hash/hash16
-   br $~lib/util/hash/HASH<u16>|inlined.4
+   br $~lib/util/hash/HASH<u16>|inlined.6
   end
   call $~lib/map/Map<u16,i32>#find
   local.set $3
@@ -6755,9 +10455,15 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<u16,i32> (; 74 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<u16,i32> (; 150 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   i32.const 0
   call $~lib/map/Map<u16,i32>#constructor
   local.set $0
@@ -6940,32 +10646,134 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
+  call $~lib/map/Map<u16,i32>#keys
+  local.set $1
+  local.get $0
+  call $~lib/map/Map<u16,i32>#values
+  local.set $2
+  i32.const 0
+  call $~lib/map/Map<u16,u16>#constructor
+  local.set $3
+  i32.const 0
+  call $~lib/map/Map<i32,i32>#constructor
+  local.set $4
   block $break|2
    i32.const 0
-   local.set $1
+   local.set $5
    loop $loop|2
+    local.get $5
     local.get $1
-    i32.const 50
-    i32.lt_u
+    call $~lib/array/Array<u16>#get:length
+    i32.lt_s
     i32.eqz
     br_if $break|2
-    local.get $0
     local.get $1
+    local.get $5
+    call $~lib/array/Array<u16>#__get
+    local.set $6
+    local.get $2
+    local.get $5
+    call $~lib/array/Array<i32>#__get
+    local.set $7
+    local.get $0
+    local.get $6
     call $~lib/map/Map<u16,i32>#has
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 25
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $0
-    local.get $1
+    local.get $7
+    i32.const 20
+    i32.sub
+    call $~lib/map/Map<u16,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 32
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $3
+    local.get $6
+    local.get $6
+    call $~lib/map/Map<u16,u16>#set
+    local.get $4
+    local.get $7
+    i32.const 20
+    i32.sub
+    local.get $7
+    i32.const 20
+    i32.sub
+    call $~lib/map/Map<i32,i32>#set
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|2
+   end
+   unreachable
+  end
+  local.get $3
+  call $~lib/map/Map<u16,u16>#get:size
+  i32.const 100
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 36
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $4
+  call $~lib/map/Map<i32,i32>#get:size
+  i32.const 100
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 37
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $break|3
+   i32.const 0
+   local.set $5
+   loop $loop|3
+    local.get $5
+    i32.const 50
+    i32.lt_u
+    i32.eqz
+    br_if $break|3
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<u16,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 41
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $5
     call $~lib/map/Map<u16,i32>#get
     i32.const 20
-    local.get $1
+    local.get $5
     i32.const 65535
     i32.and
     i32.add
@@ -6974,112 +10782,32 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 26
+     i32.const 42
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $0
-    local.get $1
+    local.get $5
     call $~lib/map/Map<u16,i32>#delete
     drop
     local.get $0
-    local.get $1
+    local.get $5
     call $~lib/map/Map<u16,i32>#has
     i32.eqz
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 28
+     i32.const 44
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $5
     i32.const 1
     i32.add
-    local.set $1
-    br $loop|2
-   end
-   unreachable
-  end
-  local.get $0
-  call $~lib/map/Map<u16,i32>#get:size
-  i32.const 50
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 376
-   i32.const 30
-   i32.const 2
-   call $~lib/builtins/abort
-   unreachable
-  end
-  block $break|3
-   i32.const 0
-   local.set $1
-   loop $loop|3
-    local.get $1
-    i32.const 50
-    i32.lt_u
-    i32.eqz
-    br_if $break|3
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<u16,i32>#has
-    i32.eqz
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 34
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    i32.const 10
-    local.get $1
-    i32.const 65535
-    i32.and
-    i32.add
-    call $~lib/map/Map<u16,i32>#set
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<u16,i32>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 36
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<u16,i32>#delete
-    drop
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<u16,i32>#has
-    i32.eqz
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 38
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    i32.const 1
-    i32.add
-    local.set $1
+    local.set $5
     br $loop|3
    end
    unreachable
@@ -7092,7 +10820,87 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 46
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $break|4
+   i32.const 0
+   local.set $5
+   loop $loop|4
+    local.get $5
+    i32.const 50
+    i32.lt_u
+    i32.eqz
+    br_if $break|4
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<u16,i32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 50
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $5
+    i32.const 10
+    local.get $5
+    i32.const 65535
+    i32.and
+    i32.add
+    call $~lib/map/Map<u16,i32>#set
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<u16,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 52
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<u16,i32>#delete
+    drop
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<u16,i32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 54
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|4
+   end
+   unreachable
+  end
+  local.get $0
+  call $~lib/map/Map<u16,i32>#get:size
+  i32.const 50
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 56
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -7107,452 +10915,38 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 44
+   i32.const 60
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i32,i32>#clear (; 75 ;) (type $FUNCSIG$vi) (param $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 16
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store
-  local.get $0
-  i32.const 4
-  i32.const 1
-  i32.sub
-  i32.store offset=4
-  local.get $0
-  local.tee $1
-  i32.const 0
-  i32.const 48
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $2
-  local.get $1
-  i32.load offset=8
-  call $~lib/rt/pure/__release
-  local.get $2
-  i32.store offset=8
-  local.get $0
-  i32.const 4
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
- )
- (func $~lib/map/Map<i32,i32>#constructor (; 76 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  local.get $0
-  i32.eqz
-  if
-   i32.const 24
-   i32.const 7
-   call $~lib/rt/tlsf/__alloc
-   call $~lib/rt/pure/__retain
-   local.set $0
-  end
-  local.get $0
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.const 0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=8
-  local.get $0
-  i32.const 0
-  i32.store offset=12
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  local.get $0
-  i32.const 0
-  i32.store offset=20
-  local.get $0
-  call $~lib/map/Map<i32,i32>#clear
-  local.get $0
- )
- (func $~lib/util/hash/hash32 (; 77 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  i32.const -2128831035
-  local.set $1
-  local.get $1
-  local.get $0
-  i32.const 255
-  i32.and
-  i32.xor
-  i32.const 16777619
-  i32.mul
-  local.set $1
-  local.get $1
-  local.get $0
-  i32.const 8
-  i32.shr_u
-  i32.const 255
-  i32.and
-  i32.xor
-  i32.const 16777619
-  i32.mul
-  local.set $1
-  local.get $1
-  local.get $0
-  i32.const 16
-  i32.shr_u
-  i32.const 255
-  i32.and
-  i32.xor
-  i32.const 16777619
-  i32.mul
-  local.set $1
-  local.get $1
-  local.get $0
-  i32.const 24
-  i32.shr_u
-  i32.xor
-  i32.const 16777619
-  i32.mul
-  local.set $1
-  local.get $1
- )
- (func $~lib/map/Map<i32,i32>#find (; 78 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  local.get $0
-  i32.load
-  local.get $2
-  local.get $0
-  i32.load offset=4
-  i32.and
-  i32.const 4
-  i32.mul
-  i32.add
-  i32.load
-  local.set $3
-  block $break|0
-   loop $continue|0
-    local.get $3
-    i32.eqz
-    br_if $break|0
-    local.get $3
-    i32.load offset=8
-    i32.const 1
-    i32.and
-    i32.eqz
-    if (result i32)
-     local.get $3
-     i32.load
-     local.get $1
-     i32.eq
-    else
-     i32.const 0
-    end
-    if
-     local.get $3
-     return
-    end
-    local.get $3
-    i32.load offset=8
-    i32.const 1
-    i32.const -1
-    i32.xor
-    i32.and
-    local.set $3
-    br $continue|0
-   end
-   unreachable
-  end
-  i32.const 0
- )
- (func $~lib/map/Map<i32,i32>#has (; 79 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#has (; 151 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
-  block $~lib/util/hash/HASH<i32>|inlined.0 (result i32)
+  block $~lib/util/hash/HASH<i32>|inlined.2 (result i32)
    local.get $1
    local.set $2
    local.get $2
    call $~lib/util/hash/hash32
-   br $~lib/util/hash/HASH<i32>|inlined.0
+   br $~lib/util/hash/HASH<i32>|inlined.2
   end
   call $~lib/map/Map<i32,i32>#find
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i32,i32>#rehash (; 80 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  local.get $1
-  i32.const 1
-  i32.add
-  local.set $2
-  i32.const 0
-  local.get $2
-  i32.const 4
-  i32.mul
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $3
-  local.get $2
-  i32.const 8
-  i32.mul
-  i32.const 3
-  i32.div_s
-  local.set $4
-  i32.const 0
-  local.get $4
-  i32.const 12
-  i32.mul
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  local.set $5
-  local.get $0
-  i32.load offset=8
-  local.set $6
-  local.get $6
-  local.get $0
-  i32.load offset=16
-  i32.const 12
-  i32.mul
-  i32.add
-  local.set $7
-  local.get $5
-  local.set $8
-  block $break|0
-   loop $continue|0
-    local.get $6
-    local.get $7
-    i32.ne
-    i32.eqz
-    br_if $break|0
-    local.get $6
-    local.set $9
-    local.get $9
-    i32.load offset=8
-    i32.const 1
-    i32.and
-    i32.eqz
-    if
-     local.get $8
-     local.set $10
-     local.get $10
-     local.get $9
-     i32.load
-     i32.store
-     local.get $10
-     local.get $9
-     i32.load offset=4
-     i32.store offset=4
-     block $~lib/util/hash/HASH<i32>|inlined.2 (result i32)
-      local.get $9
-      i32.load
-      local.set $11
-      local.get $11
-      call $~lib/util/hash/hash32
-      br $~lib/util/hash/HASH<i32>|inlined.2
-     end
-     local.get $1
-     i32.and
-     local.set $11
-     local.get $3
-     local.get $11
-     i32.const 4
-     i32.mul
-     i32.add
-     local.set $12
-     local.get $10
-     local.get $12
-     i32.load
-     i32.store offset=8
-     local.get $12
-     local.get $8
-     i32.store
-     local.get $8
-     i32.const 12
-     i32.add
-     local.set $8
-    end
-    local.get $6
-    i32.const 12
-    i32.add
-    local.set $6
-    br $continue|0
-   end
-   unreachable
-  end
-  local.get $0
-  local.tee $9
-  local.get $3
-  local.tee $10
-  local.get $9
-  i32.load
-  local.tee $12
-  i32.ne
-  if
-   local.get $10
-   call $~lib/rt/pure/__retain
-   local.set $10
-   local.get $12
-   call $~lib/rt/pure/__release
-  end
-  local.get $10
-  i32.store
-  local.get $0
-  local.get $1
-  i32.store offset=4
-  local.get $0
-  local.tee $9
-  local.get $5
-  local.tee $11
-  local.get $9
-  i32.load offset=8
-  local.tee $10
-  i32.ne
-  if
-   local.get $11
-   call $~lib/rt/pure/__retain
-   local.set $11
-   local.get $10
-   call $~lib/rt/pure/__release
-  end
-  local.get $11
-  i32.store offset=8
-  local.get $0
-  local.get $4
-  i32.store offset=12
-  local.get $0
-  local.get $0
-  i32.load offset=20
-  i32.store offset=16
-  local.get $3
-  call $~lib/rt/pure/__release
-  local.get $5
-  call $~lib/rt/pure/__release
- )
- (func $~lib/map/Map<i32,i32>#set (; 81 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  block $~lib/util/hash/HASH<i32>|inlined.1 (result i32)
-   local.get $1
-   local.set $3
-   local.get $3
-   call $~lib/util/hash/hash32
-   br $~lib/util/hash/HASH<i32>|inlined.1
-  end
-  local.set $4
-  local.get $0
-  local.get $1
-  local.get $4
-  call $~lib/map/Map<i32,i32>#find
-  local.set $5
-  local.get $5
-  if
-   local.get $5
-   local.get $2
-   i32.store offset=4
-  else
-   local.get $0
-   i32.load offset=16
-   local.get $0
-   i32.load offset=12
-   i32.eq
-   if
-    local.get $0
-    local.get $0
-    i32.load offset=20
-    local.get $0
-    i32.load offset=12
-    i32.const 3
-    i32.mul
-    i32.const 4
-    i32.div_s
-    i32.lt_s
-    if (result i32)
-     local.get $0
-     i32.load offset=4
-    else
-     local.get $0
-     i32.load offset=4
-     i32.const 1
-     i32.shl
-     i32.const 1
-     i32.or
-    end
-    call $~lib/map/Map<i32,i32>#rehash
-   end
-   local.get $0
-   i32.load offset=8
-   call $~lib/rt/pure/__retain
-   local.set $3
-   local.get $3
-   local.get $0
-   local.get $0
-   i32.load offset=16
-   local.tee $6
-   i32.const 1
-   i32.add
-   i32.store offset=16
-   local.get $6
-   i32.const 12
-   i32.mul
-   i32.add
-   local.set $5
-   local.get $5
-   local.get $1
-   i32.store
-   local.get $5
-   local.get $2
-   i32.store offset=4
-   local.get $0
-   local.get $0
-   i32.load offset=20
-   i32.const 1
-   i32.add
-   i32.store offset=20
-   local.get $0
-   i32.load
-   local.get $4
-   local.get $0
-   i32.load offset=4
-   i32.and
-   i32.const 4
-   i32.mul
-   i32.add
-   local.set $6
-   local.get $5
-   local.get $6
-   i32.load
-   i32.store offset=8
-   local.get $6
-   local.get $5
-   i32.store
-   local.get $3
-   call $~lib/rt/pure/__release
-  end
- )
- (func $~lib/map/Map<i32,i32>#get (; 82 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<i32,i32>#get (; 152 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -7579,11 +10973,181 @@
   local.get $3
   i32.load offset=4
  )
- (func $~lib/map/Map<i32,i32>#get:size (; 83 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i32>#__unchecked_set (; 153 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
-  i32.load offset=20
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store
  )
- (func $~lib/map/Map<i32,i32>#delete (; 84 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#__set (; 154 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 512
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.const 2
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.store offset=12
+  end
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/array/Array<i32>#__unchecked_set
+ )
+ (func $~lib/map/Map<i32,i32>#keys (; 155 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<i32>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 12
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $4
+     local.get $6
+     i32.load
+     call $~lib/array/Array<i32>#__set
+     local.get $4
+     i32.const 1
+     i32.add
+     local.set $4
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+  local.get $4
+  call $~lib/array/Array<i32>#set:length
+  local.get $3
+ )
+ (func $~lib/map/Map<i32,i32>#values (; 156 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<i32>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 12
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $6
+     i32.load offset=4
+     call $~lib/array/Array<i32>#push
+     drop
+     local.get $4
+     i32.const 1
+     i32.add
+     local.set $4
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+  local.get $4
+  call $~lib/array/Array<i32>#set:length
+  local.get $3
+ )
+ (func $~lib/array/Array<i32>#get:length (; 157 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=12
+ )
+ (func $~lib/map/Map<i32,i32>#delete (; 158 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7655,9 +11219,15 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<i32,i32> (; 85 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<i32,i32> (; 159 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   i32.const 0
   call $~lib/map/Map<i32,i32>#constructor
   local.set $0
@@ -7830,142 +11400,166 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
+  call $~lib/map/Map<i32,i32>#keys
+  local.set $1
+  local.get $0
+  call $~lib/map/Map<i32,i32>#values
+  local.set $2
+  i32.const 0
+  call $~lib/map/Map<i32,i32>#constructor
+  local.set $3
+  i32.const 0
+  call $~lib/map/Map<i32,i32>#constructor
+  local.set $4
   block $break|2
    i32.const 0
-   local.set $1
+   local.set $5
    loop $loop|2
+    local.get $5
     local.get $1
-    i32.const 50
+    call $~lib/array/Array<i32>#get:length
     i32.lt_s
     i32.eqz
     br_if $break|2
-    local.get $0
     local.get $1
+    local.get $5
+    call $~lib/array/Array<i32>#__get
+    local.set $6
+    local.get $2
+    local.get $5
+    call $~lib/array/Array<i32>#__get
+    local.set $7
+    local.get $0
+    local.get $6
     call $~lib/map/Map<i32,i32>#has
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 25
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $0
-    local.get $1
-    call $~lib/map/Map<i32,i32>#get
+    local.get $7
     i32.const 20
-    local.get $1
-    i32.add
-    i32.eq
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 26
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<i32,i32>#delete
-    drop
-    local.get $0
-    local.get $1
+    i32.sub
     call $~lib/map/Map<i32,i32>#has
     i32.eqz
-    i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 28
+     i32.const 32
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $3
+    local.get $6
+    local.get $6
+    call $~lib/map/Map<i32,i32>#set
+    local.get $4
+    local.get $7
+    i32.const 20
+    i32.sub
+    local.get $7
+    i32.const 20
+    i32.sub
+    call $~lib/map/Map<i32,i32>#set
+    local.get $5
     i32.const 1
     i32.add
-    local.set $1
+    local.set $5
     br $loop|2
    end
    unreachable
   end
-  local.get $0
+  local.get $3
   call $~lib/map/Map<i32,i32>#get:size
-  i32.const 50
+  i32.const 100
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 30
+   i32.const 36
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $4
+  call $~lib/map/Map<i32,i32>#get:size
+  i32.const 100
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 37
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
   block $break|3
    i32.const 0
-   local.set $1
+   local.set $5
    loop $loop|3
-    local.get $1
+    local.get $5
     i32.const 50
     i32.lt_s
     i32.eqz
     br_if $break|3
     local.get $0
-    local.get $1
+    local.get $5
     call $~lib/map/Map<i32,i32>#has
-    i32.eqz
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 41
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $0
-    local.get $1
-    i32.const 10
-    local.get $1
+    local.get $5
+    call $~lib/map/Map<i32,i32>#get
+    i32.const 20
+    local.get $5
     i32.add
-    call $~lib/map/Map<i32,i32>#set
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<i32,i32>#has
+    i32.eq
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 36
+     i32.const 42
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $0
-    local.get $1
+    local.get $5
     call $~lib/map/Map<i32,i32>#delete
     drop
     local.get $0
-    local.get $1
+    local.get $5
     call $~lib/map/Map<i32,i32>#has
     i32.eqz
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 38
+     i32.const 44
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $5
     i32.const 1
     i32.add
-    local.set $1
+    local.set $5
     br $loop|3
    end
    unreachable
@@ -7978,7 +11572,85 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 46
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $break|4
+   i32.const 0
+   local.set $5
+   loop $loop|4
+    local.get $5
+    i32.const 50
+    i32.lt_s
+    i32.eqz
+    br_if $break|4
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<i32,i32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 50
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $5
+    i32.const 10
+    local.get $5
+    i32.add
+    call $~lib/map/Map<i32,i32>#set
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<i32,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 52
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<i32,i32>#delete
+    drop
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<i32,i32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 54
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|4
+   end
+   unreachable
+  end
+  local.get $0
+  call $~lib/map/Map<i32,i32>#get:size
+  i32.const 50
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 56
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -7993,15 +11665,23 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 44
+   i32.const 60
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u32,i32>#clear (; 86 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<u32,i32>#clear (; 160 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -8041,12 +11721,12 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u32,i32>#constructor (; 87 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#constructor (; 161 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
    i32.const 24
-   i32.const 8
+   i32.const 17
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
    local.set $0
@@ -8073,7 +11753,7 @@
   call $~lib/map/Map<u32,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u32,i32>#find (; 88 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#find (; 162 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -8121,7 +11801,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u32,i32>#has (; 89 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#has (; 163 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -8136,7 +11816,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u32,i32>#rehash (; 90 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u32,i32>#rehash (; 164 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8293,7 +11973,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u32,i32>#set (; 91 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/map/Map<u32,i32>#set (; 165 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -8396,7 +12076,7 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/map/Map<u32,i32>#get (; 92 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#get (; 166 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -8423,23 +12103,645 @@
   local.get $3
   i32.load offset=4
  )
- (func $~lib/map/Map<u32,i32>#get:size (; 93 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u32,i32>#get:size (; 167 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<u32,i32>#delete (; 94 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#constructor (; 168 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  if (result i32)
+   local.get $0
+  else
+   i32.const 16
+   i32.const 18
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+  end
+  local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  local.get $1
+  i32.store offset=12
+  local.get $0
+ )
+ (func $~lib/array/Array<u32>#__unchecked_set (; 169 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store
+ )
+ (func $~lib/array/Array<u32>#__set (; 170 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 512
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.const 2
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.store offset=12
+  end
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/array/Array<u32>#__unchecked_set
+ )
+ (func $~lib/array/Array<u32>#set:length (; 171 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load offset=12
+  local.set $2
+  local.get $0
+  local.get $1
+  i32.const 2
+  call $~lib/array/ensureSize
+  local.get $0
+  local.get $1
+  i32.store offset=12
+ )
+ (func $~lib/map/Map<u32,i32>#keys (; 172 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<u32>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 12
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $4
+     local.get $6
+     i32.load
+     call $~lib/array/Array<u32>#__set
+     local.get $4
+     i32.const 1
+     i32.add
+     local.set $4
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+  local.get $4
+  call $~lib/array/Array<u32>#set:length
+  local.get $3
+ )
+ (func $~lib/map/Map<u32,i32>#values (; 173 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<i32>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 12
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $6
+     i32.load offset=4
+     call $~lib/array/Array<i32>#push
+     drop
+     local.get $4
+     i32.const 1
+     i32.add
+     local.set $4
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+  local.get $4
+  call $~lib/array/Array<i32>#set:length
+  local.get $3
+ )
+ (func $~lib/map/Map<u32,u32>#clear (; 174 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 48
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+ )
+ (func $~lib/map/Map<u32,u32>#constructor (; 175 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 24
+   i32.const 19
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+  local.get $0
+  call $~lib/map/Map<u32,u32>#clear
+  local.get $0
+ )
+ (func $~lib/array/Array<u32>#get:length (; 176 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=12
+ )
+ (func $~lib/array/Array<u32>#__unchecked_get (; 177 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
+ )
+ (func $~lib/array/Array<u32>#__get (; 178 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 512
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<u32>#__unchecked_get
+  local.set $2
+  local.get $2
+ )
+ (func $~lib/map/Map<u32,u32>#find (; 179 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  local.get $0
+  i32.load
+  local.get $2
+  local.get $0
+  i32.load offset=4
+  i32.and
+  i32.const 4
+  i32.mul
+  i32.add
+  i32.load
+  local.set $3
+  block $break|0
+   loop $continue|0
+    local.get $3
+    i32.eqz
+    br_if $break|0
+    local.get $3
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if (result i32)
+     local.get $3
+     i32.load
+     local.get $1
+     i32.eq
+    else
+     i32.const 0
+    end
+    if
+     local.get $3
+     return
+    end
+    local.get $3
+    i32.load offset=8
+    i32.const 1
+    i32.const -1
+    i32.xor
+    i32.and
+    local.set $3
+    br $continue|0
+   end
+   unreachable
+  end
+  i32.const 0
+ )
+ (func $~lib/map/Map<u32,u32>#rehash (; 180 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  local.get $1
+  i32.const 1
+  i32.add
+  local.set $2
+  i32.const 0
+  local.get $2
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $3
+  local.get $2
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
+  local.set $4
+  i32.const 0
+  local.get $4
+  i32.const 12
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $5
+  local.get $0
+  i32.load offset=8
+  local.set $6
+  local.get $6
+  local.get $0
+  i32.load offset=16
+  i32.const 12
+  i32.mul
+  i32.add
+  local.set $7
+  local.get $5
+  local.set $8
+  block $break|0
+   loop $continue|0
+    local.get $6
+    local.get $7
+    i32.ne
+    i32.eqz
+    br_if $break|0
+    local.get $6
+    local.set $9
+    local.get $9
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $8
+     local.set $10
+     local.get $10
+     local.get $9
+     i32.load
+     i32.store
+     local.get $10
+     local.get $9
+     i32.load offset=4
+     i32.store offset=4
+     block $~lib/util/hash/HASH<u32>|inlined.5 (result i32)
+      local.get $9
+      i32.load
+      local.set $11
+      local.get $11
+      call $~lib/util/hash/hash32
+      br $~lib/util/hash/HASH<u32>|inlined.5
+     end
+     local.get $1
+     i32.and
+     local.set $11
+     local.get $3
+     local.get $11
+     i32.const 4
+     i32.mul
+     i32.add
+     local.set $12
+     local.get $10
+     local.get $12
+     i32.load
+     i32.store offset=8
+     local.get $12
+     local.get $8
+     i32.store
+     local.get $8
+     i32.const 12
+     i32.add
+     local.set $8
+    end
+    local.get $6
+    i32.const 12
+    i32.add
+    local.set $6
+    br $continue|0
+   end
+   unreachable
+  end
+  local.get $0
+  local.tee $9
+  local.get $3
+  local.tee $10
+  local.get $9
+  i32.load
+  local.tee $12
+  i32.ne
+  if
+   local.get $10
+   call $~lib/rt/pure/__retain
+   local.set $10
+   local.get $12
+   call $~lib/rt/pure/__release
+  end
+  local.get $10
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $0
+  local.tee $9
+  local.get $5
+  local.tee $11
+  local.get $9
+  i32.load offset=8
+  local.tee $10
+  i32.ne
+  if
+   local.get $11
+   call $~lib/rt/pure/__retain
+   local.set $11
+   local.get $10
+   call $~lib/rt/pure/__release
+  end
+  local.get $11
+  i32.store offset=8
+  local.get $0
+  local.get $4
+  i32.store offset=12
+  local.get $0
+  local.get $0
+  i32.load offset=20
+  i32.store offset=16
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/map/Map<u32,u32>#set (; 181 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  block $~lib/util/hash/HASH<u32>|inlined.4 (result i32)
+   local.get $1
+   local.set $3
+   local.get $3
+   call $~lib/util/hash/hash32
+   br $~lib/util/hash/HASH<u32>|inlined.4
+  end
+  local.set $4
+  local.get $0
+  local.get $1
+  local.get $4
+  call $~lib/map/Map<u32,u32>#find
+  local.set $5
+  local.get $5
+  if
+   local.get $5
+   local.get $2
+   i32.store offset=4
+  else
+   local.get $0
+   i32.load offset=16
+   local.get $0
+   i32.load offset=12
+   i32.eq
+   if
+    local.get $0
+    local.get $0
+    i32.load offset=20
+    local.get $0
+    i32.load offset=12
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
+    i32.lt_s
+    if (result i32)
+     local.get $0
+     i32.load offset=4
+    else
+     local.get $0
+     i32.load offset=4
+     i32.const 1
+     i32.shl
+     i32.const 1
+     i32.or
+    end
+    call $~lib/map/Map<u32,u32>#rehash
+   end
+   local.get $0
+   i32.load offset=8
+   call $~lib/rt/pure/__retain
+   local.set $3
+   local.get $3
+   local.get $0
+   local.get $0
+   i32.load offset=16
+   local.tee $6
+   i32.const 1
+   i32.add
+   i32.store offset=16
+   local.get $6
+   i32.const 12
+   i32.mul
+   i32.add
+   local.set $5
+   local.get $5
+   local.get $1
+   i32.store
+   local.get $5
+   local.get $2
+   i32.store offset=4
+   local.get $0
+   local.get $0
+   i32.load offset=20
+   i32.const 1
+   i32.add
+   i32.store offset=20
+   local.get $0
+   i32.load
+   local.get $4
+   local.get $0
+   i32.load offset=4
+   i32.and
+   i32.const 4
+   i32.mul
+   i32.add
+   local.set $6
+   local.get $5
+   local.get $6
+   i32.load
+   i32.store offset=8
+   local.get $6
+   local.get $5
+   i32.store
+   local.get $3
+   call $~lib/rt/pure/__release
+  end
+ )
+ (func $~lib/map/Map<u32,u32>#get:size (; 182 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=20
+ )
+ (func $~lib/map/Map<u32,i32>#delete (; 183 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   local.get $0
   local.get $1
-  block $~lib/util/hash/HASH<u32>|inlined.4 (result i32)
+  block $~lib/util/hash/HASH<u32>|inlined.6 (result i32)
    local.get $1
    local.set $2
    local.get $2
    call $~lib/util/hash/hash32
-   br $~lib/util/hash/HASH<u32>|inlined.4
+   br $~lib/util/hash/HASH<u32>|inlined.6
   end
   call $~lib/map/Map<u32,i32>#find
   local.set $3
@@ -8499,9 +12801,15 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<u32,i32> (; 95 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<u32,i32> (; 184 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   i32.const 0
   call $~lib/map/Map<u32,i32>#constructor
   local.set $0
@@ -8674,142 +12982,166 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
+  call $~lib/map/Map<u32,i32>#keys
+  local.set $1
+  local.get $0
+  call $~lib/map/Map<u32,i32>#values
+  local.set $2
+  i32.const 0
+  call $~lib/map/Map<u32,u32>#constructor
+  local.set $3
+  i32.const 0
+  call $~lib/map/Map<i32,i32>#constructor
+  local.set $4
   block $break|2
    i32.const 0
-   local.set $1
+   local.set $5
    loop $loop|2
+    local.get $5
     local.get $1
-    i32.const 50
-    i32.lt_u
+    call $~lib/array/Array<u32>#get:length
+    i32.lt_s
     i32.eqz
     br_if $break|2
-    local.get $0
     local.get $1
+    local.get $5
+    call $~lib/array/Array<u32>#__get
+    local.set $6
+    local.get $2
+    local.get $5
+    call $~lib/array/Array<i32>#__get
+    local.set $7
+    local.get $0
+    local.get $6
     call $~lib/map/Map<u32,i32>#has
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 25
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $0
-    local.get $1
-    call $~lib/map/Map<u32,i32>#get
+    local.get $7
     i32.const 20
-    local.get $1
-    i32.add
-    i32.eq
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 26
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<u32,i32>#delete
-    drop
-    local.get $0
-    local.get $1
+    i32.sub
     call $~lib/map/Map<u32,i32>#has
     i32.eqz
-    i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 28
+     i32.const 32
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $3
+    local.get $6
+    local.get $6
+    call $~lib/map/Map<u32,u32>#set
+    local.get $4
+    local.get $7
+    i32.const 20
+    i32.sub
+    local.get $7
+    i32.const 20
+    i32.sub
+    call $~lib/map/Map<i32,i32>#set
+    local.get $5
     i32.const 1
     i32.add
-    local.set $1
+    local.set $5
     br $loop|2
    end
    unreachable
   end
-  local.get $0
-  call $~lib/map/Map<u32,i32>#get:size
-  i32.const 50
+  local.get $3
+  call $~lib/map/Map<u32,u32>#get:size
+  i32.const 100
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 30
+   i32.const 36
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $4
+  call $~lib/map/Map<i32,i32>#get:size
+  i32.const 100
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 37
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
   block $break|3
    i32.const 0
-   local.set $1
+   local.set $5
    loop $loop|3
-    local.get $1
+    local.get $5
     i32.const 50
     i32.lt_u
     i32.eqz
     br_if $break|3
     local.get $0
-    local.get $1
+    local.get $5
     call $~lib/map/Map<u32,i32>#has
-    i32.eqz
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 41
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $0
-    local.get $1
-    i32.const 10
-    local.get $1
+    local.get $5
+    call $~lib/map/Map<u32,i32>#get
+    i32.const 20
+    local.get $5
     i32.add
-    call $~lib/map/Map<u32,i32>#set
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<u32,i32>#has
+    i32.eq
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 36
+     i32.const 42
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $0
-    local.get $1
+    local.get $5
     call $~lib/map/Map<u32,i32>#delete
     drop
     local.get $0
-    local.get $1
+    local.get $5
     call $~lib/map/Map<u32,i32>#has
     i32.eqz
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 38
+     i32.const 44
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $5
     i32.const 1
     i32.add
-    local.set $1
+    local.set $5
     br $loop|3
    end
    unreachable
@@ -8822,7 +13154,85 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 46
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $break|4
+   i32.const 0
+   local.set $5
+   loop $loop|4
+    local.get $5
+    i32.const 50
+    i32.lt_u
+    i32.eqz
+    br_if $break|4
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<u32,i32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 50
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $5
+    i32.const 10
+    local.get $5
+    i32.add
+    call $~lib/map/Map<u32,i32>#set
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<u32,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 52
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<u32,i32>#delete
+    drop
+    local.get $0
+    local.get $5
+    call $~lib/map/Map<u32,i32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 54
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|4
+   end
+   unreachable
+  end
+  local.get $0
+  call $~lib/map/Map<u32,i32>#get:size
+  i32.const 50
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 56
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -8837,15 +13247,23 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 44
+   i32.const 60
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i64,i32>#clear (; 96 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<i64,i32>#clear (; 185 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -8885,12 +13303,12 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<i64,i32>#constructor (; 97 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#constructor (; 186 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
    i32.const 24
-   i32.const 9
+   i32.const 20
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
    local.set $0
@@ -8917,7 +13335,7 @@
   call $~lib/map/Map<i64,i32>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash64 (; 98 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/hash/hash64 (; 187 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -9005,7 +13423,7 @@
   local.set $3
   local.get $3
  )
- (func $~lib/map/Map<i64,i32>#find (; 99 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#find (; 188 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -9053,7 +13471,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<i64,i32>#has (; 100 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<i64,i32>#has (; 189 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   local.get $0
   local.get $1
@@ -9068,7 +13486,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<i64,i32>#rehash (; 101 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i64,i32>#rehash (; 190 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9226,7 +13644,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<i64,i32>#set (; 102 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/map/Map<i64,i32>#set (; 191 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -9330,7 +13748,7 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/map/Map<i64,i32>#get (; 103 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<i64,i32>#get (; 192 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   local.get $0
@@ -9357,11 +13775,635 @@
   local.get $3
   i32.load offset=8
  )
- (func $~lib/map/Map<i64,i32>#get:size (; 104 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<i64,i32>#get:size (; 193 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<i64,i32>#delete (; 105 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/array/Array<i64>#constructor (; 194 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  if (result i32)
+   local.get $0
+  else
+   i32.const 16
+   i32.const 21
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+  end
+  local.get $1
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  local.get $1
+  i32.store offset=12
+  local.get $0
+ )
+ (func $~lib/array/Array<i64>#__unchecked_set (; 195 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 3
+  i32.shl
+  i32.add
+  local.get $2
+  i64.store
+ )
+ (func $~lib/array/Array<i64>#__set (; 196 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 512
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.const 3
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.store offset=12
+  end
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/array/Array<i64>#__unchecked_set
+ )
+ (func $~lib/array/Array<i64>#set:length (; 197 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load offset=12
+  local.set $2
+  local.get $0
+  local.get $1
+  i32.const 3
+  call $~lib/array/ensureSize
+  local.get $0
+  local.get $1
+  i32.store offset=12
+ )
+ (func $~lib/map/Map<i64,i32>#keys (; 198 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<i64>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 16
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=12
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $4
+     local.get $6
+     i64.load
+     call $~lib/array/Array<i64>#__set
+     local.get $4
+     i32.const 1
+     i32.add
+     local.set $4
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+  local.get $4
+  call $~lib/array/Array<i64>#set:length
+  local.get $3
+ )
+ (func $~lib/map/Map<i64,i32>#values (; 199 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<i32>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 16
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=12
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $6
+     i32.load offset=8
+     call $~lib/array/Array<i32>#push
+     drop
+     local.get $4
+     i32.const 1
+     i32.add
+     local.set $4
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+  local.get $4
+  call $~lib/array/Array<i32>#set:length
+  local.get $3
+ )
+ (func $~lib/map/Map<i64,i64>#clear (; 200 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 96
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+ )
+ (func $~lib/map/Map<i64,i64>#constructor (; 201 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 24
+   i32.const 22
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+  local.get $0
+  call $~lib/map/Map<i64,i64>#clear
+  local.get $0
+ )
+ (func $~lib/array/Array<i64>#get:length (; 202 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=12
+ )
+ (func $~lib/array/Array<i64>#__unchecked_get (; 203 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 3
+  i32.shl
+  i32.add
+  i64.load
+ )
+ (func $~lib/array/Array<i64>#__get (; 204 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i64)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 512
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<i64>#__unchecked_get
+  local.set $2
+  local.get $2
+ )
+ (func $~lib/map/Map<i64,i64>#find (; 205 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+  (local $3 i32)
+  local.get $0
+  i32.load
+  local.get $2
+  local.get $0
+  i32.load offset=4
+  i32.and
+  i32.const 4
+  i32.mul
+  i32.add
+  i32.load
+  local.set $3
+  block $break|0
+   loop $continue|0
+    local.get $3
+    i32.eqz
+    br_if $break|0
+    local.get $3
+    i32.load offset=16
+    i32.const 1
+    i32.and
+    i32.eqz
+    if (result i32)
+     local.get $3
+     i64.load
+     local.get $1
+     i64.eq
+    else
+     i32.const 0
+    end
+    if
+     local.get $3
+     return
+    end
+    local.get $3
+    i32.load offset=16
+    i32.const 1
+    i32.const -1
+    i32.xor
+    i32.and
+    local.set $3
+    br $continue|0
+   end
+   unreachable
+  end
+  i32.const 0
+ )
+ (func $~lib/map/Map<i64,i64>#rehash (; 206 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i64)
+  (local $12 i32)
+  (local $13 i32)
+  local.get $1
+  i32.const 1
+  i32.add
+  local.set $2
+  i32.const 0
+  local.get $2
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $3
+  local.get $2
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
+  local.set $4
+  i32.const 0
+  local.get $4
+  i32.const 24
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $5
+  local.get $0
+  i32.load offset=8
+  local.set $6
+  local.get $6
+  local.get $0
+  i32.load offset=16
+  i32.const 24
+  i32.mul
+  i32.add
+  local.set $7
+  local.get $5
+  local.set $8
+  block $break|0
+   loop $continue|0
+    local.get $6
+    local.get $7
+    i32.ne
+    i32.eqz
+    br_if $break|0
+    local.get $6
+    local.set $9
+    local.get $9
+    i32.load offset=16
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $8
+     local.set $10
+     local.get $10
+     local.get $9
+     i64.load
+     i64.store
+     local.get $10
+     local.get $9
+     i64.load offset=8
+     i64.store offset=8
+     block $~lib/util/hash/HASH<i64>|inlined.5 (result i32)
+      local.get $9
+      i64.load
+      local.set $11
+      local.get $11
+      call $~lib/util/hash/hash64
+      br $~lib/util/hash/HASH<i64>|inlined.5
+     end
+     local.get $1
+     i32.and
+     local.set $12
+     local.get $3
+     local.get $12
+     i32.const 4
+     i32.mul
+     i32.add
+     local.set $13
+     local.get $10
+     local.get $13
+     i32.load
+     i32.store offset=16
+     local.get $13
+     local.get $8
+     i32.store
+     local.get $8
+     i32.const 24
+     i32.add
+     local.set $8
+    end
+    local.get $6
+    i32.const 24
+    i32.add
+    local.set $6
+    br $continue|0
+   end
+   unreachable
+  end
+  local.get $0
+  local.tee $9
+  local.get $3
+  local.tee $10
+  local.get $9
+  i32.load
+  local.tee $13
+  i32.ne
+  if
+   local.get $10
+   call $~lib/rt/pure/__retain
+   local.set $10
+   local.get $13
+   call $~lib/rt/pure/__release
+  end
+  local.get $10
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $0
+  local.tee $9
+  local.get $5
+  local.tee $12
+  local.get $9
+  i32.load offset=8
+  local.tee $10
+  i32.ne
+  if
+   local.get $12
+   call $~lib/rt/pure/__retain
+   local.set $12
+   local.get $10
+   call $~lib/rt/pure/__release
+  end
+  local.get $12
+  i32.store offset=8
+  local.get $0
+  local.get $4
+  i32.store offset=12
+  local.get $0
+  local.get $0
+  i32.load offset=20
+  i32.store offset=16
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/map/Map<i64,i64>#set (; 207 ;) (type $FUNCSIG$vijj) (param $0 i32) (param $1 i64) (param $2 i64)
+  (local $3 i64)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  block $~lib/util/hash/HASH<i64>|inlined.4 (result i32)
+   local.get $1
+   local.set $3
+   local.get $3
+   call $~lib/util/hash/hash64
+   br $~lib/util/hash/HASH<i64>|inlined.4
+  end
+  local.set $4
+  local.get $0
+  local.get $1
+  local.get $4
+  call $~lib/map/Map<i64,i64>#find
+  local.set $5
+  local.get $5
+  if
+   local.get $5
+   local.get $2
+   i64.store offset=8
+  else
+   local.get $0
+   i32.load offset=16
+   local.get $0
+   i32.load offset=12
+   i32.eq
+   if
+    local.get $0
+    local.get $0
+    i32.load offset=20
+    local.get $0
+    i32.load offset=12
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
+    i32.lt_s
+    if (result i32)
+     local.get $0
+     i32.load offset=4
+    else
+     local.get $0
+     i32.load offset=4
+     i32.const 1
+     i32.shl
+     i32.const 1
+     i32.or
+    end
+    call $~lib/map/Map<i64,i64>#rehash
+   end
+   local.get $0
+   i32.load offset=8
+   call $~lib/rt/pure/__retain
+   local.set $6
+   local.get $6
+   local.get $0
+   local.get $0
+   i32.load offset=16
+   local.tee $7
+   i32.const 1
+   i32.add
+   i32.store offset=16
+   local.get $7
+   i32.const 24
+   i32.mul
+   i32.add
+   local.set $5
+   local.get $5
+   local.get $1
+   i64.store
+   local.get $5
+   local.get $2
+   i64.store offset=8
+   local.get $0
+   local.get $0
+   i32.load offset=20
+   i32.const 1
+   i32.add
+   i32.store offset=20
+   local.get $0
+   i32.load
+   local.get $4
+   local.get $0
+   i32.load offset=4
+   i32.and
+   i32.const 4
+   i32.mul
+   i32.add
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.load
+   i32.store offset=16
+   local.get $7
+   local.get $5
+   i32.store
+   local.get $6
+   call $~lib/rt/pure/__release
+  end
+ )
+ (func $~lib/map/Map<i64,i64>#get:size (; 208 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=20
+ )
+ (func $~lib/map/Map<i64,i32>#delete (; 209 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -9369,12 +14411,12 @@
   (local $6 i32)
   local.get $0
   local.get $1
-  block $~lib/util/hash/HASH<i64>|inlined.4 (result i32)
+  block $~lib/util/hash/HASH<i64>|inlined.6 (result i32)
    local.get $1
    local.set $2
    local.get $2
    call $~lib/util/hash/hash64
-   br $~lib/util/hash/HASH<i64>|inlined.4
+   br $~lib/util/hash/HASH<i64>|inlined.6
   end
   call $~lib/map/Map<i64,i32>#find
   local.set $3
@@ -9434,9 +14476,15 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<i64,i32> (; 106 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<i64,i32> (; 210 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i64)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   i32.const 0
   call $~lib/map/Map<i64,i32>#constructor
   local.set $0
@@ -9614,78 +14662,105 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
+  call $~lib/map/Map<i64,i32>#keys
+  local.set $2
+  local.get $0
+  call $~lib/map/Map<i64,i32>#values
+  local.set $3
+  i32.const 0
+  call $~lib/map/Map<i64,i64>#constructor
+  local.set $4
+  i32.const 0
+  call $~lib/map/Map<i32,i32>#constructor
+  local.set $5
   block $break|2
-   i64.const 0
-   local.set $1
+   i32.const 0
+   local.set $6
    loop $loop|2
-    local.get $1
-    i64.const 50
-    i64.lt_s
+    local.get $6
+    local.get $2
+    call $~lib/array/Array<i64>#get:length
+    i32.lt_s
     i32.eqz
     br_if $break|2
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<i64,i32>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 25
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<i64,i32>#get
-    i32.const 20
-    local.get $1
-    i32.wrap_i64
-    i32.add
-    i32.eq
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 26
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<i64,i32>#delete
-    drop
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<i64,i32>#has
-    i32.eqz
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 28
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    i64.const 1
-    i64.add
+    local.get $2
+    local.get $6
+    call $~lib/array/Array<i64>#__get
     local.set $1
+    local.get $3
+    local.get $6
+    call $~lib/array/Array<i32>#__get
+    local.set $7
+    local.get $0
+    local.get $1
+    call $~lib/map/Map<i64,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 31
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $7
+    i32.const 20
+    i32.sub
+    i64.extend_i32_s
+    call $~lib/map/Map<i64,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 32
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $4
+    local.get $1
+    local.get $1
+    call $~lib/map/Map<i64,i64>#set
+    local.get $5
+    local.get $7
+    i32.const 20
+    i32.sub
+    local.get $7
+    i32.const 20
+    i32.sub
+    call $~lib/map/Map<i32,i32>#set
+    local.get $6
+    i32.const 1
+    i32.add
+    local.set $6
     br $loop|2
    end
    unreachable
   end
-  local.get $0
-  call $~lib/map/Map<i64,i32>#get:size
-  i32.const 50
+  local.get $4
+  call $~lib/map/Map<i64,i64>#get:size
+  i32.const 100
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 30
+   i32.const 36
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  call $~lib/map/Map<i32,i32>#get:size
+  i32.const 100
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 37
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -9703,30 +14778,27 @@
     local.get $1
     call $~lib/map/Map<i64,i32>#has
     i32.eqz
-    i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 41
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $0
     local.get $1
-    i32.const 10
+    call $~lib/map/Map<i64,i32>#get
+    i32.const 20
     local.get $1
     i32.wrap_i64
     i32.add
-    call $~lib/map/Map<i64,i32>#set
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<i64,i32>#has
+    i32.eq
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 36
+     i32.const 42
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -9743,7 +14815,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 38
+     i32.const 44
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -9764,7 +14836,86 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 46
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $break|4
+   i64.const 0
+   local.set $1
+   loop $loop|4
+    local.get $1
+    i64.const 50
+    i64.lt_s
+    i32.eqz
+    br_if $break|4
+    local.get $0
+    local.get $1
+    call $~lib/map/Map<i64,i32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 50
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $1
+    i32.const 10
+    local.get $1
+    i32.wrap_i64
+    i32.add
+    call $~lib/map/Map<i64,i32>#set
+    local.get $0
+    local.get $1
+    call $~lib/map/Map<i64,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 52
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $1
+    call $~lib/map/Map<i64,i32>#delete
+    drop
+    local.get $0
+    local.get $1
+    call $~lib/map/Map<i64,i32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 54
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    i64.const 1
+    i64.add
+    local.set $1
+    br $loop|4
+   end
+   unreachable
+  end
+  local.get $0
+  call $~lib/map/Map<i64,i32>#get:size
+  i32.const 50
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 56
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -9779,15 +14930,23 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 44
+   i32.const 60
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u64,i32>#clear (; 107 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<u64,i32>#clear (; 211 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -9827,12 +14986,12 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<u64,i32>#constructor (; 108 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#constructor (; 212 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
    i32.const 24
-   i32.const 10
+   i32.const 23
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
    local.set $0
@@ -9859,7 +15018,7 @@
   call $~lib/map/Map<u64,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<u64,i32>#find (; 109 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#find (; 213 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -9907,7 +15066,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<u64,i32>#has (; 110 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<u64,i32>#has (; 214 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   local.get $0
   local.get $1
@@ -9922,7 +15081,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<u64,i32>#rehash (; 111 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u64,i32>#rehash (; 215 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10080,7 +15239,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<u64,i32>#set (; 112 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
+ (func $~lib/map/Map<u64,i32>#set (; 216 ;) (type $FUNCSIG$viji) (param $0 i32) (param $1 i64) (param $2 i32)
   (local $3 i64)
   (local $4 i32)
   (local $5 i32)
@@ -10184,7 +15343,7 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/map/Map<u64,i32>#get (; 113 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/map/Map<u64,i32>#get (; 217 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   local.get $0
@@ -10211,11 +15370,635 @@
   local.get $3
   i32.load offset=8
  )
- (func $~lib/map/Map<u64,i32>#get:size (; 114 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<u64,i32>#get:size (; 218 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<u64,i32>#delete (; 115 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/array/Array<u64>#constructor (; 219 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  if (result i32)
+   local.get $0
+  else
+   i32.const 16
+   i32.const 24
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+  end
+  local.get $1
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  local.get $1
+  i32.store offset=12
+  local.get $0
+ )
+ (func $~lib/array/Array<u64>#__unchecked_set (; 220 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 3
+  i32.shl
+  i32.add
+  local.get $2
+  i64.store
+ )
+ (func $~lib/array/Array<u64>#__set (; 221 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 512
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.const 3
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.store offset=12
+  end
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/array/Array<u64>#__unchecked_set
+ )
+ (func $~lib/array/Array<u64>#set:length (; 222 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load offset=12
+  local.set $2
+  local.get $0
+  local.get $1
+  i32.const 3
+  call $~lib/array/ensureSize
+  local.get $0
+  local.get $1
+  i32.store offset=12
+ )
+ (func $~lib/map/Map<u64,i32>#keys (; 223 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<u64>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 16
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=12
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $4
+     local.get $6
+     i64.load
+     call $~lib/array/Array<u64>#__set
+     local.get $4
+     i32.const 1
+     i32.add
+     local.set $4
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+  local.get $4
+  call $~lib/array/Array<u64>#set:length
+  local.get $3
+ )
+ (func $~lib/map/Map<u64,i32>#values (; 224 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<i32>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 16
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=12
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $6
+     i32.load offset=8
+     call $~lib/array/Array<i32>#push
+     drop
+     local.get $4
+     i32.const 1
+     i32.add
+     local.set $4
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+  local.get $4
+  call $~lib/array/Array<i32>#set:length
+  local.get $3
+ )
+ (func $~lib/map/Map<u64,u64>#clear (; 225 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 96
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+ )
+ (func $~lib/map/Map<u64,u64>#constructor (; 226 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 24
+   i32.const 25
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+  local.get $0
+  call $~lib/map/Map<u64,u64>#clear
+  local.get $0
+ )
+ (func $~lib/array/Array<u64>#get:length (; 227 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=12
+ )
+ (func $~lib/array/Array<u64>#__unchecked_get (; 228 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 3
+  i32.shl
+  i32.add
+  i64.load
+ )
+ (func $~lib/array/Array<u64>#__get (; 229 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i64)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 512
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<u64>#__unchecked_get
+  local.set $2
+  local.get $2
+ )
+ (func $~lib/map/Map<u64,u64>#find (; 230 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+  (local $3 i32)
+  local.get $0
+  i32.load
+  local.get $2
+  local.get $0
+  i32.load offset=4
+  i32.and
+  i32.const 4
+  i32.mul
+  i32.add
+  i32.load
+  local.set $3
+  block $break|0
+   loop $continue|0
+    local.get $3
+    i32.eqz
+    br_if $break|0
+    local.get $3
+    i32.load offset=16
+    i32.const 1
+    i32.and
+    i32.eqz
+    if (result i32)
+     local.get $3
+     i64.load
+     local.get $1
+     i64.eq
+    else
+     i32.const 0
+    end
+    if
+     local.get $3
+     return
+    end
+    local.get $3
+    i32.load offset=16
+    i32.const 1
+    i32.const -1
+    i32.xor
+    i32.and
+    local.set $3
+    br $continue|0
+   end
+   unreachable
+  end
+  i32.const 0
+ )
+ (func $~lib/map/Map<u64,u64>#rehash (; 231 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i64)
+  (local $12 i32)
+  (local $13 i32)
+  local.get $1
+  i32.const 1
+  i32.add
+  local.set $2
+  i32.const 0
+  local.get $2
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $3
+  local.get $2
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
+  local.set $4
+  i32.const 0
+  local.get $4
+  i32.const 24
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $5
+  local.get $0
+  i32.load offset=8
+  local.set $6
+  local.get $6
+  local.get $0
+  i32.load offset=16
+  i32.const 24
+  i32.mul
+  i32.add
+  local.set $7
+  local.get $5
+  local.set $8
+  block $break|0
+   loop $continue|0
+    local.get $6
+    local.get $7
+    i32.ne
+    i32.eqz
+    br_if $break|0
+    local.get $6
+    local.set $9
+    local.get $9
+    i32.load offset=16
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $8
+     local.set $10
+     local.get $10
+     local.get $9
+     i64.load
+     i64.store
+     local.get $10
+     local.get $9
+     i64.load offset=8
+     i64.store offset=8
+     block $~lib/util/hash/HASH<u64>|inlined.5 (result i32)
+      local.get $9
+      i64.load
+      local.set $11
+      local.get $11
+      call $~lib/util/hash/hash64
+      br $~lib/util/hash/HASH<u64>|inlined.5
+     end
+     local.get $1
+     i32.and
+     local.set $12
+     local.get $3
+     local.get $12
+     i32.const 4
+     i32.mul
+     i32.add
+     local.set $13
+     local.get $10
+     local.get $13
+     i32.load
+     i32.store offset=16
+     local.get $13
+     local.get $8
+     i32.store
+     local.get $8
+     i32.const 24
+     i32.add
+     local.set $8
+    end
+    local.get $6
+    i32.const 24
+    i32.add
+    local.set $6
+    br $continue|0
+   end
+   unreachable
+  end
+  local.get $0
+  local.tee $9
+  local.get $3
+  local.tee $10
+  local.get $9
+  i32.load
+  local.tee $13
+  i32.ne
+  if
+   local.get $10
+   call $~lib/rt/pure/__retain
+   local.set $10
+   local.get $13
+   call $~lib/rt/pure/__release
+  end
+  local.get $10
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $0
+  local.tee $9
+  local.get $5
+  local.tee $12
+  local.get $9
+  i32.load offset=8
+  local.tee $10
+  i32.ne
+  if
+   local.get $12
+   call $~lib/rt/pure/__retain
+   local.set $12
+   local.get $10
+   call $~lib/rt/pure/__release
+  end
+  local.get $12
+  i32.store offset=8
+  local.get $0
+  local.get $4
+  i32.store offset=12
+  local.get $0
+  local.get $0
+  i32.load offset=20
+  i32.store offset=16
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/map/Map<u64,u64>#set (; 232 ;) (type $FUNCSIG$vijj) (param $0 i32) (param $1 i64) (param $2 i64)
+  (local $3 i64)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  block $~lib/util/hash/HASH<u64>|inlined.4 (result i32)
+   local.get $1
+   local.set $3
+   local.get $3
+   call $~lib/util/hash/hash64
+   br $~lib/util/hash/HASH<u64>|inlined.4
+  end
+  local.set $4
+  local.get $0
+  local.get $1
+  local.get $4
+  call $~lib/map/Map<u64,u64>#find
+  local.set $5
+  local.get $5
+  if
+   local.get $5
+   local.get $2
+   i64.store offset=8
+  else
+   local.get $0
+   i32.load offset=16
+   local.get $0
+   i32.load offset=12
+   i32.eq
+   if
+    local.get $0
+    local.get $0
+    i32.load offset=20
+    local.get $0
+    i32.load offset=12
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
+    i32.lt_s
+    if (result i32)
+     local.get $0
+     i32.load offset=4
+    else
+     local.get $0
+     i32.load offset=4
+     i32.const 1
+     i32.shl
+     i32.const 1
+     i32.or
+    end
+    call $~lib/map/Map<u64,u64>#rehash
+   end
+   local.get $0
+   i32.load offset=8
+   call $~lib/rt/pure/__retain
+   local.set $6
+   local.get $6
+   local.get $0
+   local.get $0
+   i32.load offset=16
+   local.tee $7
+   i32.const 1
+   i32.add
+   i32.store offset=16
+   local.get $7
+   i32.const 24
+   i32.mul
+   i32.add
+   local.set $5
+   local.get $5
+   local.get $1
+   i64.store
+   local.get $5
+   local.get $2
+   i64.store offset=8
+   local.get $0
+   local.get $0
+   i32.load offset=20
+   i32.const 1
+   i32.add
+   i32.store offset=20
+   local.get $0
+   i32.load
+   local.get $4
+   local.get $0
+   i32.load offset=4
+   i32.and
+   i32.const 4
+   i32.mul
+   i32.add
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.load
+   i32.store offset=16
+   local.get $7
+   local.get $5
+   i32.store
+   local.get $6
+   call $~lib/rt/pure/__release
+  end
+ )
+ (func $~lib/map/Map<u64,u64>#get:size (; 233 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=20
+ )
+ (func $~lib/map/Map<u64,i32>#delete (; 234 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -10223,12 +16006,12 @@
   (local $6 i32)
   local.get $0
   local.get $1
-  block $~lib/util/hash/HASH<u64>|inlined.4 (result i32)
+  block $~lib/util/hash/HASH<u64>|inlined.6 (result i32)
    local.get $1
    local.set $2
    local.get $2
    call $~lib/util/hash/hash64
-   br $~lib/util/hash/HASH<u64>|inlined.4
+   br $~lib/util/hash/HASH<u64>|inlined.6
   end
   call $~lib/map/Map<u64,i32>#find
   local.set $3
@@ -10288,9 +16071,15 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<u64,i32> (; 116 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<u64,i32> (; 235 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i64)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   i32.const 0
   call $~lib/map/Map<u64,i32>#constructor
   local.set $0
@@ -10468,78 +16257,105 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
+  call $~lib/map/Map<u64,i32>#keys
+  local.set $2
+  local.get $0
+  call $~lib/map/Map<u64,i32>#values
+  local.set $3
+  i32.const 0
+  call $~lib/map/Map<u64,u64>#constructor
+  local.set $4
+  i32.const 0
+  call $~lib/map/Map<i32,i32>#constructor
+  local.set $5
   block $break|2
-   i64.const 0
-   local.set $1
+   i32.const 0
+   local.set $6
    loop $loop|2
-    local.get $1
-    i64.const 50
-    i64.lt_u
+    local.get $6
+    local.get $2
+    call $~lib/array/Array<u64>#get:length
+    i32.lt_s
     i32.eqz
     br_if $break|2
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<u64,i32>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 25
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<u64,i32>#get
-    i32.const 20
-    local.get $1
-    i32.wrap_i64
-    i32.add
-    i32.eq
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 26
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<u64,i32>#delete
-    drop
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<u64,i32>#has
-    i32.eqz
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 28
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    i64.const 1
-    i64.add
+    local.get $2
+    local.get $6
+    call $~lib/array/Array<u64>#__get
     local.set $1
+    local.get $3
+    local.get $6
+    call $~lib/array/Array<i32>#__get
+    local.set $7
+    local.get $0
+    local.get $1
+    call $~lib/map/Map<u64,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 31
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $7
+    i32.const 20
+    i32.sub
+    i64.extend_i32_s
+    call $~lib/map/Map<u64,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 32
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $4
+    local.get $1
+    local.get $1
+    call $~lib/map/Map<u64,u64>#set
+    local.get $5
+    local.get $7
+    i32.const 20
+    i32.sub
+    local.get $7
+    i32.const 20
+    i32.sub
+    call $~lib/map/Map<i32,i32>#set
+    local.get $6
+    i32.const 1
+    i32.add
+    local.set $6
     br $loop|2
    end
    unreachable
   end
-  local.get $0
-  call $~lib/map/Map<u64,i32>#get:size
-  i32.const 50
+  local.get $4
+  call $~lib/map/Map<u64,u64>#get:size
+  i32.const 100
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 30
+   i32.const 36
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  call $~lib/map/Map<i32,i32>#get:size
+  i32.const 100
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 37
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10557,30 +16373,27 @@
     local.get $1
     call $~lib/map/Map<u64,i32>#has
     i32.eqz
-    i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 41
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $0
     local.get $1
-    i32.const 10
+    call $~lib/map/Map<u64,i32>#get
+    i32.const 20
     local.get $1
     i32.wrap_i64
     i32.add
-    call $~lib/map/Map<u64,i32>#set
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<u64,i32>#has
+    i32.eq
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 36
+     i32.const 42
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -10597,7 +16410,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 38
+     i32.const 44
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -10618,7 +16431,86 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 46
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $break|4
+   i64.const 0
+   local.set $1
+   loop $loop|4
+    local.get $1
+    i64.const 50
+    i64.lt_u
+    i32.eqz
+    br_if $break|4
+    local.get $0
+    local.get $1
+    call $~lib/map/Map<u64,i32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 50
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $1
+    i32.const 10
+    local.get $1
+    i32.wrap_i64
+    i32.add
+    call $~lib/map/Map<u64,i32>#set
+    local.get $0
+    local.get $1
+    call $~lib/map/Map<u64,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 52
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $1
+    call $~lib/map/Map<u64,i32>#delete
+    drop
+    local.get $0
+    local.get $1
+    call $~lib/map/Map<u64,i32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 54
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    i64.const 1
+    i64.add
+    local.set $1
+    br $loop|4
+   end
+   unreachable
+  end
+  local.get $0
+  call $~lib/map/Map<u64,i32>#get:size
+  i32.const 50
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 56
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10633,15 +16525,23 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 44
+   i32.const 60
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f32,i32>#clear (; 117 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<f32,i32>#clear (; 236 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -10681,12 +16581,12 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<f32,i32>#constructor (; 118 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#constructor (; 237 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
    i32.const 24
-   i32.const 11
+   i32.const 26
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
    local.set $0
@@ -10713,7 +16613,7 @@
   call $~lib/map/Map<f32,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<f32,i32>#find (; 119 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#find (; 238 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -10761,7 +16661,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f32,i32>#has (; 120 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/map/Map<f32,i32>#has (; 239 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
   (local $2 f32)
   local.get $0
   local.get $1
@@ -10777,7 +16677,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<f32,i32>#rehash (; 121 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f32,i32>#rehash (; 240 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10936,7 +16836,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f32,i32>#set (; 122 ;) (type $FUNCSIG$vifi) (param $0 i32) (param $1 f32) (param $2 i32)
+ (func $~lib/map/Map<f32,i32>#set (; 241 ;) (type $FUNCSIG$vifi) (param $0 i32) (param $1 f32) (param $2 i32)
   (local $3 f32)
   (local $4 i32)
   (local $5 i32)
@@ -11041,7 +16941,7 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/map/Map<f32,i32>#get (; 123 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/map/Map<f32,i32>#get (; 242 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
   (local $2 f32)
   (local $3 i32)
   local.get $0
@@ -11069,11 +16969,637 @@
   local.get $3
   i32.load offset=4
  )
- (func $~lib/map/Map<f32,i32>#get:size (; 124 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f32,i32>#get:size (; 243 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<f32,i32>#delete (; 125 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/array/Array<f32>#constructor (; 244 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  if (result i32)
+   local.get $0
+  else
+   i32.const 16
+   i32.const 27
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+  end
+  local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  local.get $1
+  i32.store offset=12
+  local.get $0
+ )
+ (func $~lib/array/Array<f32>#__unchecked_set (; 245 ;) (type $FUNCSIG$viif) (param $0 i32) (param $1 i32) (param $2 f32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $2
+  f32.store
+ )
+ (func $~lib/array/Array<f32>#__set (; 246 ;) (type $FUNCSIG$viif) (param $0 i32) (param $1 i32) (param $2 f32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 512
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.const 2
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.store offset=12
+  end
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/array/Array<f32>#__unchecked_set
+ )
+ (func $~lib/array/Array<f32>#set:length (; 247 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load offset=12
+  local.set $2
+  local.get $0
+  local.get $1
+  i32.const 2
+  call $~lib/array/ensureSize
+  local.get $0
+  local.get $1
+  i32.store offset=12
+ )
+ (func $~lib/map/Map<f32,i32>#keys (; 248 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<f32>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 12
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $4
+     local.get $6
+     f32.load
+     call $~lib/array/Array<f32>#__set
+     local.get $4
+     i32.const 1
+     i32.add
+     local.set $4
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+  local.get $4
+  call $~lib/array/Array<f32>#set:length
+  local.get $3
+ )
+ (func $~lib/map/Map<f32,i32>#values (; 249 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<i32>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 12
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $6
+     i32.load offset=4
+     call $~lib/array/Array<i32>#push
+     drop
+     local.get $4
+     i32.const 1
+     i32.add
+     local.set $4
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+  local.get $4
+  call $~lib/array/Array<i32>#set:length
+  local.get $3
+ )
+ (func $~lib/map/Map<f32,f32>#clear (; 250 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 48
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+ )
+ (func $~lib/map/Map<f32,f32>#constructor (; 251 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 24
+   i32.const 28
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+  local.get $0
+  call $~lib/map/Map<f32,f32>#clear
+  local.get $0
+ )
+ (func $~lib/array/Array<f32>#get:length (; 252 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=12
+ )
+ (func $~lib/array/Array<f32>#__unchecked_get (; 253 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  f32.load
+ )
+ (func $~lib/array/Array<f32>#__get (; 254 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
+  (local $2 f32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 512
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<f32>#__unchecked_get
+  local.set $2
+  local.get $2
+ )
+ (func $~lib/map/Map<f32,f32>#find (; 255 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+  (local $3 i32)
+  local.get $0
+  i32.load
+  local.get $2
+  local.get $0
+  i32.load offset=4
+  i32.and
+  i32.const 4
+  i32.mul
+  i32.add
+  i32.load
+  local.set $3
+  block $break|0
+   loop $continue|0
+    local.get $3
+    i32.eqz
+    br_if $break|0
+    local.get $3
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if (result i32)
+     local.get $3
+     f32.load
+     local.get $1
+     f32.eq
+    else
+     i32.const 0
+    end
+    if
+     local.get $3
+     return
+    end
+    local.get $3
+    i32.load offset=8
+    i32.const 1
+    i32.const -1
+    i32.xor
+    i32.and
+    local.set $3
+    br $continue|0
+   end
+   unreachable
+  end
+  i32.const 0
+ )
+ (func $~lib/map/Map<f32,f32>#rehash (; 256 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 f32)
+  (local $12 i32)
+  (local $13 i32)
+  local.get $1
+  i32.const 1
+  i32.add
+  local.set $2
+  i32.const 0
+  local.get $2
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $3
+  local.get $2
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
+  local.set $4
+  i32.const 0
+  local.get $4
+  i32.const 12
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $5
+  local.get $0
+  i32.load offset=8
+  local.set $6
+  local.get $6
+  local.get $0
+  i32.load offset=16
+  i32.const 12
+  i32.mul
+  i32.add
+  local.set $7
+  local.get $5
+  local.set $8
+  block $break|0
+   loop $continue|0
+    local.get $6
+    local.get $7
+    i32.ne
+    i32.eqz
+    br_if $break|0
+    local.get $6
+    local.set $9
+    local.get $9
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $8
+     local.set $10
+     local.get $10
+     local.get $9
+     f32.load
+     f32.store
+     local.get $10
+     local.get $9
+     f32.load offset=4
+     f32.store offset=4
+     block $~lib/util/hash/HASH<f32>|inlined.5 (result i32)
+      local.get $9
+      f32.load
+      local.set $11
+      local.get $11
+      i32.reinterpret_f32
+      call $~lib/util/hash/hash32
+      br $~lib/util/hash/HASH<f32>|inlined.5
+     end
+     local.get $1
+     i32.and
+     local.set $12
+     local.get $3
+     local.get $12
+     i32.const 4
+     i32.mul
+     i32.add
+     local.set $13
+     local.get $10
+     local.get $13
+     i32.load
+     i32.store offset=8
+     local.get $13
+     local.get $8
+     i32.store
+     local.get $8
+     i32.const 12
+     i32.add
+     local.set $8
+    end
+    local.get $6
+    i32.const 12
+    i32.add
+    local.set $6
+    br $continue|0
+   end
+   unreachable
+  end
+  local.get $0
+  local.tee $9
+  local.get $3
+  local.tee $10
+  local.get $9
+  i32.load
+  local.tee $13
+  i32.ne
+  if
+   local.get $10
+   call $~lib/rt/pure/__retain
+   local.set $10
+   local.get $13
+   call $~lib/rt/pure/__release
+  end
+  local.get $10
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $0
+  local.tee $9
+  local.get $5
+  local.tee $12
+  local.get $9
+  i32.load offset=8
+  local.tee $10
+  i32.ne
+  if
+   local.get $12
+   call $~lib/rt/pure/__retain
+   local.set $12
+   local.get $10
+   call $~lib/rt/pure/__release
+  end
+  local.get $12
+  i32.store offset=8
+  local.get $0
+  local.get $4
+  i32.store offset=12
+  local.get $0
+  local.get $0
+  i32.load offset=20
+  i32.store offset=16
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/map/Map<f32,f32>#set (; 257 ;) (type $FUNCSIG$viff) (param $0 i32) (param $1 f32) (param $2 f32)
+  (local $3 f32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  block $~lib/util/hash/HASH<f32>|inlined.4 (result i32)
+   local.get $1
+   local.set $3
+   local.get $3
+   i32.reinterpret_f32
+   call $~lib/util/hash/hash32
+   br $~lib/util/hash/HASH<f32>|inlined.4
+  end
+  local.set $4
+  local.get $0
+  local.get $1
+  local.get $4
+  call $~lib/map/Map<f32,f32>#find
+  local.set $5
+  local.get $5
+  if
+   local.get $5
+   local.get $2
+   f32.store offset=4
+  else
+   local.get $0
+   i32.load offset=16
+   local.get $0
+   i32.load offset=12
+   i32.eq
+   if
+    local.get $0
+    local.get $0
+    i32.load offset=20
+    local.get $0
+    i32.load offset=12
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
+    i32.lt_s
+    if (result i32)
+     local.get $0
+     i32.load offset=4
+    else
+     local.get $0
+     i32.load offset=4
+     i32.const 1
+     i32.shl
+     i32.const 1
+     i32.or
+    end
+    call $~lib/map/Map<f32,f32>#rehash
+   end
+   local.get $0
+   i32.load offset=8
+   call $~lib/rt/pure/__retain
+   local.set $6
+   local.get $6
+   local.get $0
+   local.get $0
+   i32.load offset=16
+   local.tee $7
+   i32.const 1
+   i32.add
+   i32.store offset=16
+   local.get $7
+   i32.const 12
+   i32.mul
+   i32.add
+   local.set $5
+   local.get $5
+   local.get $1
+   f32.store
+   local.get $5
+   local.get $2
+   f32.store offset=4
+   local.get $0
+   local.get $0
+   i32.load offset=20
+   i32.const 1
+   i32.add
+   i32.store offset=20
+   local.get $0
+   i32.load
+   local.get $4
+   local.get $0
+   i32.load offset=4
+   i32.and
+   i32.const 4
+   i32.mul
+   i32.add
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.load
+   i32.store offset=8
+   local.get $7
+   local.get $5
+   i32.store
+   local.get $6
+   call $~lib/rt/pure/__release
+  end
+ )
+ (func $~lib/map/Map<f32,f32>#get:size (; 258 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=20
+ )
+ (func $~lib/map/Map<f32,i32>#delete (; 259 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
   (local $2 f32)
   (local $3 i32)
   (local $4 i32)
@@ -11081,13 +17607,13 @@
   (local $6 i32)
   local.get $0
   local.get $1
-  block $~lib/util/hash/HASH<f32>|inlined.4 (result i32)
+  block $~lib/util/hash/HASH<f32>|inlined.6 (result i32)
    local.get $1
    local.set $2
    local.get $2
    i32.reinterpret_f32
    call $~lib/util/hash/hash32
-   br $~lib/util/hash/HASH<f32>|inlined.4
+   br $~lib/util/hash/HASH<f32>|inlined.6
   end
   call $~lib/map/Map<f32,i32>#find
   local.set $3
@@ -11147,9 +17673,15 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<f32,i32> (; 126 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<f32,i32> (; 260 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   i32.const 0
   call $~lib/map/Map<f32,i32>#constructor
   local.set $0
@@ -11327,78 +17859,105 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
+  call $~lib/map/Map<f32,i32>#keys
+  local.set $2
+  local.get $0
+  call $~lib/map/Map<f32,i32>#values
+  local.set $3
+  i32.const 0
+  call $~lib/map/Map<f32,f32>#constructor
+  local.set $4
+  i32.const 0
+  call $~lib/map/Map<i32,i32>#constructor
+  local.set $5
   block $break|2
-   f32.const 0
-   local.set $1
+   i32.const 0
+   local.set $6
    loop $loop|2
-    local.get $1
-    f32.const 50
-    f32.lt
+    local.get $6
+    local.get $2
+    call $~lib/array/Array<f32>#get:length
+    i32.lt_s
     i32.eqz
     br_if $break|2
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<f32,i32>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 25
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<f32,i32>#get
-    i32.const 20
-    local.get $1
-    i32.trunc_f32_s
-    i32.add
-    i32.eq
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 26
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<f32,i32>#delete
-    drop
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<f32,i32>#has
-    i32.eqz
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 28
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    f32.const 1
-    f32.add
+    local.get $2
+    local.get $6
+    call $~lib/array/Array<f32>#__get
     local.set $1
+    local.get $3
+    local.get $6
+    call $~lib/array/Array<i32>#__get
+    local.set $7
+    local.get $0
+    local.get $1
+    call $~lib/map/Map<f32,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 31
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $7
+    i32.const 20
+    i32.sub
+    f32.convert_i32_s
+    call $~lib/map/Map<f32,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 32
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $4
+    local.get $1
+    local.get $1
+    call $~lib/map/Map<f32,f32>#set
+    local.get $5
+    local.get $7
+    i32.const 20
+    i32.sub
+    local.get $7
+    i32.const 20
+    i32.sub
+    call $~lib/map/Map<i32,i32>#set
+    local.get $6
+    i32.const 1
+    i32.add
+    local.set $6
     br $loop|2
    end
    unreachable
   end
-  local.get $0
-  call $~lib/map/Map<f32,i32>#get:size
-  i32.const 50
+  local.get $4
+  call $~lib/map/Map<f32,f32>#get:size
+  i32.const 100
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 30
+   i32.const 36
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  call $~lib/map/Map<i32,i32>#get:size
+  i32.const 100
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 37
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11416,30 +17975,27 @@
     local.get $1
     call $~lib/map/Map<f32,i32>#has
     i32.eqz
-    i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 41
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $0
     local.get $1
-    i32.const 10
+    call $~lib/map/Map<f32,i32>#get
+    i32.const 20
     local.get $1
     i32.trunc_f32_s
     i32.add
-    call $~lib/map/Map<f32,i32>#set
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<f32,i32>#has
+    i32.eq
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 36
+     i32.const 42
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -11456,7 +18012,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 38
+     i32.const 44
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -11477,7 +18033,86 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 46
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $break|4
+   f32.const 0
+   local.set $1
+   loop $loop|4
+    local.get $1
+    f32.const 50
+    f32.lt
+    i32.eqz
+    br_if $break|4
+    local.get $0
+    local.get $1
+    call $~lib/map/Map<f32,i32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 50
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $1
+    i32.const 10
+    local.get $1
+    i32.trunc_f32_s
+    i32.add
+    call $~lib/map/Map<f32,i32>#set
+    local.get $0
+    local.get $1
+    call $~lib/map/Map<f32,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 52
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $1
+    call $~lib/map/Map<f32,i32>#delete
+    drop
+    local.get $0
+    local.get $1
+    call $~lib/map/Map<f32,i32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 54
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    f32.const 1
+    f32.add
+    local.set $1
+    br $loop|4
+   end
+   unreachable
+  end
+  local.get $0
+  call $~lib/map/Map<f32,i32>#get:size
+  i32.const 50
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 56
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11492,15 +18127,23 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 44
+   i32.const 60
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f64,i32>#clear (; 127 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/map/Map<f64,i32>#clear (; 261 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -11540,12 +18183,12 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/map/Map<f64,i32>#constructor (; 128 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#constructor (; 262 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
    i32.const 24
-   i32.const 12
+   i32.const 29
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
    local.set $0
@@ -11572,7 +18215,7 @@
   call $~lib/map/Map<f64,i32>#clear
   local.get $0
  )
- (func $~lib/map/Map<f64,i32>#find (; 129 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#find (; 263 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -11620,7 +18263,7 @@
   end
   i32.const 0
  )
- (func $~lib/map/Map<f64,i32>#has (; 130 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/map/Map<f64,i32>#has (; 264 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 f64)
   local.get $0
   local.get $1
@@ -11636,7 +18279,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/map/Map<f64,i32>#rehash (; 131 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<f64,i32>#rehash (; 265 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -11795,7 +18438,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/map/Map<f64,i32>#set (; 132 ;) (type $FUNCSIG$vidi) (param $0 i32) (param $1 f64) (param $2 i32)
+ (func $~lib/map/Map<f64,i32>#set (; 266 ;) (type $FUNCSIG$vidi) (param $0 i32) (param $1 f64) (param $2 i32)
   (local $3 f64)
   (local $4 i32)
   (local $5 i32)
@@ -11900,7 +18543,7 @@
    call $~lib/rt/pure/__release
   end
  )
- (func $~lib/map/Map<f64,i32>#get (; 133 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/map/Map<f64,i32>#get (; 267 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 f64)
   (local $3 i32)
   local.get $0
@@ -11928,11 +18571,637 @@
   local.get $3
   i32.load offset=8
  )
- (func $~lib/map/Map<f64,i32>#get:size (; 134 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/map/Map<f64,i32>#get:size (; 268 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/map/Map<f64,i32>#delete (; 135 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/array/Array<f64>#constructor (; 269 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  if (result i32)
+   local.get $0
+  else
+   i32.const 16
+   i32.const 30
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+  end
+  local.get $1
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  local.get $1
+  i32.store offset=12
+  local.get $0
+ )
+ (func $~lib/array/Array<f64>#__unchecked_set (; 270 ;) (type $FUNCSIG$viid) (param $0 i32) (param $1 i32) (param $2 f64)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 3
+  i32.shl
+  i32.add
+  local.get $2
+  f64.store
+ )
+ (func $~lib/array/Array<f64>#__set (; 271 ;) (type $FUNCSIG$viid) (param $0 i32) (param $1 i32) (param $2 f64)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 512
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.const 3
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.store offset=12
+  end
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/array/Array<f64>#__unchecked_set
+ )
+ (func $~lib/array/Array<f64>#set:length (; 272 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load offset=12
+  local.set $2
+  local.get $0
+  local.get $1
+  i32.const 3
+  call $~lib/array/ensureSize
+  local.get $0
+  local.get $1
+  i32.store offset=12
+ )
+ (func $~lib/map/Map<f64,i32>#keys (; 273 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<f64>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 16
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=12
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $4
+     local.get $6
+     f64.load
+     call $~lib/array/Array<f64>#__set
+     local.get $4
+     i32.const 1
+     i32.add
+     local.set $4
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+  local.get $4
+  call $~lib/array/Array<f64>#set:length
+  local.get $3
+ )
+ (func $~lib/map/Map<f64,i32>#values (; 274 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<i32>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 16
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=12
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $6
+     i32.load offset=8
+     call $~lib/array/Array<i32>#push
+     drop
+     local.get $4
+     i32.const 1
+     i32.add
+     local.set $4
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+  local.get $4
+  call $~lib/array/Array<i32>#set:length
+  local.get $3
+ )
+ (func $~lib/map/Map<f64,f64>#clear (; 275 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 16
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store
+  local.get $0
+  i32.const 4
+  i32.const 1
+  i32.sub
+  i32.store offset=4
+  local.get $0
+  local.tee $1
+  i32.const 0
+  i32.const 96
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $2
+  local.get $1
+  i32.load offset=8
+  call $~lib/rt/pure/__release
+  local.get $2
+  i32.store offset=8
+  local.get $0
+  i32.const 4
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+ )
+ (func $~lib/map/Map<f64,f64>#constructor (; 276 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 24
+   i32.const 31
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  i32.const 0
+  i32.store offset=16
+  local.get $0
+  i32.const 0
+  i32.store offset=20
+  local.get $0
+  call $~lib/map/Map<f64,f64>#clear
+  local.get $0
+ )
+ (func $~lib/array/Array<f64>#get:length (; 277 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=12
+ )
+ (func $~lib/array/Array<f64>#__unchecked_get (; 278 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 3
+  i32.shl
+  i32.add
+  f64.load
+ )
+ (func $~lib/array/Array<f64>#__get (; 279 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 f64)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 512
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<f64>#__unchecked_get
+  local.set $2
+  local.get $2
+ )
+ (func $~lib/map/Map<f64,f64>#find (; 280 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+  (local $3 i32)
+  local.get $0
+  i32.load
+  local.get $2
+  local.get $0
+  i32.load offset=4
+  i32.and
+  i32.const 4
+  i32.mul
+  i32.add
+  i32.load
+  local.set $3
+  block $break|0
+   loop $continue|0
+    local.get $3
+    i32.eqz
+    br_if $break|0
+    local.get $3
+    i32.load offset=16
+    i32.const 1
+    i32.and
+    i32.eqz
+    if (result i32)
+     local.get $3
+     f64.load
+     local.get $1
+     f64.eq
+    else
+     i32.const 0
+    end
+    if
+     local.get $3
+     return
+    end
+    local.get $3
+    i32.load offset=16
+    i32.const 1
+    i32.const -1
+    i32.xor
+    i32.and
+    local.set $3
+    br $continue|0
+   end
+   unreachable
+  end
+  i32.const 0
+ )
+ (func $~lib/map/Map<f64,f64>#rehash (; 281 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 f64)
+  (local $12 i32)
+  (local $13 i32)
+  local.get $1
+  i32.const 1
+  i32.add
+  local.set $2
+  i32.const 0
+  local.get $2
+  i32.const 4
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $3
+  local.get $2
+  i32.const 8
+  i32.mul
+  i32.const 3
+  i32.div_s
+  local.set $4
+  i32.const 0
+  local.get $4
+  i32.const 24
+  i32.mul
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $5
+  local.get $0
+  i32.load offset=8
+  local.set $6
+  local.get $6
+  local.get $0
+  i32.load offset=16
+  i32.const 24
+  i32.mul
+  i32.add
+  local.set $7
+  local.get $5
+  local.set $8
+  block $break|0
+   loop $continue|0
+    local.get $6
+    local.get $7
+    i32.ne
+    i32.eqz
+    br_if $break|0
+    local.get $6
+    local.set $9
+    local.get $9
+    i32.load offset=16
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $8
+     local.set $10
+     local.get $10
+     local.get $9
+     f64.load
+     f64.store
+     local.get $10
+     local.get $9
+     f64.load offset=8
+     f64.store offset=8
+     block $~lib/util/hash/HASH<f64>|inlined.5 (result i32)
+      local.get $9
+      f64.load
+      local.set $11
+      local.get $11
+      i64.reinterpret_f64
+      call $~lib/util/hash/hash64
+      br $~lib/util/hash/HASH<f64>|inlined.5
+     end
+     local.get $1
+     i32.and
+     local.set $12
+     local.get $3
+     local.get $12
+     i32.const 4
+     i32.mul
+     i32.add
+     local.set $13
+     local.get $10
+     local.get $13
+     i32.load
+     i32.store offset=16
+     local.get $13
+     local.get $8
+     i32.store
+     local.get $8
+     i32.const 24
+     i32.add
+     local.set $8
+    end
+    local.get $6
+    i32.const 24
+    i32.add
+    local.set $6
+    br $continue|0
+   end
+   unreachable
+  end
+  local.get $0
+  local.tee $9
+  local.get $3
+  local.tee $10
+  local.get $9
+  i32.load
+  local.tee $13
+  i32.ne
+  if
+   local.get $10
+   call $~lib/rt/pure/__retain
+   local.set $10
+   local.get $13
+   call $~lib/rt/pure/__release
+  end
+  local.get $10
+  i32.store
+  local.get $0
+  local.get $1
+  i32.store offset=4
+  local.get $0
+  local.tee $9
+  local.get $5
+  local.tee $12
+  local.get $9
+  i32.load offset=8
+  local.tee $10
+  i32.ne
+  if
+   local.get $12
+   call $~lib/rt/pure/__retain
+   local.set $12
+   local.get $10
+   call $~lib/rt/pure/__release
+  end
+  local.get $12
+  i32.store offset=8
+  local.get $0
+  local.get $4
+  i32.store offset=12
+  local.get $0
+  local.get $0
+  i32.load offset=20
+  i32.store offset=16
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
+ )
+ (func $~lib/map/Map<f64,f64>#set (; 282 ;) (type $FUNCSIG$vidd) (param $0 i32) (param $1 f64) (param $2 f64)
+  (local $3 f64)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  block $~lib/util/hash/HASH<f64>|inlined.4 (result i32)
+   local.get $1
+   local.set $3
+   local.get $3
+   i64.reinterpret_f64
+   call $~lib/util/hash/hash64
+   br $~lib/util/hash/HASH<f64>|inlined.4
+  end
+  local.set $4
+  local.get $0
+  local.get $1
+  local.get $4
+  call $~lib/map/Map<f64,f64>#find
+  local.set $5
+  local.get $5
+  if
+   local.get $5
+   local.get $2
+   f64.store offset=8
+  else
+   local.get $0
+   i32.load offset=16
+   local.get $0
+   i32.load offset=12
+   i32.eq
+   if
+    local.get $0
+    local.get $0
+    i32.load offset=20
+    local.get $0
+    i32.load offset=12
+    i32.const 3
+    i32.mul
+    i32.const 4
+    i32.div_s
+    i32.lt_s
+    if (result i32)
+     local.get $0
+     i32.load offset=4
+    else
+     local.get $0
+     i32.load offset=4
+     i32.const 1
+     i32.shl
+     i32.const 1
+     i32.or
+    end
+    call $~lib/map/Map<f64,f64>#rehash
+   end
+   local.get $0
+   i32.load offset=8
+   call $~lib/rt/pure/__retain
+   local.set $6
+   local.get $6
+   local.get $0
+   local.get $0
+   i32.load offset=16
+   local.tee $7
+   i32.const 1
+   i32.add
+   i32.store offset=16
+   local.get $7
+   i32.const 24
+   i32.mul
+   i32.add
+   local.set $5
+   local.get $5
+   local.get $1
+   f64.store
+   local.get $5
+   local.get $2
+   f64.store offset=8
+   local.get $0
+   local.get $0
+   i32.load offset=20
+   i32.const 1
+   i32.add
+   i32.store offset=20
+   local.get $0
+   i32.load
+   local.get $4
+   local.get $0
+   i32.load offset=4
+   i32.and
+   i32.const 4
+   i32.mul
+   i32.add
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.load
+   i32.store offset=16
+   local.get $7
+   local.get $5
+   i32.store
+   local.get $6
+   call $~lib/rt/pure/__release
+  end
+ )
+ (func $~lib/map/Map<f64,f64>#get:size (; 283 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=20
+ )
+ (func $~lib/map/Map<f64,i32>#delete (; 284 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
@@ -11940,13 +19209,13 @@
   (local $6 i32)
   local.get $0
   local.get $1
-  block $~lib/util/hash/HASH<f64>|inlined.4 (result i32)
+  block $~lib/util/hash/HASH<f64>|inlined.6 (result i32)
    local.get $1
    local.set $2
    local.get $2
    i64.reinterpret_f64
    call $~lib/util/hash/hash64
-   br $~lib/util/hash/HASH<f64>|inlined.4
+   br $~lib/util/hash/HASH<f64>|inlined.6
   end
   call $~lib/map/Map<f64,i32>#find
   local.set $3
@@ -12006,9 +19275,15 @@
   end
   i32.const 1
  )
- (func $std/map/testNumeric<f64,i32> (; 136 ;) (type $FUNCSIG$v)
+ (func $std/map/testNumeric<f64,i32> (; 285 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f64)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
   i32.const 0
   call $~lib/map/Map<f64,i32>#constructor
   local.set $0
@@ -12186,78 +19461,105 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
+  call $~lib/map/Map<f64,i32>#keys
+  local.set $2
+  local.get $0
+  call $~lib/map/Map<f64,i32>#values
+  local.set $3
+  i32.const 0
+  call $~lib/map/Map<f64,f64>#constructor
+  local.set $4
+  i32.const 0
+  call $~lib/map/Map<i32,i32>#constructor
+  local.set $5
   block $break|2
-   f64.const 0
-   local.set $1
+   i32.const 0
+   local.set $6
    loop $loop|2
-    local.get $1
-    f64.const 50
-    f64.lt
+    local.get $6
+    local.get $2
+    call $~lib/array/Array<f64>#get:length
+    i32.lt_s
     i32.eqz
     br_if $break|2
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<f64,i32>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 25
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<f64,i32>#get
-    i32.const 20
-    local.get $1
-    i32.trunc_f64_s
-    i32.add
-    i32.eq
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 26
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<f64,i32>#delete
-    drop
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<f64,i32>#has
-    i32.eqz
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 28
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    f64.const 1
-    f64.add
+    local.get $2
+    local.get $6
+    call $~lib/array/Array<f64>#__get
     local.set $1
+    local.get $3
+    local.get $6
+    call $~lib/array/Array<i32>#__get
+    local.set $7
+    local.get $0
+    local.get $1
+    call $~lib/map/Map<f64,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 31
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $7
+    i32.const 20
+    i32.sub
+    f64.convert_i32_s
+    call $~lib/map/Map<f64,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 32
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $4
+    local.get $1
+    local.get $1
+    call $~lib/map/Map<f64,f64>#set
+    local.get $5
+    local.get $7
+    i32.const 20
+    i32.sub
+    local.get $7
+    i32.const 20
+    i32.sub
+    call $~lib/map/Map<i32,i32>#set
+    local.get $6
+    i32.const 1
+    i32.add
+    local.set $6
     br $loop|2
    end
    unreachable
   end
-  local.get $0
-  call $~lib/map/Map<f64,i32>#get:size
-  i32.const 50
+  local.get $4
+  call $~lib/map/Map<f64,f64>#get:size
+  i32.const 100
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 30
+   i32.const 36
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  call $~lib/map/Map<i32,i32>#get:size
+  i32.const 100
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 37
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12275,30 +19577,27 @@
     local.get $1
     call $~lib/map/Map<f64,i32>#has
     i32.eqz
-    i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 41
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $0
     local.get $1
-    i32.const 10
+    call $~lib/map/Map<f64,i32>#get
+    i32.const 20
     local.get $1
     i32.trunc_f64_s
     i32.add
-    call $~lib/map/Map<f64,i32>#set
-    local.get $0
-    local.get $1
-    call $~lib/map/Map<f64,i32>#has
+    i32.eq
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 36
+     i32.const 42
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -12315,7 +19614,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 38
+     i32.const 44
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -12336,7 +19635,86 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 46
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $break|4
+   f64.const 0
+   local.set $1
+   loop $loop|4
+    local.get $1
+    f64.const 50
+    f64.lt
+    i32.eqz
+    br_if $break|4
+    local.get $0
+    local.get $1
+    call $~lib/map/Map<f64,i32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 50
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $1
+    i32.const 10
+    local.get $1
+    i32.trunc_f64_s
+    i32.add
+    call $~lib/map/Map<f64,i32>#set
+    local.get $0
+    local.get $1
+    call $~lib/map/Map<f64,i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 52
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $1
+    call $~lib/map/Map<f64,i32>#delete
+    drop
+    local.get $0
+    local.get $1
+    call $~lib/map/Map<f64,i32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 54
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    f64.const 1
+    f64.add
+    local.set $1
+    br $loop|4
+   end
+   unreachable
+  end
+  local.get $0
+  call $~lib/map/Map<f64,i32>#get:size
+  i32.const 50
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 56
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -12351,15 +19729,23 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 44
+   i32.const 60
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
+  local.get $5
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $start:std/map (; 137 ;) (type $FUNCSIG$v)
+ (func $start:std/map (; 286 ;) (type $FUNCSIG$v)
   call $std/map/testNumeric<i8,i32>
   call $std/map/testNumeric<u8,i32>
   call $std/map/testNumeric<i16,i32>
@@ -12371,10 +19757,10 @@
   call $std/map/testNumeric<f32,i32>
   call $std/map/testNumeric<f64,i32>
  )
- (func $start (; 138 ;) (type $FUNCSIG$v)
+ (func $start (; 287 ;) (type $FUNCSIG$v)
   call $start:std/map
  )
- (func $~lib/rt/pure/__visit (; 139 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 288 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -12504,7 +19890,7 @@
    end
   end
  )
- (func $~lib/map/Map<i8,i32>#__visit_impl (; 140 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i8,i32>#__visit_impl (; 289 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -12517,7 +19903,13 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<u8,i32>#__visit_impl (; 141 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i8>#__visit_impl (; 290 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  nop
+ )
+ (func $~lib/array/Array<i32>#__visit_impl (; 291 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  nop
+ )
+ (func $~lib/map/Map<i8,i8>#__visit_impl (; 292 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -12530,7 +19922,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<i16,i32>#__visit_impl (; 142 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i32,i32>#__visit_impl (; 293 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -12543,7 +19935,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<u16,i32>#__visit_impl (; 143 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u8,i32>#__visit_impl (; 294 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -12556,7 +19948,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<i32,i32>#__visit_impl (; 144 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u8>#__visit_impl (; 295 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  nop
+ )
+ (func $~lib/map/Map<u8,u8>#__visit_impl (; 296 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -12569,7 +19964,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<u32,i32>#__visit_impl (; 145 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<i16,i32>#__visit_impl (; 297 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -12582,7 +19977,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<i64,i32>#__visit_impl (; 146 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i16>#__visit_impl (; 298 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  nop
+ )
+ (func $~lib/map/Map<i16,i16>#__visit_impl (; 299 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -12595,7 +19993,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<u64,i32>#__visit_impl (; 147 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u16,i32>#__visit_impl (; 300 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -12608,7 +20006,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<f32,i32>#__visit_impl (; 148 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u16>#__visit_impl (; 301 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  nop
+ )
+ (func $~lib/map/Map<u16,u16>#__visit_impl (; 302 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -12621,7 +20022,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/map/Map<f64,i32>#__visit_impl (; 149 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/map/Map<u32,i32>#__visit_impl (; 303 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -12634,92 +20035,341 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/rt/__visit_members (; 150 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u32>#__visit_impl (; 304 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  nop
+ )
+ (func $~lib/map/Map<u32,u32>#__visit_impl (; 305 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
-  block $switch$1$default
-   block $switch$1$case$14
-    block $switch$1$case$13
-     block $switch$1$case$12
-      block $switch$1$case$11
-       block $switch$1$case$10
-        block $switch$1$case$9
-         block $switch$1$case$8
-          block $switch$1$case$7
-           block $switch$1$case$6
-            block $switch$1$case$5
-             block $switch$1$case$4
-              block $switch$1$case$2
+  local.get $0
+  i32.load
+  local.get $1
+  call $~lib/rt/pure/__visit
+  local.get $0
+  i32.load offset=8
+  local.set $2
+  local.get $2
+  local.get $1
+  call $~lib/rt/pure/__visit
+ )
+ (func $~lib/map/Map<i64,i32>#__visit_impl (; 306 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load
+  local.get $1
+  call $~lib/rt/pure/__visit
+  local.get $0
+  i32.load offset=8
+  local.set $2
+  local.get $2
+  local.get $1
+  call $~lib/rt/pure/__visit
+ )
+ (func $~lib/array/Array<i64>#__visit_impl (; 307 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  nop
+ )
+ (func $~lib/map/Map<i64,i64>#__visit_impl (; 308 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load
+  local.get $1
+  call $~lib/rt/pure/__visit
+  local.get $0
+  i32.load offset=8
+  local.set $2
+  local.get $2
+  local.get $1
+  call $~lib/rt/pure/__visit
+ )
+ (func $~lib/map/Map<u64,i32>#__visit_impl (; 309 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load
+  local.get $1
+  call $~lib/rt/pure/__visit
+  local.get $0
+  i32.load offset=8
+  local.set $2
+  local.get $2
+  local.get $1
+  call $~lib/rt/pure/__visit
+ )
+ (func $~lib/array/Array<u64>#__visit_impl (; 310 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  nop
+ )
+ (func $~lib/map/Map<u64,u64>#__visit_impl (; 311 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load
+  local.get $1
+  call $~lib/rt/pure/__visit
+  local.get $0
+  i32.load offset=8
+  local.set $2
+  local.get $2
+  local.get $1
+  call $~lib/rt/pure/__visit
+ )
+ (func $~lib/map/Map<f32,i32>#__visit_impl (; 312 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load
+  local.get $1
+  call $~lib/rt/pure/__visit
+  local.get $0
+  i32.load offset=8
+  local.set $2
+  local.get $2
+  local.get $1
+  call $~lib/rt/pure/__visit
+ )
+ (func $~lib/array/Array<f32>#__visit_impl (; 313 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  nop
+ )
+ (func $~lib/map/Map<f32,f32>#__visit_impl (; 314 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load
+  local.get $1
+  call $~lib/rt/pure/__visit
+  local.get $0
+  i32.load offset=8
+  local.set $2
+  local.get $2
+  local.get $1
+  call $~lib/rt/pure/__visit
+ )
+ (func $~lib/map/Map<f64,i32>#__visit_impl (; 315 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load
+  local.get $1
+  call $~lib/rt/pure/__visit
+  local.get $0
+  i32.load offset=8
+  local.set $2
+  local.get $2
+  local.get $1
+  call $~lib/rt/pure/__visit
+ )
+ (func $~lib/array/Array<f64>#__visit_impl (; 316 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  nop
+ )
+ (func $~lib/map/Map<f64,f64>#__visit_impl (; 317 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load
+  local.get $1
+  call $~lib/rt/pure/__visit
+  local.get $0
+  i32.load offset=8
+  local.set $2
+  local.get $2
+  local.get $1
+  call $~lib/rt/pure/__visit
+ )
+ (func $~lib/rt/__visit_members (; 318 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  block $block$4$break
+   block $switch$1$default
+    block $switch$1$case$33
+     block $switch$1$case$32
+      block $switch$1$case$31
+       block $switch$1$case$30
+        block $switch$1$case$29
+         block $switch$1$case$28
+          block $switch$1$case$27
+           block $switch$1$case$26
+            block $switch$1$case$25
+             block $switch$1$case$24
+              block $switch$1$case$23
+               block $switch$1$case$22
+                block $switch$1$case$21
+                 block $switch$1$case$20
+                  block $switch$1$case$19
+                   block $switch$1$case$18
+                    block $switch$1$case$17
+                     block $switch$1$case$16
+                      block $switch$1$case$15
+                       block $switch$1$case$14
+                        block $switch$1$case$13
+                         block $switch$1$case$12
+                          block $switch$1$case$11
+                           block $switch$1$case$10
+                            block $switch$1$case$9
+                             block $switch$1$case$8
+                              block $switch$1$case$7
+                               block $switch$1$case$6
+                                block $switch$1$case$5
+                                 block $switch$1$case$4
+                                  block $switch$1$case$2
+                                   local.get $0
+                                   i32.const 8
+                                   i32.sub
+                                   i32.load
+                                   br_table $switch$1$case$2 $switch$1$case$2 $switch$1$case$4 $switch$1$case$5 $switch$1$case$6 $switch$1$case$7 $switch$1$case$8 $switch$1$case$9 $switch$1$case$10 $switch$1$case$11 $switch$1$case$12 $switch$1$case$13 $switch$1$case$14 $switch$1$case$15 $switch$1$case$16 $switch$1$case$17 $switch$1$case$18 $switch$1$case$19 $switch$1$case$20 $switch$1$case$21 $switch$1$case$22 $switch$1$case$23 $switch$1$case$24 $switch$1$case$25 $switch$1$case$26 $switch$1$case$27 $switch$1$case$28 $switch$1$case$29 $switch$1$case$30 $switch$1$case$31 $switch$1$case$32 $switch$1$case$33 $switch$1$default
+                                  end
+                                  return
+                                 end
+                                 br $block$4$break
+                                end
+                                local.get $0
+                                local.get $1
+                                call $~lib/map/Map<i8,i32>#__visit_impl
+                                return
+                               end
+                               local.get $0
+                               local.get $1
+                               call $~lib/array/Array<i8>#__visit_impl
+                               br $block$4$break
+                              end
+                              local.get $0
+                              local.get $1
+                              call $~lib/array/Array<i32>#__visit_impl
+                              br $block$4$break
+                             end
+                             local.get $0
+                             local.get $1
+                             call $~lib/map/Map<i8,i8>#__visit_impl
+                             return
+                            end
+                            local.get $0
+                            local.get $1
+                            call $~lib/map/Map<i32,i32>#__visit_impl
+                            return
+                           end
+                           local.get $0
+                           local.get $1
+                           call $~lib/map/Map<u8,i32>#__visit_impl
+                           return
+                          end
+                          local.get $0
+                          local.get $1
+                          call $~lib/array/Array<u8>#__visit_impl
+                          br $block$4$break
+                         end
+                         local.get $0
+                         local.get $1
+                         call $~lib/map/Map<u8,u8>#__visit_impl
+                         return
+                        end
+                        local.get $0
+                        local.get $1
+                        call $~lib/map/Map<i16,i32>#__visit_impl
+                        return
+                       end
+                       local.get $0
+                       local.get $1
+                       call $~lib/array/Array<i16>#__visit_impl
+                       br $block$4$break
+                      end
+                      local.get $0
+                      local.get $1
+                      call $~lib/map/Map<i16,i16>#__visit_impl
+                      return
+                     end
+                     local.get $0
+                     local.get $1
+                     call $~lib/map/Map<u16,i32>#__visit_impl
+                     return
+                    end
+                    local.get $0
+                    local.get $1
+                    call $~lib/array/Array<u16>#__visit_impl
+                    br $block$4$break
+                   end
+                   local.get $0
+                   local.get $1
+                   call $~lib/map/Map<u16,u16>#__visit_impl
+                   return
+                  end
+                  local.get $0
+                  local.get $1
+                  call $~lib/map/Map<u32,i32>#__visit_impl
+                  return
+                 end
+                 local.get $0
+                 local.get $1
+                 call $~lib/array/Array<u32>#__visit_impl
+                 br $block$4$break
+                end
+                local.get $0
+                local.get $1
+                call $~lib/map/Map<u32,u32>#__visit_impl
+                return
+               end
                local.get $0
-               i32.const 8
-               i32.sub
-               i32.load
-               br_table $switch$1$case$2 $switch$1$case$2 $switch$1$case$4 $switch$1$case$5 $switch$1$case$6 $switch$1$case$7 $switch$1$case$8 $switch$1$case$9 $switch$1$case$10 $switch$1$case$11 $switch$1$case$12 $switch$1$case$13 $switch$1$case$14 $switch$1$default
+               local.get $1
+               call $~lib/map/Map<i64,i32>#__visit_impl
+               return
               end
-              return
+              local.get $0
+              local.get $1
+              call $~lib/array/Array<i64>#__visit_impl
+              br $block$4$break
              end
              local.get $0
-             i32.load
-             local.tee $2
-             if
-              local.get $2
-              local.get $1
-              call $~lib/rt/pure/__visit
-             end
+             local.get $1
+             call $~lib/map/Map<i64,i64>#__visit_impl
              return
             end
             local.get $0
             local.get $1
-            call $~lib/map/Map<i8,i32>#__visit_impl
+            call $~lib/map/Map<u64,i32>#__visit_impl
             return
            end
            local.get $0
            local.get $1
-           call $~lib/map/Map<u8,i32>#__visit_impl
-           return
+           call $~lib/array/Array<u64>#__visit_impl
+           br $block$4$break
           end
           local.get $0
           local.get $1
-          call $~lib/map/Map<i16,i32>#__visit_impl
+          call $~lib/map/Map<u64,u64>#__visit_impl
           return
          end
          local.get $0
          local.get $1
-         call $~lib/map/Map<u16,i32>#__visit_impl
+         call $~lib/map/Map<f32,i32>#__visit_impl
          return
         end
         local.get $0
         local.get $1
-        call $~lib/map/Map<i32,i32>#__visit_impl
-        return
+        call $~lib/array/Array<f32>#__visit_impl
+        br $block$4$break
        end
        local.get $0
        local.get $1
-       call $~lib/map/Map<u32,i32>#__visit_impl
+       call $~lib/map/Map<f32,f32>#__visit_impl
        return
       end
       local.get $0
       local.get $1
-      call $~lib/map/Map<i64,i32>#__visit_impl
+      call $~lib/map/Map<f64,i32>#__visit_impl
       return
      end
      local.get $0
      local.get $1
-     call $~lib/map/Map<u64,i32>#__visit_impl
-     return
+     call $~lib/array/Array<f64>#__visit_impl
+     br $block$4$break
     end
     local.get $0
     local.get $1
-    call $~lib/map/Map<f32,i32>#__visit_impl
+    call $~lib/map/Map<f64,f64>#__visit_impl
     return
    end
-   local.get $0
-   local.get $1
-   call $~lib/map/Map<f64,i32>#__visit_impl
-   return
+   unreachable
   end
-  unreachable
+  local.get $0
+  i32.load
+  local.tee $2
+  if
+   local.get $2
+   local.get $1
+   call $~lib/rt/pure/__visit
+  end
+  return
  )
- (func $null (; 151 ;) (type $FUNCSIG$v)
+ (func $null (; 319 ;) (type $FUNCSIG$v)
   unreachable
  )
 )

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -4424,6 +4424,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
   local.set $1
@@ -4459,13 +4460,14 @@
     if
      local.get $3
      local.get $4
-     local.get $6
-     i32.load8_s
-     call $~lib/array/Array<i8>#__set
-     local.get $4
+     local.tee $7
      i32.const 1
      i32.add
      local.set $4
+     local.get $7
+     local.get $6
+     i32.load8_s
+     call $~lib/array/Array<i8>#__set
     end
     local.get $5
     i32.const 1
@@ -4566,6 +4568,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
   local.set $1
@@ -4601,13 +4604,14 @@
     if
      local.get $3
      local.get $4
-     local.get $6
-     i32.load offset=4
-     call $~lib/array/Array<i32>#__set
-     local.get $4
+     local.tee $7
      i32.const 1
      i32.add
      local.set $4
+     local.get $7
+     local.get $6
+     i32.load offset=4
+     call $~lib/array/Array<i32>#__set
     end
     local.get $5
     i32.const 1
@@ -6588,6 +6592,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
   local.set $1
@@ -6623,13 +6628,14 @@
     if
      local.get $3
      local.get $4
-     local.get $6
-     i32.load8_u
-     call $~lib/array/Array<u8>#__set
-     local.get $4
+     local.tee $7
      i32.const 1
      i32.add
      local.set $4
+     local.get $7
+     local.get $6
+     i32.load8_u
+     call $~lib/array/Array<u8>#__set
     end
     local.get $5
     i32.const 1
@@ -6651,6 +6657,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
   local.set $1
@@ -6686,13 +6693,14 @@
     if
      local.get $3
      local.get $4
-     local.get $6
-     i32.load offset=4
-     call $~lib/array/Array<i32>#__set
-     local.get $4
+     local.tee $7
      i32.const 1
      i32.add
      local.set $4
+     local.get $7
+     local.get $6
+     i32.load offset=4
+     call $~lib/array/Array<i32>#__set
     end
     local.get $5
     i32.const 1
@@ -8228,6 +8236,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
   local.set $1
@@ -8263,13 +8272,14 @@
     if
      local.get $3
      local.get $4
-     local.get $6
-     i32.load16_s
-     call $~lib/array/Array<i16>#__set
-     local.get $4
+     local.tee $7
      i32.const 1
      i32.add
      local.set $4
+     local.get $7
+     local.get $6
+     i32.load16_s
+     call $~lib/array/Array<i16>#__set
     end
     local.get $5
     i32.const 1
@@ -8291,6 +8301,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
   local.set $1
@@ -8326,13 +8337,14 @@
     if
      local.get $3
      local.get $4
-     local.get $6
-     i32.load offset=4
-     call $~lib/array/Array<i32>#__set
-     local.get $4
+     local.tee $7
      i32.const 1
      i32.add
      local.set $4
+     local.get $7
+     local.get $6
+     i32.load offset=4
+     call $~lib/array/Array<i32>#__set
     end
     local.get $5
     i32.const 1
@@ -9858,6 +9870,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
   local.set $1
@@ -9893,13 +9906,14 @@
     if
      local.get $3
      local.get $4
-     local.get $6
-     i32.load16_u
-     call $~lib/array/Array<u16>#__set
-     local.get $4
+     local.tee $7
      i32.const 1
      i32.add
      local.set $4
+     local.get $7
+     local.get $6
+     i32.load16_u
+     call $~lib/array/Array<u16>#__set
     end
     local.get $5
     i32.const 1
@@ -9921,6 +9935,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
   local.set $1
@@ -9956,13 +9971,14 @@
     if
      local.get $3
      local.get $4
-     local.get $6
-     i32.load offset=4
-     call $~lib/array/Array<i32>#__set
-     local.get $4
+     local.tee $7
      i32.const 1
      i32.add
      local.set $4
+     local.get $7
+     local.get $6
+     i32.load offset=4
+     call $~lib/array/Array<i32>#__set
     end
     local.get $5
     i32.const 1
@@ -10997,6 +11013,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
   local.set $1
@@ -11032,13 +11049,14 @@
     if
      local.get $3
      local.get $4
-     local.get $6
-     i32.load
-     call $~lib/array/Array<i32>#__set
-     local.get $4
+     local.tee $7
      i32.const 1
      i32.add
      local.set $4
+     local.get $7
+     local.get $6
+     i32.load
+     call $~lib/array/Array<i32>#__set
     end
     local.get $5
     i32.const 1
@@ -11060,6 +11078,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
   local.set $1
@@ -11095,13 +11114,14 @@
     if
      local.get $3
      local.get $4
-     local.get $6
-     i32.load offset=4
-     call $~lib/array/Array<i32>#__set
-     local.get $4
+     local.tee $7
      i32.const 1
      i32.add
      local.set $4
+     local.get $7
+     local.get $6
+     i32.load offset=4
+     call $~lib/array/Array<i32>#__set
     end
     local.get $5
     i32.const 1
@@ -12166,6 +12186,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
   local.set $1
@@ -12201,13 +12222,14 @@
     if
      local.get $3
      local.get $4
-     local.get $6
-     i32.load
-     call $~lib/array/Array<u32>#__set
-     local.get $4
+     local.tee $7
      i32.const 1
      i32.add
      local.set $4
+     local.get $7
+     local.get $6
+     i32.load
+     call $~lib/array/Array<u32>#__set
     end
     local.get $5
     i32.const 1
@@ -12229,6 +12251,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
   local.set $1
@@ -12264,13 +12287,14 @@
     if
      local.get $3
      local.get $4
-     local.get $6
-     i32.load offset=4
-     call $~lib/array/Array<i32>#__set
-     local.get $4
+     local.tee $7
      i32.const 1
      i32.add
      local.set $4
+     local.get $7
+     local.get $6
+     i32.load offset=4
+     call $~lib/array/Array<i32>#__set
     end
     local.get $5
     i32.const 1
@@ -13838,6 +13862,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
   local.set $1
@@ -13873,13 +13898,14 @@
     if
      local.get $3
      local.get $4
-     local.get $6
-     i64.load
-     call $~lib/array/Array<i64>#__set
-     local.get $4
+     local.tee $7
      i32.const 1
      i32.add
      local.set $4
+     local.get $7
+     local.get $6
+     i64.load
+     call $~lib/array/Array<i64>#__set
     end
     local.get $5
     i32.const 1
@@ -13901,6 +13927,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
   local.set $1
@@ -13936,13 +13963,14 @@
     if
      local.get $3
      local.get $4
-     local.get $6
-     i32.load offset=8
-     call $~lib/array/Array<i32>#__set
-     local.get $4
+     local.tee $7
      i32.const 1
      i32.add
      local.set $4
+     local.get $7
+     local.get $6
+     i32.load offset=8
+     call $~lib/array/Array<i32>#__set
     end
     local.get $5
     i32.const 1
@@ -15433,6 +15461,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
   local.set $1
@@ -15468,13 +15497,14 @@
     if
      local.get $3
      local.get $4
-     local.get $6
-     i64.load
-     call $~lib/array/Array<u64>#__set
-     local.get $4
+     local.tee $7
      i32.const 1
      i32.add
      local.set $4
+     local.get $7
+     local.get $6
+     i64.load
+     call $~lib/array/Array<u64>#__set
     end
     local.get $5
     i32.const 1
@@ -15496,6 +15526,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
   local.set $1
@@ -15531,13 +15562,14 @@
     if
      local.get $3
      local.get $4
-     local.get $6
-     i32.load offset=8
-     call $~lib/array/Array<i32>#__set
-     local.get $4
+     local.tee $7
      i32.const 1
      i32.add
      local.set $4
+     local.get $7
+     local.get $6
+     i32.load offset=8
+     call $~lib/array/Array<i32>#__set
     end
     local.get $5
     i32.const 1
@@ -17032,6 +17064,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
   local.set $1
@@ -17067,13 +17100,14 @@
     if
      local.get $3
      local.get $4
-     local.get $6
-     f32.load
-     call $~lib/array/Array<f32>#__set
-     local.get $4
+     local.tee $7
      i32.const 1
      i32.add
      local.set $4
+     local.get $7
+     local.get $6
+     f32.load
+     call $~lib/array/Array<f32>#__set
     end
     local.get $5
     i32.const 1
@@ -17095,6 +17129,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
   local.set $1
@@ -17130,13 +17165,14 @@
     if
      local.get $3
      local.get $4
-     local.get $6
-     i32.load offset=4
-     call $~lib/array/Array<i32>#__set
-     local.get $4
+     local.tee $7
      i32.const 1
      i32.add
      local.set $4
+     local.get $7
+     local.get $6
+     i32.load offset=4
+     call $~lib/array/Array<i32>#__set
     end
     local.get $5
     i32.const 1
@@ -18634,6 +18670,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
   local.set $1
@@ -18669,13 +18706,14 @@
     if
      local.get $3
      local.get $4
-     local.get $6
-     f64.load
-     call $~lib/array/Array<f64>#__set
-     local.get $4
+     local.tee $7
      i32.const 1
      i32.add
      local.set $4
+     local.get $7
+     local.get $6
+     f64.load
+     call $~lib/array/Array<f64>#__set
     end
     local.get $5
     i32.const 1
@@ -18697,6 +18735,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   local.get $0
   i32.load offset=8
   local.set $1
@@ -18732,13 +18771,14 @@
     if
      local.get $3
      local.get $4
-     local.get $6
-     i32.load offset=8
-     call $~lib/array/Array<i32>#__set
-     local.get $4
+     local.tee $7
      i32.const 1
      i32.add
      local.set $4
+     local.get $7
+     local.get $6
+     i32.load offset=8
+     call $~lib/array/Array<i32>#__set
     end
     local.get $5
     i32.const 1

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -11,12 +11,18 @@
  (type $FUNCSIG$ij (func (param i64) (result i32)))
  (type $FUNCSIG$iiji (func (param i32 i64 i32) (result i32)))
  (type $FUNCSIG$vij (func (param i32 i64)))
+ (type $FUNCSIG$viij (func (param i32 i32 i64)))
+ (type $FUNCSIG$jii (func (param i32 i32) (result i64)))
  (type $FUNCSIG$iif (func (param i32 f32) (result i32)))
  (type $FUNCSIG$iifi (func (param i32 f32 i32) (result i32)))
  (type $FUNCSIG$vif (func (param i32 f32)))
+ (type $FUNCSIG$viif (func (param i32 i32 f32)))
+ (type $FUNCSIG$fii (func (param i32 i32) (result f32)))
  (type $FUNCSIG$iid (func (param i32 f64) (result i32)))
  (type $FUNCSIG$iidi (func (param i32 f64 i32) (result i32)))
  (type $FUNCSIG$vid (func (param i32 f64)))
+ (type $FUNCSIG$viid (func (param i32 i32 f64)))
+ (type $FUNCSIG$dii (func (param i32 i32) (result f64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
@@ -31,7 +37,8 @@
  (data (i32.const 264) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e")
  (data (i32.const 320) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s")
  (data (i32.const 360) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00s\00t\00d\00/\00s\00e\00t\00.\00t\00s")
- (data (i32.const 400) "\0d\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\004\04\00\00\00\00\00\004\00\00\00\00\00\00\00T\04\00\00\00\00\00\00T\00\00\00\00\00\00\00\94\04\00\00\00\00\00\00\94\00\00\00\00\00\00\00\14\05\00\00\00\00\00\00\14\01\00\00\00\00\00\00\94\0c\00\00\00\00\00\00\14\0d")
+ (data (i32.const 400) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s")
+ (data (i32.const 448) "\17\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\004\04\00\00\00\00\00\003\04\00\00\02\00\00\004\00\00\00\00\00\00\003\00\00\00\02\00\00\00T\04\00\00\00\00\00\00S\04\00\00\02\00\00\00T\00\00\00\00\00\00\00S\00\00\00\02\00\00\00\94\04\00\00\00\00\00\00\93\04\00\00\02\00\00\00\94\00\00\00\00\00\00\00\93\00\00\00\02\00\00\00\14\05\00\00\00\00\00\00\13\05\00\00\02\00\00\00\14\01\00\00\00\00\00\00\13\01\00\00\02\00\00\00\94\0c\00\00\00\00\00\00\93\0c\00\00\02\00\00\00\14\0d\00\00\00\00\00\00\13\0d\00\00\02")
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/collectLock (mut i32) (i32.const 0))
  (global $~lib/rt/pure/ROOTS (mut i32) (i32.const 0))
@@ -624,10 +631,10 @@
   if
    unreachable
   end
-  i32.const 512
+  i32.const 640
   i32.const 0
   i32.store
-  i32.const 2080
+  i32.const 2208
   i32.const 0
   i32.store
   i32.const 0
@@ -641,7 +648,7 @@
     local.get $0
     i32.const 2
     i32.shl
-    i32.const 512
+    i32.const 640
     i32.add
     i32.const 0
     i32.store offset=4
@@ -660,7 +667,7 @@
       i32.add
       i32.const 2
       i32.shl
-      i32.const 512
+      i32.const 640
       i32.add
       i32.const 0
       i32.store offset=96
@@ -678,13 +685,13 @@
     br $loop|0
    end
   end
-  i32.const 512
-  i32.const 2096
+  i32.const 640
+  i32.const 2224
   memory.size
   i32.const 16
   i32.shl
   call $~lib/rt/tlsf/addMemory
-  i32.const 512
+  i32.const 640
   global.set $~lib/rt/tlsf/ROOT
  )
  (func $~lib/rt/tlsf/prepareSize (; 9 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
@@ -1376,7 +1383,7 @@
  )
  (func $~lib/rt/pure/__retain (; 22 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
-  i32.const 508
+  i32.const 636
   i32.gt_u
   if
    local.get $0
@@ -1619,7 +1626,7 @@
  )
  (func $~lib/rt/__typeinfo (; 25 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
-  i32.const 400
+  i32.const 448
   i32.load
   i32.gt_u
   if
@@ -1633,7 +1640,7 @@
   local.get $0
   i32.const 3
   i32.shl
-  i32.const 404
+  i32.const 452
   i32.add
   i32.load
  )
@@ -2005,7 +2012,7 @@
  )
  (func $~lib/rt/pure/__release (; 31 ;) (type $FUNCSIG$vi) (param $0 i32)
   local.get $0
-  i32.const 508
+  i32.const 636
   i32.gt_u
   if
    local.get $0
@@ -2355,7 +2362,408 @@
    i32.store
   end
  )
- (func $~lib/set/Set<i8>#delete (; 39 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (; 39 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  local.get $1
+  i32.const 1073741808
+  local.get $2
+  i32.shr_u
+  i32.gt_u
+  if
+   i32.const 176
+   i32.const 224
+   i32.const 23
+   i32.const 56
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $2
+  i32.shl
+  local.tee $3
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.tee $2
+  local.get $3
+  call $~lib/memory/memory.fill
+  local.get $0
+  i32.eqz
+  if
+   i32.const 12
+   i32.const 2
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $2
+  local.set $1
+  local.get $0
+  i32.load
+  local.tee $4
+  local.get $2
+  i32.ne
+  if
+   local.get $1
+   call $~lib/rt/pure/__retain
+   local.set $1
+   local.get $4
+   call $~lib/rt/pure/__release
+  end
+  local.get $0
+  local.get $1
+  i32.store
+  local.get $0
+  local.get $2
+  i32.store offset=4
+  local.get $0
+  local.get $3
+  i32.store offset=8
+  local.get $0
+ )
+ (func $~lib/rt/tlsf/reallocateBlock (; 40 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $2
+  call $~lib/rt/tlsf/prepareSize
+  local.set $3
+  local.get $1
+  i32.load
+  local.tee $4
+  i32.const 1
+  i32.and
+  if (result i32)
+   i32.const 0
+  else
+   local.get $1
+   i32.load offset=4
+   i32.const -268435456
+   i32.and
+   i32.eqz
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 521
+   i32.const 4
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  local.get $4
+  i32.const -4
+  i32.and
+  i32.le_u
+  if
+   local.get $0
+   local.get $1
+   local.get $3
+   call $~lib/rt/tlsf/prepareBlock
+   local.get $1
+   local.get $2
+   i32.store offset=12
+   local.get $1
+   return
+  end
+  local.get $1
+  i32.const 16
+  i32.add
+  local.get $1
+  i32.load
+  i32.const -4
+  i32.and
+  i32.add
+  local.tee $6
+  i32.load
+  local.tee $5
+  i32.const 1
+  i32.and
+  if
+   local.get $4
+   i32.const -4
+   i32.and
+   i32.const 16
+   i32.add
+   local.get $5
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $5
+   local.get $3
+   i32.ge_u
+   if
+    local.get $0
+    local.get $6
+    call $~lib/rt/tlsf/removeBlock
+    local.get $1
+    local.get $4
+    i32.const 3
+    i32.and
+    local.get $5
+    i32.or
+    i32.store
+    local.get $1
+    local.get $2
+    i32.store offset=12
+    local.get $0
+    local.get $1
+    local.get $3
+    call $~lib/rt/tlsf/prepareBlock
+    local.get $1
+    return
+   end
+  end
+  local.get $0
+  local.get $2
+  call $~lib/rt/tlsf/allocateBlock
+  local.tee $3
+  local.get $1
+  i32.load offset=8
+  i32.store offset=8
+  local.get $3
+  i32.const 16
+  i32.add
+  local.get $1
+  i32.const 16
+  i32.add
+  local.get $2
+  call $~lib/memory/memory.copy
+  local.get $1
+  local.get $4
+  i32.const 1
+  i32.or
+  i32.store
+  local.get $0
+  local.get $1
+  call $~lib/rt/tlsf/insertBlock
+  local.get $1
+  call $~lib/rt/rtrace/onfree
+  local.get $3
+ )
+ (func $~lib/rt/tlsf/__realloc (; 41 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  global.get $~lib/rt/tlsf/ROOT
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 585
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 15
+  i32.and
+  i32.eqz
+  i32.const 0
+  local.get $0
+  select
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 586
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/rt/tlsf/ROOT
+  local.get $0
+  i32.const 16
+  i32.sub
+  local.get $1
+  call $~lib/rt/tlsf/reallocateBlock
+  i32.const 16
+  i32.add
+ )
+ (func $~lib/array/ensureSize (; 42 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=8
+  local.tee $3
+  local.get $2
+  i32.shr_u
+  i32.gt_u
+  if
+   local.get $1
+   i32.const 1073741808
+   local.get $2
+   i32.shr_u
+   i32.gt_u
+   if
+    i32.const 176
+    i32.const 416
+    i32.const 14
+    i32.const 47
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   i32.load
+   local.tee $4
+   local.get $1
+   local.get $2
+   i32.shl
+   local.tee $2
+   call $~lib/rt/tlsf/__realloc
+   local.tee $1
+   local.get $3
+   i32.add
+   local.get $2
+   local.get $3
+   i32.sub
+   call $~lib/memory/memory.fill
+   local.get $1
+   local.get $4
+   i32.ne
+   if
+    local.get $0
+    local.get $1
+    call $~lib/rt/pure/__retain
+    i32.store
+    local.get $0
+    local.get $1
+    i32.store offset=4
+   end
+   local.get $0
+   local.get $2
+   i32.store offset=8
+  end
+ )
+ (func $~lib/array/Array<i8>#__set (; 43 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 416
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   i32.const 0
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $3
+   i32.store offset=12
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.add
+  local.get $2
+  i32.store8
+ )
+ (func $~lib/set/Set<i8>#values (; 44 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.set $1
+  i32.const 16
+  i32.const 4
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.get $1
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $2
+  i32.const 0
+  i32.store offset=12
+  local.get $2
+  local.get $1
+  i32.store offset=12
+  i32.const 0
+  local.set $0
+  loop $loop|0
+   local.get $3
+   local.get $1
+   i32.lt_s
+   if
+    local.get $3
+    i32.const 3
+    i32.shl
+    local.get $4
+    i32.add
+    local.tee $5
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $0
+     local.tee $6
+     i32.const 1
+     i32.add
+     local.set $0
+     local.get $2
+     local.get $6
+     local.get $5
+     i32.load8_s
+     call $~lib/array/Array<i8>#__set
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $loop|0
+   end
+  end
+  local.get $2
+ )
+ (func $~lib/array/Array<i8>#__get (; 45 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 416
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.add
+  i32.load8_s
+ )
+ (func $~lib/set/Set<i8>#delete (; 46 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -2418,9 +2826,11 @@
    call $~lib/set/Set<i8>#rehash
   end
  )
- (func $std/set/testNumeric<i8> (; 40 ;) (type $FUNCSIG$v)
+ (func $std/set/testNumeric<i8> (; 47 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   call $~lib/set/Set<i8>#constructor
   local.set $1
   loop $loop|0
@@ -2528,56 +2938,55 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/set/Set<i8>#values
+  local.set $2
+  call $~lib/set/Set<i8>#constructor
+  local.set $3
   i32.const 0
   local.set $0
   loop $loop|2
    local.get $0
-   i32.const 50
+   local.get $2
+   i32.load offset=12
    i32.lt_s
    if
     local.get $1
+    local.get $2
     local.get $0
-    call $~lib/set/Set<i8>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 22
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<i8>#delete
-    local.get $1
-    local.get $0
+    call $~lib/array/Array<i8>#__get
     call $~lib/set/Set<i8>#has
     if
+     local.get $3
+     local.get $2
+     local.get $0
+     call $~lib/array/Array<i8>#__get
+     call $~lib/set/Set<i8>#add
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+     br $loop|2
+    else
      i32.const 0
      i32.const 376
      i32.const 24
      i32.const 4
      call $~lib/builtins/abort
      unreachable
-    else
-     local.get $0
-     i32.const 1
-     i32.add
-     local.set $0
-     br $loop|2
     end
     unreachable
    end
   end
+  local.get $3
+  i32.load offset=20
   local.get $1
   i32.load offset=20
-  i32.const 50
   i32.ne
   if
    i32.const 0
    i32.const 376
-   i32.const 26
+   i32.const 27
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2592,25 +3001,11 @@
     local.get $1
     local.get $0
     call $~lib/set/Set<i8>#has
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 30
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<i8>#add
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<i8>#has
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 32
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -2624,7 +3019,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 33
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -2645,7 +3040,75 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 36
+   i32.const 35
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  local.set $0
+  loop $loop|4
+   local.get $0
+   i32.const 50
+   i32.lt_s
+   if
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i8>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 39
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i8>#add
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i8>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 41
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i8>#delete
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i8>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 43
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    else
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+     br $loop|4
+    end
+    unreachable
+   end
+  end
+  local.get $1
+  i32.load offset=20
+  i32.const 50
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 45
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2657,18 +3120,22 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 49
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u8>#constructor (; 41 ;) (result i32)
+ (func $~lib/set/Set<u8>#constructor (; 48 ;) (result i32)
   (local $0 i32)
   i32.const 24
-  i32.const 4
+  i32.const 5
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
@@ -2693,7 +3160,7 @@
   call $~lib/set/Set<i8>#clear
   local.get $0
  )
- (func $~lib/set/Set<u8>#has (; 42 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u8>#has (; 49 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -2704,7 +3171,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u8>#rehash (; 43 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u8>#rehash (; 50 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2832,7 +3299,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u8>#add (; 44 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u8>#add (; 51 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2917,7 +3384,90 @@
    i32.store
   end
  )
- (func $~lib/set/Set<u8>#delete (; 45 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u8>#values (; 52 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.set $1
+  i32.const 16
+  i32.const 6
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.get $1
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $2
+  i32.const 0
+  i32.store offset=12
+  local.get $2
+  local.get $1
+  i32.store offset=12
+  i32.const 0
+  local.set $0
+  loop $loop|0
+   local.get $3
+   local.get $1
+   i32.lt_s
+   if
+    local.get $3
+    i32.const 3
+    i32.shl
+    local.get $4
+    i32.add
+    local.tee $5
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $0
+     local.tee $6
+     i32.const 1
+     i32.add
+     local.set $0
+     local.get $2
+     local.get $6
+     local.get $5
+     i32.load8_u
+     call $~lib/array/Array<i8>#__set
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $loop|0
+   end
+  end
+  local.get $2
+ )
+ (func $~lib/array/Array<u8>#__get (; 53 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 416
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.add
+  i32.load8_u
+ )
+ (func $~lib/set/Set<u8>#delete (; 54 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -2978,9 +3528,11 @@
    call $~lib/set/Set<u8>#rehash
   end
  )
- (func $std/set/testNumeric<u8> (; 46 ;) (type $FUNCSIG$v)
+ (func $std/set/testNumeric<u8> (; 55 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   call $~lib/set/Set<u8>#constructor
   local.set $1
   loop $loop|0
@@ -3088,56 +3640,55 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/set/Set<u8>#values
+  local.set $2
+  call $~lib/set/Set<u8>#constructor
+  local.set $3
   i32.const 0
   local.set $0
   loop $loop|2
    local.get $0
-   i32.const 50
-   i32.lt_u
+   local.get $2
+   i32.load offset=12
+   i32.lt_s
    if
     local.get $1
+    local.get $2
     local.get $0
-    call $~lib/set/Set<u8>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 22
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<u8>#delete
-    local.get $1
-    local.get $0
+    call $~lib/array/Array<u8>#__get
     call $~lib/set/Set<u8>#has
     if
+     local.get $3
+     local.get $2
+     local.get $0
+     call $~lib/array/Array<u8>#__get
+     call $~lib/set/Set<u8>#add
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+     br $loop|2
+    else
      i32.const 0
      i32.const 376
      i32.const 24
      i32.const 4
      call $~lib/builtins/abort
      unreachable
-    else
-     local.get $0
-     i32.const 1
-     i32.add
-     local.set $0
-     br $loop|2
     end
     unreachable
    end
   end
+  local.get $3
+  i32.load offset=20
   local.get $1
   i32.load offset=20
-  i32.const 50
   i32.ne
   if
    i32.const 0
    i32.const 376
-   i32.const 26
+   i32.const 27
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3152,25 +3703,11 @@
     local.get $1
     local.get $0
     call $~lib/set/Set<u8>#has
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 30
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<u8>#add
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<u8>#has
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 32
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -3184,7 +3721,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 33
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -3205,7 +3742,75 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 36
+   i32.const 35
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  local.set $0
+  loop $loop|4
+   local.get $0
+   i32.const 50
+   i32.lt_u
+   if
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<u8>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 39
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<u8>#add
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<u8>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 41
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<u8>#delete
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<u8>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 43
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    else
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+     br $loop|4
+    end
+    unreachable
+   end
+  end
+  local.get $1
+  i32.load offset=20
+  i32.const 50
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 45
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3217,18 +3822,22 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 49
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i16>#constructor (; 47 ;) (result i32)
+ (func $~lib/set/Set<i16>#constructor (; 56 ;) (result i32)
   (local $0 i32)
   i32.const 24
-  i32.const 5
+  i32.const 7
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
@@ -3253,7 +3862,7 @@
   call $~lib/set/Set<i8>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash16 (; 48 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash16 (; 57 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -3268,7 +3877,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/set/Set<i16>#find (; 49 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i16>#find (; 58 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -3313,7 +3922,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i16>#has (; 50 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i16>#has (; 59 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -3326,7 +3935,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i16>#rehash (; 51 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i16>#rehash (; 60 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3454,7 +4063,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i16>#add (; 52 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i16>#add (; 61 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3541,7 +4150,130 @@
    i32.store
   end
  )
- (func $~lib/set/Set<i16>#delete (; 53 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i16>#__set (; 62 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 416
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   i32.const 1
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $3
+   i32.store offset=12
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 1
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store16
+ )
+ (func $~lib/set/Set<i16>#values (; 63 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.set $1
+  i32.const 16
+  i32.const 8
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.get $1
+  i32.const 1
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $2
+  i32.const 0
+  i32.store offset=12
+  local.get $2
+  local.get $1
+  i32.store offset=12
+  i32.const 0
+  local.set $0
+  loop $loop|0
+   local.get $3
+   local.get $1
+   i32.lt_s
+   if
+    local.get $3
+    i32.const 3
+    i32.shl
+    local.get $4
+    i32.add
+    local.tee $5
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $0
+     local.tee $6
+     i32.const 1
+     i32.add
+     local.set $0
+     local.get $2
+     local.get $6
+     local.get $5
+     i32.load16_s
+     call $~lib/array/Array<i16>#__set
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $loop|0
+   end
+  end
+  local.get $2
+ )
+ (func $~lib/array/Array<i16>#__get (; 64 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 416
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 1
+  i32.shl
+  i32.add
+  i32.load16_s
+ )
+ (func $~lib/set/Set<i16>#delete (; 65 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -3604,9 +4336,11 @@
    call $~lib/set/Set<i16>#rehash
   end
  )
- (func $std/set/testNumeric<i16> (; 54 ;) (type $FUNCSIG$v)
+ (func $std/set/testNumeric<i16> (; 66 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   call $~lib/set/Set<i16>#constructor
   local.set $1
   loop $loop|0
@@ -3714,56 +4448,55 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/set/Set<i16>#values
+  local.set $2
+  call $~lib/set/Set<i16>#constructor
+  local.set $3
   i32.const 0
   local.set $0
   loop $loop|2
    local.get $0
-   i32.const 50
+   local.get $2
+   i32.load offset=12
    i32.lt_s
    if
     local.get $1
+    local.get $2
     local.get $0
-    call $~lib/set/Set<i16>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 22
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<i16>#delete
-    local.get $1
-    local.get $0
+    call $~lib/array/Array<i16>#__get
     call $~lib/set/Set<i16>#has
     if
+     local.get $3
+     local.get $2
+     local.get $0
+     call $~lib/array/Array<i16>#__get
+     call $~lib/set/Set<i16>#add
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+     br $loop|2
+    else
      i32.const 0
      i32.const 376
      i32.const 24
      i32.const 4
      call $~lib/builtins/abort
      unreachable
-    else
-     local.get $0
-     i32.const 1
-     i32.add
-     local.set $0
-     br $loop|2
     end
     unreachable
    end
   end
+  local.get $3
+  i32.load offset=20
   local.get $1
   i32.load offset=20
-  i32.const 50
   i32.ne
   if
    i32.const 0
    i32.const 376
-   i32.const 26
+   i32.const 27
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3778,25 +4511,11 @@
     local.get $1
     local.get $0
     call $~lib/set/Set<i16>#has
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 30
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<i16>#add
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<i16>#has
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 32
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -3810,7 +4529,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 33
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -3831,7 +4550,75 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 36
+   i32.const 35
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  local.set $0
+  loop $loop|4
+   local.get $0
+   i32.const 50
+   i32.lt_s
+   if
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i16>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 39
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i16>#add
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i16>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 41
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i16>#delete
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i16>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 43
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    else
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+     br $loop|4
+    end
+    unreachable
+   end
+  end
+  local.get $1
+  i32.load offset=20
+  i32.const 50
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 45
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3843,18 +4630,22 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 49
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u16>#constructor (; 55 ;) (result i32)
+ (func $~lib/set/Set<u16>#constructor (; 67 ;) (result i32)
   (local $0 i32)
   i32.const 24
-  i32.const 6
+  i32.const 9
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
@@ -3879,7 +4670,7 @@
   call $~lib/set/Set<i8>#clear
   local.get $0
  )
- (func $~lib/set/Set<u16>#has (; 56 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u16>#has (; 68 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -3890,7 +4681,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u16>#rehash (; 57 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u16>#rehash (; 69 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4018,7 +4809,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u16>#add (; 58 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u16>#add (; 70 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4103,7 +4894,92 @@
    i32.store
   end
  )
- (func $~lib/set/Set<u16>#delete (; 59 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u16>#values (; 71 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.set $1
+  i32.const 16
+  i32.const 10
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.get $1
+  i32.const 1
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $2
+  i32.const 0
+  i32.store offset=12
+  local.get $2
+  local.get $1
+  i32.store offset=12
+  i32.const 0
+  local.set $0
+  loop $loop|0
+   local.get $3
+   local.get $1
+   i32.lt_s
+   if
+    local.get $3
+    i32.const 3
+    i32.shl
+    local.get $4
+    i32.add
+    local.tee $5
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $0
+     local.tee $6
+     i32.const 1
+     i32.add
+     local.set $0
+     local.get $2
+     local.get $6
+     local.get $5
+     i32.load16_u
+     call $~lib/array/Array<i16>#__set
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $loop|0
+   end
+  end
+  local.get $2
+ )
+ (func $~lib/array/Array<u16>#__get (; 72 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 416
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 1
+  i32.shl
+  i32.add
+  i32.load16_u
+ )
+ (func $~lib/set/Set<u16>#delete (; 73 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -4164,9 +5040,11 @@
    call $~lib/set/Set<u16>#rehash
   end
  )
- (func $std/set/testNumeric<u16> (; 60 ;) (type $FUNCSIG$v)
+ (func $std/set/testNumeric<u16> (; 74 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   call $~lib/set/Set<u16>#constructor
   local.set $1
   loop $loop|0
@@ -4274,56 +5152,55 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/set/Set<u16>#values
+  local.set $2
+  call $~lib/set/Set<u16>#constructor
+  local.set $3
   i32.const 0
   local.set $0
   loop $loop|2
    local.get $0
-   i32.const 50
-   i32.lt_u
+   local.get $2
+   i32.load offset=12
+   i32.lt_s
    if
     local.get $1
+    local.get $2
     local.get $0
-    call $~lib/set/Set<u16>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 22
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<u16>#delete
-    local.get $1
-    local.get $0
+    call $~lib/array/Array<u16>#__get
     call $~lib/set/Set<u16>#has
     if
+     local.get $3
+     local.get $2
+     local.get $0
+     call $~lib/array/Array<u16>#__get
+     call $~lib/set/Set<u16>#add
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+     br $loop|2
+    else
      i32.const 0
      i32.const 376
      i32.const 24
      i32.const 4
      call $~lib/builtins/abort
      unreachable
-    else
-     local.get $0
-     i32.const 1
-     i32.add
-     local.set $0
-     br $loop|2
     end
     unreachable
    end
   end
+  local.get $3
+  i32.load offset=20
   local.get $1
   i32.load offset=20
-  i32.const 50
   i32.ne
   if
    i32.const 0
    i32.const 376
-   i32.const 26
+   i32.const 27
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -4338,25 +5215,11 @@
     local.get $1
     local.get $0
     call $~lib/set/Set<u16>#has
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 30
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<u16>#add
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<u16>#has
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 32
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -4370,7 +5233,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 33
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -4391,7 +5254,75 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 36
+   i32.const 35
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  local.set $0
+  loop $loop|4
+   local.get $0
+   i32.const 50
+   i32.lt_u
+   if
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<u16>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 39
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<u16>#add
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<u16>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 41
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<u16>#delete
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<u16>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 43
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    else
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+     br $loop|4
+    end
+    unreachable
+   end
+  end
+  local.get $1
+  i32.load offset=20
+  i32.const 50
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 45
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -4403,18 +5334,22 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 49
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i32>#constructor (; 61 ;) (result i32)
+ (func $~lib/set/Set<i32>#constructor (; 75 ;) (result i32)
   (local $0 i32)
   i32.const 24
-  i32.const 7
+  i32.const 11
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
@@ -4439,7 +5374,7 @@
   call $~lib/set/Set<i8>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash32 (; 62 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash32 (; 76 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const 255
   i32.and
@@ -4470,7 +5405,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/set/Set<i32>#find (; 63 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i32>#find (; 77 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -4513,7 +5448,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i32>#has (; 64 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i32>#has (; 78 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -4522,7 +5457,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i32>#rehash (; 65 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i32>#rehash (; 79 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4650,7 +5585,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i32>#add (; 66 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i32>#add (; 80 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4733,7 +5668,130 @@
    i32.store
   end
  )
- (func $~lib/set/Set<i32>#delete (; 67 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#__set (; 81 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 416
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   i32.const 2
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $3
+   i32.store offset=12
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store
+ )
+ (func $~lib/set/Set<i32>#values (; 82 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.set $1
+  i32.const 16
+  i32.const 12
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $2
+  i32.const 0
+  i32.store offset=12
+  local.get $2
+  local.get $1
+  i32.store offset=12
+  i32.const 0
+  local.set $0
+  loop $loop|0
+   local.get $3
+   local.get $1
+   i32.lt_s
+   if
+    local.get $3
+    i32.const 3
+    i32.shl
+    local.get $4
+    i32.add
+    local.tee $5
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $0
+     local.tee $6
+     i32.const 1
+     i32.add
+     local.set $0
+     local.get $2
+     local.get $6
+     local.get $5
+     i32.load
+     call $~lib/array/Array<i32>#__set
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $loop|0
+   end
+  end
+  local.get $2
+ )
+ (func $~lib/array/Array<i32>#__get (; 83 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 416
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
+ )
+ (func $~lib/set/Set<i32>#delete (; 84 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -4792,9 +5850,11 @@
    call $~lib/set/Set<i32>#rehash
   end
  )
- (func $std/set/testNumeric<i32> (; 68 ;) (type $FUNCSIG$v)
+ (func $std/set/testNumeric<i32> (; 85 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   call $~lib/set/Set<i32>#constructor
   local.set $1
   loop $loop|0
@@ -4902,56 +5962,55 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/set/Set<i32>#values
+  local.set $2
+  call $~lib/set/Set<i32>#constructor
+  local.set $3
   i32.const 0
   local.set $0
   loop $loop|2
    local.get $0
-   i32.const 50
+   local.get $2
+   i32.load offset=12
    i32.lt_s
    if
     local.get $1
+    local.get $2
     local.get $0
-    call $~lib/set/Set<i32>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 22
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<i32>#delete
-    local.get $1
-    local.get $0
+    call $~lib/array/Array<i32>#__get
     call $~lib/set/Set<i32>#has
     if
+     local.get $3
+     local.get $2
+     local.get $0
+     call $~lib/array/Array<i32>#__get
+     call $~lib/set/Set<i32>#add
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+     br $loop|2
+    else
      i32.const 0
      i32.const 376
      i32.const 24
      i32.const 4
      call $~lib/builtins/abort
      unreachable
-    else
-     local.get $0
-     i32.const 1
-     i32.add
-     local.set $0
-     br $loop|2
     end
     unreachable
    end
   end
+  local.get $3
+  i32.load offset=20
   local.get $1
   i32.load offset=20
-  i32.const 50
   i32.ne
   if
    i32.const 0
    i32.const 376
-   i32.const 26
+   i32.const 27
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -4966,25 +6025,11 @@
     local.get $1
     local.get $0
     call $~lib/set/Set<i32>#has
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 30
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<i32>#add
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<i32>#has
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 32
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -4998,7 +6043,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 33
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -5019,7 +6064,75 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 36
+   i32.const 35
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  local.set $0
+  loop $loop|4
+   local.get $0
+   i32.const 50
+   i32.lt_s
+   if
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i32>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 39
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i32>#add
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 41
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i32>#delete
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i32>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 43
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    else
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+     br $loop|4
+    end
+    unreachable
+   end
+  end
+  local.get $1
+  i32.load offset=20
+  i32.const 50
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 45
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -5031,18 +6144,22 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 49
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u32>#constructor (; 69 ;) (result i32)
+ (func $~lib/set/Set<u32>#constructor (; 86 ;) (result i32)
   (local $0 i32)
   i32.const 24
-  i32.const 8
+  i32.const 13
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
@@ -5067,9 +6184,75 @@
   call $~lib/set/Set<i8>#clear
   local.get $0
  )
- (func $std/set/testNumeric<u32> (; 70 ;) (type $FUNCSIG$v)
+ (func $~lib/set/Set<u32>#values (; 87 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.set $1
+  i32.const 16
+  i32.const 14
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $2
+  i32.const 0
+  i32.store offset=12
+  local.get $2
+  local.get $1
+  i32.store offset=12
+  i32.const 0
+  local.set $0
+  loop $loop|0
+   local.get $3
+   local.get $1
+   i32.lt_s
+   if
+    local.get $3
+    i32.const 3
+    i32.shl
+    local.get $4
+    i32.add
+    local.tee $5
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $0
+     local.tee $6
+     i32.const 1
+     i32.add
+     local.set $0
+     local.get $2
+     local.get $6
+     local.get $5
+     i32.load
+     call $~lib/array/Array<i32>#__set
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $loop|0
+   end
+  end
+  local.get $2
+ )
+ (func $std/set/testNumeric<u32> (; 88 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   call $~lib/set/Set<u32>#constructor
   local.set $1
   loop $loop|0
@@ -5177,56 +6360,55 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/set/Set<u32>#values
+  local.set $2
+  call $~lib/set/Set<u32>#constructor
+  local.set $3
   i32.const 0
   local.set $0
   loop $loop|2
    local.get $0
-   i32.const 50
-   i32.lt_u
+   local.get $2
+   i32.load offset=12
+   i32.lt_s
    if
     local.get $1
+    local.get $2
     local.get $0
-    call $~lib/set/Set<i32>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 22
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<i32>#delete
-    local.get $1
-    local.get $0
+    call $~lib/array/Array<i32>#__get
     call $~lib/set/Set<i32>#has
     if
+     local.get $3
+     local.get $2
+     local.get $0
+     call $~lib/array/Array<i32>#__get
+     call $~lib/set/Set<i32>#add
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+     br $loop|2
+    else
      i32.const 0
      i32.const 376
      i32.const 24
      i32.const 4
      call $~lib/builtins/abort
      unreachable
-    else
-     local.get $0
-     i32.const 1
-     i32.add
-     local.set $0
-     br $loop|2
     end
     unreachable
    end
   end
+  local.get $3
+  i32.load offset=20
   local.get $1
   i32.load offset=20
-  i32.const 50
   i32.ne
   if
    i32.const 0
    i32.const 376
-   i32.const 26
+   i32.const 27
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -5241,25 +6423,11 @@
     local.get $1
     local.get $0
     call $~lib/set/Set<i32>#has
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 30
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<i32>#add
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<i32>#has
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 32
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -5273,7 +6441,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 33
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -5294,7 +6462,75 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 36
+   i32.const 35
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  local.set $0
+  loop $loop|4
+   local.get $0
+   i32.const 50
+   i32.lt_u
+   if
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i32>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 39
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i32>#add
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 41
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i32>#delete
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i32>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 43
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    else
+     local.get $0
+     i32.const 1
+     i32.add
+     local.set $0
+     br $loop|4
+    end
+    unreachable
+   end
+  end
+  local.get $1
+  i32.load offset=20
+  i32.const 50
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 45
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -5306,15 +6542,19 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 49
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i64>#clear (; 71 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/set/Set<i64>#clear (; 89 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   i32.const 16
   call $~lib/arraybuffer/ArrayBuffer#constructor
@@ -5347,10 +6587,10 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<i64>#constructor (; 72 ;) (result i32)
+ (func $~lib/set/Set<i64>#constructor (; 90 ;) (result i32)
   (local $0 i32)
   i32.const 24
-  i32.const 9
+  i32.const 15
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
@@ -5375,7 +6615,7 @@
   call $~lib/set/Set<i64>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash64 (; 73 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/hash/hash64 (; 91 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   local.get $0
   i32.wrap_i64
@@ -5441,7 +6681,7 @@
   i32.const 16777619
   i32.mul
  )
- (func $~lib/set/Set<i64>#find (; 74 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i64>#find (; 92 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -5484,7 +6724,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i64>#has (; 75 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/set/Set<i64>#has (; 93 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -5493,7 +6733,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i64>#rehash (; 76 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i64>#rehash (; 94 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5621,7 +6861,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i64>#add (; 77 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
+ (func $~lib/set/Set<i64>#add (; 95 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5704,7 +6944,130 @@
    i32.store
   end
  )
- (func $~lib/set/Set<i64>#delete (; 78 ;) (param $0 i32) (param $1 i64)
+ (func $~lib/array/Array<i64>#__set (; 96 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 416
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   i32.const 3
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $3
+   i32.store offset=12
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 3
+  i32.shl
+  i32.add
+  local.get $2
+  i64.store
+ )
+ (func $~lib/set/Set<i64>#values (; 97 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.set $1
+  i32.const 16
+  i32.const 16
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.get $1
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $2
+  i32.const 0
+  i32.store offset=12
+  local.get $2
+  local.get $1
+  i32.store offset=12
+  i32.const 0
+  local.set $0
+  loop $loop|0
+   local.get $3
+   local.get $1
+   i32.lt_s
+   if
+    local.get $3
+    i32.const 4
+    i32.shl
+    local.get $4
+    i32.add
+    local.tee $5
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $0
+     local.tee $6
+     i32.const 1
+     i32.add
+     local.set $0
+     local.get $2
+     local.get $6
+     local.get $5
+     i64.load
+     call $~lib/array/Array<i64>#__set
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $loop|0
+   end
+  end
+  local.get $2
+ )
+ (func $~lib/array/Array<i64>#__get (; 98 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 416
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 3
+  i32.shl
+  i32.add
+  i64.load
+ )
+ (func $~lib/set/Set<i64>#delete (; 99 ;) (param $0 i32) (param $1 i64)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -5764,9 +7127,12 @@
    call $~lib/set/Set<i64>#rehash
   end
  )
- (func $std/set/testNumeric<i64> (; 79 ;) (type $FUNCSIG$v)
+ (func $std/set/testNumeric<i64> (; 100 ;) (type $FUNCSIG$v)
   (local $0 i64)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   call $~lib/set/Set<i64>#constructor
   local.set $1
   loop $loop|0
@@ -5874,56 +7240,53 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 0
-  local.set $0
+  local.get $1
+  call $~lib/set/Set<i64>#values
+  local.set $2
+  call $~lib/set/Set<i64>#constructor
+  local.set $4
   loop $loop|2
-   local.get $0
-   i64.const 50
-   i64.lt_s
+   local.get $3
+   local.get $2
+   i32.load offset=12
+   i32.lt_s
    if
     local.get $1
-    local.get $0
-    call $~lib/set/Set<i64>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 22
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<i64>#delete
-    local.get $1
-    local.get $0
+    local.get $2
+    local.get $3
+    call $~lib/array/Array<i64>#__get
     call $~lib/set/Set<i64>#has
     if
+     local.get $4
+     local.get $2
+     local.get $3
+     call $~lib/array/Array<i64>#__get
+     call $~lib/set/Set<i64>#add
+     local.get $3
+     i32.const 1
+     i32.add
+     local.set $3
+     br $loop|2
+    else
      i32.const 0
      i32.const 376
      i32.const 24
      i32.const 4
      call $~lib/builtins/abort
      unreachable
-    else
-     local.get $0
-     i64.const 1
-     i64.add
-     local.set $0
-     br $loop|2
     end
     unreachable
    end
   end
+  local.get $4
+  i32.load offset=20
   local.get $1
   i32.load offset=20
-  i32.const 50
   i32.ne
   if
    i32.const 0
    i32.const 376
-   i32.const 26
+   i32.const 27
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -5938,25 +7301,11 @@
     local.get $1
     local.get $0
     call $~lib/set/Set<i64>#has
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 30
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<i64>#add
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<i64>#has
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 32
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -5970,7 +7319,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 33
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -5991,7 +7340,75 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 36
+   i32.const 35
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 0
+  local.set $0
+  loop $loop|4
+   local.get $0
+   i64.const 50
+   i64.lt_s
+   if
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i64>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 39
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i64>#add
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i64>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 41
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i64>#delete
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i64>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 43
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    else
+     local.get $0
+     i64.const 1
+     i64.add
+     local.set $0
+     br $loop|4
+    end
+    unreachable
+   end
+  end
+  local.get $1
+  i32.load offset=20
+  i32.const 50
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 45
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -6003,18 +7420,22 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 49
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u64>#constructor (; 80 ;) (result i32)
+ (func $~lib/set/Set<u64>#constructor (; 101 ;) (result i32)
   (local $0 i32)
   i32.const 24
-  i32.const 10
+  i32.const 17
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
@@ -6039,9 +7460,76 @@
   call $~lib/set/Set<i64>#clear
   local.get $0
  )
- (func $std/set/testNumeric<u64> (; 81 ;) (type $FUNCSIG$v)
+ (func $~lib/set/Set<u64>#values (; 102 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.set $1
+  i32.const 16
+  i32.const 18
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.get $1
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $2
+  i32.const 0
+  i32.store offset=12
+  local.get $2
+  local.get $1
+  i32.store offset=12
+  i32.const 0
+  local.set $0
+  loop $loop|0
+   local.get $3
+   local.get $1
+   i32.lt_s
+   if
+    local.get $3
+    i32.const 4
+    i32.shl
+    local.get $4
+    i32.add
+    local.tee $5
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $0
+     local.tee $6
+     i32.const 1
+     i32.add
+     local.set $0
+     local.get $2
+     local.get $6
+     local.get $5
+     i64.load
+     call $~lib/array/Array<i64>#__set
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $loop|0
+   end
+  end
+  local.get $2
+ )
+ (func $std/set/testNumeric<u64> (; 103 ;) (type $FUNCSIG$v)
   (local $0 i64)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   call $~lib/set/Set<u64>#constructor
   local.set $1
   loop $loop|0
@@ -6149,56 +7637,53 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 0
-  local.set $0
+  local.get $1
+  call $~lib/set/Set<u64>#values
+  local.set $2
+  call $~lib/set/Set<u64>#constructor
+  local.set $4
   loop $loop|2
-   local.get $0
-   i64.const 50
-   i64.lt_u
+   local.get $3
+   local.get $2
+   i32.load offset=12
+   i32.lt_s
    if
     local.get $1
-    local.get $0
-    call $~lib/set/Set<i64>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 22
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<i64>#delete
-    local.get $1
-    local.get $0
+    local.get $2
+    local.get $3
+    call $~lib/array/Array<i64>#__get
     call $~lib/set/Set<i64>#has
     if
+     local.get $4
+     local.get $2
+     local.get $3
+     call $~lib/array/Array<i64>#__get
+     call $~lib/set/Set<i64>#add
+     local.get $3
+     i32.const 1
+     i32.add
+     local.set $3
+     br $loop|2
+    else
      i32.const 0
      i32.const 376
      i32.const 24
      i32.const 4
      call $~lib/builtins/abort
      unreachable
-    else
-     local.get $0
-     i64.const 1
-     i64.add
-     local.set $0
-     br $loop|2
     end
     unreachable
    end
   end
+  local.get $4
+  i32.load offset=20
   local.get $1
   i32.load offset=20
-  i32.const 50
   i32.ne
   if
    i32.const 0
    i32.const 376
-   i32.const 26
+   i32.const 27
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -6213,25 +7698,11 @@
     local.get $1
     local.get $0
     call $~lib/set/Set<i64>#has
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 30
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<i64>#add
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<i64>#has
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 32
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -6245,7 +7716,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 33
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -6266,7 +7737,75 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 36
+   i32.const 35
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 0
+  local.set $0
+  loop $loop|4
+   local.get $0
+   i64.const 50
+   i64.lt_u
+   if
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i64>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 39
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i64>#add
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i64>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 41
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i64>#delete
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<i64>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 43
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    else
+     local.get $0
+     i64.const 1
+     i64.add
+     local.set $0
+     br $loop|4
+    end
+    unreachable
+   end
+  end
+  local.get $1
+  i32.load offset=20
+  i32.const 50
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 45
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -6278,18 +7817,22 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 49
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f32>#constructor (; 82 ;) (result i32)
+ (func $~lib/set/Set<f32>#constructor (; 104 ;) (result i32)
   (local $0 i32)
   i32.const 24
-  i32.const 11
+  i32.const 19
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
@@ -6314,7 +7857,7 @@
   call $~lib/set/Set<i8>#clear
   local.get $0
  )
- (func $~lib/set/Set<f32>#find (; 83 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<f32>#find (; 105 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -6357,7 +7900,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<f32>#has (; 84 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/set/Set<f32>#has (; 106 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -6367,7 +7910,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<f32>#rehash (; 85 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<f32>#rehash (; 107 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6496,7 +8039,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f32>#add (; 86 ;) (type $FUNCSIG$vif) (param $0 i32) (param $1 f32)
+ (func $~lib/set/Set<f32>#add (; 108 ;) (type $FUNCSIG$vif) (param $0 i32) (param $1 f32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6580,7 +8123,130 @@
    i32.store
   end
  )
- (func $~lib/set/Set<f32>#delete (; 87 ;) (param $0 i32) (param $1 f32)
+ (func $~lib/array/Array<f32>#__set (; 109 ;) (type $FUNCSIG$viif) (param $0 i32) (param $1 i32) (param $2 f32)
+  (local $3 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 416
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   i32.const 2
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $3
+   i32.store offset=12
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $2
+  f32.store
+ )
+ (func $~lib/set/Set<f32>#values (; 110 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.set $1
+  i32.const 16
+  i32.const 20
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $2
+  i32.const 0
+  i32.store offset=12
+  local.get $2
+  local.get $1
+  i32.store offset=12
+  i32.const 0
+  local.set $0
+  loop $loop|0
+   local.get $3
+   local.get $1
+   i32.lt_s
+   if
+    local.get $3
+    i32.const 3
+    i32.shl
+    local.get $4
+    i32.add
+    local.tee $5
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $0
+     local.tee $6
+     i32.const 1
+     i32.add
+     local.set $0
+     local.get $2
+     local.get $6
+     local.get $5
+     f32.load
+     call $~lib/array/Array<f32>#__set
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $loop|0
+   end
+  end
+  local.get $2
+ )
+ (func $~lib/array/Array<f32>#__get (; 111 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 416
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  f32.load
+ )
+ (func $~lib/set/Set<f32>#delete (; 112 ;) (param $0 i32) (param $1 f32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -6641,9 +8307,12 @@
    call $~lib/set/Set<f32>#rehash
   end
  )
- (func $std/set/testNumeric<f32> (; 88 ;) (type $FUNCSIG$v)
+ (func $std/set/testNumeric<f32> (; 113 ;) (type $FUNCSIG$v)
   (local $0 f32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   call $~lib/set/Set<f32>#constructor
   local.set $1
   loop $loop|0
@@ -6751,56 +8420,53 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  local.set $0
+  local.get $1
+  call $~lib/set/Set<f32>#values
+  local.set $2
+  call $~lib/set/Set<f32>#constructor
+  local.set $4
   loop $loop|2
-   local.get $0
-   f32.const 50
-   f32.lt
+   local.get $3
+   local.get $2
+   i32.load offset=12
+   i32.lt_s
    if
     local.get $1
-    local.get $0
-    call $~lib/set/Set<f32>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 22
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<f32>#delete
-    local.get $1
-    local.get $0
+    local.get $2
+    local.get $3
+    call $~lib/array/Array<f32>#__get
     call $~lib/set/Set<f32>#has
     if
+     local.get $4
+     local.get $2
+     local.get $3
+     call $~lib/array/Array<f32>#__get
+     call $~lib/set/Set<f32>#add
+     local.get $3
+     i32.const 1
+     i32.add
+     local.set $3
+     br $loop|2
+    else
      i32.const 0
      i32.const 376
      i32.const 24
      i32.const 4
      call $~lib/builtins/abort
      unreachable
-    else
-     local.get $0
-     f32.const 1
-     f32.add
-     local.set $0
-     br $loop|2
     end
     unreachable
    end
   end
+  local.get $4
+  i32.load offset=20
   local.get $1
   i32.load offset=20
-  i32.const 50
   i32.ne
   if
    i32.const 0
    i32.const 376
-   i32.const 26
+   i32.const 27
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -6815,25 +8481,11 @@
     local.get $1
     local.get $0
     call $~lib/set/Set<f32>#has
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 30
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<f32>#add
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<f32>#has
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 32
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -6847,7 +8499,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 33
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -6868,7 +8520,75 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 36
+   i32.const 35
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  local.set $0
+  loop $loop|4
+   local.get $0
+   f32.const 50
+   f32.lt
+   if
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<f32>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 39
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<f32>#add
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<f32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 41
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<f32>#delete
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<f32>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 43
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    else
+     local.get $0
+     f32.const 1
+     f32.add
+     local.set $0
+     br $loop|4
+    end
+    unreachable
+   end
+  end
+  local.get $1
+  i32.load offset=20
+  i32.const 50
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 45
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -6880,18 +8600,22 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 49
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f64>#constructor (; 89 ;) (result i32)
+ (func $~lib/set/Set<f64>#constructor (; 114 ;) (result i32)
   (local $0 i32)
   i32.const 24
-  i32.const 12
+  i32.const 21
   call $~lib/rt/tlsf/__alloc
   call $~lib/rt/pure/__retain
   local.tee $0
@@ -6916,7 +8640,7 @@
   call $~lib/set/Set<i64>#clear
   local.get $0
  )
- (func $~lib/set/Set<f64>#find (; 90 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/set/Set<f64>#find (; 115 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   local.get $0
   i32.load
   local.get $0
@@ -6959,7 +8683,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<f64>#has (; 91 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/set/Set<f64>#has (; 116 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   local.get $0
   local.get $1
   local.get $1
@@ -6969,7 +8693,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<f64>#rehash (; 92 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<f64>#rehash (; 117 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7098,7 +8822,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f64>#add (; 93 ;) (type $FUNCSIG$vid) (param $0 i32) (param $1 f64)
+ (func $~lib/set/Set<f64>#add (; 118 ;) (type $FUNCSIG$vid) (param $0 i32) (param $1 f64)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7182,7 +8906,130 @@
    i32.store
   end
  )
- (func $~lib/set/Set<f64>#delete (; 94 ;) (param $0 i32) (param $1 f64)
+ (func $~lib/array/Array<f64>#__set (; 119 ;) (type $FUNCSIG$viid) (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 416
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   local.tee $3
+   i32.const 3
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $3
+   i32.store offset=12
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 3
+  i32.shl
+  i32.add
+  local.get $2
+  f64.store
+ )
+ (func $~lib/set/Set<f64>#values (; 120 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $4
+  local.get $0
+  i32.load offset=16
+  local.set $1
+  i32.const 16
+  i32.const 22
+  call $~lib/rt/tlsf/__alloc
+  call $~lib/rt/pure/__retain
+  local.get $1
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.tee $2
+  i32.const 0
+  i32.store offset=12
+  local.get $2
+  local.get $1
+  i32.store offset=12
+  i32.const 0
+  local.set $0
+  loop $loop|0
+   local.get $3
+   local.get $1
+   i32.lt_s
+   if
+    local.get $3
+    i32.const 4
+    i32.shl
+    local.get $4
+    i32.add
+    local.tee $5
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $0
+     local.tee $6
+     i32.const 1
+     i32.add
+     local.set $0
+     local.get $2
+     local.get $6
+     local.get $5
+     f64.load
+     call $~lib/array/Array<f64>#__set
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $loop|0
+   end
+  end
+  local.get $2
+ )
+ (func $~lib/array/Array<f64>#__get (; 121 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 416
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 3
+  i32.shl
+  i32.add
+  f64.load
+ )
+ (func $~lib/set/Set<f64>#delete (; 122 ;) (param $0 i32) (param $1 f64)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -7243,9 +9090,12 @@
    call $~lib/set/Set<f64>#rehash
   end
  )
- (func $std/set/testNumeric<f64> (; 95 ;) (type $FUNCSIG$v)
+ (func $std/set/testNumeric<f64> (; 123 ;) (type $FUNCSIG$v)
   (local $0 f64)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   call $~lib/set/Set<f64>#constructor
   local.set $1
   loop $loop|0
@@ -7353,56 +9203,53 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  local.set $0
+  local.get $1
+  call $~lib/set/Set<f64>#values
+  local.set $2
+  call $~lib/set/Set<f64>#constructor
+  local.set $4
   loop $loop|2
-   local.get $0
-   f64.const 50
-   f64.lt
+   local.get $3
+   local.get $2
+   i32.load offset=12
+   i32.lt_s
    if
     local.get $1
-    local.get $0
-    call $~lib/set/Set<f64>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 22
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<f64>#delete
-    local.get $1
-    local.get $0
+    local.get $2
+    local.get $3
+    call $~lib/array/Array<f64>#__get
     call $~lib/set/Set<f64>#has
     if
+     local.get $4
+     local.get $2
+     local.get $3
+     call $~lib/array/Array<f64>#__get
+     call $~lib/set/Set<f64>#add
+     local.get $3
+     i32.const 1
+     i32.add
+     local.set $3
+     br $loop|2
+    else
      i32.const 0
      i32.const 376
      i32.const 24
      i32.const 4
      call $~lib/builtins/abort
      unreachable
-    else
-     local.get $0
-     f64.const 1
-     f64.add
-     local.set $0
-     br $loop|2
     end
     unreachable
    end
   end
+  local.get $4
+  i32.load offset=20
   local.get $1
   i32.load offset=20
-  i32.const 50
   i32.ne
   if
    i32.const 0
    i32.const 376
-   i32.const 26
+   i32.const 27
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -7417,25 +9264,11 @@
     local.get $1
     local.get $0
     call $~lib/set/Set<f64>#has
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 30
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<f64>#add
-    local.get $1
-    local.get $0
-    call $~lib/set/Set<f64>#has
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 32
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -7449,7 +9282,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 33
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -7470,7 +9303,75 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 36
+   i32.const 35
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  local.set $0
+  loop $loop|4
+   local.get $0
+   f64.const 50
+   f64.lt
+   if
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<f64>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 39
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<f64>#add
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<f64>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 41
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<f64>#delete
+    local.get $1
+    local.get $0
+    call $~lib/set/Set<f64>#has
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 43
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    else
+     local.get $0
+     f64.const 1
+     f64.add
+     local.set $0
+     br $loop|4
+    end
+    unreachable
+   end
+  end
+  local.get $1
+  i32.load offset=20
+  i32.const 50
+  i32.ne
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 45
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -7482,15 +9383,19 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 49
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $4
+  call $~lib/rt/pure/__release
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $start (; 96 ;) (type $FUNCSIG$v)
+ (func $start (; 124 ;) (type $FUNCSIG$v)
   call $std/set/testNumeric<i8>
   call $std/set/testNumeric<u8>
   call $std/set/testNumeric<i16>
@@ -7502,9 +9407,9 @@
   call $std/set/testNumeric<f32>
   call $std/set/testNumeric<f64>
  )
- (func $~lib/rt/pure/__visit (; 97 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 125 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   local.get $0
-  i32.const 508
+  i32.const 636
   i32.lt_u
   if
    return
@@ -7612,30 +9517,30 @@
    unreachable
   end
  )
- (func $~lib/rt/__visit_members (; 98 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (; 126 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   block $folding-inner0
-   block $switch$1$default
-    block $switch$1$case$4
+   block $block$4$break
+    block $switch$1$default
      block $switch$1$case$2
       local.get $0
       i32.const 8
       i32.sub
       i32.load
-      br_table $switch$1$case$2 $switch$1$case$2 $switch$1$case$4 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $folding-inner0 $switch$1$default
+      br_table $switch$1$case$2 $switch$1$case$2 $block$4$break $folding-inner0 $block$4$break $folding-inner0 $block$4$break $folding-inner0 $block$4$break $folding-inner0 $block$4$break $folding-inner0 $block$4$break $folding-inner0 $block$4$break $folding-inner0 $block$4$break $folding-inner0 $block$4$break $folding-inner0 $block$4$break $folding-inner0 $block$4$break $switch$1$default
      end
      return
     end
-    local.get $0
-    i32.load
-    local.tee $0
-    if
-     local.get $0
-     local.get $1
-     call $~lib/rt/pure/__visit
-    end
-    return
+    unreachable
    end
-   unreachable
+   local.get $0
+   i32.load
+   local.tee $0
+   if
+    local.get $0
+    local.get $1
+    call $~lib/rt/pure/__visit
+   end
+   return
   end
   local.get $0
   i32.load
@@ -7646,7 +9551,7 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $null (; 99 ;) (type $FUNCSIG$v)
+ (func $null (; 127 ;) (type $FUNCSIG$v)
   unreachable
  )
 )

--- a/tests/compiler/std/set.ts
+++ b/tests/compiler/std/set.ts
@@ -17,6 +17,15 @@ function testNumeric<K extends number>(): void {
   }
   assert(set.size == 100);
 
+  // values 
+  let vals = set.values();
+  let valSet = new Set<K>(); 
+  for (let index = 0; index < vals.length; ++index) {
+    assert(set.has(vals[index]));
+    valSet.add(vals[index]);
+  }
+  assert(valSet.size == set.size);
+
   // delete
   for (let k: K = 0; k < 50; ++k) {
     assert(set.has(k));

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -11,12 +11,18 @@
  (type $FUNCSIG$ij (func (param i64) (result i32)))
  (type $FUNCSIG$iiji (func (param i32 i64 i32) (result i32)))
  (type $FUNCSIG$vij (func (param i32 i64)))
+ (type $FUNCSIG$viij (func (param i32 i32 i64)))
+ (type $FUNCSIG$jii (func (param i32 i32) (result i64)))
  (type $FUNCSIG$iif (func (param i32 f32) (result i32)))
  (type $FUNCSIG$iifi (func (param i32 f32 i32) (result i32)))
  (type $FUNCSIG$vif (func (param i32 f32)))
+ (type $FUNCSIG$viif (func (param i32 i32 f32)))
+ (type $FUNCSIG$fii (func (param i32 i32) (result f32)))
  (type $FUNCSIG$iid (func (param i32 f64) (result i32)))
  (type $FUNCSIG$iidi (func (param i32 f64 i32) (result i32)))
  (type $FUNCSIG$vid (func (param i32 f64)))
+ (type $FUNCSIG$viid (func (param i32 i32 f64)))
+ (type $FUNCSIG$dii (func (param i32 i32) (result f64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (import "rtrace" "onfree" (func $~lib/rt/rtrace/onfree (param i32)))
  (import "rtrace" "onalloc" (func $~lib/rt/rtrace/onalloc (param i32)))
@@ -31,7 +37,8 @@
  (data (i32.const 264) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e\00")
  (data (i32.const 320) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s\00")
  (data (i32.const 360) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00s\00t\00d\00/\00s\00e\00t\00.\00t\00s\00")
- (data (i32.const 400) "\0d\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\004\04\00\00\00\00\00\004\00\00\00\00\00\00\00T\04\00\00\00\00\00\00T\00\00\00\00\00\00\00\94\04\00\00\00\00\00\00\94\00\00\00\00\00\00\00\14\05\00\00\00\00\00\00\14\01\00\00\00\00\00\00\94\0c\00\00\00\00\00\00\14\0d\00\00\00\00\00\00")
+ (data (i32.const 400) "\1a\00\00\00\01\00\00\00\01\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s\00")
+ (data (i32.const 448) "\17\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\004\04\00\00\00\00\00\003\04\00\00\02\00\00\004\00\00\00\00\00\00\003\00\00\00\02\00\00\00T\04\00\00\00\00\00\00S\04\00\00\02\00\00\00T\00\00\00\00\00\00\00S\00\00\00\02\00\00\00\94\04\00\00\00\00\00\00\93\04\00\00\02\00\00\00\94\00\00\00\00\00\00\00\93\00\00\00\02\00\00\00\14\05\00\00\00\00\00\00\13\05\00\00\02\00\00\00\14\01\00\00\00\00\00\00\13\01\00\00\02\00\00\00\94\0c\00\00\00\00\00\00\93\0c\00\00\02\00\00\00\14\0d\00\00\00\00\00\00\13\0d\00\00\02\00\00\00")
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
@@ -41,8 +48,8 @@
  (global $~lib/rt/pure/CUR (mut i32) (i32.const 0))
  (global $~lib/ASC_SHRINK_LEVEL i32 (i32.const 0))
  (global $~lib/rt/pure/END (mut i32) (i32.const 0))
- (global $~lib/rt/__rtti_base i32 (i32.const 400))
- (global $~lib/heap/__heap_base i32 (i32.const 508))
+ (global $~lib/rt/__rtti_base i32 (i32.const 448))
+ (global $~lib/heap/__heap_base i32 (i32.const 636))
  (export "memory" (memory $0))
  (start $start)
  (func $~lib/rt/tlsf/removeBlock (; 5 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
@@ -3966,7 +3973,481 @@
   local.get $0
   i32.load offset=20
  )
- (func $~lib/set/Set<i8>#delete (; 41 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (; 41 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $1
+  i32.const 1073741808
+  local.get $2
+  i32.shr_u
+  i32.gt_u
+  if
+   i32.const 176
+   i32.const 224
+   i32.const 23
+   i32.const 56
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $2
+  i32.shl
+  local.tee $1
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.set $3
+  local.get $3
+  i32.const 0
+  local.get $1
+  call $~lib/memory/memory.fill
+  local.get $0
+  i32.eqz
+  if
+   i32.const 12
+   i32.const 2
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+   local.set $0
+  end
+  local.get $0
+  i32.const 0
+  i32.store
+  local.get $0
+  i32.const 0
+  i32.store offset=4
+  local.get $0
+  i32.const 0
+  i32.store offset=8
+  local.get $0
+  local.tee $4
+  local.get $3
+  local.tee $5
+  local.get $4
+  i32.load
+  local.tee $6
+  i32.ne
+  if
+   local.get $5
+   call $~lib/rt/pure/__retain
+   local.set $5
+   local.get $6
+   call $~lib/rt/pure/__release
+  end
+  local.get $5
+  i32.store
+  local.get $0
+  local.get $3
+  i32.store offset=4
+  local.get $0
+  local.get $1
+  i32.store offset=8
+  local.get $0
+ )
+ (func $~lib/array/Array<i8>#constructor (; 42 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  if (result i32)
+   local.get $0
+  else
+   i32.const 16
+   i32.const 4
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+  end
+  local.get $1
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  local.get $1
+  i32.store offset=12
+  local.get $0
+ )
+ (func $~lib/rt/tlsf/reallocateBlock (; 43 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $2
+  call $~lib/rt/tlsf/prepareSize
+  local.set $3
+  local.get $1
+  i32.load
+  local.set $4
+  local.get $4
+  i32.const 1
+  i32.and
+  i32.eqz
+  if (result i32)
+   local.get $1
+   i32.load offset=4
+   i32.const -268435456
+   i32.and
+   i32.eqz
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 521
+   i32.const 4
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  local.get $4
+  i32.const -4
+  i32.and
+  i32.le_u
+  if
+   local.get $0
+   local.get $1
+   local.get $3
+   call $~lib/rt/tlsf/prepareBlock
+   local.get $1
+   local.get $2
+   i32.store offset=12
+   local.get $1
+   return
+  end
+  local.get $1
+  local.set $5
+  local.get $5
+  i32.const 16
+  i32.add
+  local.get $5
+  i32.load
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+  i32.add
+  local.set $6
+  local.get $6
+  i32.load
+  local.set $7
+  local.get $7
+  i32.const 1
+  i32.and
+  if
+   local.get $4
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $5
+   local.get $5
+   local.get $3
+   i32.ge_u
+   if
+    local.get $0
+    local.get $6
+    call $~lib/rt/tlsf/removeBlock
+    local.get $1
+    local.get $4
+    i32.const 3
+    i32.and
+    local.get $5
+    i32.or
+    i32.store
+    local.get $1
+    local.get $2
+    i32.store offset=12
+    local.get $0
+    local.get $1
+    local.get $3
+    call $~lib/rt/tlsf/prepareBlock
+    local.get $1
+    return
+   end
+  end
+  local.get $0
+  local.get $2
+  call $~lib/rt/tlsf/allocateBlock
+  local.set $8
+  local.get $8
+  local.get $1
+  i32.load offset=8
+  i32.store offset=8
+  local.get $8
+  i32.const 16
+  i32.add
+  local.get $1
+  i32.const 16
+  i32.add
+  local.get $2
+  call $~lib/memory/memory.copy
+  local.get $1
+  local.get $4
+  i32.const 1
+  i32.or
+  i32.store
+  local.get $0
+  local.get $1
+  call $~lib/rt/tlsf/insertBlock
+  local.get $1
+  call $~lib/rt/rtrace/onfree
+  local.get $8
+ )
+ (func $~lib/rt/tlsf/__realloc (; 44 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  global.get $~lib/rt/tlsf/ROOT
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 585
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 0
+  i32.ne
+  if (result i32)
+   local.get $0
+   i32.const 15
+   i32.and
+   i32.eqz
+  else
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 586
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/rt/tlsf/ROOT
+  local.get $0
+  i32.const 16
+  i32.sub
+  local.get $1
+  call $~lib/rt/tlsf/reallocateBlock
+  i32.const 16
+  i32.add
+ )
+ (func $~lib/array/ensureSize (; 45 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $3
+  local.get $1
+  local.get $3
+  local.get $2
+  i32.shr_u
+  i32.gt_u
+  if
+   local.get $1
+   i32.const 1073741808
+   local.get $2
+   i32.shr_u
+   i32.gt_u
+   if
+    i32.const 176
+    i32.const 416
+    i32.const 14
+    i32.const 47
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   i32.load
+   local.set $4
+   local.get $1
+   local.get $2
+   i32.shl
+   local.set $5
+   local.get $4
+   local.get $5
+   call $~lib/rt/tlsf/__realloc
+   local.set $6
+   local.get $6
+   local.get $3
+   i32.add
+   i32.const 0
+   local.get $5
+   local.get $3
+   i32.sub
+   call $~lib/memory/memory.fill
+   local.get $6
+   local.get $4
+   i32.ne
+   if
+    local.get $0
+    local.get $6
+    call $~lib/rt/pure/__retain
+    i32.store
+    local.get $0
+    local.get $6
+    i32.store offset=4
+   end
+   local.get $0
+   local.get $5
+   i32.store offset=8
+  end
+ )
+ (func $~lib/array/Array<i8>#__unchecked_set (; 46 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 0
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store8
+ )
+ (func $~lib/array/Array<i8>#__set (; 47 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 416
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.const 0
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.store offset=12
+  end
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/array/Array<i8>#__unchecked_set
+ )
+ (func $~lib/set/Set<i8>#values (; 48 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<i8>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 8
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $4
+     local.tee $7
+     i32.const 1
+     i32.add
+     local.set $4
+     local.get $7
+     local.get $6
+     i32.load8_s
+     call $~lib/array/Array<i8>#__set
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+ )
+ (func $~lib/array/Array<i8>#get:length (; 49 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=12
+ )
+ (func $~lib/array/Array<i8>#__unchecked_get (; 50 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 0
+  i32.shl
+  i32.add
+  i32.load8_s
+ )
+ (func $~lib/array/Array<i8>#__get (; 51 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 416
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<i8>#__unchecked_get
+  local.set $2
+  local.get $2
+ )
+ (func $~lib/set/Set<i8>#delete (; 52 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4042,9 +4523,11 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<i8> (; 42 ;) (type $FUNCSIG$v)
+ (func $std/set/testNumeric<i8> (; 53 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   i32.const 0
   call $~lib/set/Set<i8>#constructor
   local.set $0
@@ -4163,35 +4646,27 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
+  call $~lib/set/Set<i8>#values
+  local.set $1
+  i32.const 0
+  call $~lib/set/Set<i8>#constructor
+  local.set $2
   block $break|2
    i32.const 0
-   local.set $1
+   local.set $3
    loop $loop|2
+    local.get $3
     local.get $1
-    i32.const 50
+    call $~lib/array/Array<i8>#get:length
     i32.lt_s
     i32.eqz
     br_if $break|2
     local.get $0
     local.get $1
+    local.get $3
+    call $~lib/array/Array<i8>#__get
     call $~lib/set/Set<i8>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 22
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<i8>#delete
-    drop
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<i8>#has
-    i32.eqz
     i32.eqz
     if
      i32.const 0
@@ -4201,85 +4676,75 @@
      call $~lib/builtins/abort
      unreachable
     end
+    local.get $2
     local.get $1
+    local.get $3
+    call $~lib/array/Array<i8>#__get
+    call $~lib/set/Set<i8>#add
+    local.get $3
     i32.const 1
     i32.add
-    local.set $1
+    local.set $3
     br $loop|2
    end
    unreachable
   end
+  local.get $2
+  call $~lib/set/Set<i8>#get:size
   local.get $0
   call $~lib/set/Set<i8>#get:size
-  i32.const 50
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 26
+   i32.const 27
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
   block $break|3
    i32.const 0
-   local.set $1
+   local.set $3
    loop $loop|3
-    local.get $1
+    local.get $3
     i32.const 50
     i32.lt_s
     i32.eqz
     br_if $break|3
     local.get $0
-    local.get $1
-    call $~lib/set/Set<i8>#has
-    i32.eqz
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 30
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<i8>#add
-    local.get $0
-    local.get $1
+    local.get $3
     call $~lib/set/Set<i8>#has
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 32
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $0
-    local.get $1
+    local.get $3
     call $~lib/set/Set<i8>#delete
     drop
     local.get $0
-    local.get $1
+    local.get $3
     call $~lib/set/Set<i8>#has
     i32.eqz
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 33
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $3
     i32.const 1
     i32.add
-    local.set $1
+    local.set $3
     br $loop|3
    end
    unreachable
@@ -4292,7 +4757,82 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 36
+   i32.const 35
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $break|4
+   i32.const 0
+   local.set $3
+   loop $loop|4
+    local.get $3
+    i32.const 50
+    i32.lt_s
+    i32.eqz
+    br_if $break|4
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<i8>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 39
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<i8>#add
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<i8>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 41
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<i8>#delete
+    drop
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<i8>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 43
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $loop|4
+   end
+   unreachable
+  end
+  local.get $0
+  call $~lib/set/Set<i8>#get:size
+  i32.const 50
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 45
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -4307,15 +4847,19 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 49
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u8>#clear (; 43 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/set/Set<u8>#clear (; 54 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -4355,12 +4899,12 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<u8>#constructor (; 44 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u8>#constructor (; 55 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
    i32.const 24
-   i32.const 4
+   i32.const 5
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
    local.set $0
@@ -4387,7 +4931,7 @@
   call $~lib/set/Set<u8>#clear
   local.get $0
  )
- (func $~lib/set/Set<u8>#find (; 45 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<u8>#find (; 56 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -4437,7 +4981,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<u8>#has (; 46 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u8>#has (; 57 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -4454,7 +4998,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u8>#rehash (; 47 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u8>#rehash (; 58 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4607,7 +5151,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u8>#add (; 48 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u8>#add (; 59 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4700,11 +5244,172 @@
    i32.store
   end
  )
- (func $~lib/set/Set<u8>#get:size (; 49 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u8>#get:size (; 60 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/set/Set<u8>#delete (; 50 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#constructor (; 61 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  if (result i32)
+   local.get $0
+  else
+   i32.const 16
+   i32.const 6
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+  end
+  local.get $1
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  local.get $1
+  i32.store offset=12
+  local.get $0
+ )
+ (func $~lib/array/Array<u8>#__unchecked_set (; 62 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 0
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store8
+ )
+ (func $~lib/array/Array<u8>#__set (; 63 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 416
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.const 0
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.store offset=12
+  end
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/array/Array<u8>#__unchecked_set
+ )
+ (func $~lib/set/Set<u8>#values (; 64 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<u8>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 8
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $4
+     local.tee $7
+     i32.const 1
+     i32.add
+     local.set $4
+     local.get $7
+     local.get $6
+     i32.load8_u
+     call $~lib/array/Array<u8>#__set
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+ )
+ (func $~lib/array/Array<u8>#get:length (; 65 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=12
+ )
+ (func $~lib/array/Array<u8>#__unchecked_get (; 66 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 0
+  i32.shl
+  i32.add
+  i32.load8_u
+ )
+ (func $~lib/array/Array<u8>#__get (; 67 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 416
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<u8>#__unchecked_get
+  local.set $2
+  local.get $2
+ )
+ (func $~lib/set/Set<u8>#delete (; 68 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -4778,9 +5483,11 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<u8> (; 51 ;) (type $FUNCSIG$v)
+ (func $std/set/testNumeric<u8> (; 69 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   i32.const 0
   call $~lib/set/Set<u8>#constructor
   local.set $0
@@ -4899,35 +5606,27 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
+  call $~lib/set/Set<u8>#values
+  local.set $1
+  i32.const 0
+  call $~lib/set/Set<u8>#constructor
+  local.set $2
   block $break|2
    i32.const 0
-   local.set $1
+   local.set $3
    loop $loop|2
+    local.get $3
     local.get $1
-    i32.const 50
-    i32.lt_u
+    call $~lib/array/Array<u8>#get:length
+    i32.lt_s
     i32.eqz
     br_if $break|2
     local.get $0
     local.get $1
+    local.get $3
+    call $~lib/array/Array<u8>#__get
     call $~lib/set/Set<u8>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 22
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<u8>#delete
-    drop
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<u8>#has
-    i32.eqz
     i32.eqz
     if
      i32.const 0
@@ -4937,85 +5636,75 @@
      call $~lib/builtins/abort
      unreachable
     end
+    local.get $2
     local.get $1
+    local.get $3
+    call $~lib/array/Array<u8>#__get
+    call $~lib/set/Set<u8>#add
+    local.get $3
     i32.const 1
     i32.add
-    local.set $1
+    local.set $3
     br $loop|2
    end
    unreachable
   end
+  local.get $2
+  call $~lib/set/Set<u8>#get:size
   local.get $0
   call $~lib/set/Set<u8>#get:size
-  i32.const 50
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 26
+   i32.const 27
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
   block $break|3
    i32.const 0
-   local.set $1
+   local.set $3
    loop $loop|3
-    local.get $1
+    local.get $3
     i32.const 50
     i32.lt_u
     i32.eqz
     br_if $break|3
     local.get $0
-    local.get $1
-    call $~lib/set/Set<u8>#has
-    i32.eqz
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 30
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<u8>#add
-    local.get $0
-    local.get $1
+    local.get $3
     call $~lib/set/Set<u8>#has
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 32
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $0
-    local.get $1
+    local.get $3
     call $~lib/set/Set<u8>#delete
     drop
     local.get $0
-    local.get $1
+    local.get $3
     call $~lib/set/Set<u8>#has
     i32.eqz
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 33
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $3
     i32.const 1
     i32.add
-    local.set $1
+    local.set $3
     br $loop|3
    end
    unreachable
@@ -5028,7 +5717,82 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 36
+   i32.const 35
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $break|4
+   i32.const 0
+   local.set $3
+   loop $loop|4
+    local.get $3
+    i32.const 50
+    i32.lt_u
+    i32.eqz
+    br_if $break|4
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<u8>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 39
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<u8>#add
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<u8>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 41
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<u8>#delete
+    drop
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<u8>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 43
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $loop|4
+   end
+   unreachable
+  end
+  local.get $0
+  call $~lib/set/Set<u8>#get:size
+  i32.const 50
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 45
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -5043,15 +5807,19 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 49
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i16>#clear (; 52 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/set/Set<i16>#clear (; 70 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -5091,12 +5859,12 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<i16>#constructor (; 53 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i16>#constructor (; 71 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
    i32.const 24
-   i32.const 5
+   i32.const 7
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
    local.set $0
@@ -5123,7 +5891,7 @@
   call $~lib/set/Set<i16>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash16 (; 54 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash16 (; 72 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   i32.const -2128831035
   local.set $1
@@ -5145,7 +5913,7 @@
   local.set $1
   local.get $1
  )
- (func $~lib/set/Set<i16>#find (; 55 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i16>#find (; 73 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -5197,7 +5965,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i16>#has (; 56 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i16>#has (; 74 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -5216,7 +5984,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i16>#rehash (; 57 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i16>#rehash (; 75 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5369,7 +6137,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i16>#add (; 58 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i16>#add (; 76 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5464,11 +6232,172 @@
    i32.store
   end
  )
- (func $~lib/set/Set<i16>#get:size (; 59 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i16>#get:size (; 77 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/set/Set<i16>#delete (; 60 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i16>#constructor (; 78 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  if (result i32)
+   local.get $0
+  else
+   i32.const 16
+   i32.const 8
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+  end
+  local.get $1
+  i32.const 1
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  local.get $1
+  i32.store offset=12
+  local.get $0
+ )
+ (func $~lib/array/Array<i16>#__unchecked_set (; 79 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 1
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store16
+ )
+ (func $~lib/array/Array<i16>#__set (; 80 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 416
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.const 1
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.store offset=12
+  end
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/array/Array<i16>#__unchecked_set
+ )
+ (func $~lib/set/Set<i16>#values (; 81 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<i16>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 8
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $4
+     local.tee $7
+     i32.const 1
+     i32.add
+     local.set $4
+     local.get $7
+     local.get $6
+     i32.load16_s
+     call $~lib/array/Array<i16>#__set
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+ )
+ (func $~lib/array/Array<i16>#get:length (; 82 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=12
+ )
+ (func $~lib/array/Array<i16>#__unchecked_get (; 83 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 1
+  i32.shl
+  i32.add
+  i32.load16_s
+ )
+ (func $~lib/array/Array<i16>#__get (; 84 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 416
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<i16>#__unchecked_get
+  local.set $2
+  local.get $2
+ )
+ (func $~lib/set/Set<i16>#delete (; 85 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5544,9 +6473,11 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<i16> (; 61 ;) (type $FUNCSIG$v)
+ (func $std/set/testNumeric<i16> (; 86 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   i32.const 0
   call $~lib/set/Set<i16>#constructor
   local.set $0
@@ -5665,35 +6596,27 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
+  call $~lib/set/Set<i16>#values
+  local.set $1
+  i32.const 0
+  call $~lib/set/Set<i16>#constructor
+  local.set $2
   block $break|2
    i32.const 0
-   local.set $1
+   local.set $3
    loop $loop|2
+    local.get $3
     local.get $1
-    i32.const 50
+    call $~lib/array/Array<i16>#get:length
     i32.lt_s
     i32.eqz
     br_if $break|2
     local.get $0
     local.get $1
+    local.get $3
+    call $~lib/array/Array<i16>#__get
     call $~lib/set/Set<i16>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 22
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<i16>#delete
-    drop
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<i16>#has
-    i32.eqz
     i32.eqz
     if
      i32.const 0
@@ -5703,85 +6626,75 @@
      call $~lib/builtins/abort
      unreachable
     end
+    local.get $2
     local.get $1
+    local.get $3
+    call $~lib/array/Array<i16>#__get
+    call $~lib/set/Set<i16>#add
+    local.get $3
     i32.const 1
     i32.add
-    local.set $1
+    local.set $3
     br $loop|2
    end
    unreachable
   end
+  local.get $2
+  call $~lib/set/Set<i16>#get:size
   local.get $0
   call $~lib/set/Set<i16>#get:size
-  i32.const 50
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 26
+   i32.const 27
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
   block $break|3
    i32.const 0
-   local.set $1
+   local.set $3
    loop $loop|3
-    local.get $1
+    local.get $3
     i32.const 50
     i32.lt_s
     i32.eqz
     br_if $break|3
     local.get $0
-    local.get $1
-    call $~lib/set/Set<i16>#has
-    i32.eqz
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 30
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<i16>#add
-    local.get $0
-    local.get $1
+    local.get $3
     call $~lib/set/Set<i16>#has
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 32
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $0
-    local.get $1
+    local.get $3
     call $~lib/set/Set<i16>#delete
     drop
     local.get $0
-    local.get $1
+    local.get $3
     call $~lib/set/Set<i16>#has
     i32.eqz
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 33
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $3
     i32.const 1
     i32.add
-    local.set $1
+    local.set $3
     br $loop|3
    end
    unreachable
@@ -5794,7 +6707,82 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 36
+   i32.const 35
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $break|4
+   i32.const 0
+   local.set $3
+   loop $loop|4
+    local.get $3
+    i32.const 50
+    i32.lt_s
+    i32.eqz
+    br_if $break|4
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<i16>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 39
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<i16>#add
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<i16>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 41
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<i16>#delete
+    drop
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<i16>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 43
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $loop|4
+   end
+   unreachable
+  end
+  local.get $0
+  call $~lib/set/Set<i16>#get:size
+  i32.const 50
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 45
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -5809,15 +6797,19 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 49
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u16>#clear (; 62 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/set/Set<u16>#clear (; 87 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -5857,12 +6849,12 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<u16>#constructor (; 63 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u16>#constructor (; 88 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
    i32.const 24
-   i32.const 6
+   i32.const 9
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
    local.set $0
@@ -5889,7 +6881,7 @@
   call $~lib/set/Set<u16>#clear
   local.get $0
  )
- (func $~lib/set/Set<u16>#find (; 64 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<u16>#find (; 89 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -5939,7 +6931,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<u16>#has (; 65 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u16>#has (; 90 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -5956,7 +6948,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u16>#rehash (; 66 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u16>#rehash (; 91 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6109,7 +7101,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u16>#add (; 67 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u16>#add (; 92 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6202,11 +7194,172 @@
    i32.store
   end
  )
- (func $~lib/set/Set<u16>#get:size (; 68 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u16>#get:size (; 93 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/set/Set<u16>#delete (; 69 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#constructor (; 94 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  if (result i32)
+   local.get $0
+  else
+   i32.const 16
+   i32.const 10
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+  end
+  local.get $1
+  i32.const 1
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  local.get $1
+  i32.store offset=12
+  local.get $0
+ )
+ (func $~lib/array/Array<u16>#__unchecked_set (; 95 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 1
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store16
+ )
+ (func $~lib/array/Array<u16>#__set (; 96 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 416
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.const 1
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.store offset=12
+  end
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/array/Array<u16>#__unchecked_set
+ )
+ (func $~lib/set/Set<u16>#values (; 97 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<u16>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 8
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $4
+     local.tee $7
+     i32.const 1
+     i32.add
+     local.set $4
+     local.get $7
+     local.get $6
+     i32.load16_u
+     call $~lib/array/Array<u16>#__set
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+ )
+ (func $~lib/array/Array<u16>#get:length (; 98 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=12
+ )
+ (func $~lib/array/Array<u16>#__unchecked_get (; 99 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 1
+  i32.shl
+  i32.add
+  i32.load16_u
+ )
+ (func $~lib/array/Array<u16>#__get (; 100 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 416
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<u16>#__unchecked_get
+  local.set $2
+  local.get $2
+ )
+ (func $~lib/set/Set<u16>#delete (; 101 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6280,9 +7433,11 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<u16> (; 70 ;) (type $FUNCSIG$v)
+ (func $std/set/testNumeric<u16> (; 102 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   i32.const 0
   call $~lib/set/Set<u16>#constructor
   local.set $0
@@ -6401,35 +7556,27 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
+  call $~lib/set/Set<u16>#values
+  local.set $1
+  i32.const 0
+  call $~lib/set/Set<u16>#constructor
+  local.set $2
   block $break|2
    i32.const 0
-   local.set $1
+   local.set $3
    loop $loop|2
+    local.get $3
     local.get $1
-    i32.const 50
-    i32.lt_u
+    call $~lib/array/Array<u16>#get:length
+    i32.lt_s
     i32.eqz
     br_if $break|2
     local.get $0
     local.get $1
+    local.get $3
+    call $~lib/array/Array<u16>#__get
     call $~lib/set/Set<u16>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 22
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<u16>#delete
-    drop
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<u16>#has
-    i32.eqz
     i32.eqz
     if
      i32.const 0
@@ -6439,85 +7586,75 @@
      call $~lib/builtins/abort
      unreachable
     end
+    local.get $2
     local.get $1
+    local.get $3
+    call $~lib/array/Array<u16>#__get
+    call $~lib/set/Set<u16>#add
+    local.get $3
     i32.const 1
     i32.add
-    local.set $1
+    local.set $3
     br $loop|2
    end
    unreachable
   end
+  local.get $2
+  call $~lib/set/Set<u16>#get:size
   local.get $0
   call $~lib/set/Set<u16>#get:size
-  i32.const 50
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 26
+   i32.const 27
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
   block $break|3
    i32.const 0
-   local.set $1
+   local.set $3
    loop $loop|3
-    local.get $1
+    local.get $3
     i32.const 50
     i32.lt_u
     i32.eqz
     br_if $break|3
     local.get $0
-    local.get $1
-    call $~lib/set/Set<u16>#has
-    i32.eqz
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 30
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<u16>#add
-    local.get $0
-    local.get $1
+    local.get $3
     call $~lib/set/Set<u16>#has
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 32
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $0
-    local.get $1
+    local.get $3
     call $~lib/set/Set<u16>#delete
     drop
     local.get $0
-    local.get $1
+    local.get $3
     call $~lib/set/Set<u16>#has
     i32.eqz
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 33
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $3
     i32.const 1
     i32.add
-    local.set $1
+    local.set $3
     br $loop|3
    end
    unreachable
@@ -6530,7 +7667,82 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 36
+   i32.const 35
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $break|4
+   i32.const 0
+   local.set $3
+   loop $loop|4
+    local.get $3
+    i32.const 50
+    i32.lt_u
+    i32.eqz
+    br_if $break|4
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<u16>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 39
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<u16>#add
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<u16>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 41
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<u16>#delete
+    drop
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<u16>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 43
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $loop|4
+   end
+   unreachable
+  end
+  local.get $0
+  call $~lib/set/Set<u16>#get:size
+  i32.const 50
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 45
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -6545,15 +7757,19 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 49
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i32>#clear (; 71 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/set/Set<i32>#clear (; 103 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -6593,12 +7809,12 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<i32>#constructor (; 72 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i32>#constructor (; 104 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
    i32.const 24
-   i32.const 7
+   i32.const 11
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
    local.set $0
@@ -6625,7 +7841,7 @@
   call $~lib/set/Set<i32>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash32 (; 73 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/util/hash/hash32 (; 105 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   i32.const -2128831035
   local.set $1
@@ -6667,7 +7883,7 @@
   local.set $1
   local.get $1
  )
- (func $~lib/set/Set<i32>#find (; 74 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i32>#find (; 106 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -6715,7 +7931,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i32>#has (; 75 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<i32>#has (; 107 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -6730,7 +7946,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i32>#rehash (; 76 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i32>#rehash (; 108 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6883,7 +8099,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i32>#add (; 77 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i32>#add (; 109 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -6974,11 +8190,172 @@
    i32.store
   end
  )
- (func $~lib/set/Set<i32>#get:size (; 78 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i32>#get:size (; 110 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/set/Set<i32>#delete (; 79 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<i32>#constructor (; 111 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  if (result i32)
+   local.get $0
+  else
+   i32.const 16
+   i32.const 12
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+  end
+  local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  local.get $1
+  i32.store offset=12
+  local.get $0
+ )
+ (func $~lib/array/Array<i32>#__unchecked_set (; 112 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store
+ )
+ (func $~lib/array/Array<i32>#__set (; 113 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 416
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.const 2
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.store offset=12
+  end
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/array/Array<i32>#__unchecked_set
+ )
+ (func $~lib/set/Set<i32>#values (; 114 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<i32>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 8
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $4
+     local.tee $7
+     i32.const 1
+     i32.add
+     local.set $4
+     local.get $7
+     local.get $6
+     i32.load
+     call $~lib/array/Array<i32>#__set
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+ )
+ (func $~lib/array/Array<i32>#get:length (; 115 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=12
+ )
+ (func $~lib/array/Array<i32>#__unchecked_get (; 116 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
+ )
+ (func $~lib/array/Array<i32>#__get (; 117 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 416
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<i32>#__unchecked_get
+  local.set $2
+  local.get $2
+ )
+ (func $~lib/set/Set<i32>#delete (; 118 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7050,9 +8427,11 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<i32> (; 80 ;) (type $FUNCSIG$v)
+ (func $std/set/testNumeric<i32> (; 119 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   i32.const 0
   call $~lib/set/Set<i32>#constructor
   local.set $0
@@ -7171,35 +8550,27 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
+  call $~lib/set/Set<i32>#values
+  local.set $1
+  i32.const 0
+  call $~lib/set/Set<i32>#constructor
+  local.set $2
   block $break|2
    i32.const 0
-   local.set $1
+   local.set $3
    loop $loop|2
+    local.get $3
     local.get $1
-    i32.const 50
+    call $~lib/array/Array<i32>#get:length
     i32.lt_s
     i32.eqz
     br_if $break|2
     local.get $0
     local.get $1
+    local.get $3
+    call $~lib/array/Array<i32>#__get
     call $~lib/set/Set<i32>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 22
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<i32>#delete
-    drop
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<i32>#has
-    i32.eqz
     i32.eqz
     if
      i32.const 0
@@ -7209,85 +8580,75 @@
      call $~lib/builtins/abort
      unreachable
     end
+    local.get $2
     local.get $1
+    local.get $3
+    call $~lib/array/Array<i32>#__get
+    call $~lib/set/Set<i32>#add
+    local.get $3
     i32.const 1
     i32.add
-    local.set $1
+    local.set $3
     br $loop|2
    end
    unreachable
   end
+  local.get $2
+  call $~lib/set/Set<i32>#get:size
   local.get $0
   call $~lib/set/Set<i32>#get:size
-  i32.const 50
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 26
+   i32.const 27
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
   block $break|3
    i32.const 0
-   local.set $1
+   local.set $3
    loop $loop|3
-    local.get $1
+    local.get $3
     i32.const 50
     i32.lt_s
     i32.eqz
     br_if $break|3
     local.get $0
-    local.get $1
-    call $~lib/set/Set<i32>#has
-    i32.eqz
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 30
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<i32>#add
-    local.get $0
-    local.get $1
+    local.get $3
     call $~lib/set/Set<i32>#has
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 32
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $0
-    local.get $1
+    local.get $3
     call $~lib/set/Set<i32>#delete
     drop
     local.get $0
-    local.get $1
+    local.get $3
     call $~lib/set/Set<i32>#has
     i32.eqz
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 33
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $3
     i32.const 1
     i32.add
-    local.set $1
+    local.set $3
     br $loop|3
    end
    unreachable
@@ -7300,7 +8661,82 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 36
+   i32.const 35
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $break|4
+   i32.const 0
+   local.set $3
+   loop $loop|4
+    local.get $3
+    i32.const 50
+    i32.lt_s
+    i32.eqz
+    br_if $break|4
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<i32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 39
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<i32>#add
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<i32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 41
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<i32>#delete
+    drop
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<i32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 43
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $loop|4
+   end
+   unreachable
+  end
+  local.get $0
+  call $~lib/set/Set<i32>#get:size
+  i32.const 50
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 45
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -7315,15 +8751,19 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 49
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u32>#clear (; 81 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/set/Set<u32>#clear (; 120 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -7363,12 +8803,12 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<u32>#constructor (; 82 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u32>#constructor (; 121 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
    i32.const 24
-   i32.const 8
+   i32.const 13
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
    local.set $0
@@ -7395,7 +8835,7 @@
   call $~lib/set/Set<u32>#clear
   local.get $0
  )
- (func $~lib/set/Set<u32>#find (; 83 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<u32>#find (; 122 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -7443,7 +8883,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<u32>#has (; 84 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/set/Set<u32>#has (; 123 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   local.get $1
@@ -7458,7 +8898,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u32>#rehash (; 85 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u32>#rehash (; 124 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7611,7 +9051,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u32>#add (; 86 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u32>#add (; 125 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7702,11 +9142,172 @@
    i32.store
   end
  )
- (func $~lib/set/Set<u32>#get:size (; 87 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u32>#get:size (; 126 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/set/Set<u32>#delete (; 88 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#constructor (; 127 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  if (result i32)
+   local.get $0
+  else
+   i32.const 16
+   i32.const 14
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+  end
+  local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  local.get $1
+  i32.store offset=12
+  local.get $0
+ )
+ (func $~lib/array/Array<u32>#__unchecked_set (; 128 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $2
+  i32.store
+ )
+ (func $~lib/array/Array<u32>#__set (; 129 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 416
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.const 2
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.store offset=12
+  end
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/array/Array<u32>#__unchecked_set
+ )
+ (func $~lib/set/Set<u32>#values (; 130 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<u32>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 8
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $4
+     local.tee $7
+     i32.const 1
+     i32.add
+     local.set $4
+     local.get $7
+     local.get $6
+     i32.load
+     call $~lib/array/Array<u32>#__set
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+ )
+ (func $~lib/array/Array<u32>#get:length (; 131 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=12
+ )
+ (func $~lib/array/Array<u32>#__unchecked_get (; 132 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
+ )
+ (func $~lib/array/Array<u32>#__get (; 133 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 416
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<u32>#__unchecked_get
+  local.set $2
+  local.get $2
+ )
+ (func $~lib/set/Set<u32>#delete (; 134 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -7778,9 +9379,11 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<u32> (; 89 ;) (type $FUNCSIG$v)
+ (func $std/set/testNumeric<u32> (; 135 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   i32.const 0
   call $~lib/set/Set<u32>#constructor
   local.set $0
@@ -7899,35 +9502,27 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
+  call $~lib/set/Set<u32>#values
+  local.set $1
+  i32.const 0
+  call $~lib/set/Set<u32>#constructor
+  local.set $2
   block $break|2
    i32.const 0
-   local.set $1
+   local.set $3
    loop $loop|2
+    local.get $3
     local.get $1
-    i32.const 50
-    i32.lt_u
+    call $~lib/array/Array<u32>#get:length
+    i32.lt_s
     i32.eqz
     br_if $break|2
     local.get $0
     local.get $1
+    local.get $3
+    call $~lib/array/Array<u32>#__get
     call $~lib/set/Set<u32>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 22
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<u32>#delete
-    drop
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<u32>#has
-    i32.eqz
     i32.eqz
     if
      i32.const 0
@@ -7937,85 +9532,75 @@
      call $~lib/builtins/abort
      unreachable
     end
+    local.get $2
     local.get $1
+    local.get $3
+    call $~lib/array/Array<u32>#__get
+    call $~lib/set/Set<u32>#add
+    local.get $3
     i32.const 1
     i32.add
-    local.set $1
+    local.set $3
     br $loop|2
    end
    unreachable
   end
+  local.get $2
+  call $~lib/set/Set<u32>#get:size
   local.get $0
   call $~lib/set/Set<u32>#get:size
-  i32.const 50
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 26
+   i32.const 27
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
   block $break|3
    i32.const 0
-   local.set $1
+   local.set $3
    loop $loop|3
-    local.get $1
+    local.get $3
     i32.const 50
     i32.lt_u
     i32.eqz
     br_if $break|3
     local.get $0
-    local.get $1
-    call $~lib/set/Set<u32>#has
-    i32.eqz
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 30
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<u32>#add
-    local.get $0
-    local.get $1
+    local.get $3
     call $~lib/set/Set<u32>#has
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 32
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
     local.get $0
-    local.get $1
+    local.get $3
     call $~lib/set/Set<u32>#delete
     drop
     local.get $0
-    local.get $1
+    local.get $3
     call $~lib/set/Set<u32>#has
     i32.eqz
     i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 33
      i32.const 4
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $3
     i32.const 1
     i32.add
-    local.set $1
+    local.set $3
     br $loop|3
    end
    unreachable
@@ -8028,7 +9613,82 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 36
+   i32.const 35
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $break|4
+   i32.const 0
+   local.set $3
+   loop $loop|4
+    local.get $3
+    i32.const 50
+    i32.lt_u
+    i32.eqz
+    br_if $break|4
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<u32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 39
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<u32>#add
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<u32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 41
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<u32>#delete
+    drop
+    local.get $0
+    local.get $3
+    call $~lib/set/Set<u32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 43
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $3
+    i32.const 1
+    i32.add
+    local.set $3
+    br $loop|4
+   end
+   unreachable
+  end
+  local.get $0
+  call $~lib/set/Set<u32>#get:size
+  i32.const 50
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 45
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -8043,15 +9703,19 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 49
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i64>#clear (; 90 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/set/Set<i64>#clear (; 136 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -8091,12 +9755,12 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<i64>#constructor (; 91 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i64>#constructor (; 137 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
    i32.const 24
-   i32.const 9
+   i32.const 15
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
    local.set $0
@@ -8123,7 +9787,7 @@
   call $~lib/set/Set<i64>#clear
   local.get $0
  )
- (func $~lib/util/hash/hash64 (; 92 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
+ (func $~lib/util/hash/hash64 (; 138 ;) (type $FUNCSIG$ij) (param $0 i64) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -8211,7 +9875,7 @@
   local.set $3
   local.get $3
  )
- (func $~lib/set/Set<i64>#find (; 93 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/set/Set<i64>#find (; 139 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -8259,7 +9923,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<i64>#has (; 94 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/set/Set<i64>#has (; 140 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   local.get $0
   local.get $1
@@ -8274,7 +9938,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<i64>#rehash (; 95 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i64>#rehash (; 141 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -8428,7 +10092,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<i64>#add (; 96 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
+ (func $~lib/set/Set<i64>#add (; 142 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -8520,11 +10184,172 @@
    i32.store
   end
  )
- (func $~lib/set/Set<i64>#get:size (; 97 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<i64>#get:size (; 143 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/set/Set<i64>#delete (; 98 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/array/Array<i64>#constructor (; 144 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  if (result i32)
+   local.get $0
+  else
+   i32.const 16
+   i32.const 16
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+  end
+  local.get $1
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  local.get $1
+  i32.store offset=12
+  local.get $0
+ )
+ (func $~lib/array/Array<i64>#__unchecked_set (; 145 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 3
+  i32.shl
+  i32.add
+  local.get $2
+  i64.store
+ )
+ (func $~lib/array/Array<i64>#__set (; 146 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 416
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.const 3
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.store offset=12
+  end
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/array/Array<i64>#__unchecked_set
+ )
+ (func $~lib/set/Set<i64>#values (; 147 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<i64>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 16
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $4
+     local.tee $7
+     i32.const 1
+     i32.add
+     local.set $4
+     local.get $7
+     local.get $6
+     i64.load
+     call $~lib/array/Array<i64>#__set
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+ )
+ (func $~lib/array/Array<i64>#get:length (; 148 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=12
+ )
+ (func $~lib/array/Array<i64>#__unchecked_get (; 149 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 3
+  i32.shl
+  i32.add
+  i64.load
+ )
+ (func $~lib/array/Array<i64>#__get (; 150 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i64)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 416
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<i64>#__unchecked_get
+  local.set $2
+  local.get $2
+ )
+ (func $~lib/set/Set<i64>#delete (; 151 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -8597,9 +10422,12 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<i64> (; 99 ;) (type $FUNCSIG$v)
+ (func $std/set/testNumeric<i64> (; 152 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i64)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   i32.const 0
   call $~lib/set/Set<i64>#constructor
   local.set $0
@@ -8718,35 +10546,27 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
+  call $~lib/set/Set<i64>#values
+  local.set $2
+  i32.const 0
+  call $~lib/set/Set<i64>#constructor
+  local.set $3
   block $break|2
-   i64.const 0
-   local.set $1
+   i32.const 0
+   local.set $4
    loop $loop|2
-    local.get $1
-    i64.const 50
-    i64.lt_s
+    local.get $4
+    local.get $2
+    call $~lib/array/Array<i64>#get:length
+    i32.lt_s
     i32.eqz
     br_if $break|2
     local.get $0
-    local.get $1
+    local.get $2
+    local.get $4
+    call $~lib/array/Array<i64>#__get
     call $~lib/set/Set<i64>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 22
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<i64>#delete
-    drop
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<i64>#has
-    i32.eqz
     i32.eqz
     if
      i32.const 0
@@ -8756,23 +10576,29 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
-    i64.const 1
-    i64.add
-    local.set $1
+    local.get $3
+    local.get $2
+    local.get $4
+    call $~lib/array/Array<i64>#__get
+    call $~lib/set/Set<i64>#add
+    local.get $4
+    i32.const 1
+    i32.add
+    local.set $4
     br $loop|2
    end
    unreachable
   end
+  local.get $3
+  call $~lib/set/Set<i64>#get:size
   local.get $0
   call $~lib/set/Set<i64>#get:size
-  i32.const 50
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 26
+   i32.const 27
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -8790,26 +10616,10 @@
     local.get $1
     call $~lib/set/Set<i64>#has
     i32.eqz
-    i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 30
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<i64>#add
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<i64>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 32
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -8826,7 +10636,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 33
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -8847,7 +10657,82 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 36
+   i32.const 35
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $break|4
+   i64.const 0
+   local.set $1
+   loop $loop|4
+    local.get $1
+    i64.const 50
+    i64.lt_s
+    i32.eqz
+    br_if $break|4
+    local.get $0
+    local.get $1
+    call $~lib/set/Set<i64>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 39
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $1
+    call $~lib/set/Set<i64>#add
+    local.get $0
+    local.get $1
+    call $~lib/set/Set<i64>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 41
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $1
+    call $~lib/set/Set<i64>#delete
+    drop
+    local.get $0
+    local.get $1
+    call $~lib/set/Set<i64>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 43
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    i64.const 1
+    i64.add
+    local.set $1
+    br $loop|4
+   end
+   unreachable
+  end
+  local.get $0
+  call $~lib/set/Set<i64>#get:size
+  i32.const 50
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 45
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -8862,15 +10747,19 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 49
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u64>#clear (; 100 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/set/Set<u64>#clear (; 153 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -8910,12 +10799,12 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<u64>#constructor (; 101 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u64>#constructor (; 154 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
    i32.const 24
-   i32.const 10
+   i32.const 17
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
    local.set $0
@@ -8942,7 +10831,7 @@
   call $~lib/set/Set<u64>#clear
   local.get $0
  )
- (func $~lib/set/Set<u64>#find (; 102 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
+ (func $~lib/set/Set<u64>#find (; 155 ;) (type $FUNCSIG$iiji) (param $0 i32) (param $1 i64) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -8990,7 +10879,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<u64>#has (; 103 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/set/Set<u64>#has (; 156 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   local.get $0
   local.get $1
@@ -9005,7 +10894,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<u64>#rehash (; 104 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<u64>#rehash (; 157 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9159,7 +11048,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<u64>#add (; 105 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
+ (func $~lib/set/Set<u64>#add (; 158 ;) (type $FUNCSIG$vij) (param $0 i32) (param $1 i64)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -9251,11 +11140,172 @@
    i32.store
   end
  )
- (func $~lib/set/Set<u64>#get:size (; 106 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<u64>#get:size (; 159 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/set/Set<u64>#delete (; 107 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
+ (func $~lib/array/Array<u64>#constructor (; 160 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  if (result i32)
+   local.get $0
+  else
+   i32.const 16
+   i32.const 18
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+  end
+  local.get $1
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  local.get $1
+  i32.store offset=12
+  local.get $0
+ )
+ (func $~lib/array/Array<u64>#__unchecked_set (; 161 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 3
+  i32.shl
+  i32.add
+  local.get $2
+  i64.store
+ )
+ (func $~lib/array/Array<u64>#__set (; 162 ;) (type $FUNCSIG$viij) (param $0 i32) (param $1 i32) (param $2 i64)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 416
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.const 3
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.store offset=12
+  end
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/array/Array<u64>#__unchecked_set
+ )
+ (func $~lib/set/Set<u64>#values (; 163 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<u64>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 16
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $4
+     local.tee $7
+     i32.const 1
+     i32.add
+     local.set $4
+     local.get $7
+     local.get $6
+     i64.load
+     call $~lib/array/Array<u64>#__set
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+ )
+ (func $~lib/array/Array<u64>#get:length (; 164 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=12
+ )
+ (func $~lib/array/Array<u64>#__unchecked_get (; 165 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 3
+  i32.shl
+  i32.add
+  i64.load
+ )
+ (func $~lib/array/Array<u64>#__get (; 166 ;) (type $FUNCSIG$jii) (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i64)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 416
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<u64>#__unchecked_get
+  local.set $2
+  local.get $2
+ )
+ (func $~lib/set/Set<u64>#delete (; 167 ;) (type $FUNCSIG$iij) (param $0 i32) (param $1 i64) (result i32)
   (local $2 i64)
   (local $3 i32)
   (local $4 i32)
@@ -9328,9 +11378,12 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<u64> (; 108 ;) (type $FUNCSIG$v)
+ (func $std/set/testNumeric<u64> (; 168 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 i64)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   i32.const 0
   call $~lib/set/Set<u64>#constructor
   local.set $0
@@ -9449,35 +11502,27 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
+  call $~lib/set/Set<u64>#values
+  local.set $2
+  i32.const 0
+  call $~lib/set/Set<u64>#constructor
+  local.set $3
   block $break|2
-   i64.const 0
-   local.set $1
+   i32.const 0
+   local.set $4
    loop $loop|2
-    local.get $1
-    i64.const 50
-    i64.lt_u
+    local.get $4
+    local.get $2
+    call $~lib/array/Array<u64>#get:length
+    i32.lt_s
     i32.eqz
     br_if $break|2
     local.get $0
-    local.get $1
+    local.get $2
+    local.get $4
+    call $~lib/array/Array<u64>#__get
     call $~lib/set/Set<u64>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 22
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<u64>#delete
-    drop
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<u64>#has
-    i32.eqz
     i32.eqz
     if
      i32.const 0
@@ -9487,23 +11532,29 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
-    i64.const 1
-    i64.add
-    local.set $1
+    local.get $3
+    local.get $2
+    local.get $4
+    call $~lib/array/Array<u64>#__get
+    call $~lib/set/Set<u64>#add
+    local.get $4
+    i32.const 1
+    i32.add
+    local.set $4
     br $loop|2
    end
    unreachable
   end
+  local.get $3
+  call $~lib/set/Set<u64>#get:size
   local.get $0
   call $~lib/set/Set<u64>#get:size
-  i32.const 50
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 26
+   i32.const 27
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -9521,26 +11572,10 @@
     local.get $1
     call $~lib/set/Set<u64>#has
     i32.eqz
-    i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 30
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<u64>#add
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<u64>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 32
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -9557,7 +11592,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 33
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -9578,7 +11613,82 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 36
+   i32.const 35
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $break|4
+   i64.const 0
+   local.set $1
+   loop $loop|4
+    local.get $1
+    i64.const 50
+    i64.lt_u
+    i32.eqz
+    br_if $break|4
+    local.get $0
+    local.get $1
+    call $~lib/set/Set<u64>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 39
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $1
+    call $~lib/set/Set<u64>#add
+    local.get $0
+    local.get $1
+    call $~lib/set/Set<u64>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 41
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $1
+    call $~lib/set/Set<u64>#delete
+    drop
+    local.get $0
+    local.get $1
+    call $~lib/set/Set<u64>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 43
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    i64.const 1
+    i64.add
+    local.set $1
+    br $loop|4
+   end
+   unreachable
+  end
+  local.get $0
+  call $~lib/set/Set<u64>#get:size
+  i32.const 50
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 45
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -9593,15 +11703,19 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 49
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f32>#clear (; 109 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/set/Set<f32>#clear (; 169 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -9641,12 +11755,12 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<f32>#constructor (; 110 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<f32>#constructor (; 170 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
    i32.const 24
-   i32.const 11
+   i32.const 19
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
    local.set $0
@@ -9673,7 +11787,7 @@
   call $~lib/set/Set<f32>#clear
   local.get $0
  )
- (func $~lib/set/Set<f32>#find (; 111 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
+ (func $~lib/set/Set<f32>#find (; 171 ;) (type $FUNCSIG$iifi) (param $0 i32) (param $1 f32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -9721,7 +11835,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<f32>#has (; 112 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/set/Set<f32>#has (; 172 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
   (local $2 f32)
   local.get $0
   local.get $1
@@ -9737,7 +11851,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<f32>#rehash (; 113 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<f32>#rehash (; 173 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -9892,7 +12006,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f32>#add (; 114 ;) (type $FUNCSIG$vif) (param $0 i32) (param $1 f32)
+ (func $~lib/set/Set<f32>#add (; 174 ;) (type $FUNCSIG$vif) (param $0 i32) (param $1 f32)
   (local $2 f32)
   (local $3 i32)
   (local $4 i32)
@@ -9985,11 +12099,172 @@
    i32.store
   end
  )
- (func $~lib/set/Set<f32>#get:size (; 115 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<f32>#get:size (; 175 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/set/Set<f32>#delete (; 116 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
+ (func $~lib/array/Array<f32>#constructor (; 176 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  if (result i32)
+   local.get $0
+  else
+   i32.const 16
+   i32.const 20
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+  end
+  local.get $1
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  local.get $1
+  i32.store offset=12
+  local.get $0
+ )
+ (func $~lib/array/Array<f32>#__unchecked_set (; 177 ;) (type $FUNCSIG$viif) (param $0 i32) (param $1 i32) (param $2 f32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $2
+  f32.store
+ )
+ (func $~lib/array/Array<f32>#__set (; 178 ;) (type $FUNCSIG$viif) (param $0 i32) (param $1 i32) (param $2 f32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 416
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.const 2
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.store offset=12
+  end
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/array/Array<f32>#__unchecked_set
+ )
+ (func $~lib/set/Set<f32>#values (; 179 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<f32>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 8
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=4
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $4
+     local.tee $7
+     i32.const 1
+     i32.add
+     local.set $4
+     local.get $7
+     local.get $6
+     f32.load
+     call $~lib/array/Array<f32>#__set
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+ )
+ (func $~lib/array/Array<f32>#get:length (; 180 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=12
+ )
+ (func $~lib/array/Array<f32>#__unchecked_get (; 181 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  f32.load
+ )
+ (func $~lib/array/Array<f32>#__get (; 182 ;) (type $FUNCSIG$fii) (param $0 i32) (param $1 i32) (result f32)
+  (local $2 f32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 416
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<f32>#__unchecked_get
+  local.set $2
+  local.get $2
+ )
+ (func $~lib/set/Set<f32>#delete (; 183 ;) (type $FUNCSIG$iif) (param $0 i32) (param $1 f32) (result i32)
   (local $2 f32)
   (local $3 i32)
   (local $4 i32)
@@ -10063,9 +12338,12 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<f32> (; 117 ;) (type $FUNCSIG$v)
+ (func $std/set/testNumeric<f32> (; 184 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   i32.const 0
   call $~lib/set/Set<f32>#constructor
   local.set $0
@@ -10184,35 +12462,27 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
+  call $~lib/set/Set<f32>#values
+  local.set $2
+  i32.const 0
+  call $~lib/set/Set<f32>#constructor
+  local.set $3
   block $break|2
-   f32.const 0
-   local.set $1
+   i32.const 0
+   local.set $4
    loop $loop|2
-    local.get $1
-    f32.const 50
-    f32.lt
+    local.get $4
+    local.get $2
+    call $~lib/array/Array<f32>#get:length
+    i32.lt_s
     i32.eqz
     br_if $break|2
     local.get $0
-    local.get $1
+    local.get $2
+    local.get $4
+    call $~lib/array/Array<f32>#__get
     call $~lib/set/Set<f32>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 22
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<f32>#delete
-    drop
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<f32>#has
-    i32.eqz
     i32.eqz
     if
      i32.const 0
@@ -10222,23 +12492,29 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
-    f32.const 1
-    f32.add
-    local.set $1
+    local.get $3
+    local.get $2
+    local.get $4
+    call $~lib/array/Array<f32>#__get
+    call $~lib/set/Set<f32>#add
+    local.get $4
+    i32.const 1
+    i32.add
+    local.set $4
     br $loop|2
    end
    unreachable
   end
+  local.get $3
+  call $~lib/set/Set<f32>#get:size
   local.get $0
   call $~lib/set/Set<f32>#get:size
-  i32.const 50
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 26
+   i32.const 27
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10256,26 +12532,10 @@
     local.get $1
     call $~lib/set/Set<f32>#has
     i32.eqz
-    i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 30
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<f32>#add
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<f32>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 32
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -10292,7 +12552,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 33
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -10313,7 +12573,82 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 36
+   i32.const 35
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $break|4
+   f32.const 0
+   local.set $1
+   loop $loop|4
+    local.get $1
+    f32.const 50
+    f32.lt
+    i32.eqz
+    br_if $break|4
+    local.get $0
+    local.get $1
+    call $~lib/set/Set<f32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 39
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $1
+    call $~lib/set/Set<f32>#add
+    local.get $0
+    local.get $1
+    call $~lib/set/Set<f32>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 41
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $1
+    call $~lib/set/Set<f32>#delete
+    drop
+    local.get $0
+    local.get $1
+    call $~lib/set/Set<f32>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 43
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    f32.const 1
+    f32.add
+    local.set $1
+    br $loop|4
+   end
+   unreachable
+  end
+  local.get $0
+  call $~lib/set/Set<f32>#get:size
+  i32.const 50
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 45
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10328,15 +12663,19 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 49
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f64>#clear (; 118 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $~lib/set/Set<f64>#clear (; 185 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -10376,12 +12715,12 @@
   i32.const 0
   i32.store offset=20
  )
- (func $~lib/set/Set<f64>#constructor (; 119 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<f64>#constructor (; 186 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.eqz
   if
    i32.const 24
-   i32.const 12
+   i32.const 21
    call $~lib/rt/tlsf/__alloc
    call $~lib/rt/pure/__retain
    local.set $0
@@ -10408,7 +12747,7 @@
   call $~lib/set/Set<f64>#clear
   local.get $0
  )
- (func $~lib/set/Set<f64>#find (; 120 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
+ (func $~lib/set/Set<f64>#find (; 187 ;) (type $FUNCSIG$iidi) (param $0 i32) (param $1 f64) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   i32.load
@@ -10456,7 +12795,7 @@
   end
   i32.const 0
  )
- (func $~lib/set/Set<f64>#has (; 121 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/set/Set<f64>#has (; 188 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 f64)
   local.get $0
   local.get $1
@@ -10472,7 +12811,7 @@
   i32.const 0
   i32.ne
  )
- (func $~lib/set/Set<f64>#rehash (; 122 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<f64>#rehash (; 189 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -10627,7 +12966,7 @@
   local.get $5
   call $~lib/rt/pure/__release
  )
- (func $~lib/set/Set<f64>#add (; 123 ;) (type $FUNCSIG$vid) (param $0 i32) (param $1 f64)
+ (func $~lib/set/Set<f64>#add (; 190 ;) (type $FUNCSIG$vid) (param $0 i32) (param $1 f64)
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
@@ -10720,11 +13059,172 @@
    i32.store
   end
  )
- (func $~lib/set/Set<f64>#get:size (; 124 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/set/Set<f64>#get:size (; 191 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=20
  )
- (func $~lib/set/Set<f64>#delete (; 125 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
+ (func $~lib/array/Array<f64>#constructor (; 192 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  if (result i32)
+   local.get $0
+  else
+   i32.const 16
+   i32.const 22
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
+  end
+  local.get $1
+  i32.const 3
+  call $~lib/arraybuffer/ArrayBufferView#constructor
+  local.set $0
+  local.get $0
+  i32.const 0
+  i32.store offset=12
+  local.get $0
+  local.get $1
+  i32.store offset=12
+  local.get $0
+ )
+ (func $~lib/array/Array<f64>#__unchecked_set (; 193 ;) (type $FUNCSIG$viid) (param $0 i32) (param $1 i32) (param $2 f64)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 3
+  i32.shl
+  i32.add
+  local.get $2
+  f64.store
+ )
+ (func $~lib/array/Array<f64>#__set (; 194 ;) (type $FUNCSIG$viid) (param $0 i32) (param $1 i32) (param $2 f64)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   local.get $1
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 280
+    i32.const 416
+    i32.const 109
+    i32.const 21
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.const 3
+   call $~lib/array/ensureSize
+   local.get $0
+   local.get $1
+   i32.const 1
+   i32.add
+   i32.store offset=12
+  end
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/array/Array<f64>#__unchecked_set
+ )
+ (func $~lib/set/Set<f64>#values (; 195 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $0
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  i32.load offset=16
+  local.set $2
+  i32.const 0
+  local.get $2
+  call $~lib/array/Array<f64>#constructor
+  local.set $3
+  i32.const 0
+  local.set $4
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    local.get $2
+    i32.lt_s
+    i32.eqz
+    br_if $break|0
+    local.get $1
+    local.get $5
+    i32.const 16
+    i32.mul
+    i32.add
+    local.set $6
+    local.get $6
+    i32.load offset=8
+    i32.const 1
+    i32.and
+    i32.eqz
+    if
+     local.get $3
+     local.get $4
+     local.tee $7
+     i32.const 1
+     i32.add
+     local.set $4
+     local.get $7
+     local.get $6
+     f64.load
+     call $~lib/array/Array<f64>#__set
+    end
+    local.get $5
+    i32.const 1
+    i32.add
+    local.set $5
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $3
+ )
+ (func $~lib/array/Array<f64>#get:length (; 196 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load offset=12
+ )
+ (func $~lib/array/Array<f64>#__unchecked_get (; 197 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 3
+  i32.shl
+  i32.add
+  f64.load
+ )
+ (func $~lib/array/Array<f64>#__get (; 198 ;) (type $FUNCSIG$dii) (param $0 i32) (param $1 i32) (result f64)
+  (local $2 f64)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 280
+   i32.const 416
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<f64>#__unchecked_get
+  local.set $2
+  local.get $2
+ )
+ (func $~lib/set/Set<f64>#delete (; 199 ;) (type $FUNCSIG$iid) (param $0 i32) (param $1 f64) (result i32)
   (local $2 f64)
   (local $3 i32)
   (local $4 i32)
@@ -10798,9 +13298,12 @@
   end
   i32.const 1
  )
- (func $std/set/testNumeric<f64> (; 126 ;) (type $FUNCSIG$v)
+ (func $std/set/testNumeric<f64> (; 200 ;) (type $FUNCSIG$v)
   (local $0 i32)
   (local $1 f64)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   i32.const 0
   call $~lib/set/Set<f64>#constructor
   local.set $0
@@ -10919,35 +13422,27 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $0
+  call $~lib/set/Set<f64>#values
+  local.set $2
+  i32.const 0
+  call $~lib/set/Set<f64>#constructor
+  local.set $3
   block $break|2
-   f64.const 0
-   local.set $1
+   i32.const 0
+   local.set $4
    loop $loop|2
-    local.get $1
-    f64.const 50
-    f64.lt
+    local.get $4
+    local.get $2
+    call $~lib/array/Array<f64>#get:length
+    i32.lt_s
     i32.eqz
     br_if $break|2
     local.get $0
-    local.get $1
+    local.get $2
+    local.get $4
+    call $~lib/array/Array<f64>#__get
     call $~lib/set/Set<f64>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 22
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<f64>#delete
-    drop
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<f64>#has
-    i32.eqz
     i32.eqz
     if
      i32.const 0
@@ -10957,23 +13452,29 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
-    f64.const 1
-    f64.add
-    local.set $1
+    local.get $3
+    local.get $2
+    local.get $4
+    call $~lib/array/Array<f64>#__get
+    call $~lib/set/Set<f64>#add
+    local.get $4
+    i32.const 1
+    i32.add
+    local.set $4
     br $loop|2
    end
    unreachable
   end
+  local.get $3
+  call $~lib/set/Set<f64>#get:size
   local.get $0
   call $~lib/set/Set<f64>#get:size
-  i32.const 50
   i32.eq
   i32.eqz
   if
    i32.const 0
    i32.const 376
-   i32.const 26
+   i32.const 27
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -10991,26 +13492,10 @@
     local.get $1
     call $~lib/set/Set<f64>#has
     i32.eqz
-    i32.eqz
     if
      i32.const 0
      i32.const 376
-     i32.const 30
-     i32.const 4
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<f64>#add
-    local.get $0
-    local.get $1
-    call $~lib/set/Set<f64>#has
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 376
-     i32.const 32
+     i32.const 31
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -11027,7 +13512,7 @@
     if
      i32.const 0
      i32.const 376
-     i32.const 34
+     i32.const 33
      i32.const 4
      call $~lib/builtins/abort
      unreachable
@@ -11048,7 +13533,82 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 36
+   i32.const 35
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $break|4
+   f64.const 0
+   local.set $1
+   loop $loop|4
+    local.get $1
+    f64.const 50
+    f64.lt
+    i32.eqz
+    br_if $break|4
+    local.get $0
+    local.get $1
+    call $~lib/set/Set<f64>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 39
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $1
+    call $~lib/set/Set<f64>#add
+    local.get $0
+    local.get $1
+    call $~lib/set/Set<f64>#has
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 41
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $1
+    call $~lib/set/Set<f64>#delete
+    drop
+    local.get $0
+    local.get $1
+    call $~lib/set/Set<f64>#has
+    i32.eqz
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 376
+     i32.const 43
+     i32.const 4
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    f64.const 1
+    f64.add
+    local.set $1
+    br $loop|4
+   end
+   unreachable
+  end
+  local.get $0
+  call $~lib/set/Set<f64>#get:size
+  i32.const 50
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 376
+   i32.const 45
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11063,15 +13623,19 @@
   if
    i32.const 0
    i32.const 376
-   i32.const 40
+   i32.const 49
    i32.const 2
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $start:std/set (; 127 ;) (type $FUNCSIG$v)
+ (func $start:std/set (; 201 ;) (type $FUNCSIG$v)
   call $std/set/testNumeric<i8>
   call $std/set/testNumeric<u8>
   call $std/set/testNumeric<i16>
@@ -11083,10 +13647,10 @@
   call $std/set/testNumeric<f32>
   call $std/set/testNumeric<f64>
  )
- (func $start (; 128 ;) (type $FUNCSIG$v)
+ (func $start (; 202 ;) (type $FUNCSIG$v)
   call $start:std/set
  )
- (func $~lib/rt/pure/__visit (; 129 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 203 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -11216,7 +13780,7 @@
    end
   end
  )
- (func $~lib/set/Set<i8>#__visit_impl (; 130 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/set/Set<i8>#__visit_impl (; 204 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -11229,7 +13793,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/set/Set<u8>#__visit_impl (; 131 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i8>#__visit_impl (; 205 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  nop
+ )
+ (func $~lib/set/Set<u8>#__visit_impl (; 206 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -11242,7 +13809,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/set/Set<i16>#__visit_impl (; 132 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u8>#__visit_impl (; 207 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  nop
+ )
+ (func $~lib/set/Set<i16>#__visit_impl (; 208 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -11255,7 +13825,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/set/Set<u16>#__visit_impl (; 133 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i16>#__visit_impl (; 209 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  nop
+ )
+ (func $~lib/set/Set<u16>#__visit_impl (; 210 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -11268,7 +13841,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/set/Set<i32>#__visit_impl (; 134 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u16>#__visit_impl (; 211 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  nop
+ )
+ (func $~lib/set/Set<i32>#__visit_impl (; 212 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -11281,7 +13857,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/set/Set<u32>#__visit_impl (; 135 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#__visit_impl (; 213 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  nop
+ )
+ (func $~lib/set/Set<u32>#__visit_impl (; 214 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -11294,7 +13873,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/set/Set<i64>#__visit_impl (; 136 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u32>#__visit_impl (; 215 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  nop
+ )
+ (func $~lib/set/Set<i64>#__visit_impl (; 216 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -11307,7 +13889,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/set/Set<u64>#__visit_impl (; 137 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i64>#__visit_impl (; 217 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  nop
+ )
+ (func $~lib/set/Set<u64>#__visit_impl (; 218 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -11320,7 +13905,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/set/Set<f32>#__visit_impl (; 138 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u64>#__visit_impl (; 219 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  nop
+ )
+ (func $~lib/set/Set<f32>#__visit_impl (; 220 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -11333,7 +13921,10 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/set/Set<f64>#__visit_impl (; 139 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f32>#__visit_impl (; 221 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  nop
+ )
+ (func $~lib/set/Set<f64>#__visit_impl (; 222 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   i32.load
@@ -11346,92 +13937,158 @@
   local.get $1
   call $~lib/rt/pure/__visit
  )
- (func $~lib/rt/__visit_members (; 140 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f64>#__visit_impl (; 223 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  nop
+ )
+ (func $~lib/rt/__visit_members (; 224 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
-  block $switch$1$default
-   block $switch$1$case$14
-    block $switch$1$case$13
-     block $switch$1$case$12
-      block $switch$1$case$11
-       block $switch$1$case$10
-        block $switch$1$case$9
-         block $switch$1$case$8
-          block $switch$1$case$7
-           block $switch$1$case$6
-            block $switch$1$case$5
-             block $switch$1$case$4
-              block $switch$1$case$2
+  block $block$4$break
+   block $switch$1$default
+    block $switch$1$case$24
+     block $switch$1$case$23
+      block $switch$1$case$22
+       block $switch$1$case$21
+        block $switch$1$case$20
+         block $switch$1$case$19
+          block $switch$1$case$18
+           block $switch$1$case$17
+            block $switch$1$case$16
+             block $switch$1$case$15
+              block $switch$1$case$14
+               block $switch$1$case$13
+                block $switch$1$case$12
+                 block $switch$1$case$11
+                  block $switch$1$case$10
+                   block $switch$1$case$9
+                    block $switch$1$case$8
+                     block $switch$1$case$7
+                      block $switch$1$case$6
+                       block $switch$1$case$5
+                        block $switch$1$case$4
+                         block $switch$1$case$2
+                          local.get $0
+                          i32.const 8
+                          i32.sub
+                          i32.load
+                          br_table $switch$1$case$2 $switch$1$case$2 $switch$1$case$4 $switch$1$case$5 $switch$1$case$6 $switch$1$case$7 $switch$1$case$8 $switch$1$case$9 $switch$1$case$10 $switch$1$case$11 $switch$1$case$12 $switch$1$case$13 $switch$1$case$14 $switch$1$case$15 $switch$1$case$16 $switch$1$case$17 $switch$1$case$18 $switch$1$case$19 $switch$1$case$20 $switch$1$case$21 $switch$1$case$22 $switch$1$case$23 $switch$1$case$24 $switch$1$default
+                         end
+                         return
+                        end
+                        br $block$4$break
+                       end
+                       local.get $0
+                       local.get $1
+                       call $~lib/set/Set<i8>#__visit_impl
+                       return
+                      end
+                      local.get $0
+                      local.get $1
+                      call $~lib/array/Array<i8>#__visit_impl
+                      br $block$4$break
+                     end
+                     local.get $0
+                     local.get $1
+                     call $~lib/set/Set<u8>#__visit_impl
+                     return
+                    end
+                    local.get $0
+                    local.get $1
+                    call $~lib/array/Array<u8>#__visit_impl
+                    br $block$4$break
+                   end
+                   local.get $0
+                   local.get $1
+                   call $~lib/set/Set<i16>#__visit_impl
+                   return
+                  end
+                  local.get $0
+                  local.get $1
+                  call $~lib/array/Array<i16>#__visit_impl
+                  br $block$4$break
+                 end
+                 local.get $0
+                 local.get $1
+                 call $~lib/set/Set<u16>#__visit_impl
+                 return
+                end
+                local.get $0
+                local.get $1
+                call $~lib/array/Array<u16>#__visit_impl
+                br $block$4$break
+               end
                local.get $0
-               i32.const 8
-               i32.sub
-               i32.load
-               br_table $switch$1$case$2 $switch$1$case$2 $switch$1$case$4 $switch$1$case$5 $switch$1$case$6 $switch$1$case$7 $switch$1$case$8 $switch$1$case$9 $switch$1$case$10 $switch$1$case$11 $switch$1$case$12 $switch$1$case$13 $switch$1$case$14 $switch$1$default
+               local.get $1
+               call $~lib/set/Set<i32>#__visit_impl
+               return
               end
-              return
+              local.get $0
+              local.get $1
+              call $~lib/array/Array<i32>#__visit_impl
+              br $block$4$break
              end
              local.get $0
-             i32.load
-             local.tee $2
-             if
-              local.get $2
-              local.get $1
-              call $~lib/rt/pure/__visit
-             end
+             local.get $1
+             call $~lib/set/Set<u32>#__visit_impl
              return
             end
             local.get $0
             local.get $1
-            call $~lib/set/Set<i8>#__visit_impl
-            return
+            call $~lib/array/Array<u32>#__visit_impl
+            br $block$4$break
            end
            local.get $0
            local.get $1
-           call $~lib/set/Set<u8>#__visit_impl
+           call $~lib/set/Set<i64>#__visit_impl
            return
           end
           local.get $0
           local.get $1
-          call $~lib/set/Set<i16>#__visit_impl
-          return
+          call $~lib/array/Array<i64>#__visit_impl
+          br $block$4$break
          end
          local.get $0
          local.get $1
-         call $~lib/set/Set<u16>#__visit_impl
+         call $~lib/set/Set<u64>#__visit_impl
          return
         end
         local.get $0
         local.get $1
-        call $~lib/set/Set<i32>#__visit_impl
-        return
+        call $~lib/array/Array<u64>#__visit_impl
+        br $block$4$break
        end
        local.get $0
        local.get $1
-       call $~lib/set/Set<u32>#__visit_impl
+       call $~lib/set/Set<f32>#__visit_impl
        return
       end
       local.get $0
       local.get $1
-      call $~lib/set/Set<i64>#__visit_impl
-      return
+      call $~lib/array/Array<f32>#__visit_impl
+      br $block$4$break
      end
      local.get $0
      local.get $1
-     call $~lib/set/Set<u64>#__visit_impl
+     call $~lib/set/Set<f64>#__visit_impl
      return
     end
     local.get $0
     local.get $1
-    call $~lib/set/Set<f32>#__visit_impl
-    return
+    call $~lib/array/Array<f64>#__visit_impl
+    br $block$4$break
    end
-   local.get $0
-   local.get $1
-   call $~lib/set/Set<f64>#__visit_impl
-   return
+   unreachable
   end
-  unreachable
+  local.get $0
+  i32.load
+  local.tee $2
+  if
+   local.get $2
+   local.get $1
+   call $~lib/rt/pure/__visit
+  end
+  return
  )
- (func $null (; 141 ;) (type $FUNCSIG$v)
+ (func $null (; 225 ;) (type $FUNCSIG$v)
   unreachable
  )
 )


### PR DESCRIPTION
1. Fix the about map.keys and map.values and set.values.
Because of initializing the array of keys and value with size, so using `push` will append data to array.

2. Add test cases for map.keys, map.values and set.values.