### PR TITLE
Fix undone autorelease in inlined context

### DIFF
--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -3383,20 +3383,16 @@
   block $~lib/typedarray/SORT<~lib/typedarray/Float64Array,f64>|inlined.0
    local.get $0
    call $~lib/rt/pure/__retain
-   local.tee $1
-   call $~lib/typedarray/Int64Array#get:length
    local.tee $2
+   call $~lib/typedarray/Int64Array#get:length
+   local.tee $1
    i32.const 1
    i32.le_s
-   if
-    local.get $1
-    call $~lib/rt/pure/__release
-    br $~lib/typedarray/SORT<~lib/typedarray/Float64Array,f64>|inlined.0
-   end
-   local.get $1
+   br_if $~lib/typedarray/SORT<~lib/typedarray/Float64Array,f64>|inlined.0
+   local.get $2
    i32.load offset=4
    local.set $0
-   local.get $2
+   local.get $1
    i32.const 2
    i32.eq
    if
@@ -3421,24 +3417,22 @@
      local.get $3
      f64.store
     end
-    local.get $1
-    call $~lib/rt/pure/__release
     br $~lib/typedarray/SORT<~lib/typedarray/Float64Array,f64>|inlined.0
    end
-   local.get $2
+   local.get $1
    i32.const 256
    i32.lt_s
    if
     local.get $0
-    local.get $2
+    local.get $1
     call $~lib/util/sort/insertionSort<f64>
    else
     local.get $0
-    local.get $2
+    local.get $1
     call $~lib/util/sort/weakHeapSort<f64>
    end
   end
-  local.get $1
+  local.get $2
  )
  (func $~lib/util/sort/COMPARATOR<f64>~anonymous|0 (; 57 ;) (param $0 f64) (param $1 f64) (result i32)
   (local $2 i64)

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -5246,10 +5246,6 @@
    i32.le_s
    if
     local.get $3
-    local.set $5
-    local.get $3
-    call $~lib/rt/pure/__release
-    local.get $5
     br $~lib/typedarray/SORT<~lib/typedarray/Float64Array,f64>|inlined.0
    end
    local.get $3
@@ -5282,10 +5278,6 @@
      f64.store
     end
     local.get $3
-    local.set $8
-    local.get $3
-    call $~lib/rt/pure/__release
-    local.get $8
     br $~lib/typedarray/SORT<~lib/typedarray/Float64Array,f64>|inlined.0
    end
    local.get $5


### PR DESCRIPTION
This should fix the release issue reported in #1039 and worked around in #1040. What happened there was that when an autorelease was undone in an inner flow, the outer flow would still append a release in inline contexts due to checking local flags in the parent instead of the child flow. This now walks the locals of the parent flow and checks against states in the child flow.

fixes #1039
fixes #1040