### PR TITLE
Minor fix for fast path for Math.pow. (-0) ** 0.5 should be 0 instead -0

### DIFF
--- a/std/assembly/math.ts
+++ b/std/assembly/math.ts
@@ -1182,12 +1182,21 @@ export namespace NativeMath {
   export function pow(x: f64, y: f64): f64 { // see: musl/src/math/pow.c and SUN COPYRIGHT NOTICE above
     // TODO: remove this fast pathes after introduced own mid-end IR with "stdlib call simplify" transforms
     if (builtin_abs<f64>(y) <= 2) {
-      if (y ==  2.0) return x * x;
-      if (y ==  0.5) return select<f64>(Infinity, builtin_abs<f64>(builtin_sqrt<f64>(x)), x == -Infinity);
+      if (y == 2.0) return x * x;
+      if (y == 0.5) {
+        return select<f64>(
+          builtin_abs<f64>(builtin_sqrt<f64>(x)),
+          Infinity,
+          x != -Infinity
+        );
+      }
       if (y == -1.0) return 1 / x;
       if (y == -0.5) {
-        if (x == 0.0) return Infinity;
-        return select<f64>(0, 1 / builtin_sqrt<f64>(x), x == -Infinity);
+        return select<f64>(
+          select<f64>(1 / builtin_sqrt<f64>(x), 0, x != -Infinity),
+          Infinity,
+          x != 0
+        );
       }
       if (y == 1.0) return x;
       if (y == 0.0) return 1.0;
@@ -2578,12 +2587,21 @@ export namespace NativeMathf {
   export function pow(x: f32, y: f32): f32 { // see: musl/src/math/powf.c and SUN COPYRIGHT NOTICE above
     // TODO: remove this fast pathes after introduced own mid-end IR with "stdlib call simplify" transforms
     if (builtin_abs<f32>(y) <= 2) {
-      if (y ==  2.0) return x * x;
-      if (y ==  0.5) return select<f32>(Infinity, builtin_abs<f32>(builtin_sqrt<f32>(x)), x == -Infinity);
+      if (y == 2.0) return x * x;
+      if (y == 0.5) {
+        return select<f32>(
+          builtin_abs<f32>(builtin_sqrt<f32>(x)),
+          Infinity,
+          x != -Infinity
+        );
+      }
       if (y == -1.0) return 1 / x;
       if (y == -0.5) {
-        if (x == 0.0) return Infinity;
-        return select<f32>(0, 1 / builtin_sqrt<f32>(x), x == -Infinity);
+        return select<f32>(
+          select<f32>(1 / builtin_sqrt<f32>(x), 0, x != -Infinity),
+          Infinity,
+          x != 0
+        );
       }
       if (y == 1.0) return x;
       if (y == 0.0) return 1.0;

--- a/std/assembly/math.ts
+++ b/std/assembly/math.ts
@@ -1191,13 +1191,6 @@ export namespace NativeMath {
         );
       }
       if (y == -1.0) return 1 / x;
-      if (y == -0.5) {
-        return select<f64>(
-          select<f64>(1 / builtin_sqrt<f64>(x), 0, x != -Infinity),
-          Infinity,
-          x != 0
-        );
-      }
       if (y == 1.0) return x;
       if (y == 0.0) return 1.0;
     }
@@ -2596,13 +2589,6 @@ export namespace NativeMathf {
         );
       }
       if (y == -1.0) return 1 / x;
-      if (y == -0.5) {
-        return select<f32>(
-          select<f32>(1 / builtin_sqrt<f32>(x), 0, x != -Infinity),
-          Infinity,
-          x != 0
-        );
-      }
       if (y == 1.0) return x;
       if (y == 0.0) return 1.0;
     }

--- a/std/assembly/math.ts
+++ b/std/assembly/math.ts
@@ -1183,11 +1183,11 @@ export namespace NativeMath {
     // TODO: remove this fast pathes after introduced own mid-end IR with "stdlib call simplify" transforms
     if (builtin_abs<f64>(y) <= 2) {
       if (y ==  2.0) return x * x;
-      if (y ==  0.5) return select<f64>(Infinity, builtin_sqrt<f64>(x), builtin_abs<f64>(x) == Infinity);
+      if (y ==  0.5) return select<f64>(Infinity, builtin_abs<f64>(builtin_sqrt<f64>(x)), x == -Infinity);
       if (y == -1.0) return 1 / x;
       if (y == -0.5) {
         if (x == 0.0) return Infinity;
-        return select<f64>(0, 1 / builtin_sqrt<f64>(x), builtin_abs<f64>(x) == Infinity);
+        return select<f64>(0, 1 / builtin_sqrt<f64>(x), x == -Infinity);
       }
       if (y == 1.0) return x;
       if (y == 0.0) return 1.0;
@@ -2579,11 +2579,11 @@ export namespace NativeMathf {
     // TODO: remove this fast pathes after introduced own mid-end IR with "stdlib call simplify" transforms
     if (builtin_abs<f32>(y) <= 2) {
       if (y ==  2.0) return x * x;
-      if (y ==  0.5) return select<f32>(Infinity, builtin_sqrt<f32>(x), builtin_abs<f32>(x) == Infinity);
+      if (y ==  0.5) return select<f32>(Infinity, builtin_abs<f32>(builtin_sqrt<f32>(x)), x == -Infinity);
       if (y == -1.0) return 1 / x;
       if (y == -0.5) {
         if (x == 0.0) return Infinity;
-        return select<f32>(0, 1 / builtin_sqrt<f32>(x), builtin_abs<f32>(x) == Infinity);
+        return select<f32>(0, 1 / builtin_sqrt<f32>(x), x == -Infinity);
       }
       if (y == 1.0) return x;
       if (y == 0.0) return 1.0;

--- a/tests/compiler/binary.untouched.wat
+++ b/tests/compiler/binary.untouched.wat
@@ -92,14 +92,14 @@
    f64.const 0.5
    f64.eq
    if
-    f64.const inf
     local.get $0
     f64.sqrt
     f64.abs
+    f64.const inf
     local.get $0
     f64.const inf
     f64.neg
-    f64.eq
+    f64.ne
     select
     return
    end
@@ -116,22 +116,20 @@
    f64.const -0.5
    f64.eq
    if
-    local.get $0
-    f64.const 0
-    f64.eq
-    if
-     f64.const inf
-     return
-    end
-    f64.const 0
     f64.const 1
     local.get $0
     f64.sqrt
     f64.div
+    f64.const 0
     local.get $0
     f64.const inf
     f64.neg
-    f64.eq
+    f64.ne
+    select
+    f64.const inf
+    local.get $0
+    f64.const 0
+    f64.ne
     select
     return
    end
@@ -1312,14 +1310,14 @@
    f32.const 0.5
    f32.eq
    if
-    f32.const inf
     local.get $0
     f32.sqrt
     f32.abs
+    f32.const inf
     local.get $0
     f32.const inf
     f32.neg
-    f32.eq
+    f32.ne
     select
     return
    end
@@ -1336,22 +1334,20 @@
    f32.const -0.5
    f32.eq
    if
-    local.get $0
-    f32.const 0
-    f32.eq
-    if
-     f32.const inf
-     return
-    end
-    f32.const 0
     f32.const 1
     local.get $0
     f32.sqrt
     f32.div
+    f32.const 0
     local.get $0
     f32.const inf
     f32.neg
-    f32.eq
+    f32.ne
+    select
+    f32.const inf
+    local.get $0
+    f32.const 0
+    f32.ne
     select
     return
    end

--- a/tests/compiler/binary.untouched.wat
+++ b/tests/compiler/binary.untouched.wat
@@ -113,27 +113,6 @@
     return
    end
    local.get $1
-   f64.const -0.5
-   f64.eq
-   if
-    f64.const 1
-    local.get $0
-    f64.sqrt
-    f64.div
-    f64.const 0
-    local.get $0
-    f64.const inf
-    f64.neg
-    f64.ne
-    select
-    f64.const inf
-    local.get $0
-    f64.const 0
-    f64.ne
-    select
-    return
-   end
-   local.get $1
    f64.const 1
    f64.eq
    if
@@ -1328,27 +1307,6 @@
     f32.const 1
     local.get $0
     f32.div
-    return
-   end
-   local.get $1
-   f32.const -0.5
-   f32.eq
-   if
-    f32.const 1
-    local.get $0
-    f32.sqrt
-    f32.div
-    f32.const 0
-    local.get $0
-    f32.const inf
-    f32.neg
-    f32.ne
-    select
-    f32.const inf
-    local.get $0
-    f32.const 0
-    f32.ne
-    select
     return
    end
    local.get $1

--- a/tests/compiler/binary.untouched.wat
+++ b/tests/compiler/binary.untouched.wat
@@ -95,9 +95,10 @@
     f64.const inf
     local.get $0
     f64.sqrt
-    local.get $0
     f64.abs
+    local.get $0
     f64.const inf
+    f64.neg
     f64.eq
     select
     return
@@ -128,8 +129,8 @@
     f64.sqrt
     f64.div
     local.get $0
-    f64.abs
     f64.const inf
+    f64.neg
     f64.eq
     select
     return
@@ -1314,9 +1315,10 @@
     f32.const inf
     local.get $0
     f32.sqrt
-    local.get $0
     f32.abs
+    local.get $0
     f32.const inf
+    f32.neg
     f32.eq
     select
     return
@@ -1347,8 +1349,8 @@
     f32.sqrt
     f32.div
     local.get $0
-    f32.abs
     f32.const inf
+    f32.neg
     f32.eq
     select
     return

--- a/tests/compiler/resolve-binary.untouched.wat
+++ b/tests/compiler/resolve-binary.untouched.wat
@@ -742,9 +742,10 @@
     f64.const inf
     local.get $0
     f64.sqrt
-    local.get $0
     f64.abs
+    local.get $0
     f64.const inf
+    f64.neg
     f64.eq
     select
     return
@@ -775,8 +776,8 @@
     f64.sqrt
     f64.div
     local.get $0
-    f64.abs
     f64.const inf
+    f64.neg
     f64.eq
     select
     return

--- a/tests/compiler/resolve-binary.untouched.wat
+++ b/tests/compiler/resolve-binary.untouched.wat
@@ -760,27 +760,6 @@
     return
    end
    local.get $1
-   f64.const -0.5
-   f64.eq
-   if
-    f64.const 1
-    local.get $0
-    f64.sqrt
-    f64.div
-    f64.const 0
-    local.get $0
-    f64.const inf
-    f64.neg
-    f64.ne
-    select
-    f64.const inf
-    local.get $0
-    f64.const 0
-    f64.ne
-    select
-    return
-   end
-   local.get $1
    f64.const 1
    f64.eq
    if

--- a/tests/compiler/resolve-binary.untouched.wat
+++ b/tests/compiler/resolve-binary.untouched.wat
@@ -739,14 +739,14 @@
    f64.const 0.5
    f64.eq
    if
-    f64.const inf
     local.get $0
     f64.sqrt
     f64.abs
+    f64.const inf
     local.get $0
     f64.const inf
     f64.neg
-    f64.eq
+    f64.ne
     select
     return
    end
@@ -763,22 +763,20 @@
    f64.const -0.5
    f64.eq
    if
-    local.get $0
-    f64.const 0
-    f64.eq
-    if
-     f64.const inf
-     return
-    end
-    f64.const 0
     f64.const 1
     local.get $0
     f64.sqrt
     f64.div
+    f64.const 0
     local.get $0
     f64.const inf
     f64.neg
-    f64.eq
+    f64.ne
+    select
+    f64.const inf
+    local.get $0
+    f64.const 0
+    f64.ne
     select
     return
    end

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -4667,7 +4667,7 @@
   if
    i32.const 0
    i32.const 4080
-   i32.const 1413
+   i32.const 1406
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -6128,7 +6128,7 @@
   if
    i32.const 4912
    i32.const 4080
-   i32.const 1420
+   i32.const 1413
    i32.const 24
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -4667,7 +4667,7 @@
   if
    i32.const 0
    i32.const 4080
-   i32.const 1404
+   i32.const 1413
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -6128,7 +6128,7 @@
   if
    i32.const 4912
    i32.const 4080
-   i32.const 1411
+   i32.const 1420
    i32.const 24
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -7517,7 +7517,7 @@
   if
    i32.const 0
    i32.const 4080
-   i32.const 1404
+   i32.const 1413
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -9781,7 +9781,7 @@
   if
    i32.const 4912
    i32.const 4080
-   i32.const 1411
+   i32.const 1420
    i32.const 24
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -7517,7 +7517,7 @@
   if
    i32.const 0
    i32.const 4080
-   i32.const 1413
+   i32.const 1406
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -9781,7 +9781,7 @@
   if
    i32.const 4912
    i32.const 4080
-   i32.const 1420
+   i32.const 1413
    i32.const 24
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/libm.optimized.wat
+++ b/tests/compiler/std/libm.optimized.wat
@@ -3493,26 +3493,6 @@
     return
    end
    local.get $1
-   f64.const -0.5
-   f64.eq
-   if
-    f64.const 1
-    local.get $0
-    f64.sqrt
-    f64.div
-    f64.const 0
-    local.get $0
-    f64.const -inf
-    f64.ne
-    select
-    f64.const inf
-    local.get $0
-    f64.const 0
-    f64.ne
-    select
-    return
-   end
-   local.get $1
    f64.const 1
    f64.eq
    if
@@ -7847,26 +7827,6 @@
     f32.const 1
     local.get $0
     f32.div
-    return
-   end
-   local.get $1
-   f32.const -0.5
-   f32.eq
-   if
-    f32.const 1
-    local.get $0
-    f32.sqrt
-    f32.div
-    f32.const 0
-    local.get $0
-    f32.const -inf
-    f32.ne
-    select
-    f32.const inf
-    local.get $0
-    f32.const 0
-    f32.ne
-    select
     return
    end
    local.get $1

--- a/tests/compiler/std/libm.optimized.wat
+++ b/tests/compiler/std/libm.optimized.wat
@@ -3473,13 +3473,13 @@
    f64.const 0.5
    f64.eq
    if
-    f64.const inf
     local.get $0
     f64.sqrt
     f64.abs
+    f64.const inf
     local.get $0
     f64.const -inf
-    f64.eq
+    f64.ne
     select
     return
    end
@@ -3496,21 +3496,19 @@
    f64.const -0.5
    f64.eq
    if
-    local.get $0
-    f64.const 0
-    f64.eq
-    if
-     f64.const inf
-     return
-    end
-    f64.const 0
     f64.const 1
     local.get $0
     f64.sqrt
     f64.div
+    f64.const 0
     local.get $0
     f64.const -inf
-    f64.eq
+    f64.ne
+    select
+    f64.const inf
+    local.get $0
+    f64.const 0
+    f64.ne
     select
     return
    end
@@ -7832,13 +7830,13 @@
    f32.const 0.5
    f32.eq
    if
-    f32.const inf
     local.get $0
     f32.sqrt
     f32.abs
+    f32.const inf
     local.get $0
     f32.const -inf
-    f32.eq
+    f32.ne
     select
     return
    end
@@ -7855,21 +7853,19 @@
    f32.const -0.5
    f32.eq
    if
-    local.get $0
-    f32.const 0
-    f32.eq
-    if
-     f32.const inf
-     return
-    end
-    f32.const 0
     f32.const 1
     local.get $0
     f32.sqrt
     f32.div
+    f32.const 0
     local.get $0
     f32.const -inf
-    f32.eq
+    f32.ne
+    select
+    f32.const inf
+    local.get $0
+    f32.const 0
+    f32.ne
     select
     return
    end

--- a/tests/compiler/std/libm.optimized.wat
+++ b/tests/compiler/std/libm.optimized.wat
@@ -3476,9 +3476,9 @@
     f64.const inf
     local.get $0
     f64.sqrt
-    local.get $0
     f64.abs
-    f64.const inf
+    local.get $0
+    f64.const -inf
     f64.eq
     select
     return
@@ -3509,8 +3509,7 @@
     f64.sqrt
     f64.div
     local.get $0
-    f64.abs
-    f64.const inf
+    f64.const -inf
     f64.eq
     select
     return
@@ -7836,9 +7835,9 @@
     f32.const inf
     local.get $0
     f32.sqrt
-    local.get $0
     f32.abs
-    f32.const inf
+    local.get $0
+    f32.const -inf
     f32.eq
     select
     return
@@ -7869,8 +7868,7 @@
     f32.sqrt
     f32.div
     local.get $0
-    f32.abs
-    f32.const inf
+    f32.const -inf
     f32.eq
     select
     return

--- a/tests/compiler/std/libm.untouched.wat
+++ b/tests/compiler/std/libm.untouched.wat
@@ -4712,14 +4712,14 @@
    f64.const 0.5
    f64.eq
    if
-    f64.const inf
     local.get $0
     f64.sqrt
     f64.abs
+    f64.const inf
     local.get $0
     f64.const inf
     f64.neg
-    f64.eq
+    f64.ne
     select
     return
    end
@@ -4736,22 +4736,20 @@
    f64.const -0.5
    f64.eq
    if
-    local.get $0
-    f64.const 0
-    f64.eq
-    if
-     f64.const inf
-     return
-    end
-    f64.const 0
     f64.const 1
     local.get $0
     f64.sqrt
     f64.div
+    f64.const 0
     local.get $0
     f64.const inf
     f64.neg
-    f64.eq
+    f64.ne
+    select
+    f64.const inf
+    local.get $0
+    f64.const 0
+    f64.ne
     select
     return
    end
@@ -10211,14 +10209,14 @@
    f32.const 0.5
    f32.eq
    if
-    f32.const inf
     local.get $0
     f32.sqrt
     f32.abs
+    f32.const inf
     local.get $0
     f32.const inf
     f32.neg
-    f32.eq
+    f32.ne
     select
     return
    end
@@ -10235,22 +10233,20 @@
    f32.const -0.5
    f32.eq
    if
-    local.get $0
-    f32.const 0
-    f32.eq
-    if
-     f32.const inf
-     return
-    end
-    f32.const 0
     f32.const 1
     local.get $0
     f32.sqrt
     f32.div
+    f32.const 0
     local.get $0
     f32.const inf
     f32.neg
-    f32.eq
+    f32.ne
+    select
+    f32.const inf
+    local.get $0
+    f32.const 0
+    f32.ne
     select
     return
    end

--- a/tests/compiler/std/libm.untouched.wat
+++ b/tests/compiler/std/libm.untouched.wat
@@ -4715,9 +4715,10 @@
     f64.const inf
     local.get $0
     f64.sqrt
-    local.get $0
     f64.abs
+    local.get $0
     f64.const inf
+    f64.neg
     f64.eq
     select
     return
@@ -4748,8 +4749,8 @@
     f64.sqrt
     f64.div
     local.get $0
-    f64.abs
     f64.const inf
+    f64.neg
     f64.eq
     select
     return
@@ -10213,9 +10214,10 @@
     f32.const inf
     local.get $0
     f32.sqrt
-    local.get $0
     f32.abs
+    local.get $0
     f32.const inf
+    f32.neg
     f32.eq
     select
     return
@@ -10246,8 +10248,8 @@
     f32.sqrt
     f32.div
     local.get $0
-    f32.abs
     f32.const inf
+    f32.neg
     f32.eq
     select
     return

--- a/tests/compiler/std/libm.untouched.wat
+++ b/tests/compiler/std/libm.untouched.wat
@@ -4733,27 +4733,6 @@
     return
    end
    local.get $1
-   f64.const -0.5
-   f64.eq
-   if
-    f64.const 1
-    local.get $0
-    f64.sqrt
-    f64.div
-    f64.const 0
-    local.get $0
-    f64.const inf
-    f64.neg
-    f64.ne
-    select
-    f64.const inf
-    local.get $0
-    f64.const 0
-    f64.ne
-    select
-    return
-   end
-   local.get $1
    f64.const 1
    f64.eq
    if
@@ -10227,27 +10206,6 @@
     f32.const 1
     local.get $0
     f32.div
-    return
-   end
-   local.get $1
-   f32.const -0.5
-   f32.eq
-   if
-    f32.const 1
-    local.get $0
-    f32.sqrt
-    f32.div
-    f32.const 0
-    local.get $0
-    f32.const inf
-    f32.neg
-    f32.ne
-    select
-    f32.const inf
-    local.get $0
-    f32.const 0
-    f32.ne
-    select
     return
    end
    local.get $1

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -7198,26 +7198,6 @@
     return
    end
    local.get $1
-   f64.const -0.5
-   f64.eq
-   if
-    f64.const 1
-    local.get $0
-    f64.sqrt
-    f64.div
-    f64.const 0
-    local.get $0
-    f64.const -inf
-    f64.ne
-    select
-    f64.const inf
-    local.get $0
-    f64.const 0
-    f64.ne
-    select
-    return
-   end
-   local.get $1
    f64.const 1
    f64.eq
    if
@@ -8181,26 +8161,6 @@
     return
    end
    local.get $1
-   f32.const -0.5
-   f32.eq
-   if
-    f32.const 1
-    local.get $0
-    f32.sqrt
-    f32.div
-    f32.const 0
-    local.get $0
-    f32.const -inf
-    f32.ne
-    select
-    f32.const inf
-    local.get $0
-    f32.const 0
-    f32.ne
-    select
-    return
-   end
-   local.get $1
    f32.const 1
    f32.eq
    if
@@ -8695,7 +8655,7 @@
   if
    i32.const 0
    i32.const 3104
-   i32.const 1413
+   i32.const 1406
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -8709,7 +8669,7 @@
   if
    i32.const 3152
    i32.const 3104
-   i32.const 1420
+   i32.const 1413
    i32.const 24
    call $~lib/builtins/abort
    unreachable
@@ -8753,7 +8713,7 @@
   if
    i32.const 3152
    i32.const 3104
-   i32.const 2620
+   i32.const 2606
    i32.const 24
    call $~lib/builtins/abort
    unreachable
@@ -35502,112 +35462,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -0.5
-  call $~lib/math/NativeMath.pow
-  f64.const inf
-  f64.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2731
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0.5
-  call $~lib/math/NativeMath.pow
-  f64.const inf
-  f64.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2732
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -0.5
-  call $~lib/math/NativeMath.pow
-  local.tee $0
-  local.get $0
-  f64.eq
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2733
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4
-  f64.const -0.5
-  call $~lib/math/NativeMath.pow
-  f64.const 0.5
-  f64.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2734
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const -0.5
-  call $~lib/math/NativeMath.pow
-  f64.const 1
-  f64.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2735
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -0.5
-  call $~lib/math/NativeMath.pow
-  f64.const 0
-  f64.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2736
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -0.5
-  call $~lib/math/NativeMath.pow
-  f64.const 0
-  f64.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2737
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const -0.5
-  call $~lib/math/NativeMath.pow
-  local.tee $0
-  local.get $0
-  f64.eq
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2738
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -8.066848754882812
   f32.const 4.535662651062012
   f32.const nan:0x400000
@@ -35617,7 +35471,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2747
+   i32.const 2738
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35631,7 +35485,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2748
+   i32.const 2739
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35645,7 +35499,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2749
+   i32.const 2740
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35659,7 +35513,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2750
+   i32.const 2741
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35673,7 +35527,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2751
+   i32.const 2742
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35687,7 +35541,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2752
+   i32.const 2743
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35701,7 +35555,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2753
+   i32.const 2744
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35715,7 +35569,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2754
+   i32.const 2745
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35729,7 +35583,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2755
+   i32.const 2746
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35743,7 +35597,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2756
+   i32.const 2747
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35757,7 +35611,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2759
+   i32.const 2750
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35771,7 +35625,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2760
+   i32.const 2751
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35785,7 +35639,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2761
+   i32.const 2752
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35799,7 +35653,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2762
+   i32.const 2753
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35813,7 +35667,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2763
+   i32.const 2754
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35827,7 +35681,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2764
+   i32.const 2755
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35841,7 +35695,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2765
+   i32.const 2756
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35855,7 +35709,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2766
+   i32.const 2757
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35869,7 +35723,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2767
+   i32.const 2758
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35883,7 +35737,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2768
+   i32.const 2759
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35897,7 +35751,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2769
+   i32.const 2760
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35911,7 +35765,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2770
+   i32.const 2761
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -35925,13 +35779,139 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2771
+   i32.const 2762
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 0
   f32.const -inf
+  f32.const inf
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2763
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2764
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const inf
+  f32.const 0
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2765
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 3
+  f32.const -0
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2766
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 2
+  f32.const 0
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2767
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 1
+  f32.const -0
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2768
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 0.5
+  f32.const 0
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2769
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 0
+  f32.const 1
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2770
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 1
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2771
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0.5
   f32.const inf
   f32.const 0
   call $std/math/test_powf
@@ -35945,132 +35925,6 @@
    unreachable
   end
   f32.const -0
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2773
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const inf
-  f32.const 0
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2774
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 3
-  f32.const -0
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2775
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 2
-  f32.const 0
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2776
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 1
-  f32.const -0
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2777
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 0.5
-  f32.const 0
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2778
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const 0
-  f32.const 1
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2779
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const 1
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2780
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0.5
-  f32.const inf
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2781
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
   f32.const -1
   f32.const -inf
   f32.const 0
@@ -36079,7 +35933,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2782
+   i32.const 2773
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36093,7 +35947,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2783
+   i32.const 2774
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36107,7 +35961,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2784
+   i32.const 2775
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36121,7 +35975,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2785
+   i32.const 2776
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36135,13 +35989,139 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2786
+   i32.const 2777
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
   f32.const 0
+  f32.const 1
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2778
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const 0
+  f32.const 1
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2779
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const 0
+  f32.const 1
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2780
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 0
+  f32.const 1
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2781
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const 0
+  f32.const 1
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2782
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.5
+  f32.const 0
+  f32.const 1
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2783
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const -0
+  f32.const 1
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2784
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const -0
+  f32.const 1
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2785
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -0
+  f32.const 1
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2786
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const -0
   f32.const 1
   f32.const 0
   call $std/math/test_powf
@@ -36154,8 +36134,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const 0
+  f32.const -1
+  f32.const -0
   f32.const 1
   f32.const 0
   call $std/math/test_powf
@@ -36168,8 +36148,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const 0
+  f32.const -0.5
+  f32.const -0
   f32.const 1
   f32.const 0
   call $std/math/test_powf
@@ -36182,9 +36162,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 0
-  f32.const 1
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -36197,8 +36177,8 @@
    unreachable
   end
   f32.const -1
-  f32.const 0
-  f32.const 1
+  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -36210,9 +36190,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const 0
-  f32.const 1
+  f32.const -1
+  f32.const -inf
+  f32.const nan:0x400000
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -36220,132 +36200,6 @@
    i32.const 0
    i32.const 32
    i32.const 2792
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const -0
-  f32.const 1
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2793
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -0
-  f32.const 1
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2794
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -0
-  f32.const 1
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2795
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const -0
-  f32.const 1
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2796
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -0
-  f32.const 1
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2797
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const -0
-  f32.const 1
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2798
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2799
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const inf
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2800
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -inf
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2801
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36359,7 +36213,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2802
+   i32.const 2793
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36373,7 +36227,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2803
+   i32.const 2794
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36387,7 +36241,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2804
+   i32.const 2795
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36401,7 +36255,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2805
+   i32.const 2796
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36415,7 +36269,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2806
+   i32.const 2797
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36429,7 +36283,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2807
+   i32.const 2798
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36443,7 +36297,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2808
+   i32.const 2799
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36457,7 +36311,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2809
+   i32.const 2800
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36471,7 +36325,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2810
+   i32.const 2801
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36485,7 +36339,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2811
+   i32.const 2802
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36499,7 +36353,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2812
+   i32.const 2803
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36513,7 +36367,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2813
+   i32.const 2804
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36527,7 +36381,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2814
+   i32.const 2805
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36541,7 +36395,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2815
+   i32.const 2806
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36555,7 +36409,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2816
+   i32.const 2807
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36569,7 +36423,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2817
+   i32.const 2808
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36583,13 +36437,139 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2818
+   i32.const 2809
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -0.5
   f32.const -inf
+  f32.const inf
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2810
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.5
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2811
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
+  f32.const inf
+  f32.const 0
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2812
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
+  f32.const -inf
+  f32.const inf
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2813
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2814
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.5
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2815
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.5
+  f32.const -inf
+  f32.const 0
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2816
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.5
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2817
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2818
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
   f32.const inf
   f32.const 0
   call $std/math/test_powf
@@ -36602,9 +36582,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const -inf
+  f32.const 0
   f32.const 0
   call $std/math/test_powf
   i32.eqz
@@ -36612,132 +36592,6 @@
    i32.const 0
    i32.const 32
    i32.const 2820
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const inf
-  f32.const 0
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2821
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const -inf
-  f32.const inf
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2822
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2823
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.5
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2824
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.5
-  f32.const -inf
-  f32.const 0
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2825
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.5
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2826
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2827
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2828
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -inf
-  f32.const 0
-  f32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2829
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36751,7 +36605,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2830
+   i32.const 2821
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36765,7 +36619,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2831
+   i32.const 2822
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36779,7 +36633,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2832
+   i32.const 2823
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36793,7 +36647,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2833
+   i32.const 2824
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36807,7 +36661,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2834
+   i32.const 2825
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36821,7 +36675,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2835
+   i32.const 2826
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36835,7 +36689,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2836
+   i32.const 2827
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36849,7 +36703,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2837
+   i32.const 2828
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36863,7 +36717,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2838
+   i32.const 2829
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36877,7 +36731,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2839
+   i32.const 2830
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36891,7 +36745,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2840
+   i32.const 2831
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36905,7 +36759,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2841
+   i32.const 2832
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36919,7 +36773,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2842
+   i32.const 2833
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36933,7 +36787,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2843
+   i32.const 2834
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36947,7 +36801,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2844
+   i32.const 2835
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36961,7 +36815,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2845
+   i32.const 2836
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36975,7 +36829,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2846
+   i32.const 2837
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -36989,7 +36843,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2847
+   i32.const 2838
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37003,7 +36857,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2848
+   i32.const 2839
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37017,7 +36871,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2849
+   i32.const 2840
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37031,7 +36885,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2850
+   i32.const 2841
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37060,7 +36914,7 @@
     if
      i32.const 0
      i32.const 32
-     i32.const 2859
+     i32.const 2850
      i32.const 2
      call $~lib/builtins/abort
      unreachable
@@ -37098,7 +36952,7 @@
     if
      i32.const 0
      i32.const 32
-     i32.const 2867
+     i32.const 2858
      i32.const 2
      call $~lib/builtins/abort
      unreachable
@@ -37117,7 +36971,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2881
+   i32.const 2872
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37129,7 +36983,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2882
+   i32.const 2873
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37141,7 +36995,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2883
+   i32.const 2874
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37153,7 +37007,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2884
+   i32.const 2875
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37165,7 +37019,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2885
+   i32.const 2876
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37177,7 +37031,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2886
+   i32.const 2877
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37189,7 +37043,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2887
+   i32.const 2878
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37201,7 +37055,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2888
+   i32.const 2879
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37213,7 +37067,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2889
+   i32.const 2880
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37225,91 +37079,91 @@
   if
    i32.const 0
    i32.const 32
+   i32.const 2881
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2884
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2885
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -inf
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2886
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2887
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2888
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 1
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2889
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const -1
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
    i32.const 2890
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2893
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2894
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -inf
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2895
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2896
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2897
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2898
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -1
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2899
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37321,7 +37175,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2900
+   i32.const 2891
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37333,7 +37187,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2901
+   i32.const 2892
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37345,7 +37199,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2902
+   i32.const 2893
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37357,7 +37211,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2903
+   i32.const 2894
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37369,7 +37223,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2904
+   i32.const 2895
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37381,7 +37235,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2905
+   i32.const 2896
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37393,7 +37247,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2906
+   i32.const 2897
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37405,7 +37259,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2907
+   i32.const 2898
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37417,7 +37271,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2908
+   i32.const 2899
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37429,7 +37283,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2909
+   i32.const 2900
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37441,7 +37295,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2918
+   i32.const 2909
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37453,7 +37307,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2919
+   i32.const 2910
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37465,7 +37319,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2920
+   i32.const 2911
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37477,7 +37331,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2921
+   i32.const 2912
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37489,7 +37343,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2922
+   i32.const 2913
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37501,7 +37355,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2923
+   i32.const 2914
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37513,7 +37367,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2924
+   i32.const 2915
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37525,7 +37379,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2925
+   i32.const 2916
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37537,7 +37391,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2926
+   i32.const 2917
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37549,91 +37403,91 @@
   if
    i32.const 0
    i32.const 32
+   i32.const 2918
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2921
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2922
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -inf
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2923
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2924
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2925
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 1
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2926
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const -1
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
    i32.const 2927
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2930
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2931
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -inf
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2932
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2933
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2934
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2935
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -1
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2936
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37645,7 +37499,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2937
+   i32.const 2928
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37657,7 +37511,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2938
+   i32.const 2929
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37669,7 +37523,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2939
+   i32.const 2930
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37681,7 +37535,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2940
+   i32.const 2931
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37693,7 +37547,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2941
+   i32.const 2932
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37705,7 +37559,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2942
+   i32.const 2933
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37717,7 +37571,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2943
+   i32.const 2934
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37729,7 +37583,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2944
+   i32.const 2935
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37741,7 +37595,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2945
+   i32.const 2936
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37753,7 +37607,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2946
+   i32.const 2937
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37765,7 +37619,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2957
+   i32.const 2948
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37777,7 +37631,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2958
+   i32.const 2949
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37789,7 +37643,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2959
+   i32.const 2950
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37801,7 +37655,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2960
+   i32.const 2951
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37813,7 +37667,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2961
+   i32.const 2952
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37825,7 +37679,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2962
+   i32.const 2953
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37837,7 +37691,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2963
+   i32.const 2954
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37849,7 +37703,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2964
+   i32.const 2955
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37861,35 +37715,35 @@
   if
    i32.const 0
    i32.const 32
+   i32.const 2956
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  call $std/math/test_signf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2964
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  call $std/math/test_signf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
    i32.const 2965
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
-  call $std/math/test_signf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2973
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  call $std/math/test_signf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2974
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const 1
   f32.const 1
   call $std/math/test_signf
@@ -37897,7 +37751,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2975
+   i32.const 2966
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37909,7 +37763,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2976
+   i32.const 2967
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37921,7 +37775,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2977
+   i32.const 2968
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37933,7 +37787,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2978
+   i32.const 2969
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37945,7 +37799,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2979
+   i32.const 2970
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37957,7 +37811,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2980
+   i32.const 2971
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37969,7 +37823,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2981
+   i32.const 2972
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37982,7 +37836,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3018
+   i32.const 3009
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -37995,7 +37849,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3019
+   i32.const 3010
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38008,7 +37862,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3020
+   i32.const 3011
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38021,7 +37875,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3021
+   i32.const 3012
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38034,7 +37888,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3022
+   i32.const 3013
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38047,7 +37901,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3023
+   i32.const 3014
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38060,7 +37914,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3024
+   i32.const 3015
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38073,7 +37927,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3025
+   i32.const 3016
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38086,7 +37940,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3026
+   i32.const 3017
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38099,7 +37953,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3027
+   i32.const 3018
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38107,6 +37961,123 @@
   f64.const 0
   f64.const 1
   f64.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3021
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const 1
+  f64.const -0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3022
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
+  f64.const 1
+  f64.const 0.5
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3023
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.5
+  f64.const 1
+  f64.const -0.5
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3024
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 1
+  f64.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3025
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const 1
+  f64.const -0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3026
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.5
+  f64.const 1
+  f64.const -0.5
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3027
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.5
+  f64.const 1
+  f64.const 0.5
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3028
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2
+  f64.const 1
+  f64.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3029
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2
+  f64.const 1
+  f64.const -0
   call $std/math/test_rem
   i32.eqz
   if
@@ -38117,9 +38088,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const inf
   f64.const 1
-  f64.const -0
+  f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
   if
@@ -38130,9 +38101,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -inf
   f64.const 1
-  f64.const 0.5
+  f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
   if
@@ -38143,9 +38114,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const nan:0x8000000000000
   f64.const 1
-  f64.const -0.5
+  f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
   if
@@ -38156,8 +38127,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 1
+  f64.const 0
+  f64.const -1
   f64.const 0
   call $std/math/test_rem
   i32.eqz
@@ -38169,8 +38140,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const -1
-  f64.const 1
   f64.const -0
   call $std/math/test_rem
   i32.eqz
@@ -38182,9 +38153,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5
-  f64.const 1
-  f64.const -0.5
+  f64.const 0.5
+  f64.const -1
+  f64.const 0.5
   call $std/math/test_rem
   i32.eqz
   if
@@ -38195,9 +38166,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.5
-  f64.const 1
-  f64.const 0.5
+  f64.const -0.5
+  f64.const -1
+  f64.const -0.5
   call $std/math/test_rem
   i32.eqz
   if
@@ -38208,8 +38179,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2
   f64.const 1
+  f64.const -1
   f64.const 0
   call $std/math/test_rem
   i32.eqz
@@ -38221,8 +38192,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2
-  f64.const 1
+  f64.const -1
+  f64.const -1
   f64.const -0
   call $std/math/test_rem
   i32.eqz
@@ -38230,123 +38201,6 @@
    i32.const 0
    i32.const 32
    i32.const 3039
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 1
-  f64.const nan:0x8000000000000
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3040
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const 1
-  f64.const nan:0x8000000000000
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3041
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3042
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -1
-  f64.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3043
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -1
-  f64.const -0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3044
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const -1
-  f64.const 0.5
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3045
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const -1
-  f64.const -0.5
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3046
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const -1
-  f64.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3047
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -1
-  f64.const -0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3048
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38359,7 +38213,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3049
+   i32.const 3040
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38372,7 +38226,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3050
+   i32.const 3041
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38385,7 +38239,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3051
+   i32.const 3042
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38398,13 +38252,130 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3052
+   i32.const 3043
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
   f64.const -1
+  f64.const nan:0x8000000000000
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3044
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -1
+  f64.const nan:0x8000000000000
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3045
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  f64.const -1
+  f64.const nan:0x8000000000000
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3046
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const nan:0x8000000000000
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3047
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -0
+  f64.const nan:0x8000000000000
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3048
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const inf
+  f64.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3049
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -inf
+  f64.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3050
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3051
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const 0
+  f64.const nan:0x8000000000000
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3052
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -38416,9 +38387,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -1
-  f64.const nan:0x8000000000000
+  f64.const -0
+  f64.const inf
+  f64.const -0
   call $std/math/test_rem
   i32.eqz
   if
@@ -38429,9 +38400,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -1
-  f64.const nan:0x8000000000000
+  f64.const -0
+  f64.const -inf
+  f64.const -0
   call $std/math/test_rem
   i32.eqz
   if
@@ -38442,8 +38413,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -0
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -38455,8 +38426,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
   f64.const 0
-  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -38468,9 +38439,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
   f64.const 0
-  f64.const inf
-  f64.const 0
+  f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
   if
@@ -38481,9 +38452,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
   f64.const 0
-  f64.const -inf
-  f64.const 0
+  f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
   if
@@ -38494,8 +38465,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -inf
   f64.const 0
-  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -38507,7 +38478,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const nan:0x8000000000000
   f64.const 0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
@@ -38520,7 +38491,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const -1
   f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
@@ -38533,9 +38504,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
   f64.const inf
   f64.const -0
+  f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
   if
@@ -38546,9 +38517,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
   f64.const -inf
   f64.const -0
+  f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
   if
@@ -38559,8 +38530,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
   f64.const nan:0x8000000000000
+  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -38572,8 +38543,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 0
+  f64.const inf
+  f64.const 2
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -38585,8 +38556,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const 0
+  f64.const inf
+  f64.const -0.5
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -38599,7 +38570,7 @@
    unreachable
   end
   f64.const inf
-  f64.const 0
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -38612,7 +38583,7 @@
    unreachable
   end
   f64.const -inf
-  f64.const 0
+  f64.const 2
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -38624,8 +38595,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const 0
+  f64.const -inf
+  f64.const -0.5
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -38637,8 +38608,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -0
+  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -38650,8 +38621,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -38663,8 +38634,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -0
+  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -38676,8 +38647,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
   f64.const nan:0x8000000000000
-  f64.const -0
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -38689,9 +38660,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
   f64.const inf
-  f64.const 2
-  f64.const nan:0x8000000000000
+  f64.const 1
   call $std/math/test_rem
   i32.eqz
   if
@@ -38702,9 +38673,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
   f64.const inf
-  f64.const -0.5
-  f64.const nan:0x8000000000000
+  f64.const -1
   call $std/math/test_rem
   i32.eqz
   if
@@ -38716,7 +38687,7 @@
    unreachable
   end
   f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const inf
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -38729,7 +38700,7 @@
    unreachable
   end
   f64.const -inf
-  f64.const 2
+  f64.const inf
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -38741,9 +38712,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
   f64.const -inf
-  f64.const -0.5
-  f64.const nan:0x8000000000000
+  f64.const 1
   call $std/math/test_rem
   i32.eqz
   if
@@ -38754,9 +38725,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
   f64.const -inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -1
   call $std/math/test_rem
   i32.eqz
   if
@@ -38767,8 +38738,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const -inf
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -38780,8 +38751,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const -inf
   f64.const nan:0x8000000000000
   call $std/math/test_rem
   i32.eqz
@@ -38793,9 +38764,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 1.75
+  f64.const 0.5
+  f64.const -0.25
   call $std/math/test_rem
   i32.eqz
   if
@@ -38806,9 +38777,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const inf
-  f64.const 1
+  f64.const -1.75
+  f64.const 0.5
+  f64.const 0.25
   call $std/math/test_rem
   i32.eqz
   if
@@ -38819,9 +38790,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const inf
-  f64.const -1
+  f64.const 1.75
+  f64.const -0.5
+  f64.const -0.25
   call $std/math/test_rem
   i32.eqz
   if
@@ -38832,9 +38803,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const -1.75
+  f64.const -0.5
+  f64.const 0.25
   call $std/math/test_rem
   i32.eqz
   if
@@ -38845,132 +38816,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const 8e-323
   f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const 8e-323
   call $std/math/test_rem
   i32.eqz
   if
    i32.const 0
    i32.const 32
    i32.const 3087
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const -inf
-  f64.const 1
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3088
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -inf
-  f64.const -1
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3089
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -inf
-  f64.const nan:0x8000000000000
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3090
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -inf
-  f64.const nan:0x8000000000000
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3091
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.75
-  f64.const 0.5
-  f64.const -0.25
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3092
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.75
-  f64.const 0.5
-  f64.const 0.25
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3093
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.75
-  f64.const -0.5
-  f64.const -0.25
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3094
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.75
-  f64.const -0.5
-  f64.const 0.25
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3095
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 8e-323
-  f64.const inf
-  f64.const 8e-323
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3096
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38983,7 +38837,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3105
+   i32.const 3096
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -38996,7 +38850,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3106
+   i32.const 3097
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39009,7 +38863,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3107
+   i32.const 3098
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39022,7 +38876,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3108
+   i32.const 3099
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39035,7 +38889,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3109
+   i32.const 3100
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39048,7 +38902,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3110
+   i32.const 3101
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39061,7 +38915,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3111
+   i32.const 3102
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39074,7 +38928,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3112
+   i32.const 3103
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39087,7 +38941,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3113
+   i32.const 3104
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39100,7 +38954,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3114
+   i32.const 3105
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39108,6 +38962,123 @@
   f32.const 0
   f32.const 1
   f32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3108
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 1
+  f32.const -0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3109
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
+  f32.const 1
+  f32.const 0.5
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3110
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.5
+  f32.const 1
+  f32.const -0.5
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3111
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 1
+  f32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3112
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const 1
+  f32.const -0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3113
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.5
+  f32.const 1
+  f32.const -0.5
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3114
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.5
+  f32.const 1
+  f32.const 0.5
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3115
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2
+  f32.const 1
+  f32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3116
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2
+  f32.const 1
+  f32.const -0
   call $std/math/test_remf
   i32.eqz
   if
@@ -39118,9 +39089,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const inf
   f32.const 1
-  f32.const -0
+  f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
   if
@@ -39131,9 +39102,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -inf
   f32.const 1
-  f32.const 0.5
+  f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
   if
@@ -39144,9 +39115,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const nan:0x400000
   f32.const 1
-  f32.const -0.5
+  f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
   if
@@ -39157,8 +39128,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const 0
+  f32.const -1
   f32.const 0
   call $std/math/test_remf
   i32.eqz
@@ -39170,8 +39141,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const -1
-  f32.const 1
   f32.const -0
   call $std/math/test_remf
   i32.eqz
@@ -39183,9 +39154,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.5
-  f32.const 1
-  f32.const -0.5
+  f32.const 0.5
+  f32.const -1
+  f32.const 0.5
   call $std/math/test_remf
   i32.eqz
   if
@@ -39196,9 +39167,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.5
-  f32.const 1
-  f32.const 0.5
+  f32.const -0.5
+  f32.const -1
+  f32.const -0.5
   call $std/math/test_remf
   i32.eqz
   if
@@ -39209,8 +39180,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2
   f32.const 1
+  f32.const -1
   f32.const 0
   call $std/math/test_remf
   i32.eqz
@@ -39222,8 +39193,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2
-  f32.const 1
+  f32.const -1
+  f32.const -1
   f32.const -0
   call $std/math/test_remf
   i32.eqz
@@ -39231,123 +39202,6 @@
    i32.const 0
    i32.const 32
    i32.const 3126
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 1
-  f32.const nan:0x400000
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3127
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const 1
-  f32.const nan:0x400000
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3128
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 1
-  f32.const nan:0x400000
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3129
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -1
-  f32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3130
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -1
-  f32.const -0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3131
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const -1
-  f32.const 0.5
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3132
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const -1
-  f32.const -0.5
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3133
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const -1
-  f32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3134
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -1
-  f32.const -0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3135
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39360,7 +39214,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3136
+   i32.const 3127
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39373,7 +39227,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3137
+   i32.const 3128
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39386,7 +39240,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3138
+   i32.const 3129
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39399,13 +39253,130 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3139
+   i32.const 3130
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const inf
   f32.const -1
+  f32.const nan:0x400000
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3131
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -1
+  f32.const nan:0x400000
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3132
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const -1
+  f32.const nan:0x400000
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3133
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  f32.const nan:0x400000
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3134
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const -0
+  f32.const nan:0x400000
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3135
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const inf
+  f32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3136
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const -inf
+  f32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3137
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3138
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 0
+  f32.const nan:0x400000
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3139
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -39417,9 +39388,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -1
-  f32.const nan:0x400000
+  f32.const -0
+  f32.const inf
+  f32.const -0
   call $std/math/test_remf
   i32.eqz
   if
@@ -39430,9 +39401,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -1
-  f32.const nan:0x400000
+  f32.const -0
+  f32.const -inf
+  f32.const -0
   call $std/math/test_remf
   i32.eqz
   if
@@ -39443,8 +39414,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -0
+  f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -39456,8 +39427,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1
   f32.const 0
-  f32.const -0
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -39469,9 +39440,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
   f32.const 0
-  f32.const inf
-  f32.const 0
+  f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
   if
@@ -39482,9 +39453,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
   f32.const 0
-  f32.const -inf
-  f32.const 0
+  f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
   if
@@ -39495,8 +39466,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -inf
   f32.const 0
-  f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -39508,7 +39479,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const nan:0x400000
   f32.const 0
   f32.const nan:0x400000
   call $std/math/test_remf
@@ -39521,7 +39492,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const -1
   f32.const -0
   f32.const nan:0x400000
   call $std/math/test_remf
@@ -39534,9 +39505,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
   f32.const inf
   f32.const -0
+  f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
   if
@@ -39547,9 +39518,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
   f32.const -inf
   f32.const -0
+  f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
   if
@@ -39560,8 +39531,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
   f32.const nan:0x400000
+  f32.const -0
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -39573,8 +39544,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 0
+  f32.const inf
+  f32.const 2
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -39586,8 +39557,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const 0
+  f32.const inf
+  f32.const -0.5
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -39600,7 +39571,7 @@
    unreachable
   end
   f32.const inf
-  f32.const 0
+  f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -39613,7 +39584,7 @@
    unreachable
   end
   f32.const -inf
-  f32.const 0
+  f32.const 2
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -39625,8 +39596,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const 0
+  f32.const -inf
+  f32.const -0.5
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -39638,8 +39609,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -0
+  f32.const -inf
+  f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -39651,8 +39622,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -39664,8 +39635,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -0
+  f32.const 1
+  f32.const nan:0x400000
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -39677,8 +39648,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
   f32.const nan:0x400000
-  f32.const -0
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -39690,9 +39661,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1
   f32.const inf
-  f32.const 2
-  f32.const nan:0x400000
+  f32.const 1
   call $std/math/test_remf
   i32.eqz
   if
@@ -39703,9 +39674,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
   f32.const inf
-  f32.const -0.5
-  f32.const nan:0x400000
+  f32.const -1
   call $std/math/test_remf
   i32.eqz
   if
@@ -39717,7 +39688,7 @@
    unreachable
   end
   f32.const inf
-  f32.const nan:0x400000
+  f32.const inf
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -39730,7 +39701,7 @@
    unreachable
   end
   f32.const -inf
-  f32.const 2
+  f32.const inf
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -39742,9 +39713,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1
   f32.const -inf
-  f32.const -0.5
-  f32.const nan:0x400000
+  f32.const 1
   call $std/math/test_remf
   i32.eqz
   if
@@ -39755,9 +39726,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
   f32.const -inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -1
   call $std/math/test_remf
   i32.eqz
   if
@@ -39768,8 +39739,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const -inf
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -39781,8 +39752,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const -inf
   f32.const nan:0x400000
   call $std/math/test_remf
   i32.eqz
@@ -39794,9 +39765,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 1.75
+  f32.const 0.5
+  f32.const -0.25
   call $std/math/test_remf
   i32.eqz
   if
@@ -39807,9 +39778,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const inf
-  f32.const 1
+  f32.const -1.75
+  f32.const 0.5
+  f32.const 0.25
   call $std/math/test_remf
   i32.eqz
   if
@@ -39820,9 +39791,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const inf
-  f32.const -1
+  f32.const 1.75
+  f32.const -0.5
+  f32.const -0.25
   call $std/math/test_remf
   i32.eqz
   if
@@ -39833,9 +39804,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
-  f32.const nan:0x400000
+  f32.const -1.75
+  f32.const -0.5
+  f32.const 0.25
   call $std/math/test_remf
   i32.eqz
   if
@@ -39846,132 +39817,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const 5.877471754111438e-39
   f32.const inf
-  f32.const nan:0x400000
+  f32.const 5.877471754111438e-39
   call $std/math/test_remf
   i32.eqz
   if
    i32.const 0
    i32.const 32
    i32.const 3174
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const -inf
-  f32.const 1
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3175
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -inf
-  f32.const -1
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3176
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -inf
-  f32.const nan:0x400000
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3177
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -inf
-  f32.const nan:0x400000
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3178
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.75
-  f32.const 0.5
-  f32.const -0.25
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3179
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.75
-  f32.const 0.5
-  f32.const 0.25
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3180
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.75
-  f32.const -0.5
-  f32.const -0.25
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3181
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.75
-  f32.const -0.5
-  f32.const 0.25
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3182
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 5.877471754111438e-39
-  f32.const inf
-  f32.const 5.877471754111438e-39
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3183
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39984,7 +39838,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3195
+   i32.const 3186
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -39997,7 +39851,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3196
+   i32.const 3187
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40010,7 +39864,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3197
+   i32.const 3188
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40023,7 +39877,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3198
+   i32.const 3189
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40036,7 +39890,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3199
+   i32.const 3190
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40049,7 +39903,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3200
+   i32.const 3191
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40062,7 +39916,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3201
+   i32.const 3192
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40075,7 +39929,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3202
+   i32.const 3193
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40088,7 +39942,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3203
+   i32.const 3194
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40101,7 +39955,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3204
+   i32.const 3195
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40114,7 +39968,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3207
+   i32.const 3198
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40127,13 +39981,130 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3208
+   i32.const 3199
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.2250738585072014e-308
   f64.const 2.2250738585072014e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3200
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3201
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 5e-324
+  f64.const 5e-324
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3202
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -5e-324
+  f64.const -5e-324
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3203
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3204
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3205
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.225073858507202e-308
+  f64.const 2.225073858507202e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3206
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.2250738585072024e-308
+  f64.const 2.2250738585072024e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3207
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.4501477170144003e-308
+  f64.const 4.4501477170144003e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3208
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.450147717014403e-308
+  f64.const 4.450147717014403e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -40145,8 +40116,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
+  f64.const 4.450147717014406e-308
+  f64.const 4.450147717014406e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -40158,8 +40129,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5e-324
-  f64.const 5e-324
+  f64.const 8.900295434028806e-308
+  f64.const 8.900295434028806e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -40167,123 +40138,6 @@
    i32.const 0
    i32.const 32
    i32.const 3211
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -5e-324
-  f64.const -5e-324
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3212
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3213
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3214
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507202e-308
-  f64.const 2.225073858507202e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3215
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072024e-308
-  f64.const 2.2250738585072024e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3216
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.4501477170144003e-308
-  f64.const 4.4501477170144003e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3217
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.450147717014403e-308
-  f64.const 4.450147717014403e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3218
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.450147717014406e-308
-  f64.const 4.450147717014406e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3219
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 8.900295434028806e-308
-  f64.const 8.900295434028806e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3220
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40296,7 +40150,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3221
+   i32.const 3212
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40309,7 +40163,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3222
+   i32.const 3213
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40322,7 +40176,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3223
+   i32.const 3214
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40335,7 +40189,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3224
+   i32.const 3215
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40348,7 +40202,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3225
+   i32.const 3216
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40361,7 +40215,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3226
+   i32.const 3217
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40374,7 +40228,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3227
+   i32.const 3218
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40387,7 +40241,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3228
+   i32.const 3219
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40400,7 +40254,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3229
+   i32.const 3220
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40408,6 +40262,123 @@
   f64.const -1.4901161193847656e-08
   f64.const -1.4901161193847656e-08
   f64.const -0.1666666716337204
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3221
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.4901161193847656e-08
+  f64.const -1.4901161193847656e-08
+  f64.const -0.1666666716337204
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3222
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1e-323
+  f64.const 1e-323
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3223
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.4e-323
+  f64.const 4.4e-323
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3224
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 5.562684646268003e-309
+  f64.const 5.562684646268003e-309
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3225
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.1125369292536007e-308
+  f64.const 1.1125369292536007e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3226
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.2250738585072004e-308
+  f64.const 2.2250738585072004e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3227
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.225073858507201e-308
+  f64.const 2.225073858507201e-308
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3228
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1e-323
+  f64.const -1e-323
+  f64.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3229
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.4e-323
+  f64.const -4.4e-323
+  f64.const 0
   call $std/math/test_sin
   i32.eqz
   if
@@ -40418,9 +40389,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.4901161193847656e-08
-  f64.const -1.4901161193847656e-08
-  f64.const -0.1666666716337204
+  f64.const -5.562684646268003e-309
+  f64.const -5.562684646268003e-309
+  f64.const 0
   call $std/math/test_sin
   i32.eqz
   if
@@ -40431,8 +40402,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1e-323
-  f64.const 1e-323
+  f64.const -1.1125369292536007e-308
+  f64.const -1.1125369292536007e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -40444,8 +40415,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4e-323
-  f64.const 4.4e-323
+  f64.const -2.2250738585072004e-308
+  f64.const -2.2250738585072004e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -40457,8 +40428,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5.562684646268003e-309
-  f64.const 5.562684646268003e-309
+  f64.const -2.225073858507201e-308
+  f64.const -2.225073858507201e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -40470,34 +40441,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.1125369292536007e-308
-  f64.const 1.1125369292536007e-308
   f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3235
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072004e-308
-  f64.const 2.2250738585072004e-308
   f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3236
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507201e-308
-  f64.const 2.225073858507201e-308
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -40509,8 +40454,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1e-323
-  f64.const -1e-323
+  f64.const -0
+  f64.const -0
   f64.const 0
   call $std/math/test_sin
   i32.eqz
@@ -40518,97 +40463,6 @@
    i32.const 0
    i32.const 32
    i32.const 3238
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.4e-323
-  f64.const -4.4e-323
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3239
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -5.562684646268003e-309
-  f64.const -5.562684646268003e-309
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3240
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.1125369292536007e-308
-  f64.const -1.1125369292536007e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3241
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.2250738585072004e-308
-  f64.const -2.2250738585072004e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3242
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.225073858507201e-308
-  f64.const -2.225073858507201e-308
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3243
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3246
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3247
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40621,7 +40475,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3248
+   i32.const 3239
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40634,7 +40488,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3249
+   i32.const 3240
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40647,7 +40501,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3250
+   i32.const 3241
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40660,7 +40514,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3253
+   i32.const 3244
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40673,7 +40527,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3254
+   i32.const 3245
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40685,7 +40539,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3257
+   i32.const 3248
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40697,7 +40551,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3258
+   i32.const 3249
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40709,7 +40563,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3260
+   i32.const 3251
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40721,7 +40575,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3261
+   i32.const 3252
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40733,7 +40587,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3264
+   i32.const 3255
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40745,7 +40599,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3265
+   i32.const 3256
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40757,7 +40611,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3266
+   i32.const 3257
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40769,7 +40623,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3267
+   i32.const 3258
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40781,7 +40635,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3269
+   i32.const 3260
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40793,7 +40647,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3270
+   i32.const 3261
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40805,7 +40659,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3272
+   i32.const 3263
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40817,7 +40671,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3273
+   i32.const 3264
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40829,7 +40683,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3274
+   i32.const 3265
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40841,7 +40695,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3275
+   i32.const 3266
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40853,7 +40707,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3276
+   i32.const 3267
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40865,7 +40719,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3279
+   i32.const 3270
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40877,7 +40731,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3280
+   i32.const 3271
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40890,7 +40744,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3289
+   i32.const 3280
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40903,7 +40757,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3290
+   i32.const 3281
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40916,7 +40770,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3291
+   i32.const 3282
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40929,7 +40783,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3292
+   i32.const 3283
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40942,7 +40796,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3293
+   i32.const 3284
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40955,7 +40809,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3294
+   i32.const 3285
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40968,7 +40822,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3295
+   i32.const 3286
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40981,7 +40835,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3296
+   i32.const 3287
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -40994,7 +40848,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3297
+   i32.const 3288
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41007,7 +40861,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3298
+   i32.const 3289
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41020,7 +40874,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3301
+   i32.const 3292
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41033,7 +40887,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3302
+   i32.const 3293
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41046,7 +40900,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3303
+   i32.const 3294
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41059,7 +40913,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3304
+   i32.const 3295
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41072,7 +40926,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3305
+   i32.const 3296
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41085,7 +40939,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3308
+   i32.const 3299
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41098,13 +40952,130 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3309
+   i32.const 3300
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.1754943508222875e-38
   f32.const 1.1754943508222875e-38
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3301
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754943508222875e-38
+  f32.const -1.1754943508222875e-38
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3302
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.401298464324817e-45
+  f32.const 1.401298464324817e-45
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3303
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.401298464324817e-45
+  f32.const -1.401298464324817e-45
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3304
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.175494490952134e-38
+  f32.const 1.175494490952134e-38
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3305
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.1754946310819804e-38
+  f32.const 1.1754946310819804e-38
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3306
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.3509880009953429e-38
+  f32.const 2.3509880009953429e-38
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3307
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.350988701644575e-38
+  f32.const 2.350988701644575e-38
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3308
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.3509895424236536e-38
+  f32.const 2.3509895424236536e-38
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3309
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4.70197740328915e-38
+  f32.const 4.70197740328915e-38
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -41112,123 +41083,6 @@
    i32.const 0
    i32.const 32
    i32.const 3310
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754943508222875e-38
-  f32.const -1.1754943508222875e-38
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3311
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.401298464324817e-45
-  f32.const 1.401298464324817e-45
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3312
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.401298464324817e-45
-  f32.const -1.401298464324817e-45
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3313
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.175494490952134e-38
-  f32.const 1.175494490952134e-38
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3314
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754946310819804e-38
-  f32.const 1.1754946310819804e-38
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3315
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.3509880009953429e-38
-  f32.const 2.3509880009953429e-38
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3316
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.350988701644575e-38
-  f32.const 2.350988701644575e-38
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3317
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.3509895424236536e-38
-  f32.const 2.3509895424236536e-38
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3318
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 4.70197740328915e-38
-  f32.const 4.70197740328915e-38
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3319
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41241,7 +41095,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3320
+   i32.const 3311
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41254,7 +41108,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3321
+   i32.const 3312
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41267,7 +41121,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3322
+   i32.const 3313
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41280,7 +41134,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3323
+   i32.const 3314
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41293,7 +41147,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3324
+   i32.const 3315
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41306,7 +41160,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3325
+   i32.const 3316
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41319,7 +41173,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3326
+   i32.const 3317
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41332,7 +41186,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3327
+   i32.const 3318
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41345,7 +41199,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3328
+   i32.const 3319
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41358,7 +41212,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3329
+   i32.const 3320
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41371,7 +41225,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3330
+   i32.const 3321
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41384,7 +41238,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3331
+   i32.const 3322
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41397,7 +41251,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3332
+   i32.const 3323
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41410,13 +41264,130 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3333
+   i32.const 3324
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 2.802596928649634e-45
   f32.const 2.802596928649634e-45
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3325
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.2611686178923354e-44
+  f32.const 1.2611686178923354e-44
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3326
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.938735877055719e-39
+  f32.const 2.938735877055719e-39
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3327
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 5.877471754111438e-39
+  f32.const 5.877471754111438e-39
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3328
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.1754940705625946e-38
+  f32.const 1.1754940705625946e-38
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3329
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.1754942106924411e-38
+  f32.const 1.1754942106924411e-38
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3330
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.802596928649634e-45
+  f32.const -2.802596928649634e-45
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3331
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.2611686178923354e-44
+  f32.const -1.2611686178923354e-44
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3332
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.938735877055719e-39
+  f32.const -2.938735877055719e-39
+  f32.const 0
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3333
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -5.877471754111438e-39
+  f32.const -5.877471754111438e-39
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -41428,8 +41399,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.2611686178923354e-44
-  f32.const 1.2611686178923354e-44
+  f32.const -1.1754940705625946e-38
+  f32.const -1.1754940705625946e-38
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -41441,8 +41412,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.938735877055719e-39
-  f32.const 2.938735877055719e-39
+  f32.const -1.1754942106924411e-38
+  f32.const -1.1754942106924411e-38
   f32.const 0
   call $std/math/test_sinf
   i32.eqz
@@ -41450,123 +41421,6 @@
    i32.const 0
    i32.const 32
    i32.const 3336
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 5.877471754111438e-39
-  f32.const 5.877471754111438e-39
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3337
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754940705625946e-38
-  f32.const 1.1754940705625946e-38
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3338
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754942106924411e-38
-  f32.const 1.1754942106924411e-38
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3339
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.802596928649634e-45
-  f32.const -2.802596928649634e-45
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3340
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.2611686178923354e-44
-  f32.const -1.2611686178923354e-44
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3341
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.938735877055719e-39
-  f32.const -2.938735877055719e-39
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3342
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -5.877471754111438e-39
-  f32.const -5.877471754111438e-39
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3343
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754940705625946e-38
-  f32.const -1.1754940705625946e-38
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3344
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754942106924411e-38
-  f32.const -1.1754942106924411e-38
-  f32.const 0
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3345
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41579,7 +41433,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3348
+   i32.const 3339
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41592,7 +41446,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3349
+   i32.const 3340
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41605,7 +41459,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3350
+   i32.const 3341
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41618,7 +41472,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3351
+   i32.const 3342
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41631,7 +41485,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3352
+   i32.const 3343
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41644,7 +41498,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3353
+   i32.const 3344
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41657,7 +41511,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3354
+   i32.const 3345
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41670,7 +41524,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3355
+   i32.const 3346
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41683,7 +41537,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3356
+   i32.const 3347
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41696,7 +41550,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3357
+   i32.const 3348
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41709,7 +41563,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3358
+   i32.const 3349
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41722,7 +41576,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3359
+   i32.const 3350
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41735,7 +41589,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3360
+   i32.const 3351
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41748,7 +41602,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3361
+   i32.const 3352
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41761,7 +41615,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3373
+   i32.const 3364
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41774,7 +41628,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3374
+   i32.const 3365
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41787,7 +41641,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3375
+   i32.const 3366
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41800,7 +41654,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3376
+   i32.const 3367
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41813,7 +41667,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3377
+   i32.const 3368
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41826,7 +41680,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3378
+   i32.const 3369
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41839,7 +41693,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3379
+   i32.const 3370
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41852,7 +41706,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3380
+   i32.const 3371
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41865,7 +41719,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3381
+   i32.const 3372
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41878,7 +41732,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3382
+   i32.const 3373
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41891,7 +41745,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3385
+   i32.const 3376
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41904,7 +41758,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3386
+   i32.const 3377
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41917,7 +41771,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3387
+   i32.const 3378
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41930,7 +41784,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3388
+   i32.const 3379
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41943,7 +41797,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3389
+   i32.const 3380
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41956,7 +41810,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3398
+   i32.const 3389
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41969,7 +41823,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3399
+   i32.const 3390
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41982,7 +41836,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3400
+   i32.const 3391
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -41995,7 +41849,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3401
+   i32.const 3392
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42008,7 +41862,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3402
+   i32.const 3393
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42021,7 +41875,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3403
+   i32.const 3394
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42034,7 +41888,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3404
+   i32.const 3395
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42047,7 +41901,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3405
+   i32.const 3396
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42060,7 +41914,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3406
+   i32.const 3397
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42073,7 +41927,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3407
+   i32.const 3398
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42086,7 +41940,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3410
+   i32.const 3401
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42099,7 +41953,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3411
+   i32.const 3402
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42112,7 +41966,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3412
+   i32.const 3403
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42125,7 +41979,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3413
+   i32.const 3404
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42138,7 +41992,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3414
+   i32.const 3405
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42151,7 +42005,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3426
+   i32.const 3417
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42164,7 +42018,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3427
+   i32.const 3418
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42177,7 +42031,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3428
+   i32.const 3419
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42190,7 +42044,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3429
+   i32.const 3420
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42203,7 +42057,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3430
+   i32.const 3421
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42216,7 +42070,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3431
+   i32.const 3422
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42229,7 +42083,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3432
+   i32.const 3423
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42242,7 +42096,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3433
+   i32.const 3424
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42255,7 +42109,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3434
+   i32.const 3425
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42268,7 +42122,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3435
+   i32.const 3426
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42281,7 +42135,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3438
+   i32.const 3429
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42294,7 +42148,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3439
+   i32.const 3430
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42307,7 +42161,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3440
+   i32.const 3431
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42320,7 +42174,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3441
+   i32.const 3432
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42333,7 +42187,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3442
+   i32.const 3433
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42346,7 +42200,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3443
+   i32.const 3434
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42359,7 +42213,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3444
+   i32.const 3435
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42372,7 +42226,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3445
+   i32.const 3436
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42385,7 +42239,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3446
+   i32.const 3437
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42398,7 +42252,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3447
+   i32.const 3438
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42411,7 +42265,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3448
+   i32.const 3439
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42424,7 +42278,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3449
+   i32.const 3440
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42437,7 +42291,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3450
+   i32.const 3441
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42450,7 +42304,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3451
+   i32.const 3442
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42463,7 +42317,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3452
+   i32.const 3443
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42476,7 +42330,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3453
+   i32.const 3444
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42489,7 +42343,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3454
+   i32.const 3445
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42502,7 +42356,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3455
+   i32.const 3446
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42515,7 +42369,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3456
+   i32.const 3447
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42528,7 +42382,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3457
+   i32.const 3448
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42541,7 +42395,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3458
+   i32.const 3449
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42554,7 +42408,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3459
+   i32.const 3450
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42567,7 +42421,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3460
+   i32.const 3451
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42580,7 +42434,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3461
+   i32.const 3452
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42593,7 +42447,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3462
+   i32.const 3453
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42606,7 +42460,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3463
+   i32.const 3454
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42619,7 +42473,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3464
+   i32.const 3455
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42632,7 +42486,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3465
+   i32.const 3456
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42645,7 +42499,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3466
+   i32.const 3457
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42658,7 +42512,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3467
+   i32.const 3458
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42671,7 +42525,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3468
+   i32.const 3459
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42684,7 +42538,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3469
+   i32.const 3460
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42697,7 +42551,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3470
+   i32.const 3461
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42710,7 +42564,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3471
+   i32.const 3462
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42723,7 +42577,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3472
+   i32.const 3463
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42736,7 +42590,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3473
+   i32.const 3464
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42749,7 +42603,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3474
+   i32.const 3465
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42762,7 +42616,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3475
+   i32.const 3466
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42775,7 +42629,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3476
+   i32.const 3467
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42788,7 +42642,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3477
+   i32.const 3468
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42801,7 +42655,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3478
+   i32.const 3469
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42814,7 +42668,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3479
+   i32.const 3470
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42827,7 +42681,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3480
+   i32.const 3471
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42840,7 +42694,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3481
+   i32.const 3472
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42853,7 +42707,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3482
+   i32.const 3473
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42866,7 +42720,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3483
+   i32.const 3474
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42879,7 +42733,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3484
+   i32.const 3475
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42892,7 +42746,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3485
+   i32.const 3476
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42905,7 +42759,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3486
+   i32.const 3477
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42918,7 +42772,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3487
+   i32.const 3478
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42931,7 +42785,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3488
+   i32.const 3479
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42944,7 +42798,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3489
+   i32.const 3480
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42957,7 +42811,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3490
+   i32.const 3481
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42970,7 +42824,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3491
+   i32.const 3482
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42983,7 +42837,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3492
+   i32.const 3483
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42996,7 +42850,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3493
+   i32.const 3484
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43009,7 +42863,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3494
+   i32.const 3485
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43022,7 +42876,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3495
+   i32.const 3486
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43035,7 +42889,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3496
+   i32.const 3487
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43048,7 +42902,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3497
+   i32.const 3488
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43061,7 +42915,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3498
+   i32.const 3489
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43074,7 +42928,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3499
+   i32.const 3490
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43087,7 +42941,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3500
+   i32.const 3491
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43100,7 +42954,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3501
+   i32.const 3492
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43113,7 +42967,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3502
+   i32.const 3493
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43126,7 +42980,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3503
+   i32.const 3494
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43139,7 +42993,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3504
+   i32.const 3495
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43152,7 +43006,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3505
+   i32.const 3496
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43165,7 +43019,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3506
+   i32.const 3497
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43178,7 +43032,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3507
+   i32.const 3498
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43191,7 +43045,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3508
+   i32.const 3499
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43204,7 +43058,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3509
+   i32.const 3500
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43217,7 +43071,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3510
+   i32.const 3501
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43230,7 +43084,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3511
+   i32.const 3502
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43243,7 +43097,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3520
+   i32.const 3511
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43256,7 +43110,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3521
+   i32.const 3512
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43269,7 +43123,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3522
+   i32.const 3513
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43282,7 +43136,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3523
+   i32.const 3514
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43295,7 +43149,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3524
+   i32.const 3515
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43308,7 +43162,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3525
+   i32.const 3516
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43321,7 +43175,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3526
+   i32.const 3517
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43334,7 +43188,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3527
+   i32.const 3518
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43347,7 +43201,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3528
+   i32.const 3519
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43360,7 +43214,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3529
+   i32.const 3520
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43373,7 +43227,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3532
+   i32.const 3523
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43386,7 +43240,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3533
+   i32.const 3524
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43399,7 +43253,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3534
+   i32.const 3525
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43412,7 +43266,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3535
+   i32.const 3526
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43425,7 +43279,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3536
+   i32.const 3527
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43438,7 +43292,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3537
+   i32.const 3528
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43451,7 +43305,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3538
+   i32.const 3529
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43464,7 +43318,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3539
+   i32.const 3530
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43477,7 +43331,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3540
+   i32.const 3531
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43490,7 +43344,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3541
+   i32.const 3532
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43503,7 +43357,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3542
+   i32.const 3533
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43516,7 +43370,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3543
+   i32.const 3534
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43529,7 +43383,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3544
+   i32.const 3535
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43542,7 +43396,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3545
+   i32.const 3536
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43555,7 +43409,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3546
+   i32.const 3537
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43568,7 +43422,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3547
+   i32.const 3538
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43581,7 +43435,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3548
+   i32.const 3539
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43594,7 +43448,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3549
+   i32.const 3540
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43607,7 +43461,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3550
+   i32.const 3541
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43620,7 +43474,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3551
+   i32.const 3542
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43633,7 +43487,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3552
+   i32.const 3543
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43646,7 +43500,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3553
+   i32.const 3544
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43659,7 +43513,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3565
+   i32.const 3556
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43672,7 +43526,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3566
+   i32.const 3557
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43685,7 +43539,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3567
+   i32.const 3558
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43698,7 +43552,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3568
+   i32.const 3559
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43711,7 +43565,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3569
+   i32.const 3560
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43724,7 +43578,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3570
+   i32.const 3561
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43737,7 +43591,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3571
+   i32.const 3562
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43750,7 +43604,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3572
+   i32.const 3563
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43763,7 +43617,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3573
+   i32.const 3564
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43776,7 +43630,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3574
+   i32.const 3565
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43789,7 +43643,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3577
+   i32.const 3568
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43802,7 +43656,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3578
+   i32.const 3569
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43815,7 +43669,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3579
+   i32.const 3570
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43828,7 +43682,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3580
+   i32.const 3571
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43841,7 +43695,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3581
+   i32.const 3572
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43854,7 +43708,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3582
+   i32.const 3573
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43867,7 +43721,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3583
+   i32.const 3574
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43880,7 +43734,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3584
+   i32.const 3575
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43893,7 +43747,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3585
+   i32.const 3576
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43906,7 +43760,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3586
+   i32.const 3577
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43919,7 +43773,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3587
+   i32.const 3578
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43932,7 +43786,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3588
+   i32.const 3579
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43945,7 +43799,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3589
+   i32.const 3580
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43958,7 +43812,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3590
+   i32.const 3581
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43971,7 +43825,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3591
+   i32.const 3582
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43984,7 +43838,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3592
+   i32.const 3583
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43997,7 +43851,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3593
+   i32.const 3584
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44010,7 +43864,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3594
+   i32.const 3585
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44023,7 +43877,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3595
+   i32.const 3586
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44036,7 +43890,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3596
+   i32.const 3587
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44049,7 +43903,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3597
+   i32.const 3588
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44062,7 +43916,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3598
+   i32.const 3589
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44075,7 +43929,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3599
+   i32.const 3590
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44088,7 +43942,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3600
+   i32.const 3591
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44101,7 +43955,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3601
+   i32.const 3592
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44114,13 +43968,130 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3602
+   i32.const 3593
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1e-323
   f64.const 1e-323
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3594
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.4e-323
+  f64.const 4.4e-323
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3595
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 5.562684646268003e-309
+  f64.const 5.562684646268003e-309
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3596
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.1125369292536007e-308
+  f64.const 1.1125369292536007e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3597
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.2250738585072004e-308
+  f64.const 2.2250738585072004e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3598
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.225073858507201e-308
+  f64.const 2.225073858507201e-308
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3599
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1e-323
+  f64.const -1e-323
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3600
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.4e-323
+  f64.const -4.4e-323
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3601
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -5.562684646268003e-309
+  f64.const -5.562684646268003e-309
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3602
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.1125369292536007e-308
+  f64.const -1.1125369292536007e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -44132,8 +44103,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4e-323
-  f64.const 4.4e-323
+  f64.const -2.2250738585072004e-308
+  f64.const -2.2250738585072004e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -44145,8 +44116,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5.562684646268003e-309
-  f64.const 5.562684646268003e-309
+  f64.const -2.225073858507201e-308
+  f64.const -2.225073858507201e-308
   f64.const 0
   call $std/math/test_tan
   i32.eqz
@@ -44158,37 +44129,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.1125369292536007e-308
-  f64.const 1.1125369292536007e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3606
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072004e-308
-  f64.const 2.2250738585072004e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3607
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507201e-308
-  f64.const 2.225073858507201e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
+  f64.const 2.3283064365386963e-10
+  call $~lib/math/NativeMath.tan
+  f64.const 2.3283064365386963e-10
+  call $~lib/bindings/Math/tan
+  f64.ne
   if
    i32.const 0
    i32.const 32
@@ -44197,11 +44142,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1e-323
-  f64.const -1e-323
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
+  f64.const -2.3283064365386963e-10
+  call $~lib/math/NativeMath.tan
+  f64.const -2.3283064365386963e-10
+  call $~lib/bindings/Math/tan
+  f64.ne
   if
    i32.const 0
    i32.const 32
@@ -44210,11 +44155,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4e-323
-  f64.const -4.4e-323
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
+  f64.const 0.6875
+  call $~lib/math/NativeMath.tan
+  f64.const 0.6875
+  call $~lib/bindings/Math/tan
+  f64.ne
   if
    i32.const 0
    i32.const 32
@@ -44223,11 +44168,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5.562684646268003e-309
-  f64.const -5.562684646268003e-309
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
+  f64.const -0.6875
+  call $~lib/math/NativeMath.tan
+  f64.const -0.6875
+  call $~lib/bindings/Math/tan
+  f64.ne
   if
    i32.const 0
    i32.const 32
@@ -44236,11 +44181,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.1125369292536007e-308
-  f64.const -1.1125369292536007e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
+  f64.const 0.39269908169872414
+  call $~lib/math/NativeMath.tan
+  f64.const 0.39269908169872414
+  call $~lib/bindings/Math/tan
+  f64.ne
   if
    i32.const 0
    i32.const 32
@@ -44249,11 +44194,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072004e-308
-  f64.const -2.2250738585072004e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
+  f64.const 0.6743358
+  call $~lib/math/NativeMath.tan
+  f64.const 0.6743358
+  call $~lib/bindings/Math/tan
+  f64.ne
   if
    i32.const 0
    i32.const 32
@@ -44262,11 +44207,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.225073858507201e-308
-  f64.const -2.225073858507201e-308
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
+  f64.const 3.725290298461914e-09
+  call $~lib/math/NativeMath.tan
+  f64.const 3.725290298461914e-09
+  call $~lib/bindings/Math/tan
+  f64.ne
   if
    i32.const 0
    i32.const 32
@@ -44275,9 +44220,22 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.3283064365386963e-10
+  f64.const 1.5707963267948966
   call $~lib/math/NativeMath.tan
-  f64.const 2.3283064365386963e-10
+  f64.const 1.5707963267948966
+  call $~lib/bindings/Math/tan
+  f64.ne
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3615
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
+  call $~lib/math/NativeMath.tan
+  f64.const 0.5
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -44288,9 +44246,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.3283064365386963e-10
+  f64.const 1.107148717794091
   call $~lib/math/NativeMath.tan
-  f64.const -2.3283064365386963e-10
+  f64.const 1.107148717794091
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -44301,9 +44259,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.6875
+  f64.const 5.497787143782138
   call $~lib/math/NativeMath.tan
-  f64.const 0.6875
+  f64.const 5.497787143782138
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -44314,9 +44272,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.6875
+  f64.const 7.0685834705770345
   call $~lib/math/NativeMath.tan
-  f64.const -0.6875
+  f64.const 7.0685834705770345
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -44327,9 +44285,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.39269908169872414
+  f64.const 1647099.3291652855
   call $~lib/math/NativeMath.tan
-  f64.const 0.39269908169872414
+  f64.const 1647099.3291652855
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -44340,9 +44298,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.6743358
+  f64.const 1647097.7583689587
   call $~lib/math/NativeMath.tan
-  f64.const 0.6743358
+  f64.const 1647097.7583689587
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -44353,9 +44311,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 3.725290298461914e-09
+  f64.const 1329227995784915872903807e12
   call $~lib/math/NativeMath.tan
-  f64.const 3.725290298461914e-09
+  f64.const 1329227995784915872903807e12
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -44366,9 +44324,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5707963267948966
+  f64.const -1329227995784915872903807e12
   call $~lib/math/NativeMath.tan
-  f64.const 1.5707963267948966
+  f64.const -1329227995784915872903807e12
   call $~lib/bindings/Math/tan
   f64.ne
   if
@@ -44379,24 +44337,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
-  call $~lib/math/NativeMath.tan
-  f64.const 0.5
-  call $~lib/bindings/Math/tan
-  f64.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3626
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.107148717794091
-  call $~lib/math/NativeMath.tan
-  f64.const 1.107148717794091
-  call $~lib/bindings/Math/tan
-  f64.ne
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
   if
    i32.const 0
    i32.const 32
@@ -44405,106 +44350,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5.497787143782138
-  call $~lib/math/NativeMath.tan
-  f64.const 5.497787143782138
-  call $~lib/bindings/Math/tan
-  f64.ne
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  call $std/math/test_tan
+  i32.eqz
   if
    i32.const 0
    i32.const 32
    i32.const 3628
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 7.0685834705770345
-  call $~lib/math/NativeMath.tan
-  f64.const 7.0685834705770345
-  call $~lib/bindings/Math/tan
-  f64.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3629
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1647099.3291652855
-  call $~lib/math/NativeMath.tan
-  f64.const 1647099.3291652855
-  call $~lib/bindings/Math/tan
-  f64.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3630
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1647097.7583689587
-  call $~lib/math/NativeMath.tan
-  f64.const 1647097.7583689587
-  call $~lib/bindings/Math/tan
-  f64.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3631
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1329227995784915872903807e12
-  call $~lib/math/NativeMath.tan
-  f64.const 1329227995784915872903807e12
-  call $~lib/bindings/Math/tan
-  f64.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3632
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1329227995784915872903807e12
-  call $~lib/math/NativeMath.tan
-  f64.const -1329227995784915872903807e12
-  call $~lib/bindings/Math/tan
-  f64.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3633
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3636
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3637
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44517,7 +44371,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3638
+   i32.const 3629
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44530,7 +44384,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3639
+   i32.const 3630
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44543,7 +44397,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3640
+   i32.const 3631
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44556,7 +44410,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3649
+   i32.const 3640
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44569,7 +44423,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3650
+   i32.const 3641
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44582,7 +44436,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3651
+   i32.const 3642
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44595,7 +44449,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3652
+   i32.const 3643
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44608,7 +44462,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3653
+   i32.const 3644
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44621,7 +44475,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3654
+   i32.const 3645
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44634,7 +44488,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3655
+   i32.const 3646
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44647,7 +44501,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3656
+   i32.const 3647
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44660,7 +44514,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3657
+   i32.const 3648
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44673,7 +44527,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3658
+   i32.const 3649
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44686,7 +44540,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3661
+   i32.const 3652
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44699,7 +44553,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3662
+   i32.const 3653
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44712,7 +44566,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3663
+   i32.const 3654
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44725,7 +44579,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3664
+   i32.const 3655
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44738,7 +44592,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3665
+   i32.const 3656
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44751,7 +44605,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3668
+   i32.const 3659
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44764,13 +44618,130 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3669
+   i32.const 3660
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.1754943508222875e-38
   f32.const 1.1754943508222875e-38
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3661
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754943508222875e-38
+  f32.const -1.1754943508222875e-38
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3662
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.401298464324817e-45
+  f32.const 1.401298464324817e-45
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3663
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.401298464324817e-45
+  f32.const -1.401298464324817e-45
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3664
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.175494490952134e-38
+  f32.const 1.175494490952134e-38
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3665
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.1754946310819804e-38
+  f32.const 1.1754946310819804e-38
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3666
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.3509880009953429e-38
+  f32.const 2.3509880009953429e-38
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3667
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.350988701644575e-38
+  f32.const 2.350988701644575e-38
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3668
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.3509895424236536e-38
+  f32.const 2.3509895424236536e-38
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3669
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4.70197740328915e-38
+  f32.const 4.70197740328915e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -44782,9 +44753,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754943508222875e-38
-  f32.const -1.1754943508222875e-38
-  f32.const 0
+  f32.const 1.1175870895385742e-08
+  f32.const 1.1175870895385742e-08
+  f32.const -5.238689482212067e-10
   call $std/math/test_tanf
   i32.eqz
   if
@@ -44795,9 +44766,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.401298464324817e-45
-  f32.const 1.401298464324817e-45
-  f32.const 0
+  f32.const 1.4901161193847656e-08
+  f32.const 1.4901161193847656e-08
+  f32.const -6.208817349140361e-10
   call $std/math/test_tanf
   i32.eqz
   if
@@ -44808,9 +44779,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.401298464324817e-45
-  f32.const -1.401298464324817e-45
-  f32.const 0
+  f32.const 0.000244140625
+  f32.const 0.000244140625
+  f32.const -0.1666666716337204
   call $std/math/test_tanf
   i32.eqz
   if
@@ -44821,8 +44792,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.175494490952134e-38
-  f32.const 1.175494490952134e-38
+  f32.const -1.175494490952134e-38
+  f32.const -1.175494490952134e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -44834,8 +44805,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754946310819804e-38
-  f32.const 1.1754946310819804e-38
+  f32.const -1.1754946310819804e-38
+  f32.const -1.1754946310819804e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -44847,8 +44818,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509880009953429e-38
-  f32.const 2.3509880009953429e-38
+  f32.const -2.3509880009953429e-38
+  f32.const -2.3509880009953429e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -44873,8 +44844,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509895424236536e-38
-  f32.const 2.3509895424236536e-38
+  f32.const -2.3509895424236536e-38
+  f32.const -2.3509895424236536e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -44886,8 +44857,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.70197740328915e-38
-  f32.const 4.70197740328915e-38
+  f32.const -4.70197740328915e-38
+  f32.const -4.70197740328915e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -44895,123 +44866,6 @@
    i32.const 0
    i32.const 32
    i32.const 3679
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1175870895385742e-08
-  f32.const 1.1175870895385742e-08
-  f32.const -5.238689482212067e-10
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3680
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.4901161193847656e-08
-  f32.const 1.4901161193847656e-08
-  f32.const -6.208817349140361e-10
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3681
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.000244140625
-  f32.const 0.000244140625
-  f32.const -0.1666666716337204
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3682
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.175494490952134e-38
-  f32.const -1.175494490952134e-38
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3683
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754946310819804e-38
-  f32.const -1.1754946310819804e-38
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3684
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.3509880009953429e-38
-  f32.const -2.3509880009953429e-38
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3685
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.350988701644575e-38
-  f32.const 2.350988701644575e-38
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3686
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.3509895424236536e-38
-  f32.const -2.3509895424236536e-38
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3687
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -4.70197740328915e-38
-  f32.const -4.70197740328915e-38
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3688
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45024,7 +44878,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3689
+   i32.const 3680
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45037,7 +44891,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3690
+   i32.const 3681
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45050,13 +44904,130 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3691
+   i32.const 3682
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 2.802596928649634e-45
   f32.const 2.802596928649634e-45
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3683
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.2611686178923354e-44
+  f32.const 1.2611686178923354e-44
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3684
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.938735877055719e-39
+  f32.const 2.938735877055719e-39
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3685
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 5.877471754111438e-39
+  f32.const 5.877471754111438e-39
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3686
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.1754940705625946e-38
+  f32.const 1.1754940705625946e-38
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3687
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.1754942106924411e-38
+  f32.const 1.1754942106924411e-38
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3688
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.802596928649634e-45
+  f32.const -2.802596928649634e-45
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3689
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.2611686178923354e-44
+  f32.const -1.2611686178923354e-44
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3690
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.938735877055719e-39
+  f32.const -2.938735877055719e-39
+  f32.const 0
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3691
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -5.877471754111438e-39
+  f32.const -5.877471754111438e-39
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -45068,8 +45039,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.2611686178923354e-44
-  f32.const 1.2611686178923354e-44
+  f32.const -1.1754940705625946e-38
+  f32.const -1.1754940705625946e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -45081,8 +45052,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.938735877055719e-39
-  f32.const 2.938735877055719e-39
+  f32.const -1.1754942106924411e-38
+  f32.const -1.1754942106924411e-38
   f32.const 0
   call $std/math/test_tanf
   i32.eqz
@@ -45090,123 +45061,6 @@
    i32.const 0
    i32.const 32
    i32.const 3694
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 5.877471754111438e-39
-  f32.const 5.877471754111438e-39
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3695
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754940705625946e-38
-  f32.const 1.1754940705625946e-38
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3696
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754942106924411e-38
-  f32.const 1.1754942106924411e-38
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3697
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.802596928649634e-45
-  f32.const -2.802596928649634e-45
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3698
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.2611686178923354e-44
-  f32.const -1.2611686178923354e-44
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3699
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.938735877055719e-39
-  f32.const -2.938735877055719e-39
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3700
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -5.877471754111438e-39
-  f32.const -5.877471754111438e-39
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3701
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754940705625946e-38
-  f32.const -1.1754940705625946e-38
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3702
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754942106924411e-38
-  f32.const -1.1754942106924411e-38
-  f32.const 0
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3703
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45219,7 +45073,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3715
+   i32.const 3706
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45232,7 +45086,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3716
+   i32.const 3707
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45245,7 +45099,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3717
+   i32.const 3708
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45258,7 +45112,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3718
+   i32.const 3709
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45271,7 +45125,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3719
+   i32.const 3710
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45284,7 +45138,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3720
+   i32.const 3711
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45297,7 +45151,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3721
+   i32.const 3712
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45310,7 +45164,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3722
+   i32.const 3713
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45323,7 +45177,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3723
+   i32.const 3714
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45336,7 +45190,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3724
+   i32.const 3715
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45349,7 +45203,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3727
+   i32.const 3718
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45362,7 +45216,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3728
+   i32.const 3719
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45375,7 +45229,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3729
+   i32.const 3720
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45388,7 +45242,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3730
+   i32.const 3721
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45401,7 +45255,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3731
+   i32.const 3722
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45414,7 +45268,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3740
+   i32.const 3731
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45427,7 +45281,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3741
+   i32.const 3732
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45440,7 +45294,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3742
+   i32.const 3733
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45453,7 +45307,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3743
+   i32.const 3734
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45466,7 +45320,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3744
+   i32.const 3735
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45479,7 +45333,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3745
+   i32.const 3736
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45492,7 +45346,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3746
+   i32.const 3737
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45505,7 +45359,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3747
+   i32.const 3738
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45518,7 +45372,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3748
+   i32.const 3739
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45531,7 +45385,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3749
+   i32.const 3740
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45544,7 +45398,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3752
+   i32.const 3743
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45557,7 +45411,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3753
+   i32.const 3744
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45570,7 +45424,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3754
+   i32.const 3745
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45583,7 +45437,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3755
+   i32.const 3746
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45596,7 +45450,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3756
+   i32.const 3747
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45608,7 +45462,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3768
+   i32.const 3759
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45620,7 +45474,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3769
+   i32.const 3760
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45632,7 +45486,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3770
+   i32.const 3761
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45644,7 +45498,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3771
+   i32.const 3762
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45656,7 +45510,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3772
+   i32.const 3763
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45668,7 +45522,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3773
+   i32.const 3764
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45680,7 +45534,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3774
+   i32.const 3765
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45692,7 +45546,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3775
+   i32.const 3766
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45704,7 +45558,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3776
+   i32.const 3767
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45716,91 +45570,91 @@
   if
    i32.const 0
    i32.const 32
+   i32.const 3768
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3771
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3772
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -inf
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3773
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3774
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3775
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 1
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3776
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const -1
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
    i32.const 3777
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3780
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3781
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -inf
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3782
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3783
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3784
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3785
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -1
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3786
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45812,7 +45666,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3787
+   i32.const 3778
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45824,7 +45678,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3788
+   i32.const 3779
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45836,7 +45690,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3789
+   i32.const 3780
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45848,7 +45702,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3790
+   i32.const 3781
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45860,7 +45714,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3791
+   i32.const 3782
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45872,7 +45726,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3792
+   i32.const 3783
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45884,7 +45738,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3793
+   i32.const 3784
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45896,7 +45750,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3794
+   i32.const 3785
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45908,7 +45762,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3803
+   i32.const 3794
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45920,7 +45774,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3804
+   i32.const 3795
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45932,7 +45786,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3805
+   i32.const 3796
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45944,7 +45798,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3806
+   i32.const 3797
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45956,7 +45810,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3807
+   i32.const 3798
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45968,7 +45822,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3808
+   i32.const 3799
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45980,7 +45834,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3809
+   i32.const 3800
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45992,7 +45846,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3810
+   i32.const 3801
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46004,7 +45858,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3811
+   i32.const 3802
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46016,91 +45870,91 @@
   if
    i32.const 0
    i32.const 32
+   i32.const 3803
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3806
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3807
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -inf
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3808
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3809
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3810
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 1
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3811
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const -1
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
    i32.const 3812
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3815
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3816
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -inf
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3817
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3818
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3819
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3820
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -1
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3821
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46112,7 +45966,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3822
+   i32.const 3813
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46124,7 +45978,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3823
+   i32.const 3814
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46136,7 +45990,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3824
+   i32.const 3815
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46148,7 +46002,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3825
+   i32.const 3816
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46160,7 +46014,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3826
+   i32.const 3817
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46172,7 +46026,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3827
+   i32.const 3818
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46184,7 +46038,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3828
+   i32.const 3819
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46196,7 +46050,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3829
+   i32.const 3820
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46269,7 +46123,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3870
+   i32.const 3861
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46282,7 +46136,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3871
+   i32.const 3862
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46295,7 +46149,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3872
+   i32.const 3863
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46308,7 +46162,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3873
+   i32.const 3864
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46321,7 +46175,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3874
+   i32.const 3865
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46334,7 +46188,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3875
+   i32.const 3866
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46347,7 +46201,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3876
+   i32.const 3867
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46360,7 +46214,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3877
+   i32.const 3868
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46373,7 +46227,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3878
+   i32.const 3869
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46386,7 +46240,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3879
+   i32.const 3870
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46399,7 +46253,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3880
+   i32.const 3871
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46412,7 +46266,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3881
+   i32.const 3872
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46424,7 +46278,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3885
+   i32.const 3876
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46436,7 +46290,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3886
+   i32.const 3877
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46448,7 +46302,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3887
+   i32.const 3878
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46460,7 +46314,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3888
+   i32.const 3879
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46472,7 +46326,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3889
+   i32.const 3880
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46484,7 +46338,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3890
+   i32.const 3881
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46496,7 +46350,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3891
+   i32.const 3882
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46508,7 +46362,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3892
+   i32.const 3883
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46520,7 +46374,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3893
+   i32.const 3884
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46532,7 +46386,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3894
+   i32.const 3885
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46544,7 +46398,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3895
+   i32.const 3886
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46556,7 +46410,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3896
+   i32.const 3887
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46568,7 +46422,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3897
+   i32.const 3888
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46580,7 +46434,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3898
+   i32.const 3889
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46592,7 +46446,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3899
+   i32.const 3890
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46604,7 +46458,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3900
+   i32.const 3891
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46617,7 +46471,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3904
+   i32.const 3895
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46627,6 +46481,97 @@
   call $~lib/math/ipow64
   i64.eqz
   i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3896
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 0
+  i32.const 2
+  call $~lib/math/ipow64
+  i64.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3897
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 0
+  i32.const 3
+  call $~lib/math/ipow64
+  i64.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3898
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 1
+  i32.const 0
+  call $~lib/math/ipow64
+  i64.const 1
+  i64.ne
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3900
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 1
+  i32.const 1
+  call $~lib/math/ipow64
+  i64.const 1
+  i64.ne
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3901
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 1
+  i32.const 2
+  call $~lib/math/ipow64
+  i64.const 1
+  i64.ne
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3902
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 1
+  i32.const 3
+  call $~lib/math/ipow64
+  i64.const 1
+  i64.ne
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3903
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 2
+  i32.const 0
+  call $~lib/math/ipow64
+  i64.const 1
+  i64.ne
   if
    i32.const 0
    i32.const 32
@@ -46635,106 +46580,15 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 0
-  i32.const 2
+  i64.const 2
+  i32.const 1
   call $~lib/math/ipow64
-  i64.eqz
-  i32.eqz
+  i64.const 2
+  i64.ne
   if
    i32.const 0
    i32.const 32
    i32.const 3906
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 0
-  i32.const 3
-  call $~lib/math/ipow64
-  i64.eqz
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3907
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 1
-  i32.const 0
-  call $~lib/math/ipow64
-  i64.const 1
-  i64.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3909
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 1
-  i32.const 1
-  call $~lib/math/ipow64
-  i64.const 1
-  i64.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3910
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 1
-  i32.const 2
-  call $~lib/math/ipow64
-  i64.const 1
-  i64.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3911
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 1
-  i32.const 3
-  call $~lib/math/ipow64
-  i64.const 1
-  i64.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3912
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 2
-  i32.const 0
-  call $~lib/math/ipow64
-  i64.const 1
-  i64.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3914
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 2
-  i32.const 1
-  call $~lib/math/ipow64
-  i64.const 2
-  i64.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3915
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46747,7 +46601,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3916
+   i32.const 3907
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46760,7 +46614,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3917
+   i32.const 3908
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46773,7 +46627,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3919
+   i32.const 3910
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46786,7 +46640,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3920
+   i32.const 3911
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46799,7 +46653,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3921
+   i32.const 3912
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46812,7 +46666,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3922
+   i32.const 3913
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46825,7 +46679,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3924
+   i32.const 3915
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46838,7 +46692,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3925
+   i32.const 3916
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46851,7 +46705,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3926
+   i32.const 3917
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46864,7 +46718,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3927
+   i32.const 3918
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46877,7 +46731,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3929
+   i32.const 3920
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46890,7 +46744,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3930
+   i32.const 3921
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46903,7 +46757,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3931
+   i32.const 3922
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46916,7 +46770,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3932
+   i32.const 3923
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46929,7 +46783,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3933
+   i32.const 3924
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46942,7 +46796,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3934
+   i32.const 3925
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46955,7 +46809,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3935
+   i32.const 3926
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46972,7 +46826,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3937
+   i32.const 3928
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46985,12 +46839,132 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3941
+   i32.const 3932
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
+  i32.const 0
+  call $~lib/math/ipow32f
+  f32.const 1
+  f32.ne
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3933
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  i32.const 1
+  call $~lib/math/ipow32f
+  local.tee $1
+  local.get $1
+  f32.eq
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3934
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  i32.const -1
+  call $~lib/math/ipow32f
+  local.tee $1
+  local.get $1
+  f32.eq
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3935
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  i32.const 2
+  call $~lib/math/ipow32f
+  local.tee $1
+  local.get $1
+  f32.eq
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3936
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  i32.const 0
+  call $~lib/math/ipow32f
+  f32.const 1
+  f32.ne
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3937
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  i32.const 1
+  call $~lib/math/ipow32f
+  f32.const inf
+  f32.ne
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3938
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  i32.const 0
+  call $~lib/math/ipow32f
+  f32.const 1
+  f32.ne
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3939
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  i32.const 1
+  call $~lib/math/ipow32f
+  f32.const -inf
+  f32.ne
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3940
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  i32.const 2
+  call $~lib/math/ipow32f
+  f32.const inf
+  f32.ne
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3941
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
   i32.const 0
   call $~lib/math/ipow32f
   f32.const 1
@@ -47003,126 +46977,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  i32.const 1
-  call $~lib/math/ipow32f
-  local.tee $1
-  local.get $1
-  f32.eq
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3943
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  i32.const -1
-  call $~lib/math/ipow32f
-  local.tee $1
-  local.get $1
-  f32.eq
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3944
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  i32.const 2
-  call $~lib/math/ipow32f
-  local.tee $1
-  local.get $1
-  f32.eq
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3945
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  i32.const 0
-  call $~lib/math/ipow32f
-  f32.const 1
-  f32.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3946
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  i32.const 1
-  call $~lib/math/ipow32f
-  f32.const inf
-  f32.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3947
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  i32.const 0
-  call $~lib/math/ipow32f
-  f32.const 1
-  f32.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3948
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  i32.const 1
-  call $~lib/math/ipow32f
-  f32.const -inf
-  f32.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3949
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  i32.const 2
-  call $~lib/math/ipow32f
-  f32.const inf
-  f32.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3950
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  i32.const 0
-  call $~lib/math/ipow32f
-  f32.const 1
-  f32.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3951
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const 3402823466385288598117041e14
   i32.const 2
   call $~lib/math/ipow32f
@@ -47131,7 +46985,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3952
+   i32.const 3943
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47144,7 +46998,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3953
+   i32.const 3944
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47157,7 +47011,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3954
+   i32.const 3945
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47170,7 +47024,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3955
+   i32.const 3946
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47183,7 +47037,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3956
+   i32.const 3947
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47196,12 +47050,132 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3960
+   i32.const 3951
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
+  i32.const 0
+  call $~lib/math/ipow64f
+  f64.const 1
+  f64.ne
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3952
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  i32.const 1
+  call $~lib/math/ipow64f
+  local.tee $0
+  local.get $0
+  f64.eq
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3953
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  i32.const -1
+  call $~lib/math/ipow64f
+  local.tee $0
+  local.get $0
+  f64.eq
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3954
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  i32.const 2
+  call $~lib/math/ipow64f
+  local.tee $0
+  local.get $0
+  f64.eq
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3955
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  i32.const 0
+  call $~lib/math/ipow64f
+  f64.const 1
+  f64.ne
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3956
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  i32.const 1
+  call $~lib/math/ipow64f
+  f64.const inf
+  f64.ne
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3957
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  i32.const 0
+  call $~lib/math/ipow64f
+  f64.const 1
+  f64.ne
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3958
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  i32.const 1
+  call $~lib/math/ipow64f
+  f64.const -inf
+  f64.ne
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3959
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  i32.const 2
+  call $~lib/math/ipow64f
+  f64.const inf
+  f64.ne
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3960
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
   i32.const 0
   call $~lib/math/ipow64f
   f64.const 1
@@ -47214,126 +47188,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  i32.const 1
-  call $~lib/math/ipow64f
-  local.tee $0
-  local.get $0
-  f64.eq
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3962
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  i32.const -1
-  call $~lib/math/ipow64f
-  local.tee $0
-  local.get $0
-  f64.eq
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3963
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  i32.const 2
-  call $~lib/math/ipow64f
-  local.tee $0
-  local.get $0
-  f64.eq
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3964
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  i32.const 0
-  call $~lib/math/ipow64f
-  f64.const 1
-  f64.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3965
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  i32.const 1
-  call $~lib/math/ipow64f
-  f64.const inf
-  f64.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3966
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  i32.const 0
-  call $~lib/math/ipow64f
-  f64.const 1
-  f64.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3967
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  i32.const 1
-  call $~lib/math/ipow64f
-  f64.const -inf
-  f64.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3968
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  i32.const 2
-  call $~lib/math/ipow64f
-  f64.const inf
-  f64.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3969
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  i32.const 0
-  call $~lib/math/ipow64f
-  f64.const 1
-  f64.ne
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3970
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const 1797693134862315708145274e284
   i32.const 2
   call $~lib/math/ipow64f
@@ -47342,7 +47196,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3971
+   i32.const 3962
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47355,7 +47209,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3972
+   i32.const 3963
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47368,7 +47222,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3973
+   i32.const 3964
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47381,7 +47235,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3974
+   i32.const 3965
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47394,7 +47248,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3975
+   i32.const 3966
    i32.const 0
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -7178,13 +7178,13 @@
    f64.const 0.5
    f64.eq
    if
-    f64.const inf
     local.get $0
     f64.sqrt
     f64.abs
+    f64.const inf
     local.get $0
     f64.const -inf
-    f64.eq
+    f64.ne
     select
     return
    end
@@ -7201,21 +7201,19 @@
    f64.const -0.5
    f64.eq
    if
-    local.get $0
-    f64.const 0
-    f64.eq
-    if
-     f64.const inf
-     return
-    end
-    f64.const 0
     f64.const 1
     local.get $0
     f64.sqrt
     f64.div
+    f64.const 0
     local.get $0
     f64.const -inf
-    f64.eq
+    f64.ne
+    select
+    f64.const inf
+    local.get $0
+    f64.const 0
+    f64.ne
     select
     return
    end
@@ -8163,13 +8161,13 @@
    f32.const 0.5
    f32.eq
    if
-    f32.const inf
     local.get $0
     f32.sqrt
     f32.abs
+    f32.const inf
     local.get $0
     f32.const -inf
-    f32.eq
+    f32.ne
     select
     return
    end
@@ -8186,21 +8184,19 @@
    f32.const -0.5
    f32.eq
    if
-    local.get $0
-    f32.const 0
-    f32.eq
-    if
-     f32.const inf
-     return
-    end
-    f32.const 0
     f32.const 1
     local.get $0
     f32.sqrt
     f32.div
+    f32.const 0
     local.get $0
     f32.const -inf
-    f32.eq
+    f32.ne
+    select
+    f32.const inf
+    local.get $0
+    f32.const 0
+    f32.ne
     select
     return
    end
@@ -8699,7 +8695,7 @@
   if
    i32.const 0
    i32.const 3104
-   i32.const 1404
+   i32.const 1413
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -8713,7 +8709,7 @@
   if
    i32.const 3152
    i32.const 3104
-   i32.const 1411
+   i32.const 1420
    i32.const 24
    call $~lib/builtins/abort
    unreachable
@@ -8757,7 +8753,7 @@
   if
    i32.const 3152
    i32.const 3104
-   i32.const 2602
+   i32.const 2620
    i32.const 24
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/math.optimized.wat
+++ b/tests/compiler/std/math.optimized.wat
@@ -7181,9 +7181,9 @@
     f64.const inf
     local.get $0
     f64.sqrt
-    local.get $0
     f64.abs
-    f64.const inf
+    local.get $0
+    f64.const -inf
     f64.eq
     select
     return
@@ -7214,8 +7214,7 @@
     f64.sqrt
     f64.div
     local.get $0
-    f64.abs
-    f64.const inf
+    f64.const -inf
     f64.eq
     select
     return
@@ -8167,9 +8166,9 @@
     f32.const inf
     local.get $0
     f32.sqrt
-    local.get $0
     f32.abs
-    f32.const inf
+    local.get $0
+    f32.const -inf
     f32.eq
     select
     return
@@ -8200,8 +8199,7 @@
     f32.sqrt
     f32.div
     local.get $0
-    f32.abs
-    f32.const inf
+    f32.const -inf
     f32.eq
     select
     return

--- a/tests/compiler/std/math.ts
+++ b/tests/compiler/std/math.ts
@@ -2728,15 +2728,6 @@ assert(NativeMath.pow(+Infinity, 0.5) == +Infinity);
 assert(NativeMath.pow(-Infinity, 0.5) == +Infinity);
 assert(isNaN(NativeMath.pow(NaN, 0.5)));
 
-assert(NativeMath.pow(+0.0,-0.5) == +Infinity);
-assert(NativeMath.pow(-0.0,-0.5) == +Infinity);
-assert(isNaN(NativeMath.pow(-1.0,-0.5)));
-assert(NativeMath.pow( 4.0,-0.5) == +0.5);
-assert(NativeMath.pow( 1.0,-0.5) == +1.0);
-assert(NativeMath.pow(+Infinity,-0.5) == +0.0);
-assert(NativeMath.pow(-Infinity,-0.5) == +0.0);
-assert(isNaN(NativeMath.pow(NaN,-0.5)));
-
 // Mathf.pow ///////////////////////////////////////////////////////////////////////////////////////
 
 function test_powf(left: f32, right: f32, expected: f32, error: f32, flags: i32): bool {

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -9687,14 +9687,14 @@
    f64.const 0.5
    f64.eq
    if
-    f64.const inf
     local.get $0
     f64.sqrt
     f64.abs
+    f64.const inf
     local.get $0
     f64.const inf
     f64.neg
-    f64.eq
+    f64.ne
     select
     return
    end
@@ -9711,22 +9711,20 @@
    f64.const -0.5
    f64.eq
    if
-    local.get $0
-    f64.const 0
-    f64.eq
-    if
-     f64.const inf
-     return
-    end
-    f64.const 0
     f64.const 1
     local.get $0
     f64.sqrt
     f64.div
+    f64.const 0
     local.get $0
     f64.const inf
     f64.neg
-    f64.eq
+    f64.ne
+    select
+    f64.const inf
+    local.get $0
+    f64.const 0
+    f64.ne
     select
     return
    end
@@ -10685,14 +10683,14 @@
    f32.const 0.5
    f32.eq
    if
-    f32.const inf
     local.get $0
     f32.sqrt
     f32.abs
+    f32.const inf
     local.get $0
     f32.const inf
     f32.neg
-    f32.eq
+    f32.ne
     select
     return
    end
@@ -10709,22 +10707,20 @@
    f32.const -0.5
    f32.eq
    if
-    local.get $0
-    f32.const 0
-    f32.eq
-    if
-     f32.const inf
-     return
-    end
-    f32.const 0
     f32.const 1
     local.get $0
     f32.sqrt
     f32.div
+    f32.const 0
     local.get $0
     f32.const inf
     f32.neg
-    f32.eq
+    f32.ne
+    select
+    f32.const inf
+    local.get $0
+    f32.const 0
+    f32.ne
     select
     return
    end
@@ -11377,7 +11373,7 @@
   if
    i32.const 0
    i32.const 13888
-   i32.const 1404
+   i32.const 1413
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -11392,7 +11388,7 @@
   if
    i32.const 13936
    i32.const 13888
-   i32.const 1411
+   i32.const 1420
    i32.const 24
    call $~lib/builtins/abort
    unreachable
@@ -11447,7 +11443,7 @@
   if
    i32.const 13936
    i32.const 13888
-   i32.const 2602
+   i32.const 2620
    i32.const 24
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -9690,9 +9690,10 @@
     f64.const inf
     local.get $0
     f64.sqrt
-    local.get $0
     f64.abs
+    local.get $0
     f64.const inf
+    f64.neg
     f64.eq
     select
     return
@@ -9723,8 +9724,8 @@
     f64.sqrt
     f64.div
     local.get $0
-    f64.abs
     f64.const inf
+    f64.neg
     f64.eq
     select
     return
@@ -10687,9 +10688,10 @@
     f32.const inf
     local.get $0
     f32.sqrt
-    local.get $0
     f32.abs
+    local.get $0
     f32.const inf
+    f32.neg
     f32.eq
     select
     return
@@ -10720,8 +10722,8 @@
     f32.sqrt
     f32.div
     local.get $0
-    f32.abs
     f32.const inf
+    f32.neg
     f32.eq
     select
     return

--- a/tests/compiler/std/math.untouched.wat
+++ b/tests/compiler/std/math.untouched.wat
@@ -9708,27 +9708,6 @@
     return
    end
    local.get $1
-   f64.const -0.5
-   f64.eq
-   if
-    f64.const 1
-    local.get $0
-    f64.sqrt
-    f64.div
-    f64.const 0
-    local.get $0
-    f64.const inf
-    f64.neg
-    f64.ne
-    select
-    f64.const inf
-    local.get $0
-    f64.const 0
-    f64.ne
-    select
-    return
-   end
-   local.get $1
    f64.const 1
    f64.eq
    if
@@ -10704,27 +10683,6 @@
     return
    end
    local.get $1
-   f32.const -0.5
-   f32.eq
-   if
-    f32.const 1
-    local.get $0
-    f32.sqrt
-    f32.div
-    f32.const 0
-    local.get $0
-    f32.const inf
-    f32.neg
-    f32.ne
-    select
-    f32.const inf
-    local.get $0
-    f32.const 0
-    f32.ne
-    select
-    return
-   end
-   local.get $1
    f32.const 1
    f32.eq
    if
@@ -11373,7 +11331,7 @@
   if
    i32.const 0
    i32.const 13888
-   i32.const 1413
+   i32.const 1406
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -11388,7 +11346,7 @@
   if
    i32.const 13936
    i32.const 13888
-   i32.const 1420
+   i32.const 1413
    i32.const 24
    call $~lib/builtins/abort
    unreachable
@@ -11443,7 +11401,7 @@
   if
    i32.const 13936
    i32.const 13888
-   i32.const 2620
+   i32.const 2606
    i32.const 24
    call $~lib/builtins/abort
    unreachable
@@ -42708,120 +42666,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const -0.5
-  call $~lib/math/NativeMath.pow
-  f64.const inf
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2731
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0.5
-  call $~lib/math/NativeMath.pow
-  f64.const inf
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2732
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -0.5
-  call $~lib/math/NativeMath.pow
-  local.tee $0
-  local.get $0
-  f64.ne
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2733
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4
-  f64.const -0.5
-  call $~lib/math/NativeMath.pow
-  f64.const 0.5
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2734
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const -0.5
-  call $~lib/math/NativeMath.pow
-  f64.const 1
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2735
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -0.5
-  call $~lib/math/NativeMath.pow
-  f64.const 0
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2736
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -0.5
-  call $~lib/math/NativeMath.pow
-  f64.const 0
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2737
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const -0.5
-  call $~lib/math/NativeMath.pow
-  local.tee $0
-  local.get $0
-  f64.ne
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2738
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const -8.066848754882812
   f32.const 4.535662651062012
   f32.const nan:0x400000
@@ -42832,7 +42676,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2747
+   i32.const 2738
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42847,7 +42691,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2748
+   i32.const 2739
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42862,7 +42706,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2749
+   i32.const 2740
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42877,7 +42721,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2750
+   i32.const 2741
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42892,7 +42736,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2751
+   i32.const 2742
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42907,7 +42751,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2752
+   i32.const 2743
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42922,7 +42766,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2753
+   i32.const 2744
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42937,7 +42781,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2754
+   i32.const 2745
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42952,7 +42796,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2755
+   i32.const 2746
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42967,7 +42811,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2756
+   i32.const 2747
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42982,7 +42826,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2759
+   i32.const 2750
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -42997,7 +42841,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2760
+   i32.const 2751
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43012,7 +42856,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2761
+   i32.const 2752
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43027,7 +42871,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2762
+   i32.const 2753
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43042,7 +42886,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2763
+   i32.const 2754
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43057,7 +42901,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2764
+   i32.const 2755
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43072,7 +42916,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2765
+   i32.const 2756
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43087,7 +42931,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2766
+   i32.const 2757
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43102,7 +42946,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2767
+   i32.const 2758
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43117,7 +42961,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2768
+   i32.const 2759
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43132,7 +42976,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2769
+   i32.const 2760
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43147,7 +42991,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2770
+   i32.const 2761
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43162,7 +43006,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2771
+   i32.const 2762
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43177,7 +43021,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2772
+   i32.const 2763
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43192,7 +43036,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2773
+   i32.const 2764
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43207,7 +43051,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2774
+   i32.const 2765
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43222,7 +43066,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2775
+   i32.const 2766
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43237,7 +43081,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2776
+   i32.const 2767
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43252,7 +43096,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2777
+   i32.const 2768
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43267,12 +43111,147 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2778
+   i32.const 2769
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -0
+  f32.const 0
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2770
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2771
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0.5
+  f32.const inf
+  f32.const 0
+  i32.const 4
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2772
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -1
+  f32.const -inf
+  f32.const 0
+  i32.const 4
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2773
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -2
+  f32.const inf
+  f32.const 0
+  i32.const 4
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2774
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -3
+  f32.const -inf
+  f32.const 0
+  i32.const 4
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2775
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -4
+  f32.const inf
+  f32.const 0
+  i32.const 4
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2776
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2777
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const 0
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2778
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
   f32.const 0
   f32.const 1
   f32.const 0
@@ -43287,8 +43266,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0
+  f32.const -inf
+  f32.const 0
   f32.const 1
   f32.const 0
   i32.const 0
@@ -43302,11 +43281,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -0.5
-  f32.const inf
+  f32.const 1
   f32.const 0
-  i32.const 4
+  f32.const 1
+  f32.const 0
+  i32.const 0
   call $std/math/test_powf
   i32.eqz
   if
@@ -43317,11 +43296,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
   f32.const -1
-  f32.const -inf
   f32.const 0
-  i32.const 4
+  f32.const 1
+  f32.const 0
+  i32.const 0
   call $std/math/test_powf
   i32.eqz
   if
@@ -43332,11 +43311,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -2
-  f32.const inf
+  f32.const -0.5
   f32.const 0
-  i32.const 4
+  f32.const 1
+  f32.const 0
+  i32.const 0
   call $std/math/test_powf
   i32.eqz
   if
@@ -43347,11 +43326,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const nan:0x400000
   f32.const -0
-  f32.const -3
-  f32.const -inf
+  f32.const 1
   f32.const 0
-  i32.const 4
+  i32.const 0
   call $std/math/test_powf
   i32.eqz
   if
@@ -43362,11 +43341,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
-  f32.const -4
   f32.const inf
+  f32.const -0
+  f32.const 1
   f32.const 0
-  i32.const 4
+  i32.const 0
   call $std/math/test_powf
   i32.eqz
   if
@@ -43377,9 +43356,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
   f32.const -inf
-  f32.const inf
+  f32.const -0
+  f32.const 1
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -43392,8 +43371,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const 0
+  f32.const 1
+  f32.const -0
   f32.const 1
   f32.const 0
   i32.const 0
@@ -43407,8 +43386,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const 0
+  f32.const -1
+  f32.const -0
   f32.const 1
   f32.const 0
   i32.const 0
@@ -43422,8 +43401,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const 0
+  f32.const -0.5
+  f32.const -0
   f32.const 1
   f32.const 0
   i32.const 0
@@ -43437,9 +43416,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 0
-  f32.const 1
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -43453,8 +43432,8 @@
    unreachable
   end
   f32.const -1
-  f32.const 0
-  f32.const 1
+  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -43467,9 +43446,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const 0
-  f32.const 1
+  f32.const -1
+  f32.const -inf
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -43478,141 +43457,6 @@
    i32.const 0
    i32.const 32
    i32.const 2792
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const -0
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2793
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -0
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2794
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -0
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2795
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const -0
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2796
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -0
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2797
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const -0
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2798
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2799
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const inf
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2800
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -inf
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2801
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43627,7 +43471,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2802
+   i32.const 2793
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43642,7 +43486,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2803
+   i32.const 2794
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43657,7 +43501,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2804
+   i32.const 2795
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43672,7 +43516,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2805
+   i32.const 2796
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43687,7 +43531,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2806
+   i32.const 2797
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43702,7 +43546,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2807
+   i32.const 2798
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43717,7 +43561,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2808
+   i32.const 2799
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43732,7 +43576,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2809
+   i32.const 2800
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43747,7 +43591,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2810
+   i32.const 2801
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43762,7 +43606,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2811
+   i32.const 2802
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43777,7 +43621,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2812
+   i32.const 2803
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43792,7 +43636,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2813
+   i32.const 2804
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43807,7 +43651,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2814
+   i32.const 2805
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43822,7 +43666,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2815
+   i32.const 2806
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43837,7 +43681,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2816
+   i32.const 2807
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43852,7 +43696,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2817
+   i32.const 2808
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -43867,13 +43711,148 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2818
+   i32.const 2809
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const -0.5
   f32.const -inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2810
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.5
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2811
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
+  f32.const inf
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2812
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
+  f32.const -inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2813
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2814
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.5
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2815
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.5
+  f32.const -inf
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2816
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.5
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2817
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_powf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2818
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
   f32.const inf
   f32.const 0
   i32.const 0
@@ -43887,9 +43866,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const -inf
+  f32.const 0
   f32.const 0
   i32.const 0
   call $std/math/test_powf
@@ -43898,141 +43877,6 @@
    i32.const 0
    i32.const 32
    i32.const 2820
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const inf
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2821
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const -inf
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2822
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2823
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.5
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2824
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.5
-  f32.const -inf
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2825
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.5
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2826
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2827
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2828
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -inf
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_powf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2829
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44047,7 +43891,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2830
+   i32.const 2821
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44062,7 +43906,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2831
+   i32.const 2822
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44077,7 +43921,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2832
+   i32.const 2823
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44092,7 +43936,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2833
+   i32.const 2824
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44107,7 +43951,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2834
+   i32.const 2825
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44122,7 +43966,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2835
+   i32.const 2826
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44137,7 +43981,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2836
+   i32.const 2827
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44152,7 +43996,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2837
+   i32.const 2828
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44167,7 +44011,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2838
+   i32.const 2829
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44182,7 +44026,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2839
+   i32.const 2830
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44197,7 +44041,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2840
+   i32.const 2831
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44212,7 +44056,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2841
+   i32.const 2832
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44227,7 +44071,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2842
+   i32.const 2833
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44242,7 +44086,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2843
+   i32.const 2834
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44257,7 +44101,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2844
+   i32.const 2835
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44272,7 +44116,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2845
+   i32.const 2836
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44287,7 +44131,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2846
+   i32.const 2837
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44302,7 +44146,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2847
+   i32.const 2838
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44317,7 +44161,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2848
+   i32.const 2839
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44332,7 +44176,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2849
+   i32.const 2840
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44347,7 +44191,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2850
+   i32.const 2841
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44381,7 +44225,7 @@
     if
      i32.const 0
      i32.const 32
-     i32.const 2859
+     i32.const 2850
      i32.const 2
      call $~lib/builtins/abort
      unreachable
@@ -44424,7 +44268,7 @@
     if
      i32.const 0
      i32.const 32
-     i32.const 2867
+     i32.const 2858
      i32.const 2
      call $~lib/builtins/abort
      unreachable
@@ -44445,7 +44289,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2881
+   i32.const 2872
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44459,7 +44303,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2882
+   i32.const 2873
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44473,7 +44317,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2883
+   i32.const 2874
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44487,7 +44331,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2884
+   i32.const 2875
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44501,7 +44345,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2885
+   i32.const 2876
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44515,7 +44359,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2886
+   i32.const 2877
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44529,7 +44373,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2887
+   i32.const 2878
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44543,7 +44387,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2888
+   i32.const 2879
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44557,7 +44401,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2889
+   i32.const 2880
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44571,105 +44415,105 @@
   if
    i32.const 0
    i32.const 32
+   i32.const 2881
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2884
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2885
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2886
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2887
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2888
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2889
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const -1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_round
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
    i32.const 2890
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2893
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2894
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2895
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2896
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2897
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2898
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_round
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2899
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44683,7 +44527,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2900
+   i32.const 2891
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44697,7 +44541,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2901
+   i32.const 2892
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44711,7 +44555,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2902
+   i32.const 2893
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44725,7 +44569,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2903
+   i32.const 2894
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44739,7 +44583,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2904
+   i32.const 2895
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44753,7 +44597,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2905
+   i32.const 2896
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44767,7 +44611,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2906
+   i32.const 2897
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44781,7 +44625,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2907
+   i32.const 2898
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44795,7 +44639,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2908
+   i32.const 2899
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44809,7 +44653,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2909
+   i32.const 2900
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44823,7 +44667,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2918
+   i32.const 2909
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44837,7 +44681,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2919
+   i32.const 2910
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44851,7 +44695,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2920
+   i32.const 2911
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44865,7 +44709,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2921
+   i32.const 2912
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44879,7 +44723,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2922
+   i32.const 2913
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44893,7 +44737,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2923
+   i32.const 2914
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44907,7 +44751,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2924
+   i32.const 2915
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44921,7 +44765,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2925
+   i32.const 2916
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44935,7 +44779,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2926
+   i32.const 2917
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -44949,105 +44793,105 @@
   if
    i32.const 0
    i32.const 32
+   i32.const 2918
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2921
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2922
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2923
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2924
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2925
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2926
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const -1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_roundf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
    i32.const 2927
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2930
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2931
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2932
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2933
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2934
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2935
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_roundf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2936
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45061,7 +44905,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2937
+   i32.const 2928
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45075,7 +44919,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2938
+   i32.const 2929
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45089,7 +44933,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2939
+   i32.const 2930
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45103,7 +44947,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2940
+   i32.const 2931
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45117,7 +44961,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2941
+   i32.const 2932
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45131,7 +44975,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2942
+   i32.const 2933
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45145,7 +44989,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2943
+   i32.const 2934
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45159,7 +45003,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2944
+   i32.const 2935
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45173,7 +45017,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2945
+   i32.const 2936
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45187,7 +45031,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2946
+   i32.const 2937
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45201,7 +45045,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2957
+   i32.const 2948
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45215,7 +45059,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2958
+   i32.const 2949
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45229,7 +45073,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2959
+   i32.const 2950
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45243,7 +45087,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2960
+   i32.const 2951
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45257,7 +45101,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2961
+   i32.const 2952
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45271,7 +45115,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2962
+   i32.const 2953
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45285,7 +45129,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2963
+   i32.const 2954
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45299,7 +45143,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2964
+   i32.const 2955
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45313,39 +45157,39 @@
   if
    i32.const 0
    i32.const 32
+   i32.const 2956
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_signf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 2964
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_signf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
    i32.const 2965
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_signf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2973
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_signf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 2974
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const 1
   f32.const 1
   f32.const 0
@@ -45355,7 +45199,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2975
+   i32.const 2966
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45369,7 +45213,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2976
+   i32.const 2967
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45383,7 +45227,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2977
+   i32.const 2968
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45397,7 +45241,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2978
+   i32.const 2969
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45411,7 +45255,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2979
+   i32.const 2970
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45425,7 +45269,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2980
+   i32.const 2971
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45439,7 +45283,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2981
+   i32.const 2972
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45463,7 +45307,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2987
+   i32.const 2978
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45487,7 +45331,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2988
+   i32.const 2979
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45511,7 +45355,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2989
+   i32.const 2980
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45535,7 +45379,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2990
+   i32.const 2981
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45559,7 +45403,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2991
+   i32.const 2982
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45583,7 +45427,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2992
+   i32.const 2983
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45607,7 +45451,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2993
+   i32.const 2984
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45631,7 +45475,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 2994
+   i32.const 2985
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45654,7 +45498,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3000
+   i32.const 2991
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45677,7 +45521,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3001
+   i32.const 2992
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45700,7 +45544,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3002
+   i32.const 2993
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45723,7 +45567,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3003
+   i32.const 2994
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45746,7 +45590,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3004
+   i32.const 2995
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45769,7 +45613,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3005
+   i32.const 2996
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45792,7 +45636,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3006
+   i32.const 2997
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45815,7 +45659,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3007
+   i32.const 2998
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45830,7 +45674,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3018
+   i32.const 3009
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45845,7 +45689,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3019
+   i32.const 3010
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45860,7 +45704,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3020
+   i32.const 3011
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45875,7 +45719,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3021
+   i32.const 3012
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45890,7 +45734,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3022
+   i32.const 3013
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45905,7 +45749,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3023
+   i32.const 3014
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45920,7 +45764,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3024
+   i32.const 3015
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45935,7 +45779,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3025
+   i32.const 3016
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45950,7 +45794,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3026
+   i32.const 3017
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45965,7 +45809,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3027
+   i32.const 3018
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -45973,6 +45817,141 @@
   f64.const 0
   f64.const 1
   f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3021
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const 1
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3022
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
+  f64.const 1
+  f64.const 0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3023
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0.5
+  f64.const 1
+  f64.const -0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3024
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 1
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3025
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const 1
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3026
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.5
+  f64.const 1
+  f64.const -0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3027
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.5
+  f64.const 1
+  f64.const 0.5
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3028
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2
+  f64.const 1
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3029
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2
+  f64.const 1
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -45985,11 +45964,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const inf
   f64.const 1
-  f64.const -0
+  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -46000,11 +45979,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
+  f64.const -inf
   f64.const 1
-  f64.const 0.5
+  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -46015,9 +45994,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.5
+  f64.const nan:0x8000000000000
   f64.const 1
-  f64.const -0.5
+  f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -46030,8 +46009,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 1
+  f64.const 0
+  f64.const -1
   f64.const 0
   f64.const 0
   i32.const 0
@@ -46045,8 +46024,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -0
   f64.const -1
-  f64.const 1
   f64.const -0
   f64.const 0
   i32.const 0
@@ -46060,9 +46039,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5
-  f64.const 1
-  f64.const -0.5
+  f64.const 0.5
+  f64.const -1
+  f64.const 0.5
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -46075,9 +46054,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.5
-  f64.const 1
-  f64.const 0.5
+  f64.const -0.5
+  f64.const -1
+  f64.const -0.5
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -46090,8 +46069,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2
   f64.const 1
+  f64.const -1
   f64.const 0
   f64.const 0
   i32.const 0
@@ -46105,8 +46084,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2
-  f64.const 1
+  f64.const -1
+  f64.const -1
   f64.const -0
   f64.const 0
   i32.const 0
@@ -46116,141 +46095,6 @@
    i32.const 0
    i32.const 32
    i32.const 3039
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3040
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3041
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const 1
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3042
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const -1
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3043
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -1
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3044
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0.5
-  f64.const -1
-  f64.const 0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3045
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0.5
-  f64.const -1
-  f64.const -0.5
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3046
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const -1
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3047
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -1
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3048
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46265,7 +46109,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3049
+   i32.const 3040
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46280,7 +46124,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3050
+   i32.const 3041
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46295,7 +46139,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3051
+   i32.const 3042
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46310,13 +46154,148 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3052
+   i32.const 3043
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const inf
   f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 2
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3044
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 2
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3045
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  f64.const -1
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3046
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 2
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3047
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 2
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3048
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const inf
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3049
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const -inf
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3050
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3051
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const 0
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 2
+  call $std/math/test_rem
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3052
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -46330,11 +46309,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -1
-  f64.const nan:0x8000000000000
+  f64.const -0
+  f64.const inf
+  f64.const -0
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -46345,9 +46324,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const -1
-  f64.const nan:0x8000000000000
+  f64.const -0
+  f64.const -inf
+  f64.const -0
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -46360,11 +46339,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0
-  f64.const 0
+  f64.const -0
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -46375,8 +46354,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
   f64.const 0
-  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -46390,11 +46369,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
   f64.const 0
-  f64.const inf
+  f64.const nan:0x8000000000000
   f64.const 0
-  f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -46405,11 +46384,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const inf
   f64.const 0
-  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const 0
-  f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -46420,11 +46399,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -inf
   f64.const 0
   f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -46435,11 +46414,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const nan:0x8000000000000
   f64.const 0
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -46450,7 +46429,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
+  f64.const -1
   f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
@@ -46465,11 +46444,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
   f64.const inf
   f64.const -0
+  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -46480,11 +46459,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
   f64.const -inf
   f64.const -0
+  f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -46495,8 +46474,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0
   f64.const nan:0x8000000000000
+  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
@@ -46510,8 +46489,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const 0
+  f64.const inf
+  f64.const 2
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -46525,8 +46504,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const 0
+  f64.const inf
+  f64.const -0.5
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -46541,10 +46520,10 @@
    unreachable
   end
   f64.const inf
-  f64.const 0
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -46556,7 +46535,7 @@
    unreachable
   end
   f64.const -inf
-  f64.const 0
+  f64.const 2
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -46570,11 +46549,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -inf
+  f64.const -0.5
   f64.const nan:0x8000000000000
   f64.const 0
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -46585,11 +46564,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const -0
+  f64.const -inf
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -46600,11 +46579,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const -0
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -46615,11 +46594,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
-  f64.const -0
+  f64.const 1
+  f64.const nan:0x8000000000000
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -46630,8 +46609,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
   f64.const nan:0x8000000000000
-  f64.const -0
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 0
@@ -46645,11 +46624,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
   f64.const inf
-  f64.const 2
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -46660,11 +46639,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
   f64.const inf
-  f64.const -0.5
-  f64.const nan:0x8000000000000
+  f64.const -1
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -46676,10 +46655,10 @@
    unreachable
   end
   f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const inf
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -46691,7 +46670,7 @@
    unreachable
   end
   f64.const -inf
-  f64.const 2
+  f64.const inf
   f64.const nan:0x8000000000000
   f64.const 0
   i32.const 2
@@ -46705,11 +46684,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const 1
   f64.const -inf
-  f64.const -0.5
-  f64.const nan:0x8000000000000
+  f64.const 1
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -46720,9 +46699,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f64.const -1
   f64.const -inf
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const -1
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -46735,11 +46714,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const inf
+  f64.const -inf
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -46750,11 +46729,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const nan:0x8000000000000
+  f64.const -inf
+  f64.const -inf
   f64.const nan:0x8000000000000
   f64.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_rem
   i32.eqz
   if
@@ -46765,9 +46744,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
+  f64.const 1.75
+  f64.const 0.5
+  f64.const -0.25
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -46780,9 +46759,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1
-  f64.const inf
-  f64.const 1
+  f64.const -1.75
+  f64.const 0.5
+  f64.const 0.25
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -46795,9 +46774,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1
-  f64.const inf
-  f64.const -1
+  f64.const 1.75
+  f64.const -0.5
+  f64.const -0.25
   f64.const 0
   i32.const 0
   call $std/math/test_rem
@@ -46810,11 +46789,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const inf
-  f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const -1.75
+  f64.const -0.5
+  f64.const 0.25
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
@@ -46825,152 +46804,17 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -inf
+  f64.const 8e-323
   f64.const inf
-  f64.const nan:0x8000000000000
+  f64.const 8e-323
   f64.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_rem
   i32.eqz
   if
    i32.const 0
    i32.const 32
    i32.const 3087
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const -inf
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3088
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -inf
-  f64.const -1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3089
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const -inf
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3090
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -inf
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 2
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3091
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.75
-  f64.const 0.5
-  f64.const -0.25
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3092
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.75
-  f64.const 0.5
-  f64.const 0.25
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3093
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.75
-  f64.const -0.5
-  f64.const -0.25
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3094
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.75
-  f64.const -0.5
-  f64.const 0.25
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3095
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 8e-323
-  f64.const inf
-  f64.const 8e-323
-  f64.const 0
-  i32.const 0
-  call $std/math/test_rem
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3096
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -46985,7 +46829,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3105
+   i32.const 3096
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47000,7 +46844,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3106
+   i32.const 3097
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47015,7 +46859,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3107
+   i32.const 3098
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47030,7 +46874,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3108
+   i32.const 3099
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47045,7 +46889,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3109
+   i32.const 3100
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47060,7 +46904,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3110
+   i32.const 3101
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47075,7 +46919,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3111
+   i32.const 3102
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47090,7 +46934,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3112
+   i32.const 3103
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47105,7 +46949,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3113
+   i32.const 3104
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47120,7 +46964,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3114
+   i32.const 3105
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47128,6 +46972,141 @@
   f32.const 0
   f32.const 1
   f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3108
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 1
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3109
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0.5
+  f32.const 1
+  f32.const 0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3110
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0.5
+  f32.const 1
+  f32.const -0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3111
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 1
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3112
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const 1
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3113
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.5
+  f32.const 1
+  f32.const -0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3114
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.5
+  f32.const 1
+  f32.const 0.5
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3115
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2
+  f32.const 1
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3116
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2
+  f32.const 1
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -47140,11 +47119,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const inf
   f32.const 1
-  f32.const -0
+  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -47155,11 +47134,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0.5
+  f32.const -inf
   f32.const 1
-  f32.const 0.5
+  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -47170,9 +47149,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0.5
+  f32.const nan:0x400000
   f32.const 1
-  f32.const -0.5
+  f32.const nan:0x400000
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -47185,8 +47164,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 1
+  f32.const 0
+  f32.const -1
   f32.const 0
   f32.const 0
   i32.const 0
@@ -47200,8 +47179,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -0
   f32.const -1
-  f32.const 1
   f32.const -0
   f32.const 0
   i32.const 0
@@ -47215,9 +47194,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.5
-  f32.const 1
-  f32.const -0.5
+  f32.const 0.5
+  f32.const -1
+  f32.const 0.5
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -47230,9 +47209,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.5
-  f32.const 1
-  f32.const 0.5
+  f32.const -0.5
+  f32.const -1
+  f32.const -0.5
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -47245,8 +47224,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2
   f32.const 1
+  f32.const -1
   f32.const 0
   f32.const 0
   i32.const 0
@@ -47260,8 +47239,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -2
-  f32.const 1
+  f32.const -1
+  f32.const -1
   f32.const -0
   f32.const 0
   i32.const 0
@@ -47271,141 +47250,6 @@
    i32.const 0
    i32.const 32
    i32.const 3126
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3127
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3128
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const 1
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3129
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const -1
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3130
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -1
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3131
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.5
-  f32.const -1
-  f32.const 0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3132
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0.5
-  f32.const -1
-  f32.const -0.5
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3133
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const -1
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3134
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -1
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3135
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47420,7 +47264,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3136
+   i32.const 3127
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47435,7 +47279,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3137
+   i32.const 3128
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47450,7 +47294,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3138
+   i32.const 3129
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -47465,13 +47309,148 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3139
+   i32.const 3130
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const inf
   f32.const -1
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 2
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3131
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 2
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3132
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const -1
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3133
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 2
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3134
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const -0
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 2
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3135
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const inf
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3136
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const -inf
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3137
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3138
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const 0
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 2
+  call $std/math/test_remf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3139
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -47485,11 +47464,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -1
-  f32.const nan:0x400000
+  f32.const -0
+  f32.const inf
+  f32.const -0
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -47500,9 +47479,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const -1
-  f32.const nan:0x400000
+  f32.const -0
+  f32.const -inf
+  f32.const -0
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -47515,11 +47494,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 0
-  f32.const 0
+  f32.const -0
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -47530,8 +47509,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1
   f32.const 0
-  f32.const -0
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -47545,11 +47524,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
   f32.const 0
-  f32.const inf
+  f32.const nan:0x400000
   f32.const 0
-  f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -47560,11 +47539,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const inf
   f32.const 0
-  f32.const -inf
+  f32.const nan:0x400000
   f32.const 0
-  f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -47575,11 +47554,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -inf
   f32.const 0
   f32.const nan:0x400000
-  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -47590,11 +47569,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const nan:0x400000
   f32.const 0
   f32.const nan:0x400000
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -47605,7 +47584,7 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
+  f32.const -1
   f32.const -0
   f32.const nan:0x400000
   f32.const 0
@@ -47620,11 +47599,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
   f32.const inf
   f32.const -0
+  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -47635,11 +47614,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
   f32.const -inf
   f32.const -0
+  f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -47650,8 +47629,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -0
   f32.const nan:0x400000
+  f32.const -0
   f32.const nan:0x400000
   f32.const 0
   i32.const 0
@@ -47665,8 +47644,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const 0
+  f32.const inf
+  f32.const 2
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -47680,8 +47659,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const 0
+  f32.const inf
+  f32.const -0.5
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -47696,10 +47675,10 @@
    unreachable
   end
   f32.const inf
-  f32.const 0
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -47711,7 +47690,7 @@
    unreachable
   end
   f32.const -inf
-  f32.const 0
+  f32.const 2
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -47725,11 +47704,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -inf
+  f32.const -0.5
   f32.const nan:0x400000
   f32.const 0
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -47740,11 +47719,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const -0
+  f32.const -inf
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -47755,11 +47734,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const -0
+  f32.const nan:0x400000
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -47770,11 +47749,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
-  f32.const -0
+  f32.const 1
+  f32.const nan:0x400000
   f32.const nan:0x400000
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -47785,8 +47764,8 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
   f32.const nan:0x400000
-  f32.const -0
   f32.const nan:0x400000
   f32.const 0
   i32.const 0
@@ -47800,11 +47779,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1
   f32.const inf
-  f32.const 2
-  f32.const nan:0x400000
+  f32.const 1
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -47815,11 +47794,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
   f32.const inf
-  f32.const -0.5
-  f32.const nan:0x400000
+  f32.const -1
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -47831,10 +47810,10 @@
    unreachable
   end
   f32.const inf
-  f32.const nan:0x400000
+  f32.const inf
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -47846,7 +47825,7 @@
    unreachable
   end
   f32.const -inf
-  f32.const 2
+  f32.const inf
   f32.const nan:0x400000
   f32.const 0
   i32.const 2
@@ -47860,11 +47839,11 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const 1
   f32.const -inf
-  f32.const -0.5
-  f32.const nan:0x400000
+  f32.const 1
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -47875,9 +47854,9 @@
    call $~lib/builtins/abort
    unreachable
   end
+  f32.const -1
   f32.const -inf
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const -1
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -47890,11 +47869,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const inf
+  f32.const -inf
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -47905,11 +47884,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const nan:0x400000
+  f32.const -inf
+  f32.const -inf
   f32.const nan:0x400000
   f32.const 0
-  i32.const 0
+  i32.const 2
   call $std/math/test_remf
   i32.eqz
   if
@@ -47920,9 +47899,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const nan:0x400000
-  f32.const nan:0x400000
+  f32.const 1.75
+  f32.const 0.5
+  f32.const -0.25
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -47935,9 +47914,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1
-  f32.const inf
-  f32.const 1
+  f32.const -1.75
+  f32.const 0.5
+  f32.const 0.25
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -47950,9 +47929,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1
-  f32.const inf
-  f32.const -1
+  f32.const 1.75
+  f32.const -0.5
+  f32.const -0.25
   f32.const 0
   i32.const 0
   call $std/math/test_remf
@@ -47965,11 +47944,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const inf
-  f32.const inf
-  f32.const nan:0x400000
+  f32.const -1.75
+  f32.const -0.5
+  f32.const 0.25
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
@@ -47980,152 +47959,17 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -inf
+  f32.const 5.877471754111438e-39
   f32.const inf
-  f32.const nan:0x400000
+  f32.const 5.877471754111438e-39
   f32.const 0
-  i32.const 2
+  i32.const 0
   call $std/math/test_remf
   i32.eqz
   if
    i32.const 0
    i32.const 32
    i32.const 3174
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const -inf
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3175
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -inf
-  f32.const -1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3176
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const -inf
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3177
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -inf
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 2
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3178
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.75
-  f32.const 0.5
-  f32.const -0.25
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3179
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.75
-  f32.const 0.5
-  f32.const 0.25
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3180
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.75
-  f32.const -0.5
-  f32.const -0.25
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3181
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.75
-  f32.const -0.5
-  f32.const 0.25
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3182
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 5.877471754111438e-39
-  f32.const inf
-  f32.const 5.877471754111438e-39
-  f32.const 0
-  i32.const 0
-  call $std/math/test_remf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3183
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48139,7 +47983,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3195
+   i32.const 3186
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48153,7 +47997,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3196
+   i32.const 3187
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48167,7 +48011,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3197
+   i32.const 3188
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48181,7 +48025,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3198
+   i32.const 3189
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48195,7 +48039,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3199
+   i32.const 3190
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48209,7 +48053,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3200
+   i32.const 3191
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48223,7 +48067,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3201
+   i32.const 3192
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48237,7 +48081,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3202
+   i32.const 3193
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48251,7 +48095,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3203
+   i32.const 3194
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48265,7 +48109,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3204
+   i32.const 3195
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48279,7 +48123,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3207
+   i32.const 3198
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48293,13 +48137,139 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3208
+   i32.const 3199
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 2.2250738585072014e-308
   f64.const 2.2250738585072014e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3200
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -2.2250738585072014e-308
+  f64.const -2.2250738585072014e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3201
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 5e-324
+  f64.const 5e-324
+  f64.const 0
+  i32.const 9
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3202
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -5e-324
+  f64.const -5e-324
+  f64.const 0
+  i32.const 9
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3203
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3204
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3205
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.225073858507202e-308
+  f64.const 2.225073858507202e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3206
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.2250738585072024e-308
+  f64.const 2.2250738585072024e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3207
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.4501477170144003e-308
+  f64.const 4.4501477170144003e-308
+  f64.const 0
+  i32.const 1
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3208
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.450147717014403e-308
+  f64.const 4.450147717014403e-308
   f64.const 0
   i32.const 1
   call $std/math/test_sin
@@ -48312,8 +48282,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072014e-308
-  f64.const -2.2250738585072014e-308
+  f64.const 4.450147717014406e-308
+  f64.const 4.450147717014406e-308
   f64.const 0
   i32.const 1
   call $std/math/test_sin
@@ -48326,142 +48296,16 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5e-324
-  f64.const 5e-324
+  f64.const 8.900295434028806e-308
+  f64.const 8.900295434028806e-308
   f64.const 0
-  i32.const 9
+  i32.const 1
   call $std/math/test_sin
   i32.eqz
   if
    i32.const 0
    i32.const 32
    i32.const 3211
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -5e-324
-  f64.const -5e-324
-  f64.const 0
-  i32.const 9
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3212
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3213
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3214
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507202e-308
-  f64.const 2.225073858507202e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3215
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072024e-308
-  f64.const 2.2250738585072024e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3216
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.4501477170144003e-308
-  f64.const 4.4501477170144003e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3217
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.450147717014403e-308
-  f64.const 4.450147717014403e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3218
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 4.450147717014406e-308
-  f64.const 4.450147717014406e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3219
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 8.900295434028806e-308
-  f64.const 8.900295434028806e-308
-  f64.const 0
-  i32.const 1
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3220
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48475,7 +48319,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3221
+   i32.const 3212
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48489,7 +48333,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3222
+   i32.const 3213
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48503,7 +48347,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3223
+   i32.const 3214
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48517,7 +48361,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3224
+   i32.const 3215
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48531,7 +48375,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3225
+   i32.const 3216
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48545,7 +48389,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3226
+   i32.const 3217
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48559,7 +48403,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3227
+   i32.const 3218
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48573,7 +48417,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3228
+   i32.const 3219
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48587,7 +48431,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3229
+   i32.const 3220
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48596,6 +48440,132 @@
   f64.const -1.4901161193847656e-08
   f64.const -0.1666666716337204
   i32.const 1
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3221
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.4901161193847656e-08
+  f64.const -1.4901161193847656e-08
+  f64.const -0.1666666716337204
+  i32.const 1
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3222
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1e-323
+  f64.const 1e-323
+  f64.const 0
+  i32.const 9
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3223
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.4e-323
+  f64.const 4.4e-323
+  f64.const 0
+  i32.const 9
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3224
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 5.562684646268003e-309
+  f64.const 5.562684646268003e-309
+  f64.const 0
+  i32.const 9
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3225
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.1125369292536007e-308
+  f64.const 1.1125369292536007e-308
+  f64.const 0
+  i32.const 9
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3226
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.2250738585072004e-308
+  f64.const 2.2250738585072004e-308
+  f64.const 0
+  i32.const 9
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3227
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.225073858507201e-308
+  f64.const 2.225073858507201e-308
+  f64.const 0
+  i32.const 9
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3228
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1e-323
+  f64.const -1e-323
+  f64.const 0
+  i32.const 9
+  call $std/math/test_sin
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3229
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.4e-323
+  f64.const -4.4e-323
+  f64.const 0
+  i32.const 9
   call $std/math/test_sin
   i32.eqz
   if
@@ -48606,10 +48576,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.4901161193847656e-08
-  f64.const -1.4901161193847656e-08
-  f64.const -0.1666666716337204
-  i32.const 1
+  f64.const -5.562684646268003e-309
+  f64.const -5.562684646268003e-309
+  f64.const 0
+  i32.const 9
   call $std/math/test_sin
   i32.eqz
   if
@@ -48620,8 +48590,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1e-323
-  f64.const 1e-323
+  f64.const -1.1125369292536007e-308
+  f64.const -1.1125369292536007e-308
   f64.const 0
   i32.const 9
   call $std/math/test_sin
@@ -48634,8 +48604,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4e-323
-  f64.const 4.4e-323
+  f64.const -2.2250738585072004e-308
+  f64.const -2.2250738585072004e-308
   f64.const 0
   i32.const 9
   call $std/math/test_sin
@@ -48648,8 +48618,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5.562684646268003e-309
-  f64.const 5.562684646268003e-309
+  f64.const -2.225073858507201e-308
+  f64.const -2.225073858507201e-308
   f64.const 0
   i32.const 9
   call $std/math/test_sin
@@ -48662,38 +48632,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.1125369292536007e-308
-  f64.const 1.1125369292536007e-308
   f64.const 0
-  i32.const 9
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3235
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072004e-308
-  f64.const 2.2250738585072004e-308
   f64.const 0
-  i32.const 9
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3236
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507201e-308
-  f64.const 2.225073858507201e-308
   f64.const 0
-  i32.const 9
+  i32.const 0
   call $std/math/test_sin
   i32.eqz
   if
@@ -48704,114 +48646,16 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1e-323
-  f64.const -1e-323
+  f64.const -0
+  f64.const -0
   f64.const 0
-  i32.const 9
+  i32.const 0
   call $std/math/test_sin
   i32.eqz
   if
    i32.const 0
    i32.const 32
    i32.const 3238
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -4.4e-323
-  f64.const -4.4e-323
-  f64.const 0
-  i32.const 9
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3239
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -5.562684646268003e-309
-  f64.const -5.562684646268003e-309
-  f64.const 0
-  i32.const 9
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3240
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1.1125369292536007e-308
-  f64.const -1.1125369292536007e-308
-  f64.const 0
-  i32.const 9
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3241
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.2250738585072004e-308
-  f64.const -2.2250738585072004e-308
-  f64.const 0
-  i32.const 9
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3242
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -2.225073858507201e-308
-  f64.const -2.225073858507201e-308
-  f64.const 0
-  i32.const 9
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3243
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3246
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_sin
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3247
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48825,7 +48669,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3248
+   i32.const 3239
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48839,7 +48683,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3249
+   i32.const 3240
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48853,7 +48697,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3250
+   i32.const 3241
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48867,7 +48711,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3253
+   i32.const 3244
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48881,7 +48725,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3254
+   i32.const 3245
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48894,7 +48738,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3257
+   i32.const 3248
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48907,7 +48751,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3258
+   i32.const 3249
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48920,7 +48764,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3260
+   i32.const 3251
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48933,7 +48777,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3261
+   i32.const 3252
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48946,7 +48790,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3264
+   i32.const 3255
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48959,7 +48803,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3265
+   i32.const 3256
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48972,7 +48816,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3266
+   i32.const 3257
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48985,7 +48829,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3267
+   i32.const 3258
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -48998,7 +48842,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3269
+   i32.const 3260
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49011,7 +48855,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3270
+   i32.const 3261
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49024,7 +48868,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3272
+   i32.const 3263
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49037,7 +48881,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3273
+   i32.const 3264
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49050,7 +48894,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3274
+   i32.const 3265
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49063,7 +48907,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3275
+   i32.const 3266
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49076,7 +48920,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3276
+   i32.const 3267
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49089,7 +48933,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3279
+   i32.const 3270
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49102,7 +48946,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3280
+   i32.const 3271
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49116,7 +48960,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3289
+   i32.const 3280
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49130,7 +48974,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3290
+   i32.const 3281
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49144,7 +48988,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3291
+   i32.const 3282
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49158,7 +49002,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3292
+   i32.const 3283
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49172,7 +49016,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3293
+   i32.const 3284
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49186,7 +49030,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3294
+   i32.const 3285
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49200,7 +49044,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3295
+   i32.const 3286
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49214,7 +49058,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3296
+   i32.const 3287
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49228,7 +49072,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3297
+   i32.const 3288
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49242,7 +49086,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3298
+   i32.const 3289
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49256,7 +49100,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3301
+   i32.const 3292
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49270,7 +49114,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3302
+   i32.const 3293
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49284,7 +49128,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3303
+   i32.const 3294
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49298,7 +49142,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3304
+   i32.const 3295
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49312,7 +49156,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3305
+   i32.const 3296
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49326,7 +49170,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3308
+   i32.const 3299
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49340,13 +49184,139 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3309
+   i32.const 3300
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.1754943508222875e-38
   f32.const 1.1754943508222875e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3301
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754943508222875e-38
+  f32.const -1.1754943508222875e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3302
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.401298464324817e-45
+  f32.const 1.401298464324817e-45
+  f32.const 0
+  i32.const 9
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3303
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.401298464324817e-45
+  f32.const -1.401298464324817e-45
+  f32.const 0
+  i32.const 9
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3304
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.175494490952134e-38
+  f32.const 1.175494490952134e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3305
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.1754946310819804e-38
+  f32.const 1.1754946310819804e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3306
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.3509880009953429e-38
+  f32.const 2.3509880009953429e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3307
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.350988701644575e-38
+  f32.const 2.350988701644575e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3308
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.3509895424236536e-38
+  f32.const 2.3509895424236536e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3309
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4.70197740328915e-38
+  f32.const 4.70197740328915e-38
   f32.const 0
   i32.const 1
   call $std/math/test_sinf
@@ -49355,132 +49325,6 @@
    i32.const 0
    i32.const 32
    i32.const 3310
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754943508222875e-38
-  f32.const -1.1754943508222875e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3311
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.401298464324817e-45
-  f32.const 1.401298464324817e-45
-  f32.const 0
-  i32.const 9
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3312
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.401298464324817e-45
-  f32.const -1.401298464324817e-45
-  f32.const 0
-  i32.const 9
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3313
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.175494490952134e-38
-  f32.const 1.175494490952134e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3314
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754946310819804e-38
-  f32.const 1.1754946310819804e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3315
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.3509880009953429e-38
-  f32.const 2.3509880009953429e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3316
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.350988701644575e-38
-  f32.const 2.350988701644575e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3317
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.3509895424236536e-38
-  f32.const 2.3509895424236536e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3318
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 4.70197740328915e-38
-  f32.const 4.70197740328915e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3319
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49494,7 +49338,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3320
+   i32.const 3311
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49508,7 +49352,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3321
+   i32.const 3312
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49522,7 +49366,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3322
+   i32.const 3313
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49536,7 +49380,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3323
+   i32.const 3314
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49550,7 +49394,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3324
+   i32.const 3315
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49564,7 +49408,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3325
+   i32.const 3316
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49578,7 +49422,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3326
+   i32.const 3317
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49592,7 +49436,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3327
+   i32.const 3318
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49606,7 +49450,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3328
+   i32.const 3319
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49620,7 +49464,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3329
+   i32.const 3320
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49634,7 +49478,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3330
+   i32.const 3321
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49648,7 +49492,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3331
+   i32.const 3322
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49662,7 +49506,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3332
+   i32.const 3323
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49676,13 +49520,139 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3333
+   i32.const 3324
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 2.802596928649634e-45
   f32.const 2.802596928649634e-45
+  f32.const 0
+  i32.const 9
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3325
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.2611686178923354e-44
+  f32.const 1.2611686178923354e-44
+  f32.const 0
+  i32.const 9
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3326
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.938735877055719e-39
+  f32.const 2.938735877055719e-39
+  f32.const 0
+  i32.const 9
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3327
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 5.877471754111438e-39
+  f32.const 5.877471754111438e-39
+  f32.const 0
+  i32.const 9
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3328
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.1754940705625946e-38
+  f32.const 1.1754940705625946e-38
+  f32.const 0
+  i32.const 9
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3329
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.1754942106924411e-38
+  f32.const 1.1754942106924411e-38
+  f32.const 0
+  i32.const 9
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3330
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.802596928649634e-45
+  f32.const -2.802596928649634e-45
+  f32.const 0
+  i32.const 9
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3331
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.2611686178923354e-44
+  f32.const -1.2611686178923354e-44
+  f32.const 0
+  i32.const 9
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3332
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.938735877055719e-39
+  f32.const -2.938735877055719e-39
+  f32.const 0
+  i32.const 9
+  call $std/math/test_sinf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3333
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -5.877471754111438e-39
+  f32.const -5.877471754111438e-39
   f32.const 0
   i32.const 9
   call $std/math/test_sinf
@@ -49695,8 +49665,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.2611686178923354e-44
-  f32.const 1.2611686178923354e-44
+  f32.const -1.1754940705625946e-38
+  f32.const -1.1754940705625946e-38
   f32.const 0
   i32.const 9
   call $std/math/test_sinf
@@ -49709,8 +49679,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.938735877055719e-39
-  f32.const 2.938735877055719e-39
+  f32.const -1.1754942106924411e-38
+  f32.const -1.1754942106924411e-38
   f32.const 0
   i32.const 9
   call $std/math/test_sinf
@@ -49719,132 +49689,6 @@
    i32.const 0
    i32.const 32
    i32.const 3336
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 5.877471754111438e-39
-  f32.const 5.877471754111438e-39
-  f32.const 0
-  i32.const 9
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3337
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754940705625946e-38
-  f32.const 1.1754940705625946e-38
-  f32.const 0
-  i32.const 9
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3338
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754942106924411e-38
-  f32.const 1.1754942106924411e-38
-  f32.const 0
-  i32.const 9
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3339
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.802596928649634e-45
-  f32.const -2.802596928649634e-45
-  f32.const 0
-  i32.const 9
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3340
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.2611686178923354e-44
-  f32.const -1.2611686178923354e-44
-  f32.const 0
-  i32.const 9
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3341
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.938735877055719e-39
-  f32.const -2.938735877055719e-39
-  f32.const 0
-  i32.const 9
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3342
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -5.877471754111438e-39
-  f32.const -5.877471754111438e-39
-  f32.const 0
-  i32.const 9
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3343
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754940705625946e-38
-  f32.const -1.1754940705625946e-38
-  f32.const 0
-  i32.const 9
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3344
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754942106924411e-38
-  f32.const -1.1754942106924411e-38
-  f32.const 0
-  i32.const 9
-  call $std/math/test_sinf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3345
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49858,7 +49702,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3348
+   i32.const 3339
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49872,7 +49716,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3349
+   i32.const 3340
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49886,7 +49730,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3350
+   i32.const 3341
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49900,7 +49744,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3351
+   i32.const 3342
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49914,7 +49758,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3352
+   i32.const 3343
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49928,7 +49772,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3353
+   i32.const 3344
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49942,7 +49786,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3354
+   i32.const 3345
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49956,7 +49800,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3355
+   i32.const 3346
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49970,7 +49814,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3356
+   i32.const 3347
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49984,7 +49828,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3357
+   i32.const 3348
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -49998,7 +49842,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3358
+   i32.const 3349
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50012,7 +49856,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3359
+   i32.const 3350
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50026,7 +49870,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3360
+   i32.const 3351
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50040,7 +49884,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3361
+   i32.const 3352
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50054,7 +49898,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3373
+   i32.const 3364
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50068,7 +49912,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3374
+   i32.const 3365
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50082,7 +49926,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3375
+   i32.const 3366
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50096,7 +49940,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3376
+   i32.const 3367
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50110,7 +49954,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3377
+   i32.const 3368
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50124,7 +49968,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3378
+   i32.const 3369
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50138,7 +49982,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3379
+   i32.const 3370
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50152,7 +49996,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3380
+   i32.const 3371
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50166,7 +50010,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3381
+   i32.const 3372
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50180,7 +50024,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3382
+   i32.const 3373
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50194,7 +50038,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3385
+   i32.const 3376
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50208,7 +50052,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3386
+   i32.const 3377
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50222,7 +50066,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3387
+   i32.const 3378
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50236,7 +50080,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3388
+   i32.const 3379
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50250,7 +50094,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3389
+   i32.const 3380
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50264,7 +50108,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3398
+   i32.const 3389
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50278,7 +50122,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3399
+   i32.const 3390
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50292,7 +50136,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3400
+   i32.const 3391
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50306,7 +50150,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3401
+   i32.const 3392
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50320,7 +50164,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3402
+   i32.const 3393
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50334,7 +50178,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3403
+   i32.const 3394
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50348,7 +50192,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3404
+   i32.const 3395
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50362,7 +50206,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3405
+   i32.const 3396
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50376,7 +50220,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3406
+   i32.const 3397
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50390,7 +50234,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3407
+   i32.const 3398
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50404,7 +50248,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3410
+   i32.const 3401
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50418,7 +50262,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3411
+   i32.const 3402
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50432,7 +50276,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3412
+   i32.const 3403
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50446,7 +50290,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3413
+   i32.const 3404
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50460,7 +50304,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3414
+   i32.const 3405
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50474,7 +50318,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3426
+   i32.const 3417
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50488,7 +50332,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3427
+   i32.const 3418
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50502,7 +50346,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3428
+   i32.const 3419
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50516,7 +50360,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3429
+   i32.const 3420
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50530,7 +50374,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3430
+   i32.const 3421
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50544,7 +50388,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3431
+   i32.const 3422
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50558,7 +50402,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3432
+   i32.const 3423
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50572,7 +50416,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3433
+   i32.const 3424
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50586,7 +50430,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3434
+   i32.const 3425
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50600,7 +50444,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3435
+   i32.const 3426
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50614,7 +50458,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3438
+   i32.const 3429
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50628,7 +50472,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3439
+   i32.const 3430
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50642,7 +50486,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3440
+   i32.const 3431
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50656,7 +50500,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3441
+   i32.const 3432
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50670,7 +50514,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3442
+   i32.const 3433
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50684,7 +50528,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3443
+   i32.const 3434
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50698,7 +50542,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3444
+   i32.const 3435
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50712,7 +50556,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3445
+   i32.const 3436
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50726,7 +50570,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3446
+   i32.const 3437
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50740,7 +50584,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3447
+   i32.const 3438
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50754,7 +50598,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3448
+   i32.const 3439
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50768,7 +50612,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3449
+   i32.const 3440
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50782,7 +50626,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3450
+   i32.const 3441
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50796,7 +50640,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3451
+   i32.const 3442
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50810,7 +50654,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3452
+   i32.const 3443
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50824,7 +50668,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3453
+   i32.const 3444
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50838,7 +50682,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3454
+   i32.const 3445
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50852,7 +50696,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3455
+   i32.const 3446
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50866,7 +50710,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3456
+   i32.const 3447
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50880,7 +50724,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3457
+   i32.const 3448
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50894,7 +50738,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3458
+   i32.const 3449
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50908,7 +50752,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3459
+   i32.const 3450
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50922,7 +50766,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3460
+   i32.const 3451
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50936,7 +50780,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3461
+   i32.const 3452
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50950,7 +50794,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3462
+   i32.const 3453
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50964,7 +50808,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3463
+   i32.const 3454
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50978,7 +50822,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3464
+   i32.const 3455
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -50992,7 +50836,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3465
+   i32.const 3456
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51006,7 +50850,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3466
+   i32.const 3457
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51020,7 +50864,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3467
+   i32.const 3458
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51034,7 +50878,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3468
+   i32.const 3459
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51048,7 +50892,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3469
+   i32.const 3460
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51062,7 +50906,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3470
+   i32.const 3461
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51076,7 +50920,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3471
+   i32.const 3462
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51090,7 +50934,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3472
+   i32.const 3463
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51104,7 +50948,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3473
+   i32.const 3464
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51118,7 +50962,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3474
+   i32.const 3465
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51132,7 +50976,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3475
+   i32.const 3466
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51146,7 +50990,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3476
+   i32.const 3467
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51160,7 +51004,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3477
+   i32.const 3468
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51174,7 +51018,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3478
+   i32.const 3469
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51188,7 +51032,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3479
+   i32.const 3470
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51202,7 +51046,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3480
+   i32.const 3471
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51216,7 +51060,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3481
+   i32.const 3472
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51230,7 +51074,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3482
+   i32.const 3473
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51244,7 +51088,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3483
+   i32.const 3474
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51258,7 +51102,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3484
+   i32.const 3475
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51272,7 +51116,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3485
+   i32.const 3476
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51286,7 +51130,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3486
+   i32.const 3477
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51300,7 +51144,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3487
+   i32.const 3478
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51314,7 +51158,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3488
+   i32.const 3479
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51328,7 +51172,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3489
+   i32.const 3480
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51342,7 +51186,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3490
+   i32.const 3481
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51356,7 +51200,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3491
+   i32.const 3482
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51370,7 +51214,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3492
+   i32.const 3483
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51384,7 +51228,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3493
+   i32.const 3484
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51398,7 +51242,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3494
+   i32.const 3485
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51412,7 +51256,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3495
+   i32.const 3486
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51426,7 +51270,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3496
+   i32.const 3487
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51440,7 +51284,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3497
+   i32.const 3488
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51454,7 +51298,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3498
+   i32.const 3489
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51468,7 +51312,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3499
+   i32.const 3490
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51482,7 +51326,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3500
+   i32.const 3491
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51496,7 +51340,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3501
+   i32.const 3492
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51510,7 +51354,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3502
+   i32.const 3493
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51524,7 +51368,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3503
+   i32.const 3494
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51538,7 +51382,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3504
+   i32.const 3495
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51552,7 +51396,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3505
+   i32.const 3496
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51566,7 +51410,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3506
+   i32.const 3497
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51580,7 +51424,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3507
+   i32.const 3498
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51594,7 +51438,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3508
+   i32.const 3499
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51608,7 +51452,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3509
+   i32.const 3500
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51622,7 +51466,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3510
+   i32.const 3501
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51636,7 +51480,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3511
+   i32.const 3502
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51650,7 +51494,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3520
+   i32.const 3511
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51664,7 +51508,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3521
+   i32.const 3512
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51678,7 +51522,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3522
+   i32.const 3513
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51692,7 +51536,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3523
+   i32.const 3514
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51706,7 +51550,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3524
+   i32.const 3515
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51720,7 +51564,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3525
+   i32.const 3516
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51734,7 +51578,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3526
+   i32.const 3517
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51748,7 +51592,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3527
+   i32.const 3518
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51762,7 +51606,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3528
+   i32.const 3519
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51776,7 +51620,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3529
+   i32.const 3520
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51790,7 +51634,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3532
+   i32.const 3523
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51804,7 +51648,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3533
+   i32.const 3524
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51818,7 +51662,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3534
+   i32.const 3525
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51832,7 +51676,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3535
+   i32.const 3526
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51846,7 +51690,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3536
+   i32.const 3527
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51860,7 +51704,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3537
+   i32.const 3528
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51874,7 +51718,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3538
+   i32.const 3529
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51888,7 +51732,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3539
+   i32.const 3530
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51902,7 +51746,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3540
+   i32.const 3531
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51916,7 +51760,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3541
+   i32.const 3532
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51930,7 +51774,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3542
+   i32.const 3533
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51944,7 +51788,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3543
+   i32.const 3534
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51958,7 +51802,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3544
+   i32.const 3535
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51972,7 +51816,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3545
+   i32.const 3536
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -51986,7 +51830,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3546
+   i32.const 3537
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52000,7 +51844,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3547
+   i32.const 3538
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52014,7 +51858,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3548
+   i32.const 3539
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52028,7 +51872,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3549
+   i32.const 3540
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52042,7 +51886,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3550
+   i32.const 3541
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52056,7 +51900,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3551
+   i32.const 3542
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52070,7 +51914,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3552
+   i32.const 3543
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52084,7 +51928,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3553
+   i32.const 3544
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52098,7 +51942,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3565
+   i32.const 3556
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52112,7 +51956,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3566
+   i32.const 3557
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52126,7 +51970,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3567
+   i32.const 3558
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52140,7 +51984,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3568
+   i32.const 3559
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52154,7 +51998,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3569
+   i32.const 3560
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52168,7 +52012,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3570
+   i32.const 3561
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52182,7 +52026,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3571
+   i32.const 3562
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52196,7 +52040,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3572
+   i32.const 3563
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52210,7 +52054,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3573
+   i32.const 3564
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52224,7 +52068,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3574
+   i32.const 3565
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52238,7 +52082,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3577
+   i32.const 3568
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52252,7 +52096,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3578
+   i32.const 3569
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52266,7 +52110,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3579
+   i32.const 3570
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52280,7 +52124,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3580
+   i32.const 3571
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52294,7 +52138,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3581
+   i32.const 3572
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52308,7 +52152,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3582
+   i32.const 3573
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52322,7 +52166,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3583
+   i32.const 3574
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52336,7 +52180,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3584
+   i32.const 3575
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52350,7 +52194,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3585
+   i32.const 3576
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52364,7 +52208,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3586
+   i32.const 3577
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52378,7 +52222,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3587
+   i32.const 3578
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52392,7 +52236,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3588
+   i32.const 3579
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52406,7 +52250,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3589
+   i32.const 3580
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52420,7 +52264,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3590
+   i32.const 3581
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52434,7 +52278,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3591
+   i32.const 3582
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52448,7 +52292,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3592
+   i32.const 3583
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52462,7 +52306,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3593
+   i32.const 3584
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52476,7 +52320,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3594
+   i32.const 3585
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52490,7 +52334,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3595
+   i32.const 3586
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52504,7 +52348,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3596
+   i32.const 3587
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52518,7 +52362,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3597
+   i32.const 3588
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52532,7 +52376,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3598
+   i32.const 3589
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52546,7 +52390,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3599
+   i32.const 3590
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52560,7 +52404,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3600
+   i32.const 3591
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52574,7 +52418,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3601
+   i32.const 3592
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -52588,13 +52432,139 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3602
+   i32.const 3593
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const 1e-323
   f64.const 1e-323
+  f64.const 0
+  i32.const 9
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3594
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 4.4e-323
+  f64.const 4.4e-323
+  f64.const 0
+  i32.const 9
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3595
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 5.562684646268003e-309
+  f64.const 5.562684646268003e-309
+  f64.const 0
+  i32.const 9
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3596
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1.1125369292536007e-308
+  f64.const 1.1125369292536007e-308
+  f64.const 0
+  i32.const 9
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3597
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.2250738585072004e-308
+  f64.const 2.2250738585072004e-308
+  f64.const 0
+  i32.const 9
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3598
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 2.225073858507201e-308
+  f64.const 2.225073858507201e-308
+  f64.const 0
+  i32.const 9
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3599
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1e-323
+  f64.const -1e-323
+  f64.const 0
+  i32.const 9
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3600
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -4.4e-323
+  f64.const -4.4e-323
+  f64.const 0
+  i32.const 9
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3601
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -5.562684646268003e-309
+  f64.const -5.562684646268003e-309
+  f64.const 0
+  i32.const 9
+  call $std/math/test_tan
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3602
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1.1125369292536007e-308
+  f64.const -1.1125369292536007e-308
   f64.const 0
   i32.const 9
   call $std/math/test_tan
@@ -52607,8 +52577,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 4.4e-323
-  f64.const 4.4e-323
+  f64.const -2.2250738585072004e-308
+  f64.const -2.2250738585072004e-308
   f64.const 0
   i32.const 9
   call $std/math/test_tan
@@ -52621,8 +52591,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5.562684646268003e-309
-  f64.const 5.562684646268003e-309
+  f64.const -2.225073858507201e-308
+  f64.const -2.225073858507201e-308
   f64.const 0
   i32.const 9
   call $std/math/test_tan
@@ -52635,39 +52605,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.1125369292536007e-308
-  f64.const 1.1125369292536007e-308
-  f64.const 0
-  i32.const 9
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3606
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.2250738585072004e-308
-  f64.const 2.2250738585072004e-308
-  f64.const 0
-  i32.const 9
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3607
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 2.225073858507201e-308
-  f64.const 2.225073858507201e-308
-  f64.const 0
-  i32.const 9
-  call $std/math/test_tan
+  f64.const 2.3283064365386963e-10
+  call $~lib/math/NativeMath.tan
+  f64.const 2.3283064365386963e-10
+  call $~lib/bindings/Math/tan
+  f64.eq
   i32.eqz
   if
    i32.const 0
@@ -52677,11 +52619,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1e-323
-  f64.const -1e-323
-  f64.const 0
-  i32.const 9
-  call $std/math/test_tan
+  f64.const -2.3283064365386963e-10
+  call $~lib/math/NativeMath.tan
+  f64.const -2.3283064365386963e-10
+  call $~lib/bindings/Math/tan
+  f64.eq
   i32.eqz
   if
    i32.const 0
@@ -52691,11 +52633,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -4.4e-323
-  f64.const -4.4e-323
-  f64.const 0
-  i32.const 9
-  call $std/math/test_tan
+  f64.const 0.6875
+  call $~lib/math/NativeMath.tan
+  f64.const 0.6875
+  call $~lib/bindings/Math/tan
+  f64.eq
   i32.eqz
   if
    i32.const 0
@@ -52705,11 +52647,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -5.562684646268003e-309
-  f64.const -5.562684646268003e-309
-  f64.const 0
-  i32.const 9
-  call $std/math/test_tan
+  f64.const -0.6875
+  call $~lib/math/NativeMath.tan
+  f64.const -0.6875
+  call $~lib/bindings/Math/tan
+  f64.eq
   i32.eqz
   if
    i32.const 0
@@ -52719,11 +52661,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -1.1125369292536007e-308
-  f64.const -1.1125369292536007e-308
-  f64.const 0
-  i32.const 9
-  call $std/math/test_tan
+  f64.const 0.39269908169872414
+  call $~lib/math/NativeMath.tan
+  f64.const 0.39269908169872414
+  call $~lib/bindings/Math/tan
+  f64.eq
   i32.eqz
   if
    i32.const 0
@@ -52733,11 +52675,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.2250738585072004e-308
-  f64.const -2.2250738585072004e-308
-  f64.const 0
-  i32.const 9
-  call $std/math/test_tan
+  f64.const 0.6743358
+  call $~lib/math/NativeMath.tan
+  f64.const 0.6743358
+  call $~lib/bindings/Math/tan
+  f64.eq
   i32.eqz
   if
    i32.const 0
@@ -52747,11 +52689,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.225073858507201e-308
-  f64.const -2.225073858507201e-308
-  f64.const 0
-  i32.const 9
-  call $std/math/test_tan
+  f64.const 3.725290298461914e-09
+  call $~lib/math/NativeMath.tan
+  f64.const 3.725290298461914e-09
+  call $~lib/bindings/Math/tan
+  f64.eq
   i32.eqz
   if
    i32.const 0
@@ -52761,9 +52703,23 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 2.3283064365386963e-10
+  f64.const 1.5707963267948966
   call $~lib/math/NativeMath.tan
-  f64.const 2.3283064365386963e-10
+  f64.const 1.5707963267948966
+  call $~lib/bindings/Math/tan
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3615
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0.5
+  call $~lib/math/NativeMath.tan
+  f64.const 0.5
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -52775,9 +52731,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -2.3283064365386963e-10
+  f64.const 1.107148717794091
   call $~lib/math/NativeMath.tan
-  f64.const -2.3283064365386963e-10
+  f64.const 1.107148717794091
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -52789,9 +52745,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.6875
+  f64.const 5.497787143782138
   call $~lib/math/NativeMath.tan
-  f64.const 0.6875
+  f64.const 5.497787143782138
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -52803,9 +52759,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const -0.6875
+  f64.const 7.0685834705770345
   call $~lib/math/NativeMath.tan
-  f64.const -0.6875
+  f64.const 7.0685834705770345
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -52817,9 +52773,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.39269908169872414
+  f64.const 1647099.3291652855
   call $~lib/math/NativeMath.tan
-  f64.const 0.39269908169872414
+  f64.const 1647099.3291652855
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -52831,9 +52787,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.6743358
+  f64.const 1647097.7583689587
   call $~lib/math/NativeMath.tan
-  f64.const 0.6743358
+  f64.const 1647097.7583689587
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -52845,9 +52801,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 3.725290298461914e-09
+  f64.const 1329227995784915872903807e12
   call $~lib/math/NativeMath.tan
-  f64.const 3.725290298461914e-09
+  f64.const 1329227995784915872903807e12
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -52859,9 +52815,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 1.5707963267948966
+  f64.const -1329227995784915872903807e12
   call $~lib/math/NativeMath.tan
-  f64.const 1.5707963267948966
+  f64.const -1329227995784915872903807e12
   call $~lib/bindings/Math/tan
   f64.eq
   i32.eqz
@@ -52873,25 +52829,11 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 0.5
-  call $~lib/math/NativeMath.tan
-  f64.const 0.5
-  call $~lib/bindings/Math/tan
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3626
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1.107148717794091
-  call $~lib/math/NativeMath.tan
-  f64.const 1.107148717794091
-  call $~lib/bindings/Math/tan
-  f64.eq
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_tan
   i32.eqz
   if
    i32.const 0
@@ -52901,114 +52843,16 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const 5.497787143782138
-  call $~lib/math/NativeMath.tan
-  f64.const 5.497787143782138
-  call $~lib/bindings/Math/tan
-  f64.eq
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_tan
   i32.eqz
   if
    i32.const 0
    i32.const 32
    i32.const 3628
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 7.0685834705770345
-  call $~lib/math/NativeMath.tan
-  f64.const 7.0685834705770345
-  call $~lib/bindings/Math/tan
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3629
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1647099.3291652855
-  call $~lib/math/NativeMath.tan
-  f64.const 1647099.3291652855
-  call $~lib/bindings/Math/tan
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3630
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1647097.7583689587
-  call $~lib/math/NativeMath.tan
-  f64.const 1647097.7583689587
-  call $~lib/bindings/Math/tan
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3631
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1329227995784915872903807e12
-  call $~lib/math/NativeMath.tan
-  f64.const 1329227995784915872903807e12
-  call $~lib/bindings/Math/tan
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3632
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1329227995784915872903807e12
-  call $~lib/math/NativeMath.tan
-  f64.const -1329227995784915872903807e12
-  call $~lib/bindings/Math/tan
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3633
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3636
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_tan
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3637
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53022,7 +52866,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3638
+   i32.const 3629
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53036,7 +52880,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3639
+   i32.const 3630
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53050,7 +52894,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3640
+   i32.const 3631
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53064,7 +52908,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3649
+   i32.const 3640
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53078,7 +52922,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3650
+   i32.const 3641
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53092,7 +52936,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3651
+   i32.const 3642
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53106,7 +52950,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3652
+   i32.const 3643
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53120,7 +52964,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3653
+   i32.const 3644
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53134,7 +52978,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3654
+   i32.const 3645
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53148,7 +52992,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3655
+   i32.const 3646
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53162,7 +53006,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3656
+   i32.const 3647
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53176,7 +53020,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3657
+   i32.const 3648
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53190,7 +53034,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3658
+   i32.const 3649
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53204,7 +53048,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3661
+   i32.const 3652
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53218,7 +53062,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3662
+   i32.const 3653
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53232,7 +53076,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3663
+   i32.const 3654
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53246,7 +53090,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3664
+   i32.const 3655
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53260,7 +53104,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3665
+   i32.const 3656
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53274,7 +53118,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3668
+   i32.const 3659
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53288,13 +53132,139 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3669
+   i32.const 3660
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 1.1754943508222875e-38
   f32.const 1.1754943508222875e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3661
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.1754943508222875e-38
+  f32.const -1.1754943508222875e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3662
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.401298464324817e-45
+  f32.const 1.401298464324817e-45
+  f32.const 0
+  i32.const 9
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3663
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.401298464324817e-45
+  f32.const -1.401298464324817e-45
+  f32.const 0
+  i32.const 9
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3664
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.175494490952134e-38
+  f32.const 1.175494490952134e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3665
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.1754946310819804e-38
+  f32.const 1.1754946310819804e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3666
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.3509880009953429e-38
+  f32.const 2.3509880009953429e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3667
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.350988701644575e-38
+  f32.const 2.350988701644575e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3668
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.3509895424236536e-38
+  f32.const 2.3509895424236536e-38
+  f32.const 0
+  i32.const 1
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3669
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 4.70197740328915e-38
+  f32.const 4.70197740328915e-38
   f32.const 0
   i32.const 1
   call $std/math/test_tanf
@@ -53307,9 +53277,9 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.1754943508222875e-38
-  f32.const -1.1754943508222875e-38
-  f32.const 0
+  f32.const 1.1175870895385742e-08
+  f32.const 1.1175870895385742e-08
+  f32.const -5.238689482212067e-10
   i32.const 1
   call $std/math/test_tanf
   i32.eqz
@@ -53321,10 +53291,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.401298464324817e-45
-  f32.const 1.401298464324817e-45
-  f32.const 0
-  i32.const 9
+  f32.const 1.4901161193847656e-08
+  f32.const 1.4901161193847656e-08
+  f32.const -6.208817349140361e-10
+  i32.const 1
   call $std/math/test_tanf
   i32.eqz
   if
@@ -53335,10 +53305,10 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const -1.401298464324817e-45
-  f32.const -1.401298464324817e-45
-  f32.const 0
-  i32.const 9
+  f32.const 0.000244140625
+  f32.const 0.000244140625
+  f32.const -0.1666666716337204
+  i32.const 1
   call $std/math/test_tanf
   i32.eqz
   if
@@ -53349,8 +53319,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.175494490952134e-38
-  f32.const 1.175494490952134e-38
+  f32.const -1.175494490952134e-38
+  f32.const -1.175494490952134e-38
   f32.const 0
   i32.const 1
   call $std/math/test_tanf
@@ -53363,8 +53333,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.1754946310819804e-38
-  f32.const 1.1754946310819804e-38
+  f32.const -1.1754946310819804e-38
+  f32.const -1.1754946310819804e-38
   f32.const 0
   i32.const 1
   call $std/math/test_tanf
@@ -53377,8 +53347,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509880009953429e-38
-  f32.const 2.3509880009953429e-38
+  f32.const -2.3509880009953429e-38
+  f32.const -2.3509880009953429e-38
   f32.const 0
   i32.const 1
   call $std/math/test_tanf
@@ -53405,8 +53375,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.3509895424236536e-38
-  f32.const 2.3509895424236536e-38
+  f32.const -2.3509895424236536e-38
+  f32.const -2.3509895424236536e-38
   f32.const 0
   i32.const 1
   call $std/math/test_tanf
@@ -53419,8 +53389,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 4.70197740328915e-38
-  f32.const 4.70197740328915e-38
+  f32.const -4.70197740328915e-38
+  f32.const -4.70197740328915e-38
   f32.const 0
   i32.const 1
   call $std/math/test_tanf
@@ -53429,132 +53399,6 @@
    i32.const 0
    i32.const 32
    i32.const 3679
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1175870895385742e-08
-  f32.const 1.1175870895385742e-08
-  f32.const -5.238689482212067e-10
-  i32.const 1
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3680
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.4901161193847656e-08
-  f32.const 1.4901161193847656e-08
-  f32.const -6.208817349140361e-10
-  i32.const 1
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3681
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0.000244140625
-  f32.const 0.000244140625
-  f32.const -0.1666666716337204
-  i32.const 1
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3682
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.175494490952134e-38
-  f32.const -1.175494490952134e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3683
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754946310819804e-38
-  f32.const -1.1754946310819804e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3684
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.3509880009953429e-38
-  f32.const -2.3509880009953429e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3685
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 2.350988701644575e-38
-  f32.const 2.350988701644575e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3686
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.3509895424236536e-38
-  f32.const -2.3509895424236536e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3687
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -4.70197740328915e-38
-  f32.const -4.70197740328915e-38
-  f32.const 0
-  i32.const 1
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3688
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53568,7 +53412,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3689
+   i32.const 3680
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53582,7 +53426,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3690
+   i32.const 3681
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53596,13 +53440,139 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3691
+   i32.const 3682
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const 2.802596928649634e-45
   f32.const 2.802596928649634e-45
+  f32.const 0
+  i32.const 9
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3683
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.2611686178923354e-44
+  f32.const 1.2611686178923354e-44
+  f32.const 0
+  i32.const 9
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3684
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 2.938735877055719e-39
+  f32.const 2.938735877055719e-39
+  f32.const 0
+  i32.const 9
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3685
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 5.877471754111438e-39
+  f32.const 5.877471754111438e-39
+  f32.const 0
+  i32.const 9
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3686
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.1754940705625946e-38
+  f32.const 1.1754940705625946e-38
+  f32.const 0
+  i32.const 9
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3687
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1.1754942106924411e-38
+  f32.const 1.1754942106924411e-38
+  f32.const 0
+  i32.const 9
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3688
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.802596928649634e-45
+  f32.const -2.802596928649634e-45
+  f32.const 0
+  i32.const 9
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3689
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1.2611686178923354e-44
+  f32.const -1.2611686178923354e-44
+  f32.const 0
+  i32.const 9
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3690
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -2.938735877055719e-39
+  f32.const -2.938735877055719e-39
+  f32.const 0
+  i32.const 9
+  call $std/math/test_tanf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3691
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -5.877471754111438e-39
+  f32.const -5.877471754111438e-39
   f32.const 0
   i32.const 9
   call $std/math/test_tanf
@@ -53615,8 +53585,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 1.2611686178923354e-44
-  f32.const 1.2611686178923354e-44
+  f32.const -1.1754940705625946e-38
+  f32.const -1.1754940705625946e-38
   f32.const 0
   i32.const 9
   call $std/math/test_tanf
@@ -53629,8 +53599,8 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const 2.938735877055719e-39
-  f32.const 2.938735877055719e-39
+  f32.const -1.1754942106924411e-38
+  f32.const -1.1754942106924411e-38
   f32.const 0
   i32.const 9
   call $std/math/test_tanf
@@ -53639,132 +53609,6 @@
    i32.const 0
    i32.const 32
    i32.const 3694
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 5.877471754111438e-39
-  f32.const 5.877471754111438e-39
-  f32.const 0
-  i32.const 9
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3695
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754940705625946e-38
-  f32.const 1.1754940705625946e-38
-  f32.const 0
-  i32.const 9
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3696
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1.1754942106924411e-38
-  f32.const 1.1754942106924411e-38
-  f32.const 0
-  i32.const 9
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3697
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.802596928649634e-45
-  f32.const -2.802596928649634e-45
-  f32.const 0
-  i32.const 9
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3698
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.2611686178923354e-44
-  f32.const -1.2611686178923354e-44
-  f32.const 0
-  i32.const 9
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3699
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -2.938735877055719e-39
-  f32.const -2.938735877055719e-39
-  f32.const 0
-  i32.const 9
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3700
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -5.877471754111438e-39
-  f32.const -5.877471754111438e-39
-  f32.const 0
-  i32.const 9
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3701
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754940705625946e-38
-  f32.const -1.1754940705625946e-38
-  f32.const 0
-  i32.const 9
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3702
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1.1754942106924411e-38
-  f32.const -1.1754942106924411e-38
-  f32.const 0
-  i32.const 9
-  call $std/math/test_tanf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3703
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53778,7 +53622,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3715
+   i32.const 3706
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53792,7 +53636,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3716
+   i32.const 3707
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53806,7 +53650,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3717
+   i32.const 3708
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53820,7 +53664,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3718
+   i32.const 3709
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53834,7 +53678,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3719
+   i32.const 3710
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53848,7 +53692,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3720
+   i32.const 3711
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53862,7 +53706,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3721
+   i32.const 3712
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53876,7 +53720,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3722
+   i32.const 3713
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53890,7 +53734,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3723
+   i32.const 3714
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53904,7 +53748,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3724
+   i32.const 3715
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53918,7 +53762,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3727
+   i32.const 3718
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53932,7 +53776,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3728
+   i32.const 3719
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53946,7 +53790,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3729
+   i32.const 3720
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53960,7 +53804,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3730
+   i32.const 3721
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53974,7 +53818,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3731
+   i32.const 3722
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -53988,7 +53832,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3740
+   i32.const 3731
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54002,7 +53846,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3741
+   i32.const 3732
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54016,7 +53860,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3742
+   i32.const 3733
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54030,7 +53874,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3743
+   i32.const 3734
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54044,7 +53888,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3744
+   i32.const 3735
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54058,7 +53902,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3745
+   i32.const 3736
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54072,7 +53916,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3746
+   i32.const 3737
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54086,7 +53930,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3747
+   i32.const 3738
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54100,7 +53944,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3748
+   i32.const 3739
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54114,7 +53958,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3749
+   i32.const 3740
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54128,7 +53972,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3752
+   i32.const 3743
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54142,7 +53986,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3753
+   i32.const 3744
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54156,7 +54000,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3754
+   i32.const 3745
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54170,7 +54014,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3755
+   i32.const 3746
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54184,7 +54028,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3756
+   i32.const 3747
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54198,7 +54042,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3768
+   i32.const 3759
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54212,7 +54056,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3769
+   i32.const 3760
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54226,7 +54070,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3770
+   i32.const 3761
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54240,7 +54084,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3771
+   i32.const 3762
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54254,7 +54098,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3772
+   i32.const 3763
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54268,7 +54112,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3773
+   i32.const 3764
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54282,7 +54126,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3774
+   i32.const 3765
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54296,7 +54140,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3775
+   i32.const 3766
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54310,7 +54154,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3776
+   i32.const 3767
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54324,105 +54168,105 @@
   if
    i32.const 0
    i32.const 32
+   i32.const 3768
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  f64.const nan:0x8000000000000
+  f64.const 0
+  i32.const 0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3771
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  f64.const inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3772
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  f64.const -inf
+  f64.const 0
+  i32.const 0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3773
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3774
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -0
+  f64.const -0
+  f64.const 0
+  i32.const 0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3775
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
+  f64.const 1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3776
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -1
+  f64.const -1
+  f64.const 0
+  i32.const 0
+  call $std/math/test_trunc
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
    i32.const 3777
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  f64.const nan:0x8000000000000
-  f64.const 0
-  i32.const 0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3780
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  f64.const inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3781
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  f64.const -inf
-  f64.const 0
-  i32.const 0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3782
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3783
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -0
-  f64.const -0
-  f64.const 0
-  i32.const 0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3784
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  f64.const 1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3785
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -1
-  f64.const -1
-  f64.const 0
-  i32.const 0
-  call $std/math/test_trunc
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3786
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54436,7 +54280,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3787
+   i32.const 3778
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54450,7 +54294,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3788
+   i32.const 3779
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54464,7 +54308,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3789
+   i32.const 3780
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54478,7 +54322,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3790
+   i32.const 3781
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54492,7 +54336,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3791
+   i32.const 3782
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54506,7 +54350,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3792
+   i32.const 3783
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54520,7 +54364,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3793
+   i32.const 3784
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54534,7 +54378,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3794
+   i32.const 3785
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54548,7 +54392,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3803
+   i32.const 3794
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54562,7 +54406,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3804
+   i32.const 3795
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54576,7 +54420,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3805
+   i32.const 3796
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54590,7 +54434,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3806
+   i32.const 3797
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54604,7 +54448,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3807
+   i32.const 3798
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54618,7 +54462,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3808
+   i32.const 3799
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54632,7 +54476,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3809
+   i32.const 3800
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54646,7 +54490,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3810
+   i32.const 3801
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54660,7 +54504,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3811
+   i32.const 3802
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54674,105 +54518,105 @@
   if
    i32.const 0
    i32.const 32
+   i32.const 3803
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  f32.const nan:0x400000
+  f32.const 0
+  i32.const 0
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3806
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  f32.const inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3807
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  f32.const -inf
+  f32.const 0
+  i32.const 0
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3808
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 0
+  f32.const 0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3809
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -0
+  f32.const -0
+  f32.const 0
+  i32.const 0
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3810
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
+  f32.const 1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3811
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -1
+  f32.const -1
+  f32.const 0
+  i32.const 0
+  call $std/math/test_truncf
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
    i32.const 3812
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  f32.const nan:0x400000
-  f32.const 0
-  i32.const 0
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3815
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  f32.const inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3816
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  f32.const -inf
-  f32.const 0
-  i32.const 0
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3817
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 0
-  f32.const 0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3818
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -0
-  f32.const -0
-  f32.const 0
-  i32.const 0
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3819
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  f32.const 1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3820
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -1
-  f32.const -1
-  f32.const 0
-  i32.const 0
-  call $std/math/test_truncf
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3821
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54786,7 +54630,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3822
+   i32.const 3813
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54800,7 +54644,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3823
+   i32.const 3814
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54814,7 +54658,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3824
+   i32.const 3815
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54828,7 +54672,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3825
+   i32.const 3816
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54842,7 +54686,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3826
+   i32.const 3817
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54856,7 +54700,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3827
+   i32.const 3818
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54870,7 +54714,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3828
+   i32.const 3819
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54884,7 +54728,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3829
+   i32.const 3820
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54978,7 +54822,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3870
+   i32.const 3861
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -54992,7 +54836,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3871
+   i32.const 3862
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55006,7 +54850,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3872
+   i32.const 3863
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55020,7 +54864,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3873
+   i32.const 3864
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55034,7 +54878,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3874
+   i32.const 3865
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55048,7 +54892,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3875
+   i32.const 3866
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55062,7 +54906,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3876
+   i32.const 3867
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55076,7 +54920,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3877
+   i32.const 3868
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55090,7 +54934,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3878
+   i32.const 3869
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55104,7 +54948,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3879
+   i32.const 3870
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55118,7 +54962,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3880
+   i32.const 3871
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55132,7 +54976,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3881
+   i32.const 3872
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55145,7 +54989,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3885
+   i32.const 3876
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55158,7 +55002,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3886
+   i32.const 3877
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55171,7 +55015,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3887
+   i32.const 3878
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55184,7 +55028,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3888
+   i32.const 3879
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55197,7 +55041,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3889
+   i32.const 3880
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55210,7 +55054,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3890
+   i32.const 3881
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55223,7 +55067,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3891
+   i32.const 3882
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55236,7 +55080,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3892
+   i32.const 3883
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55249,7 +55093,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3893
+   i32.const 3884
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55262,7 +55106,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3894
+   i32.const 3885
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55275,7 +55119,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3895
+   i32.const 3886
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55288,7 +55132,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3896
+   i32.const 3887
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55301,7 +55145,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3897
+   i32.const 3888
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55314,7 +55158,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3898
+   i32.const 3889
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55327,7 +55171,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3899
+   i32.const 3890
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55340,7 +55184,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3900
+   i32.const 3891
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55354,7 +55198,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3904
+   i32.const 3895
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55363,6 +55207,104 @@
   i32.const 1
   call $~lib/math/ipow64
   i64.const 0
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3896
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 0
+  i32.const 2
+  call $~lib/math/ipow64
+  i64.const 0
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3897
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 0
+  i32.const 3
+  call $~lib/math/ipow64
+  i64.const 0
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3898
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 1
+  i32.const 0
+  call $~lib/math/ipow64
+  i64.const 1
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3900
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 1
+  i32.const 1
+  call $~lib/math/ipow64
+  i64.const 1
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3901
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 1
+  i32.const 2
+  call $~lib/math/ipow64
+  i64.const 1
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3902
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 1
+  i32.const 3
+  call $~lib/math/ipow64
+  i64.const 1
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3903
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i64.const 2
+  i32.const 0
+  call $~lib/math/ipow64
+  i64.const 1
   i64.eq
   i32.eqz
   if
@@ -55373,114 +55315,16 @@
    call $~lib/builtins/abort
    unreachable
   end
-  i64.const 0
-  i32.const 2
+  i64.const 2
+  i32.const 1
   call $~lib/math/ipow64
-  i64.const 0
+  i64.const 2
   i64.eq
   i32.eqz
   if
    i32.const 0
    i32.const 32
    i32.const 3906
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 0
-  i32.const 3
-  call $~lib/math/ipow64
-  i64.const 0
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3907
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 1
-  i32.const 0
-  call $~lib/math/ipow64
-  i64.const 1
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3909
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 1
-  i32.const 1
-  call $~lib/math/ipow64
-  i64.const 1
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3910
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 1
-  i32.const 2
-  call $~lib/math/ipow64
-  i64.const 1
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3911
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 1
-  i32.const 3
-  call $~lib/math/ipow64
-  i64.const 1
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3912
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 2
-  i32.const 0
-  call $~lib/math/ipow64
-  i64.const 1
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3914
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i64.const 2
-  i32.const 1
-  call $~lib/math/ipow64
-  i64.const 2
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3915
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55494,7 +55338,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3916
+   i32.const 3907
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55508,7 +55352,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3917
+   i32.const 3908
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55522,7 +55366,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3919
+   i32.const 3910
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55536,7 +55380,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3920
+   i32.const 3911
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55550,7 +55394,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3921
+   i32.const 3912
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55564,7 +55408,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3922
+   i32.const 3913
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55578,7 +55422,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3924
+   i32.const 3915
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55592,7 +55436,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3925
+   i32.const 3916
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55606,7 +55450,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3926
+   i32.const 3917
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55620,7 +55464,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3927
+   i32.const 3918
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55634,7 +55478,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3929
+   i32.const 3920
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55648,7 +55492,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3930
+   i32.const 3921
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55662,7 +55506,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3931
+   i32.const 3922
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55676,7 +55520,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3932
+   i32.const 3923
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55690,7 +55534,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3933
+   i32.const 3924
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55704,7 +55548,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3934
+   i32.const 3925
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55718,7 +55562,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3935
+   i32.const 3926
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55736,7 +55580,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3937
+   i32.const 3928
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55750,12 +55594,141 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3941
+   i32.const 3932
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f32.const nan:0x400000
+  i32.const 0
+  call $~lib/math/ipow32f
+  f32.const 1
+  f32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3933
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  i32.const 1
+  call $~lib/math/ipow32f
+  local.tee $4
+  local.get $4
+  f32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3934
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  i32.const -1
+  call $~lib/math/ipow32f
+  local.tee $4
+  local.get $4
+  f32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3935
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const nan:0x400000
+  i32.const 2
+  call $~lib/math/ipow32f
+  local.tee $4
+  local.get $4
+  f32.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3936
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  i32.const 0
+  call $~lib/math/ipow32f
+  f32.const 1
+  f32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3937
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const inf
+  i32.const 1
+  call $~lib/math/ipow32f
+  f32.const inf
+  f32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3938
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  i32.const 0
+  call $~lib/math/ipow32f
+  f32.const 1
+  f32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3939
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  i32.const 1
+  call $~lib/math/ipow32f
+  f32.const -inf
+  f32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3940
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const -inf
+  i32.const 2
+  call $~lib/math/ipow32f
+  f32.const inf
+  f32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3941
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f32.const 1
   i32.const 0
   call $~lib/math/ipow32f
   f32.const 1
@@ -55769,135 +55742,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f32.const nan:0x400000
-  i32.const 1
-  call $~lib/math/ipow32f
-  local.tee $4
-  local.get $4
-  f32.ne
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3943
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  i32.const -1
-  call $~lib/math/ipow32f
-  local.tee $4
-  local.get $4
-  f32.ne
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3944
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const nan:0x400000
-  i32.const 2
-  call $~lib/math/ipow32f
-  local.tee $4
-  local.get $4
-  f32.ne
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3945
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  i32.const 0
-  call $~lib/math/ipow32f
-  f32.const 1
-  f32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3946
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const inf
-  i32.const 1
-  call $~lib/math/ipow32f
-  f32.const inf
-  f32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3947
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  i32.const 0
-  call $~lib/math/ipow32f
-  f32.const 1
-  f32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3948
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  i32.const 1
-  call $~lib/math/ipow32f
-  f32.const -inf
-  f32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3949
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const -inf
-  i32.const 2
-  call $~lib/math/ipow32f
-  f32.const inf
-  f32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3950
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f32.const 1
-  i32.const 0
-  call $~lib/math/ipow32f
-  f32.const 1
-  f32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3951
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f32.const 3402823466385288598117041e14
   i32.const 2
   call $~lib/math/ipow32f
@@ -55907,7 +55751,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3952
+   i32.const 3943
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55921,7 +55765,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3953
+   i32.const 3944
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55935,7 +55779,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3954
+   i32.const 3945
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55949,7 +55793,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3955
+   i32.const 3946
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55963,7 +55807,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3956
+   i32.const 3947
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -55977,12 +55821,141 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3960
+   i32.const 3951
    i32.const 0
    call $~lib/builtins/abort
    unreachable
   end
   f64.const nan:0x8000000000000
+  i32.const 0
+  call $~lib/math/ipow64f
+  f64.const 1
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3952
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  i32.const 1
+  call $~lib/math/ipow64f
+  local.tee $0
+  local.get $0
+  f64.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3953
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  i32.const -1
+  call $~lib/math/ipow64f
+  local.tee $0
+  local.get $0
+  f64.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3954
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const nan:0x8000000000000
+  i32.const 2
+  call $~lib/math/ipow64f
+  local.tee $0
+  local.get $0
+  f64.ne
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3955
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  i32.const 0
+  call $~lib/math/ipow64f
+  f64.const 1
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3956
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const inf
+  i32.const 1
+  call $~lib/math/ipow64f
+  f64.const inf
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3957
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  i32.const 0
+  call $~lib/math/ipow64f
+  f64.const 1
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3958
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  i32.const 1
+  call $~lib/math/ipow64f
+  f64.const -inf
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3959
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const -inf
+  i32.const 2
+  call $~lib/math/ipow64f
+  f64.const inf
+  f64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 3960
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+  f64.const 1
   i32.const 0
   call $~lib/math/ipow64f
   f64.const 1
@@ -55996,135 +55969,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  f64.const nan:0x8000000000000
-  i32.const 1
-  call $~lib/math/ipow64f
-  local.tee $0
-  local.get $0
-  f64.ne
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3962
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  i32.const -1
-  call $~lib/math/ipow64f
-  local.tee $0
-  local.get $0
-  f64.ne
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3963
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const nan:0x8000000000000
-  i32.const 2
-  call $~lib/math/ipow64f
-  local.tee $0
-  local.get $0
-  f64.ne
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3964
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  i32.const 0
-  call $~lib/math/ipow64f
-  f64.const 1
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3965
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const inf
-  i32.const 1
-  call $~lib/math/ipow64f
-  f64.const inf
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3966
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  i32.const 0
-  call $~lib/math/ipow64f
-  f64.const 1
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3967
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  i32.const 1
-  call $~lib/math/ipow64f
-  f64.const -inf
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3968
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const -inf
-  i32.const 2
-  call $~lib/math/ipow64f
-  f64.const inf
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3969
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
-  f64.const 1
-  i32.const 0
-  call $~lib/math/ipow64f
-  f64.const 1
-  f64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 32
-   i32.const 3970
-   i32.const 0
-   call $~lib/builtins/abort
-   unreachable
-  end
   f64.const 1797693134862315708145274e284
   i32.const 2
   call $~lib/math/ipow64f
@@ -56134,7 +55978,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3971
+   i32.const 3962
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -56148,7 +55992,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3972
+   i32.const 3963
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -56162,7 +56006,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3973
+   i32.const 3964
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -56176,7 +56020,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3974
+   i32.const 3965
    i32.const 0
    call $~lib/builtins/abort
    unreachable
@@ -56190,7 +56034,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 3975
+   i32.const 3966
    i32.const 0
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/operator-overloading.optimized.wat
+++ b/tests/compiler/std/operator-overloading.optimized.wat
@@ -278,9 +278,9 @@
     f64.const inf
     local.get $0
     f64.sqrt
-    local.get $0
     f64.abs
-    f64.const inf
+    local.get $0
+    f64.const -inf
     f64.eq
     select
     return
@@ -311,8 +311,7 @@
     f64.sqrt
     f64.div
     local.get $0
-    f64.abs
-    f64.const inf
+    f64.const -inf
     f64.eq
     select
     return

--- a/tests/compiler/std/operator-overloading.optimized.wat
+++ b/tests/compiler/std/operator-overloading.optimized.wat
@@ -295,26 +295,6 @@
     return
    end
    local.get $1
-   f64.const -0.5
-   f64.eq
-   if
-    f64.const 1
-    local.get $0
-    f64.sqrt
-    f64.div
-    f64.const 0
-    local.get $0
-    f64.const -inf
-    f64.ne
-    select
-    f64.const inf
-    local.get $0
-    f64.const 0
-    f64.ne
-    select
-    return
-   end
-   local.get $1
    f64.const 1
    f64.eq
    if

--- a/tests/compiler/std/operator-overloading.optimized.wat
+++ b/tests/compiler/std/operator-overloading.optimized.wat
@@ -275,13 +275,13 @@
    f64.const 0.5
    f64.eq
    if
-    f64.const inf
     local.get $0
     f64.sqrt
     f64.abs
+    f64.const inf
     local.get $0
     f64.const -inf
-    f64.eq
+    f64.ne
     select
     return
    end
@@ -298,21 +298,19 @@
    f64.const -0.5
    f64.eq
    if
-    local.get $0
-    f64.const 0
-    f64.eq
-    if
-     f64.const inf
-     return
-    end
-    f64.const 0
     f64.const 1
     local.get $0
     f64.sqrt
     f64.div
+    f64.const 0
     local.get $0
     f64.const -inf
-    f64.eq
+    f64.ne
+    select
+    f64.const inf
+    local.get $0
+    f64.const 0
+    f64.ne
     select
     return
    end

--- a/tests/compiler/std/operator-overloading.untouched.wat
+++ b/tests/compiler/std/operator-overloading.untouched.wat
@@ -421,14 +421,14 @@
    f64.const 0.5
    f64.eq
    if
-    f64.const inf
     local.get $0
     f64.sqrt
     f64.abs
+    f64.const inf
     local.get $0
     f64.const inf
     f64.neg
-    f64.eq
+    f64.ne
     select
     return
    end
@@ -445,22 +445,20 @@
    f64.const -0.5
    f64.eq
    if
-    local.get $0
-    f64.const 0
-    f64.eq
-    if
-     f64.const inf
-     return
-    end
-    f64.const 0
     f64.const 1
     local.get $0
     f64.sqrt
     f64.div
+    f64.const 0
     local.get $0
     f64.const inf
     f64.neg
-    f64.eq
+    f64.ne
+    select
+    f64.const inf
+    local.get $0
+    f64.const 0
+    f64.ne
     select
     return
    end

--- a/tests/compiler/std/operator-overloading.untouched.wat
+++ b/tests/compiler/std/operator-overloading.untouched.wat
@@ -442,27 +442,6 @@
     return
    end
    local.get $1
-   f64.const -0.5
-   f64.eq
-   if
-    f64.const 1
-    local.get $0
-    f64.sqrt
-    f64.div
-    f64.const 0
-    local.get $0
-    f64.const inf
-    f64.neg
-    f64.ne
-    select
-    f64.const inf
-    local.get $0
-    f64.const 0
-    f64.ne
-    select
-    return
-   end
-   local.get $1
    f64.const 1
    f64.eq
    if

--- a/tests/compiler/std/operator-overloading.untouched.wat
+++ b/tests/compiler/std/operator-overloading.untouched.wat
@@ -424,9 +424,10 @@
     f64.const inf
     local.get $0
     f64.sqrt
-    local.get $0
     f64.abs
+    local.get $0
     f64.const inf
+    f64.neg
     f64.eq
     select
     return
@@ -457,8 +458,8 @@
     f64.sqrt
     f64.div
     local.get $0
-    f64.abs
     f64.const inf
+    f64.neg
     f64.eq
     select
     return


### PR DESCRIPTION
1) Fix `Math.pow(-0, 0.5)` => `0` instead `-0`.
2) Remove Math.pow(x, -0.5) because it could lead to precision loss.