### PR TITLE
Update NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,3 @@
-Copyright (c) 2017-2019 AssemblyScript authors.
-
 The following authors have all licensed their contributions to AssemblyScript
 under the licensing terms detailed in LICENSE:
 
@@ -27,261 +25,25 @@ the following terms:
 
 * TypeScript: https://github.com/Microsoft/TypeScript
 
-  Copyright (c) Microsoft Corporation. All rights reserved.
-  Apache License, Version 2.0 (see LICENSE file)
+  Copyright (c) Microsoft Corporation
+  Apache License, Version 2.0 (https://opensource.org/licenses/Apache-2.0)
 
 * Binaryen: https://github.com/WebAssembly/binaryen
 
-  Copyright 2015 WebAssembly Community Group participants
-  Apache License, Version 2.0 (see LICENSE file)
+  Copyright (c) WebAssembly Community Group participants
+  Apache License, Version 2.0 (https://opensource.org/licenses/Apache-2.0)
 
-* Arm Optimized Routines: https://github.com/ARM-software/optimized-routines
+* musl libc: http://www.musl-libc.org
 
-  ----------------------------------------------------------------------
-  MIT License
-
-  Copyright (c) 1999-2019, Arm Limited.
-
-  Permission is hereby granted, free of charge, to any person obtaining a copy
-  of this software and associated documentation files (the "Software"), to deal
-  in the Software without restriction, including without limitation the rights
-  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-  copies of the Software, and to permit persons to whom the Software is
-  furnished to do so, subject to the following conditions:
-
-  The above copyright notice and this permission notice shall be included in all
-  copies or substantial portions of the Software.
-
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-  SOFTWARE.
-
-* musl: http://www.musl-libc.org
-
-  musl as a whole is licensed under the following standard MIT license:
-
-  ----------------------------------------------------------------------
-  Copyright © 2005-2014 Rich Felker, et al.
-
-  Permission is hereby granted, free of charge, to any person obtaining
-  a copy of this software and associated documentation files (the
-  "Software"), to deal in the Software without restriction, including
-  without limitation the rights to use, copy, modify, merge, publish,
-  distribute, sublicense, and/or sell copies of the Software, and to
-  permit persons to whom the Software is furnished to do so, subject to
-  the following conditions:
-
-  The above copyright notice and this permission notice shall be
-  included in all copies or substantial portions of the Software.
-
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-  ----------------------------------------------------------------------
-
-  Authors/contributors include:
-
-  Alex Dowad
-  Alexander Monakov
-  Anthony G. Basile
-  Arvid Picciani
-  Bobby Bingham
-  Boris Brezillon
-  Brent Cook
-  Chris Spiegel
-  Clément Vasseur
-  Daniel Micay
-  Denys Vlasenko
-  Emil Renner Berthing
-  Felix Fietkau
-  Felix Janda
-  Gianluca Anzolin
-  Hauke Mehrtens
-  Hiltjo Posthuma
-  Isaac Dunham
-  Jaydeep Patil
-  Jens Gustedt
-  Jeremy Huntwork
-  Jo-Philipp Wich
-  Joakim Sindholt
-  John Spencer
-  Josiah Worcester
-  Justin Cormack
-  Khem Raj
-  Kylie McClain
-  Luca Barbato
-  Luka Perkov
-  M Farkas-Dyck (Strake)
-  Mahesh Bodapati
-  Michael Forney
-  Natanael Copa
-  Nicholas J. Kain
-  orc
-  Pascal Cuoq
-  Petr Hosek
-  Pierre Carrier
-  Rich Felker
-  Richard Pennington
-  Shiz
-  sin
-  Solar Designer
-  Stefan Kristiansson
-  Szabolcs Nagy
-  Timo Teräs
-  Trutz Behn
-  Valentin Ochs
-  William Haddon
-
-  Portions of this software are derived from third-party works licensed
-  under terms compatible with the above MIT license:
-
-  The TRE regular expression implementation (src/regex/reg* and
-  src/regex/tre*) is Copyright © 2001-2008 Ville Laurikari and licensed
-  under a 2-clause BSD license (license text in the source files). The
-  included version has been heavily modified by Rich Felker in 2012, in
-  the interests of size, simplicity, and namespace cleanliness.
-
-  Much of the math library code (src/math/* and src/complex/*) is
-  Copyright © 1993,2004 Sun Microsystems or
-  Copyright © 2003-2011 David Schultz or
-  Copyright © 2003-2009 Steven G. Kargl or
-  Copyright © 2003-2009 Bruce D. Evans or
-  Copyright © 2008 Stephen L. Moshier
-  and labelled as such in comments in the individual source files. All
-  have been licensed under extremely permissive terms.
-
-  The ARM memcpy code (src/string/arm/memcpy_el.S) is Copyright © 2008
-  The Android Open Source Project and is licensed under a two-clause BSD
-  license. It was taken from Bionic libc, used on Android.
-
-  The implementation of DES for crypt (src/crypt/crypt_des.c) is
-  Copyright © 1994 David Burren. It is licensed under a BSD license.
-
-  The implementation of blowfish crypt (src/crypt/crypt_blowfish.c) was
-  originally written by Solar Designer and placed into the public
-  domain. The code also comes with a fallback permissive license for use
-  in jurisdictions that may not recognize the public domain.
-
-  The smoothsort implementation (src/stdlib/qsort.c) is Copyright © 2011
-  Valentin Ochs and is licensed under an MIT-style license.
-
-  The BSD PRNG implementation (src/prng/random.c) and XSI search API
-  (src/search/*.c) functions are Copyright © 2011 Szabolcs Nagy and
-  licensed under following terms: "Permission to use, copy, modify,
-  and/or distribute this code for any purpose with or without fee is
-  hereby granted. There is no warranty."
-
-  The x86_64 port was written by Nicholas J. Kain and is licensed under
-  the standard MIT terms.
-
-  The mips and microblaze ports were originally written by Richard
-  Pennington for use in the ellcc project. The original code was adapted
-  by Rich Felker for build system and code conventions during upstream
-  integration. It is licensed under the standard MIT terms.
-
-  The mips64 port was contributed by Imagination Technologies and is
-  licensed under the standard MIT terms.
-
-  The powerpc port was also originally written by Richard Pennington,
-  and later supplemented and integrated by John Spencer. It is licensed
-  under the standard MIT terms.
-
-  All other files which have no copyright comments are original works
-  produced specifically for use as part of this library, written either
-  by Rich Felker, the main author of the library, or by one or more
-  contibutors listed above. Details on authorship of individual files
-  can be found in the git version control history of the project. The
-  omission of copyright and license comments in each file is in the
-  interest of source tree size.
-
-  In addition, permission is hereby granted for all public header files
-  (include/* and arch/*/bits/*) and crt files intended to be linked into
-  applications (crt/*, ldso/dlstart.c, and arch/*/crt_arch.h) to omit
-  the copyright notice and permission notice otherwise required by the
-  license, and to use these files without any requirement of
-  attribution. These files include substantial contributions from:
-
-  Bobby Bingham
-  John Spencer
-  Nicholas J. Kain
-  Rich Felker
-  Richard Pennington
-  Stefan Kristiansson
-  Szabolcs Nagy
-
-  all of whom have explicitly granted such permission.
-
-  This file previously contained text expressing a belief that most of
-  the files covered by the above exception were sufficiently trivial not
-  to be subject to copyright, resulting in confusion over whether it
-  negated the permissions granted in the license. In the spirit of
-  permissive licensing, and of not having licensing issues being an
-  obstacle to adoption, that text has been removed.
+  Copyright (c) Rich Felker, et al.
+  The MIT License (https://opensource.org/licenses/MIT)
 
 * V8: https://developers.google.com/v8/
 
-  This license applies to all parts of V8 that are not externally
-  maintained libraries.  The externally maintained libraries used by V8
-  are:
+  Copyright (c) the V8 project authors
+  The 3-Clause BSD License (https://opensource.org/licenses/BSD-3-Clause)
 
-    - PCRE test suite, located in
-      test/mjsunit/third_party/regexp-pcre/regexp-pcre.js.  This is based on the
-      test suite from PCRE-7.3, which is copyrighted by the University
-      of Cambridge and Google, Inc.  The copyright notice and license
-      are embedded in regexp-pcre.js.
-
-    - Layout tests, located in test/mjsunit/third_party/object-keys.  These are
-      based on layout tests from webkit.org which are copyrighted by
-      Apple Computer, Inc. and released under a 3-clause BSD license.
-
-    - Strongtalk assembler, the basis of the files assembler-arm-inl.h,
-      assembler-arm.cc, assembler-arm.h, assembler-ia32-inl.h,
-      assembler-ia32.cc, assembler-ia32.h, assembler-x64-inl.h,
-      assembler-x64.cc, assembler-x64.h, assembler-mips-inl.h,
-      assembler-mips.cc, assembler-mips.h, assembler.cc and assembler.h.
-      This code is copyrighted by Sun Microsystems Inc. and released
-      under a 3-clause BSD license.
-
-    - Valgrind client API header, located at third_party/valgrind/valgrind.h
-      This is release under the BSD license.
-
-  These libraries have their own licenses; we recommend you read them,
-  as their terms may differ from the terms below.
-
-  Further license information can be found in LICENSE files located in
-  sub-directories.
-
-  Copyright 2014, the V8 project authors. All rights reserved.
-  Redistribution and use in source and binary forms, with or without
-  modification, are permitted provided that the following conditions are
-  met:
-
-      * Redistributions of source code must retain the above copyright
-        notice, this list of conditions and the following disclaimer.
-      * Redistributions in binary form must reproduce the above
-        copyright notice, this list of conditions and the following
-        disclaimer in the documentation and/or other materials provided
-        with the distribution.
-      * Neither the name of Google Inc. nor the names of its
-        contributors may be used to endorse or promote products derived
-        from this software without specific prior written permission.
-
-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+* Arm Optimized Routines: https://github.com/ARM-software/optimized-routines
+  
+  Copyright (c) Arm Limited
+  The MIT License (https://opensource.org/licenses/MIT)


### PR DESCRIPTION
This makes the NOTICE file a lot easier to deal with by linking to the respective licenses instead of concatenating stuff over and over again. Did a check on the base license texts to be sure and these match 1:1.