### PR TITLE
Change type definitions for `unreachable` to make typescript recognize it as an end point

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -20,6 +20,7 @@ under the licensing terms detailed in LICENSE:
 * Jay Phelps <hello@jayphelps.com>
 * jhwgh1968 <jhwgh1968@protonmail.com>
 * Jeffrey Charles <jeffreycharles@gmail.com>
+* Vladimir Tikhonov <reg@tikhonov.by>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/std/assembly/index.d.ts
+++ b/std/assembly/index.d.ts
@@ -107,8 +107,8 @@ declare function trunc<T = f32 | f64>(value: T): T;
 declare function load<T>(ptr: usize, immOffset?: usize, immAlign?: usize): T;
 /** Stores a value of the specified type to memory. Equivalent to dereferencing a pointer in other languages when assigning a value. */
 declare function store<T>(ptr: usize, value: any, immOffset?: usize, immAlign?: usize): void;
-/** Emits an unreachable operation that results in a runtime error when executed. Both a statement and an expression of any type. */
-declare function unreachable(): any; // sic
+/** Emits an unreachable operation that results in a runtime error when executed. Both a statement and an expression. */
+declare function unreachable(): never;
 
 /** NaN (not a number) as a 32-bit or 64-bit float depending on context. */
 declare const NaN: f32 | f64;


### PR DESCRIPTION
This will help in the following scenarios:

```typescript
function bar(): bool {
  unreachable();
  return false; // typescript will report "Unreachable code detected"
}

function getImpl(implId: i32): Impl {
  switch ( implId ) {
    case 1: return new Impl1();
    case 2: return new Impl2();
    default: unreachable();
  }
  // typescript won't complain about missing return statement here.
}

```