### PR TITLE
Update Binaryen for 2020

### DIFF
--- a/lib/sdk/README.md
+++ b/lib/sdk/README.md
@@ -1,0 +1,38 @@
+# ![AS](https://avatars1.githubusercontent.com/u/28916798?s=48) SDK
+
+An overly simple SDK to use the AssemblyScript compiler on the web. This is built
+to distribution files using the exact versions of the compiler and its
+dependencies.
+
+Expects [require.js](https://requirejs.org) (or compatible) on the web,
+primarily targeting [WebAssembly Studio](https://webassembly.studio). Note that
+consuming the source file in this directory directly does not solve any
+versioning issues - use `dist/sdk.js` instead. Do not try to bundle this.
+
+Exports
+-------
+
+* **binaryen**<br />
+  The version of binaryen required by the compiler.
+
+* **assemblyscript**<br />
+  The AssemblyScript compiler as a library.
+
+* **asc**<br />
+  AssemblyScript compiler frontend that one will interact with
+  ([see](https://github.com/AssemblyScript/assemblyscript/tree/master/cli)).
+
+Example usage
+-------------
+
+```js
+require(
+  ["https://cdn.jsdelivr.net/npm/assemblyscript@nightly/dist/sdk"],
+  function(sdk) {
+    const { binaryen, assemblyscript, asc } = sdk;
+    asc.ready.then(() => {
+      asc.main(...);
+    });
+  }
+);
+```

--- a/lib/sdk/index.js
+++ b/lib/sdk/index.js
@@ -1,0 +1,22 @@
+const BINARYEN_VERSION = "nightly";
+const ASSEMBLYSCRIPT_VERSION = "nightly";
+
+// AMD/require.js (browser)
+if (typeof define === "function" && define.amd) {
+  require.config({
+    paths: {
+      "binaryen": "https://cdn.jsdelivr.net/npm/binaryen@" + BINARYEN_VERSION + "/index",
+      "assemblyscript": "https://cdn.jsdelivr.net/npm/assemblyscript@" + ASSEMBLYSCRIPT_VERSION + "/dist/assemblyscript",
+      "assemblyscript/cli/asc": "https://cdn.jsdelivr.net/npm/assemblyscript@" + ASSEMBLYSCRIPT_VERSION + "/dist/asc",
+    }
+  });
+  define(["binaryen", "assemblyscript", "assemblyscript/cli/asc"], function(binaryen, assemblyscript, asc) {
+    return { binaryen, assemblyscript, asc };
+  });
+
+// CommonJS fallback (node)
+} else if (typeof module === "object" && module.exports) {
+  exports.binaryen = require("binaryen");
+  exports.assemblyscript = require("assemblyscript");
+  exports.asc = require("assemblyscript/cli/asc");
+}

--- a/lib/sdk/index.js
+++ b/lib/sdk/index.js
@@ -3,20 +3,27 @@ const ASSEMBLYSCRIPT_VERSION = "nightly";
 
 // AMD/require.js (browser)
 if (typeof define === "function" && define.amd) {
-  require.config({
-    paths: {
-      "binaryen": "https://cdn.jsdelivr.net/npm/binaryen@" + BINARYEN_VERSION + "/index",
-      "assemblyscript": "https://cdn.jsdelivr.net/npm/assemblyscript@" + ASSEMBLYSCRIPT_VERSION + "/dist/assemblyscript",
-      "assemblyscript/cli/asc": "https://cdn.jsdelivr.net/npm/assemblyscript@" + ASSEMBLYSCRIPT_VERSION + "/dist/asc",
-    }
-  });
-  define(["binaryen", "assemblyscript", "assemblyscript/cli/asc"], function(binaryen, assemblyscript, asc) {
-    return { binaryen, assemblyscript, asc };
-  });
+  const paths = {
+    "binaryen": "https://cdn.jsdelivr.net/npm/binaryen@" + BINARYEN_VERSION + "/index",
+    "assemblyscript": "https://cdn.jsdelivr.net/npm/assemblyscript@" + ASSEMBLYSCRIPT_VERSION + "/dist/assemblyscript",
+    "assemblyscript/cli/asc": "https://cdn.jsdelivr.net/npm/assemblyscript@" + ASSEMBLYSCRIPT_VERSION + "/dist/asc",
+  };
+  require.config({ paths });
+  define(Object.keys(paths), (binaryen, assemblyscript, asc) => ({
+    BINARYEN_VERSION,
+    ASSEMBLYSCRIPT_VERSION,
+    binaryen,
+    assemblyscript,
+    asc
+  }));
 
 // CommonJS fallback (node)
 } else if (typeof module === "object" && module.exports) {
-  exports.binaryen = require("binaryen");
-  exports.assemblyscript = require("assemblyscript");
-  exports.asc = require("assemblyscript/cli/asc");
+  module.exports = {
+    BINARYEN_VERSION,
+    ASSEMBLYSCRIPT_VERSION,
+    binaryen: require("binaryen"),
+    assemblyscript: require("assemblyscript"),
+    asc: require("assemblyscript/cli/asc")
+  };
 }

--- a/lib/sdk/tests/index.html
+++ b/lib/sdk/tests/index.html
@@ -1,7 +1,17 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js"></script>
 <script>
+function assert(x) {
+  if (!x) throw Error("assertion failed");
+}
 require(["../index"], function(sdk) {
-  console.log(sdk);
-  sdk.asc.ready.then(() => console.log("ready"));
+  const { BINARYEN_VERSION, ASSEMBLYSCRIPT_VERSION, binaryen, assemblyscript, asc } = sdk;
+  assert(typeof BINARYEN_VERSION === "string");
+  assert(typeof ASSEMBLYSCRIPT_VERSION === "string");
+  console.log("Binaryen@" + BINARYEN_VERSION);
+  console.log("AssemblyScript@" + ASSEMBLYSCRIPT_VERSION);
+  assert(typeof binaryen === "object" && binaryen && typeof binaryen._BinaryenTypeNone === "function");
+  assert(typeof assemblyscript === "object" && assemblyscript && typeof assemblyscript.parse === "function");
+  assert(typeof asc === "object" && asc && typeof asc.main === "function");
+  asc.ready.then(() => console.log("ready", sdk));
 });
 </script>

--- a/lib/sdk/tests/index.html
+++ b/lib/sdk/tests/index.html
@@ -1,13 +1,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js"></script>
 <script>
-require(
-  ["../index"],
-  function(sdk) {
-    console.log(sdk);
-    const { asc } = sdk;
-    asc.ready.then(() => {
-      console.log("ready");
-    });
-  }
-);
+require(["../index"], function(sdk) {
+  console.log(sdk);
+  sdk.asc.ready.then(() => console.log("ready"));
+});
 </script>

--- a/lib/sdk/tests/index.html
+++ b/lib/sdk/tests/index.html
@@ -1,0 +1,13 @@
+<script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js"></script>
+<script>
+require(
+  ["../index"],
+  function(sdk) {
+    console.log(sdk);
+    const { asc } = sdk;
+    asc.ready.then(() => {
+      console.log("ready");
+    });
+  }
+);
+</script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -567,9 +567,9 @@
       "dev": true
     },
     "binaryen": {
-      "version": "90.0.0-nightly.20191231",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-90.0.0-nightly.20191231.tgz",
-      "integrity": "sha512-tGdUtnz8wB4vohHcAwQr3MAFbrGM1DhvxlinsVB2tX+Q9FfMqUxcSXDOacLeLA2vy0xgKXOx9JHdF8N3k3tmjw=="
+      "version": "90.0.0-nightly.20200101",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-90.0.0-nightly.20200101.tgz",
+      "integrity": "sha512-64lgruunUnkJD4YVD0DLCSRskqfo3xhoErM1H22GfkkWNT16/7tPTLG+MYqKLMALTiIyLL6L9UqmDaxOxDv0rw=="
     },
     "bindings": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -48,9 +48,10 @@
     "asinit": "bin/asinit"
   },
   "scripts": {
-    "build": "npm run build:bundle && npm run build:dts",
+    "build": "npm run build:bundle && npm run build:dts && npm run build:sdk",
     "build:bundle": "webpack --mode production --display-modules",
     "build:dts": "node scripts/build-dts && tsc --noEmit --target ESNEXT --module commonjs --experimentalDecorators tests/require/index-release",
+    "build:sdk": "node scripts/build-sdk",
     "clean": "node scripts/clean",
     "check": "npm run check:config && npm run check:compiler && tsc --noEmit --target ESNEXT --module commonjs --experimentalDecorators tests/require/index",
     "check:config": "tsc --noEmit -p src --diagnostics --listFiles",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/AssemblyScript/assemblyscript/issues"
   },
   "dependencies": {
-    "binaryen": "90.0.0-nightly.20191231",
+    "binaryen": "90.0.0-nightly.20200101",
     "long": "^4.0.0",
     "source-map-support": "^0.5.16",
     "ts-node": "^6.2.0"

--- a/scripts/build-sdk.js
+++ b/scripts/build-sdk.js
@@ -1,0 +1,13 @@
+const path = require("path");
+const fs = require("fs");
+const pkg = require("../package.json");
+
+fs.readFile(path.join(__dirname, "..", "lib", "sdk", "index.js"), "utf8", function(err, data) {
+  if (err) throw err;
+  data = data
+    .replace(/BINARYEN_VERSION = "nightly"/, "BINARYEN_VERSION = " + JSON.stringify(pkg.dependencies.binaryen))
+    .replace(/ASSEMBLYSCRIPT_VERSION = "nightly"/, "ASSEMBLYSCRIPT_VERSION = " + JSON.stringify(pkg.version));
+  fs.writeFile(path.join(__dirname, "..", "dist", "sdk.js"), data, function(err) {
+    if (err) throw err;
+  });
+});

--- a/scripts/update-constants.js
+++ b/scripts/update-constants.js
@@ -13,6 +13,7 @@ binaryen.ready.then(() => {
       var match = val.match(/\b(_Binaryen\w+)\b/);
       if (match) {
         let fn = match[1];
+        if (typeof binaryen[fn] !== "function") throw Error("API mismatch: Is Binaryen up to date?");
         let id = binaryen[fn]();
         console.log(fn + " = " + id);
         return key + " = " + id + " /* " + fn + " */";

--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -907,7 +907,6 @@ export function compileCall(
           case TypeKind.USIZE: { value = "usize"; break; }
           case TypeKind.V128: { value = "v128"; break; }
           case TypeKind.ANYREF: { value = "anyref"; break; }
-          case TypeKind.EXNREF: { value = "exnref"; break; }
           default: assert(false);
           case TypeKind.VOID: { value = "void"; break; }
         }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -7144,7 +7144,7 @@ export class Compiler extends DiagnosticEmitter {
             this.currentType = signatureReference.type.asNullable();
             return module.i32(0);
           }
-          // TODO: anyref context yields <usize>0
+          return module.ref_null();
         }
         this.currentType = options.usizeType;
         return options.isWasm64
@@ -9001,6 +9001,7 @@ export class Compiler extends DiagnosticEmitter {
       case TypeKind.F32: return module.f32(0);
       case TypeKind.F64: return module.f64(0);
       case TypeKind.V128: return module.v128(v128_zero);
+      case TypeKind.ANYREF: return module.ref_null();
     }
   }
 
@@ -9099,9 +9100,11 @@ export class Compiler extends DiagnosticEmitter {
         flow.freeTempLocal(temp);
         return ret;
       }
-      // case TypeKind.ANYREF: {
-      //   TODO: !ref.is_null
-      // }
+      case TypeKind.ANYREF: {
+        // TODO: non-null object might still be considered falseish
+        // i.e. a ref to Boolean(false), Number(0), String("") etc.
+        return module.unary(UnaryOp.EqzI32, module.ref_is_null(expr));
+      }
       default: {
         assert(false);
         return module.i32(0);

--- a/src/glue/binaryen.d.ts
+++ b/src/glue/binaryen.d.ts
@@ -32,7 +32,9 @@ export declare function _BinaryenTypeInt64(): BinaryenType;
 export declare function _BinaryenTypeFloat32(): BinaryenType;
 export declare function _BinaryenTypeFloat64(): BinaryenType;
 export declare function _BinaryenTypeVec128(): BinaryenType;
+export declare function _BinaryenTypeFuncref(): BinaryenType;
 export declare function _BinaryenTypeAnyref(): BinaryenType;
+export declare function _BinaryenTypeNullref(): BinaryenType;
 export declare function _BinaryenTypeExnref(): BinaryenType;
 export declare function _BinaryenTypeUnreachable(): BinaryenType;
 export declare function _BinaryenTypeAuto(): BinaryenType;
@@ -95,6 +97,9 @@ export declare function _BinaryenMemoryInitId(): BinaryenExpressionId;
 export declare function _BinaryenDataDropId(): BinaryenExpressionId;
 export declare function _BinaryenMemoryCopyId(): BinaryenExpressionId;
 export declare function _BinaryenMemoryFillId(): BinaryenExpressionId;
+export declare function _BinaryenRefNullId(): BinaryenExpressionId;
+export declare function _BinaryenRefIsNullId(): BinaryenExpressionId;
+export declare function _BinaryenRefFuncId(): BinaryenExpressionId;
 export declare function _BinaryenTryId(): BinaryenExpressionId;
 export declare function _BinaryenThrowId(): BinaryenExpressionId;
 export declare function _BinaryenRethrowId(): BinaryenExpressionId;
@@ -468,7 +473,7 @@ export declare function _BinaryenStore(module: BinaryenModuleRef, bytes: u32, of
 export declare function _BinaryenConst(module: BinaryenModuleRef, value: usize): BinaryenExpressionRef;
 export declare function _BinaryenUnary(module: BinaryenModuleRef, op: BinaryenOp, value: BinaryenExpressionRef): BinaryenExpressionRef;
 export declare function _BinaryenBinary(module: BinaryenModuleRef, op: BinaryenOp, left: BinaryenExpressionRef, right: BinaryenExpressionRef): BinaryenExpressionRef;
-export declare function _BinaryenSelect(module: BinaryenModuleRef, condition: BinaryenExpressionRef, ifTrue: BinaryenExpressionRef, ifFalse: BinaryenExpressionRef): BinaryenExpressionRef;
+export declare function _BinaryenSelect(module: BinaryenModuleRef, condition: BinaryenExpressionRef, ifTrue: BinaryenExpressionRef, ifFalse: BinaryenExpressionRef, type: BinaryenType): BinaryenExpressionRef;
 export declare function _BinaryenDrop(module: BinaryenModuleRef, value: BinaryenExpressionRef): BinaryenExpressionRef;
 export declare function _BinaryenReturn(module: BinaryenModuleRef, value: BinaryenExpressionRef): BinaryenExpressionRef;
 export declare function _BinaryenHost(module: BinaryenModuleRef, op: BinaryenOp, name: usize | 0, operands: usize, numOperands: BinaryenIndex): BinaryenExpressionRef;
@@ -494,6 +499,10 @@ export declare function _BinaryenMemoryInit(module: BinaryenModuleRef, segment: 
 export declare function _BinaryenDataDrop(module: BinaryenModuleRef, segment: u32): BinaryenExpressionRef;
 export declare function _BinaryenMemoryCopy(module: BinaryenModuleRef, dest: BinaryenExpressionRef, source: BinaryenExpressionRef, size: BinaryenExpressionRef): BinaryenExpressionRef;
 export declare function _BinaryenMemoryFill(module: BinaryenModuleRef, dest: BinaryenExpressionRef, value: BinaryenExpressionRef, size: BinaryenExpressionRef): BinaryenExpressionRef;
+
+export declare function _BinaryenRefNull(module: BinaryenModuleRef): BinaryenExpressionRef;
+export declare function _BinaryenRefIsNull(module: BinaryenModuleRef, value: BinaryenExpressionRef): BinaryenExpressionRef;
+export declare function _BinaryenRefFunc(module: BinaryenModuleRef, funcName: usize): BinaryenExpressionRef;
 
 export declare function _BinaryenTry(module: BinaryenModuleRef, body: BinaryenExpressionRef, catchBody: BinaryenExpressionRef): BinaryenExpressionRef;
 export declare function _BinaryenThrow(module: BinaryenModuleRef, event: usize, operands: usize, numOperands: BinaryenIndex): BinaryenExpressionRef;
@@ -650,6 +659,10 @@ export declare function _BinaryenMemoryCopyGetSize(expr: BinaryenExpressionRef):
 export declare function _BinaryenMemoryFillGetDest(expr: BinaryenExpressionRef): BinaryenExpressionRef;
 export declare function _BinaryenMemoryFillGetValue(expr: BinaryenExpressionRef): BinaryenExpressionRef;
 export declare function _BinaryenMemoryFillGetSize(expr: BinaryenExpressionRef): BinaryenExpressionRef;
+
+export declare function _BinaryenRefIsNullGetValue(expr: BinaryenExpressionRef): BinaryenExpressionRef;
+
+export declare function _BinaryenRefFuncGetFunc(expr: BinaryenExpressionRef): usize;
 
 export declare function _BinaryenTryGetBody(expr: BinaryenExpressionRef): BinaryenExpressionRef;
 export declare function _BinaryenTryGetCatchBody(expr: BinaryenExpressionRef): BinaryenExpressionRef;

--- a/src/module.ts
+++ b/src/module.ts
@@ -2142,6 +2142,44 @@ export function traverse<T>(expr: ExpressionRef, data: T, visit: (expr: Expressi
       visit(binaryen._BinaryenStoreGetValue(expr), data);
       break;
     }
+    case ExpressionId.Const: {
+      break;
+    }
+    case ExpressionId.Unary: {
+      visit(binaryen._BinaryenUnaryGetValue(expr), data);
+      break;
+    }
+    case ExpressionId.Binary: {
+      visit(binaryen._BinaryenBinaryGetLeft(expr), data);
+      visit(binaryen._BinaryenBinaryGetRight(expr), data);
+      break;
+    }
+    case ExpressionId.Select: {
+      visit(binaryen._BinaryenSelectGetIfTrue(expr), data);
+      visit(binaryen._BinaryenSelectGetIfFalse(expr), data);
+      visit(binaryen._BinaryenSelectGetCondition(expr), data);
+      break;
+    }
+    case ExpressionId.Drop: {
+      visit(binaryen._BinaryenDropGetValue(expr), data);
+      break;
+    }
+    case ExpressionId.Return: {
+      visit(binaryen._BinaryenReturnGetValue(expr), data);
+      break;
+    }
+    case ExpressionId.Host: {
+      for (let i = 0, n = binaryen._BinaryenHostGetNumOperands(expr); i < n; ++i) {
+        visit(binaryen._BinaryenHostGetOperand(expr, i), data);
+      }
+      break;
+    }
+    case ExpressionId.Nop: {
+      break;
+    }
+    case ExpressionId.Unreachable: {
+      break;
+    }
     case ExpressionId.AtomicRMW: {
       visit(binaryen._BinaryenAtomicRMWGetPtr(expr), data);
       visit(binaryen._BinaryenAtomicRMWGetValue(expr), data);
@@ -2216,6 +2254,23 @@ export function traverse<T>(expr: ExpressionRef, data: T, visit: (expr: Expressi
       visit(binaryen._BinaryenMemoryFillGetSize(expr), data);
       break;
     }
+    case ExpressionId.Push: {
+      visit(binaryen._BinaryenPushGetValue(expr), data);
+      break;
+    }
+    case ExpressionId.Pop: {
+      break;
+    }
+    case ExpressionId.RefNull: {
+      break;
+    }
+    case ExpressionId.RefIsNull: {
+      visit(binaryen._BinaryenRefIsNullGetValue(expr), data);
+      break;
+    }
+    case ExpressionId.RefFunc: {
+      break;
+    }
     case ExpressionId.Try: {
       visit(binaryen._BinaryenTryGetBody(expr), data);
       visit(binaryen._BinaryenTryGetCatchBody(expr), data);
@@ -2233,51 +2288,6 @@ export function traverse<T>(expr: ExpressionRef, data: T, visit: (expr: Expressi
     }
     case ExpressionId.BrOnExn: {
       visit(binaryen._BinaryenBrOnExnGetExnref(expr), data);
-      break;
-    }
-    case ExpressionId.Push: {
-      visit(binaryen._BinaryenPushGetValue(expr), data);
-      break;
-    }
-    case ExpressionId.Pop: {
-      break;
-    }
-    case ExpressionId.Const: {
-      break;
-    }
-    case ExpressionId.Unary: {
-      visit(binaryen._BinaryenUnaryGetValue(expr), data);
-      break;
-    }
-    case ExpressionId.Binary: {
-      visit(binaryen._BinaryenBinaryGetLeft(expr), data);
-      visit(binaryen._BinaryenBinaryGetRight(expr), data);
-      break;
-    }
-    case ExpressionId.Select: {
-      visit(binaryen._BinaryenSelectGetIfTrue(expr), data);
-      visit(binaryen._BinaryenSelectGetIfFalse(expr), data);
-      visit(binaryen._BinaryenSelectGetCondition(expr), data);
-      break;
-    }
-    case ExpressionId.Drop: {
-      visit(binaryen._BinaryenDropGetValue(expr), data);
-      break;
-    }
-    case ExpressionId.Return: {
-      visit(binaryen._BinaryenReturnGetValue(expr), data);
-      break;
-    }
-    case ExpressionId.Host: {
-      for (let i = 0, n = binaryen._BinaryenHostGetNumOperands(expr); i < n; ++i) {
-        visit(binaryen._BinaryenHostGetOperand(expr, i), data);
-      }
-      break;
-    }
-    case ExpressionId.Nop: {
-      break;
-    }
-    case ExpressionId.Unreachable: {
       break;
     }
     default: assert(false);

--- a/src/module.ts
+++ b/src/module.ts
@@ -531,6 +531,10 @@ export class Module {
     return binaryen._BinaryenConst(this.ref, out);
   }
 
+  ref_null(): ExpressionRef {
+    return binaryen._BinaryenRefNull(this.ref);
+  }
+
   // expressions
 
   unary(
@@ -943,6 +947,21 @@ export class Module {
     align: u32
   ): ExpressionRef {
     return binaryen._BinaryenSIMDLoad(this.ref, op, offset, align, ptr);
+  }
+
+  // reference types
+
+  ref_is_null(
+    expr: ExpressionRef
+  ): ExpressionRef {
+    return binaryen._BinaryenRefIsNull(this.ref, expr);
+  }
+
+  ref_func(
+    name: string
+  ): ExpressionRef {
+    var cStr = this.allocStringCached(name);
+    return binaryen._BinaryenRefFunc(this.ref, cStr);
   }
 
   // globals

--- a/src/module.ts
+++ b/src/module.ts
@@ -19,18 +19,22 @@ export type Index = u32;
 
 // The following constants must be updated by running scripts/update-constants.
 // This is necessary because the functions are not yet callable with Binaryen
-// compiled to WebAssembly, requiring awaiting the ready promise first.
+// compiled to WebAssembly, requiring awaiting the ready promise first. Note
+// that this essentially fixes the compiler to specific versions of Binaryen
+// sometimes, because these constants can differ between Binaryen versions.
 
 export enum NativeType {
   None = 0 /* _BinaryenTypeNone */,
+  Unreachable = 1 /* _BinaryenTypeUnreachable */,
   I32 = 2 /* _BinaryenTypeInt32 */,
   I64 = 3 /* _BinaryenTypeInt64 */,
   F32 = 4 /* _BinaryenTypeFloat32 */,
   F64 = 5 /* _BinaryenTypeFloat64 */,
   V128 = 6 /* _BinaryenTypeVec128 */,
-  Anyref = 7 /* _BinaryenTypeAnyref */,
-  Exnref = 8 /* _BinaryenTypeExnref */,
-  Unreachable = 1 /* _BinaryenTypeUnreachable */,
+  Funcref = 7 /* _BinaryenTypeFuncref */,
+  Anyref = 8 /* _BinaryenTypeAnyref */,
+  Nullref = 9 /* _BinaryenTypeNullref */,
+  Exnref = 10 /* _BinaryenTypeExnref */,
   Auto = -1 /* _BinaryenTypeAuto */
 }
 
@@ -87,36 +91,39 @@ export enum ExpressionId {
   DataDrop = 35 /* _BinaryenDataDropId */,
   MemoryCopy = 36 /* _BinaryenMemoryCopyId */,
   MemoryFill = 37 /* _BinaryenMemoryFillId */,
-  Try = 40 /* _BinaryenTryId */,
-  Throw = 41 /* _BinaryenThrowId */,
-  Rethrow = 42 /* _BinaryenRethrowId */,
-  BrOnExn = 43 /* _BinaryenBrOnExnId */,
   Push = 38 /* _BinaryenPushId */,
-  Pop = 39 /* _BinaryenPopId */
+  Pop = 39 /* _BinaryenPopId */,
+  RefNull = 40 /* _BinaryenRefNullId */,
+  RefIsNull = 41 /* _BinaryenRefIsNullId */,
+  RefFunc = 42 /* _BinaryenRefFuncId */,
+  Try = 43 /* _BinaryenTryId */,
+  Throw = 44 /* _BinaryenThrowId */,
+  Rethrow = 45 /* _BinaryenRethrowId */,
+  BrOnExn = 46 /* _BinaryenBrOnExnId */
 }
 
 export enum UnaryOp {
   ClzI32 = 0 /* _BinaryenClzInt32 */,
-  CtzI32 = 2 /* _BinaryenCtzInt32 */,
-  PopcntI32 = 4 /* _BinaryenPopcntInt32 */,
-  NegF32 = 6 /* _BinaryenNegFloat32 */,
-  AbsF32 = 8 /* _BinaryenAbsFloat32 */,
-  CeilF32 = 10 /* _BinaryenCeilFloat32 */,
-  FloorF32 = 12 /* _BinaryenFloorFloat32 */,
-  TruncF32 = 14 /* _BinaryenTruncFloat32 */,
-  NearestF32 = 16 /* _BinaryenNearestFloat32 */,
-  SqrtF32 = 18 /* _BinaryenSqrtFloat32 */,
-  EqzI32 = 20 /* _BinaryenEqZInt32 */,
   ClzI64 = 1 /* _BinaryenClzInt64 */,
+  CtzI32 = 2 /* _BinaryenCtzInt32 */,
   CtzI64 = 3 /* _BinaryenCtzInt64 */,
+  PopcntI32 = 4 /* _BinaryenPopcntInt32 */,
   PopcntI64 = 5 /* _BinaryenPopcntInt64 */,
+  NegF32 = 6 /* _BinaryenNegFloat32 */,
   NegF64 = 7 /* _BinaryenNegFloat64 */,
+  AbsF32 = 8 /* _BinaryenAbsFloat32 */,
   AbsF64 = 9 /* _BinaryenAbsFloat64 */,
+  CeilF32 = 10 /* _BinaryenCeilFloat32 */,
   CeilF64 = 11 /* _BinaryenCeilFloat64 */,
+  FloorF32 = 12 /* _BinaryenFloorFloat32 */,
   FloorF64 = 13 /* _BinaryenFloorFloat64 */,
+  TruncF32 = 14 /* _BinaryenTruncFloat32 */,
   TruncF64 = 15 /* _BinaryenTruncFloat64 */,
+  NearestF32 = 16 /* _BinaryenNearestFloat32 */,
   NearestF64 = 17 /* _BinaryenNearestFloat64 */,
+  SqrtF32 = 18 /* _BinaryenSqrtFloat32 */,
   SqrtF64 = 19 /* _BinaryenSqrtFloat64 */,
+  EqzI32 = 20 /* _BinaryenEqZInt32 */,
   EqzI64 = 21 /* _BinaryenEqZInt64 */,
   ExtendI32 = 22 /* _BinaryenExtendSInt32 */,
   ExtendU32 = 23 /* _BinaryenExtendUInt32 */,
@@ -196,12 +203,12 @@ export enum UnaryOp {
   ConvertI64x2ToF64x2 = 91 /* _BinaryenConvertSVecI64x2ToVecF64x2 */,
   ConvertU64x2ToF64x2 = 92 /* _BinaryenConvertUVecI64x2ToVecF64x2 */,
   WidenLowI8x16ToI16x8 = 93 /* _BinaryenWidenLowSVecI8x16ToVecI16x8 */,
-  WidenLowU8x16ToU16x8 = 95 /* _BinaryenWidenLowUVecI8x16ToVecI16x8 */,
   WidenHighI8x16ToI16x8 = 94 /* _BinaryenWidenHighSVecI8x16ToVecI16x8 */,
+  WidenLowU8x16ToU16x8 = 95 /* _BinaryenWidenLowUVecI8x16ToVecI16x8 */,
   WidenHighU8x16ToU16x8 = 96 /* _BinaryenWidenHighUVecI8x16ToVecI16x8 */,
   WidenLowI16x8ToI32x4 = 97 /* _BinaryenWidenLowSVecI16x8ToVecI32x4 */,
-  WidenLowU16x8ToU32x4 = 99 /* _BinaryenWidenLowUVecI16x8ToVecI32x4 */,
   WidenHighI16x8ToI32x4 = 98 /* _BinaryenWidenHighSVecI16x8ToVecI32x4 */,
+  WidenLowU16x8ToU32x4 = 99 /* _BinaryenWidenLowUVecI16x8ToVecI32x4 */,
   WidenHighU16x8ToU32x4 = 100 /* _BinaryenWidenHighUVecI16x8ToVecI32x4 */
 }
 
@@ -288,43 +295,43 @@ export enum BinaryOp {
   NeI8x16 = 77 /* _BinaryenNeVecI8x16 */,
   LtI8x16 = 78 /* _BinaryenLtSVecI8x16 */,
   LtU8x16 = 79 /* _BinaryenLtUVecI8x16 */,
-  LeI8x16 = 82 /* _BinaryenLeSVecI8x16 */,
-  LeU8x16 = 83 /* _BinaryenLeUVecI8x16 */,
   GtI8x16 = 80 /* _BinaryenGtSVecI8x16 */,
   GtU8x16 = 81 /* _BinaryenGtUVecI8x16 */,
+  LeI8x16 = 82 /* _BinaryenLeSVecI8x16 */,
+  LeU8x16 = 83 /* _BinaryenLeUVecI8x16 */,
   GeI8x16 = 84 /* _BinaryenGeSVecI8x16 */,
   GeU8x16 = 85 /* _BinaryenGeUVecI8x16 */,
   EqI16x8 = 86 /* _BinaryenEqVecI16x8 */,
   NeI16x8 = 87 /* _BinaryenNeVecI16x8 */,
   LtI16x8 = 88 /* _BinaryenLtSVecI16x8 */,
   LtU16x8 = 89 /* _BinaryenLtUVecI16x8 */,
-  LeI16x8 = 92 /* _BinaryenLeSVecI16x8 */,
-  LeU16x8 = 93 /* _BinaryenLeUVecI16x8 */,
   GtI16x8 = 90 /* _BinaryenGtSVecI16x8 */,
   GtU16x8 = 91 /* _BinaryenGtUVecI16x8 */,
+  LeI16x8 = 92 /* _BinaryenLeSVecI16x8 */,
+  LeU16x8 = 93 /* _BinaryenLeUVecI16x8 */,
   GeI16x8 = 94 /* _BinaryenGeSVecI16x8 */,
   GeU16x8 = 95 /* _BinaryenGeUVecI16x8 */,
   EqI32x4 = 96 /* _BinaryenEqVecI32x4 */,
   NeI32x4 = 97 /* _BinaryenNeVecI32x4 */,
   LtI32x4 = 98 /* _BinaryenLtSVecI32x4 */,
   LtU32x4 = 99 /* _BinaryenLtUVecI32x4 */,
-  LeI32x4 = 102 /* _BinaryenLeSVecI32x4 */,
-  LeU32x4 = 103 /* _BinaryenLeUVecI32x4 */,
   GtI32x4 = 100 /* _BinaryenGtSVecI32x4 */,
   GtU32x4 = 101 /* _BinaryenGtUVecI32x4 */,
+  LeI32x4 = 102 /* _BinaryenLeSVecI32x4 */,
+  LeU32x4 = 103 /* _BinaryenLeUVecI32x4 */,
   GeI32x4 = 104 /* _BinaryenGeSVecI32x4 */,
   GeU32x4 = 105 /* _BinaryenGeUVecI32x4 */,
   EqF32x4 = 106 /* _BinaryenEqVecF32x4 */,
   NeF32x4 = 107 /* _BinaryenNeVecF32x4 */,
   LtF32x4 = 108 /* _BinaryenLtVecF32x4 */,
-  LeF32x4 = 110 /* _BinaryenLeVecF32x4 */,
   GtF32x4 = 109 /* _BinaryenGtVecF32x4 */,
+  LeF32x4 = 110 /* _BinaryenLeVecF32x4 */,
   GeF32x4 = 111 /* _BinaryenGeVecF32x4 */,
   EqF64x2 = 112 /* _BinaryenEqVecF64x2 */,
   NeF64x2 = 113 /* _BinaryenNeVecF64x2 */,
   LtF64x2 = 114 /* _BinaryenLtVecF64x2 */,
-  LeF64x2 = 116 /* _BinaryenLeVecF64x2 */,
   GtF64x2 = 115 /* _BinaryenGtVecF64x2 */,
+  LeF64x2 = 116 /* _BinaryenLeVecF64x2 */,
   GeF64x2 = 117 /* _BinaryenGeVecF64x2 */,
   AndV128 = 118 /* _BinaryenAndVec128 */,
   OrV128 = 119 /* _BinaryenOrVec128 */,
@@ -734,9 +741,14 @@ export class Module {
   select(
     ifTrue: ExpressionRef,
     ifFalse: ExpressionRef,
-    condition: ExpressionRef
+    condition: ExpressionRef,
+    type: NativeType = NativeType.Auto
   ): ExpressionRef {
-    return binaryen._BinaryenSelect(this.ref, condition, ifTrue, ifFalse);
+    if (type == NativeType.Auto) {
+      type = binaryen._BinaryenExpressionGetType(ifTrue);
+      assert(type == binaryen._BinaryenExpressionGetType(ifFalse));
+    }
+    return binaryen._BinaryenSelect(this.ref, condition, ifTrue, ifFalse, type);
   }
 
   switch(

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,10 +60,8 @@ export const enum TypeKind {
 
   // references
 
-  /** A host reference. */
+  /** Any host reference. */
   ANYREF,
-  /** An internal exception reference. */
-  EXNREF,
 
   // other
 
@@ -95,7 +93,9 @@ export const enum TypeFlags {
   /** Is a nullable type. */
   NULLABLE = 1 << 9,
   /** Is a vector type. */
-  VECTOR = 1 << 10
+  VECTOR = 1 << 10,
+  /** Is a host type. */
+  HOST = 1 << 11
 }
 
 const v128_zero = new Uint8Array(16);
@@ -362,7 +362,6 @@ export class Type {
       case TypeKind.F64: return NativeType.F64;
       case TypeKind.V128: return NativeType.V128;
       case TypeKind.ANYREF: return NativeType.Anyref;
-      case TypeKind.EXNREF: return NativeType.Exnref;
       case TypeKind.VOID: return NativeType.None;
     }
   }
@@ -494,13 +493,9 @@ export class Type {
     TypeFlags.VALUE, 128
   );
 
-  /** A host reference. */
+  /** Any host reference. */
   static readonly anyref: Type = new Type(TypeKind.ANYREF,
-    TypeFlags.REFERENCE, 0
-  );
-
-  /** An internal exception reference. */
-  static readonly exnref: Type = new Type(TypeKind.EXNREF,
+    TypeFlags.HOST       |
     TypeFlags.REFERENCE, 0
   );
 

--- a/tests/compiler/features/reference-types.optimized.wat
+++ b/tests/compiler/features/reference-types.optimized.wat
@@ -14,6 +14,8 @@
  (import "reference-types" "external" (func $features/reference-types/external (param anyref) (result anyref)))
  (memory $0 1)
  (data (i32.const 16) "6\00\00\00\01\00\00\00\01\00\00\006\00\00\00f\00e\00a\00t\00u\00r\00e\00s\00/\00r\00e\00f\00e\00r\00e\00n\00c\00e\00-\00t\00y\00p\00e\00s\00.\00t\00s")
+ (global $features/reference-types/nullGlobal (mut anyref) (ref.null))
+ (global $features/reference-types/nullGlobalInit (mut anyref) (ref.null))
  (export "memory" (memory $0))
  (export "external" (func $features/reference-types/external))
  (export "internal" (func $features/reference-types/internal))
@@ -39,6 +41,21 @@
   global.get $features/reference-types/someKey
   call $~lib/bindings/Reflect/get
   call $~lib/bindings/console/log
+  global.get $features/reference-types/nullGlobal
+  ref.is_null
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 32
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  ref.null
+  global.set $features/reference-types/nullGlobal
+  ref.null
+  global.set $features/reference-types/nullGlobalInit
  )
  (func $features/reference-types/internal (; 6 ;) (param $0 anyref) (result anyref)
   local.get $0

--- a/tests/compiler/features/reference-types.optimized.wat
+++ b/tests/compiler/features/reference-types.optimized.wat
@@ -16,11 +16,15 @@
  (data (i32.const 16) "6\00\00\00\01\00\00\00\01\00\00\006\00\00\00f\00e\00a\00t\00u\00r\00e\00s\00/\00r\00e\00f\00e\00r\00e\00n\00c\00e\00-\00t\00y\00p\00e\00s\00.\00t\00s")
  (global $features/reference-types/nullGlobal (mut anyref) (ref.null))
  (global $features/reference-types/nullGlobalInit (mut anyref) (ref.null))
+ (global $features/reference-types/funcGlobal (mut anyref) (ref.null))
  (export "memory" (memory $0))
  (export "external" (func $features/reference-types/external))
  (export "internal" (func $features/reference-types/internal))
  (start $start)
- (func $start:features/reference-types (; 5 ;)
+ (func $features/reference-types/someFunc (; 5 ;)
+  nop
+ )
+ (func $start:features/reference-types (; 6 ;)
   global.get $features/reference-types/someObject
   global.get $features/reference-types/someKey
   call $~lib/bindings/Reflect/has
@@ -56,14 +60,16 @@
   global.set $features/reference-types/nullGlobal
   ref.null
   global.set $features/reference-types/nullGlobalInit
+  ref.func $features/reference-types/someFunc
+  global.set $features/reference-types/funcGlobal
  )
- (func $features/reference-types/internal (; 6 ;) (param $0 anyref) (result anyref)
+ (func $features/reference-types/internal (; 7 ;) (param $0 anyref) (result anyref)
   local.get $0
   call $features/reference-types/external
   call $features/reference-types/external
   call $features/reference-types/external
  )
- (func $start (; 7 ;)
+ (func $start (; 8 ;)
   call $start:features/reference-types
  )
 )

--- a/tests/compiler/features/reference-types.ts
+++ b/tests/compiler/features/reference-types.ts
@@ -42,3 +42,11 @@ assert(!nullGlobalInit);
   let nullLocalInit: anyref = null;
   assert(!nullLocalInit);
 }
+
+// can represent function references
+
+function someFunc(): void {}
+var funcGlobal: anyref = someFunc;
+{
+  let funcLocal: anyref = someFunc;
+}

--- a/tests/compiler/features/reference-types.ts
+++ b/tests/compiler/features/reference-types.ts
@@ -25,3 +25,20 @@ import * as console from "bindings/console";
 console.log(someObject);
 console.log(someKey);
 console.log(Reflect.get(someObject, someKey));
+
+// can represent and recognize 'null'
+
+var nullGlobal: anyref;
+assert(!nullGlobal);
+nullGlobal = null;
+assert(!nullGlobal);
+var nullGlobalInit: anyref = null;
+assert(!nullGlobalInit);
+{
+  let nullLocal: anyref;
+  assert(!nullLocal);
+  nullLocal = null;
+  assert(!nullLocal);
+  let nullLocalInit: anyref = null;
+  assert(!nullLocalInit);
+}

--- a/tests/compiler/features/reference-types.untouched.wat
+++ b/tests/compiler/features/reference-types.untouched.wat
@@ -15,11 +15,15 @@
  (memory $0 1)
  (data (i32.const 16) "6\00\00\00\01\00\00\00\01\00\00\006\00\00\00f\00e\00a\00t\00u\00r\00e\00s\00/\00r\00e\00f\00e\00r\00e\00n\00c\00e\00-\00t\00y\00p\00e\00s\00.\00t\00s\00")
  (table $0 1 funcref)
+ (global $features/reference-types/nullGlobal (mut anyref) (ref.null))
+ (global $features/reference-types/nullGlobalInit (mut anyref) (ref.null))
  (export "memory" (memory $0))
  (export "external" (func $features/reference-types/external))
  (export "internal" (func $features/reference-types/internal))
  (start $start)
  (func $start:features/reference-types (; 5 ;)
+  (local $0 anyref)
+  (local $1 anyref)
   global.get $features/reference-types/someObject
   global.get $features/reference-types/someKey
   call $~lib/bindings/Reflect/has
@@ -42,6 +46,92 @@
   global.get $features/reference-types/someKey
   call $~lib/bindings/Reflect/get
   call $~lib/bindings/console/log
+  global.get $features/reference-types/nullGlobal
+  ref.is_null
+  i32.eqz
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 32
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  ref.null
+  global.set $features/reference-types/nullGlobal
+  global.get $features/reference-types/nullGlobal
+  ref.is_null
+  i32.eqz
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 34
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  ref.null
+  global.set $features/reference-types/nullGlobalInit
+  global.get $features/reference-types/nullGlobalInit
+  ref.is_null
+  i32.eqz
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 36
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  ref.is_null
+  i32.eqz
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 39
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  ref.null
+  local.set $0
+  local.get $0
+  ref.is_null
+  i32.eqz
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 41
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  ref.null
+  local.set $1
+  local.get $1
+  ref.is_null
+  i32.eqz
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 43
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
  )
  (func $features/reference-types/internal (; 6 ;) (param $0 anyref) (result anyref)
   (local $1 anyref)

--- a/tests/compiler/features/reference-types.untouched.wat
+++ b/tests/compiler/features/reference-types.untouched.wat
@@ -17,11 +17,15 @@
  (table $0 1 funcref)
  (global $features/reference-types/nullGlobal (mut anyref) (ref.null))
  (global $features/reference-types/nullGlobalInit (mut anyref) (ref.null))
+ (global $features/reference-types/funcGlobal (mut anyref) (ref.null))
  (export "memory" (memory $0))
  (export "external" (func $features/reference-types/external))
  (export "internal" (func $features/reference-types/internal))
  (start $start)
- (func $start:features/reference-types (; 5 ;)
+ (func $features/reference-types/someFunc (; 5 ;)
+  nop
+ )
+ (func $start:features/reference-types (; 6 ;)
   (local $0 anyref)
   (local $1 anyref)
   global.get $features/reference-types/someObject
@@ -132,8 +136,12 @@
    call $~lib/builtins/abort
    unreachable
   end
+  ref.func $features/reference-types/someFunc
+  global.set $features/reference-types/funcGlobal
+  ref.func $features/reference-types/someFunc
+  local.set $1
  )
- (func $features/reference-types/internal (; 6 ;) (param $0 anyref) (result anyref)
+ (func $features/reference-types/internal (; 7 ;) (param $0 anyref) (result anyref)
   (local $1 anyref)
   (local $2 anyref)
   (local $3 anyref)
@@ -148,7 +156,7 @@
   local.set $3
   local.get $3
  )
- (func $start (; 7 ;)
+ (func $start (; 8 ;)
   call $start:features/reference-types
  )
 )


### PR DESCRIPTION
In celebration of the new year, this updates our Binaryen bindings to include fireworks.

- [x] Update bindings
- [x] Attempt to avoid versioning issues on the web
- [x] Integrate new reference types features (ref.null, ref.is_null, ref.func)