### PR TITLE
Fix assertion hit by unmanaged super calls

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -5771,7 +5771,7 @@ export class Compiler extends DiagnosticEmitter {
         ),
         Constraints.WILL_RETAIN
       );
-      assert(this.skippedAutoreleases.has(theCall)); // guaranteed
+      assert(baseClassInstance.type.isUnmanaged || this.skippedAutoreleases.has(theCall)); // guaranteed
       let stmts: ExpressionRef[] = [
         module.local_set(thisLocal.index, theCall)
       ];


### PR DESCRIPTION
The existing assertion checks that we don't miss a retain when calling super, setting up the class instance's memory, but this misses that the class can be `@unmanaged` so there isn't anything to retain.

fixes https://github.com/AssemblyScript/assemblyscript/issues/1013