### PR TITLE
Fix recursive extends/aggregation

### DIFF
--- a/src/diagnosticMessages.generated.ts
+++ b/src/diagnosticMessages.generated.ts
@@ -125,6 +125,7 @@ export enum DiagnosticCode {
   The_0_operator_cannot_be_applied_to_type_1 = 2469,
   In_const_enum_declarations_member_initializer_must_be_constant_expression = 2474,
   Export_declaration_conflicts_with_exported_declaration_of_0 = 2484,
+  _0_is_referenced_directly_or_indirectly_in_its_own_base_expression = 2506,
   Object_is_possibly_null = 2531,
   Cannot_assign_to_0_because_it_is_a_constant_or_a_read_only_property = 2540,
   The_target_of_an_assignment_must_be_a_variable_or_a_property_access = 2541,
@@ -268,6 +269,7 @@ export function diagnosticCodeToString(code: DiagnosticCode): string {
     case 2469: return "The '{0}' operator cannot be applied to type '{1}'.";
     case 2474: return "In 'const' enum declarations member initializer must be constant expression.";
     case 2484: return "Export declaration conflicts with exported declaration of '{0}'.";
+    case 2506: return "'{0}' is referenced directly or indirectly in its own base expression.";
     case 2531: return "Object is possibly 'null'.";
     case 2540: return "Cannot assign to '{0}' because it is a constant or a read-only property.";
     case 2541: return "The target of an assignment must be a variable or a property access.";

--- a/src/diagnosticMessages.json
+++ b/src/diagnosticMessages.json
@@ -120,6 +120,7 @@
   "The '{0}' operator cannot be applied to type '{1}'.": 2469,
   "In 'const' enum declarations member initializer must be constant expression.": 2474,
   "Export declaration conflicts with exported declaration of '{0}'.": 2484,
+  "'{0}' is referenced directly or indirectly in its own base expression.": 2506,
   "Object is possibly 'null'.": 2531,
   "Cannot assign to '{0}' because it is a constant or a read-only property.": 2540,
   "The target of an assignment must be a variable or a property access.": 2541,

--- a/tests/compiler/extends-recursive.json
+++ b/tests/compiler/extends-recursive.json
@@ -1,0 +1,5 @@
+{
+  "asc_flags": [
+    "--runtime none"
+  ]
+}

--- a/tests/compiler/extends-recursive.optimized.wat
+++ b/tests/compiler/extends-recursive.optimized.wat
@@ -1,0 +1,24 @@
+(module
+ (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (memory $0 0)
+ (global $extends-recursive/Child i32 (i32.const 4))
+ (export "memory" (memory $0))
+ (export "Child" (global $extends-recursive/Child))
+ (export "Child#get:child" (func $Child#get:child))
+ (export "Child#set:child" (func $Child#set:child))
+ (func $Child#get:child (; 0 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load
+ )
+ (func $Child#set:child (; 1 ;) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  local.get $1
+  local.tee $0
+  i32.load
+  drop
+  local.get $0
+  i32.store
+ )
+)

--- a/tests/compiler/extends-recursive.ts
+++ b/tests/compiler/extends-recursive.ts
@@ -1,0 +1,4 @@
+class Parent {
+  child: Child | null = null;
+}
+export class Child extends Parent { }

--- a/tests/compiler/extends-recursive.untouched.wat
+++ b/tests/compiler/extends-recursive.untouched.wat
@@ -1,0 +1,41 @@
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_=>_none (func (param i32)))
+ (type $i32_i32_=>_none (func (param i32 i32)))
+ (memory $0 0)
+ (table $0 1 funcref)
+ (global $extends-recursive/Child i32 (i32.const 4))
+ (export "memory" (memory $0))
+ (export "Child" (global $extends-recursive/Child))
+ (export "Child#get:child" (func $Child#get:child))
+ (export "Child#set:child" (func $Child#set:child))
+ (func $~lib/rt/stub/__retain (; 0 ;) (param $0 i32) (result i32)
+  local.get $0
+ )
+ (func $Child#get:child (; 1 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load
+  call $~lib/rt/stub/__retain
+ )
+ (func $~lib/rt/stub/__release (; 2 ;) (param $0 i32)
+  nop
+ )
+ (func $Child#set:child (; 3 ;) (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  local.tee $0
+  local.get $0
+  i32.load
+  local.tee $1
+  i32.ne
+  if
+   local.get $0
+   call $~lib/rt/stub/__retain
+   local.set $0
+   local.get $1
+   call $~lib/rt/stub/__release
+  end
+  local.get $0
+  i32.store
+ )
+)

--- a/tests/compiler/extends-self.json
+++ b/tests/compiler/extends-self.json
@@ -1,0 +1,9 @@
+{
+  "asc_flags": [
+    "--runtime none"
+  ],
+  "stderr": [
+    "TS2506",
+    "EOF"
+  ]
+}

--- a/tests/compiler/extends-self.ts
+++ b/tests/compiler/extends-self.ts
@@ -1,0 +1,4 @@
+class Parent extends Child { }
+class Child extends Parent { }
+new Child();
+ERROR("EOF");


### PR DESCRIPTION
This fixes two problems:

1. As reported in https://github.com/AssemblyScript/assemblyscript/issues/1024, resolving the base class prior to constructing this class can lead to situations where the base class already triggered resolving this class, in turn hitting an assertion.
2. A diagnostic was missing for when a class is directly or indirectly referencing itself in the extends chain.

fixes https://github.com/AssemblyScript/assemblyscript/issues/1024