### PR TITLE
Fix TLSF state corruption

### DIFF
--- a/std/assembly/rt/tlsf.ts
+++ b/std/assembly/rt/tlsf.ts
@@ -552,14 +552,10 @@ export function reallocateBlock(root: Root, block: Block, size: usize): Block {
   }
 
   // otherwise move the block
-  var newBlock = allocateBlock(root, size);
+  var newBlock = allocateBlock(root, size); // may invalidate cached blockInfo
   newBlock.rtId = block.rtId;
   memory.copy(changetype<usize>(newBlock) + BLOCK_OVERHEAD, changetype<usize>(block) + BLOCK_OVERHEAD, size);
-  if (changetype<usize>(block) >= __heap_base) {
-    block.mmInfo = blockInfo | FREE;
-    insertBlock(root, block);
-    if (isDefined(ASC_RTRACE)) onfree(block);
-  }
+  if (changetype<usize>(block) >= __heap_base) freeBlock(root, block);
   return newBlock;
 }
 

--- a/tests/compiler/do.optimized.wat
+++ b/tests/compiler/do.optimized.wat
@@ -1116,7 +1116,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1824,7 +1824,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/do.untouched.wat
+++ b/tests/compiler/do.untouched.wat
@@ -1534,7 +1534,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3437,7 +3437,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/extends-baseaggregate.optimized.wat
+++ b/tests/compiler/extends-baseaggregate.optimized.wat
@@ -869,7 +869,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1670,14 +1670,9 @@
   i32.const 556
   i32.ge_u
   if
-   local.get $1
-   local.get $4
-   i32.const 1
-   i32.or
-   i32.store
    local.get $0
    local.get $1
-   call $~lib/rt/tlsf/insertBlock
+   call $~lib/rt/tlsf/freeBlock
   end
   local.get $3
  )
@@ -1693,7 +1688,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 586
+   i32.const 582
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2005,7 +2000,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/extends-baseaggregate.untouched.wat
+++ b/tests/compiler/extends-baseaggregate.untouched.wat
@@ -1146,7 +1146,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3156,14 +3156,9 @@
   global.get $~lib/heap/__heap_base
   i32.ge_u
   if
-   local.get $1
-   local.get $4
-   i32.const 1
-   i32.or
-   i32.store
    local.get $0
    local.get $1
-   call $~lib/rt/tlsf/insertBlock
+   call $~lib/rt/tlsf/freeBlock
   end
   local.get $8
  )
@@ -3183,7 +3178,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 586
+   i32.const 582
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3565,7 +3560,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/for.optimized.wat
+++ b/tests/compiler/for.optimized.wat
@@ -1136,7 +1136,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1844,7 +1844,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/for.untouched.wat
+++ b/tests/compiler/for.untouched.wat
@@ -1568,7 +1568,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3471,7 +3471,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/managed-cast.optimized.wat
+++ b/tests/compiler/managed-cast.optimized.wat
@@ -867,7 +867,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1588,7 +1588,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/managed-cast.untouched.wat
+++ b/tests/compiler/managed-cast.untouched.wat
@@ -1144,7 +1144,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3065,7 +3065,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/global-init.untouched.wat
+++ b/tests/compiler/rc/global-init.untouched.wat
@@ -668,7 +668,7 @@
   if
    i32.const 0
    i32.const 96
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3039,7 +3039,7 @@
   if
    i32.const 0
    i32.const 96
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/local-init.optimized.wat
+++ b/tests/compiler/rc/local-init.optimized.wat
@@ -486,7 +486,7 @@
   if
    i32.const 0
    i32.const 96
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1517,7 +1517,7 @@
   if
    i32.const 0
    i32.const 96
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/local-init.untouched.wat
+++ b/tests/compiler/rc/local-init.untouched.wat
@@ -606,7 +606,7 @@
   if
    i32.const 0
    i32.const 96
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2977,7 +2977,7 @@
   if
    i32.const 0
    i32.const 96
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/logical-and-mismatch.optimized.wat
+++ b/tests/compiler/rc/logical-and-mismatch.optimized.wat
@@ -866,7 +866,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1576,7 +1576,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/logical-and-mismatch.untouched.wat
+++ b/tests/compiler/rc/logical-and-mismatch.untouched.wat
@@ -1143,7 +1143,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3050,7 +3050,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/logical-or-mismatch.optimized.wat
+++ b/tests/compiler/rc/logical-or-mismatch.optimized.wat
@@ -866,7 +866,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1576,7 +1576,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/logical-or-mismatch.untouched.wat
+++ b/tests/compiler/rc/logical-or-mismatch.untouched.wat
@@ -1143,7 +1143,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3050,7 +3050,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/optimize.optimized.wat
+++ b/tests/compiler/rc/optimize.optimized.wat
@@ -957,7 +957,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1614,7 +1614,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/optimize.untouched.wat
+++ b/tests/compiler/rc/optimize.untouched.wat
@@ -1238,7 +1238,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3088,7 +3088,7 @@
   if
    i32.const 0
    i32.const 80
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/rereturn.optimized.wat
+++ b/tests/compiler/rc/rereturn.optimized.wat
@@ -866,7 +866,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1564,7 +1564,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/rereturn.untouched.wat
+++ b/tests/compiler/rc/rereturn.untouched.wat
@@ -1143,7 +1143,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3028,7 +3028,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/ternary-mismatch.optimized.wat
+++ b/tests/compiler/rc/ternary-mismatch.optimized.wat
@@ -868,7 +868,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1587,7 +1587,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/rc/ternary-mismatch.untouched.wat
+++ b/tests/compiler/rc/ternary-mismatch.untouched.wat
@@ -1145,7 +1145,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3061,7 +3061,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-ternary.optimized.wat
+++ b/tests/compiler/resolve-ternary.optimized.wat
@@ -892,7 +892,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1590,7 +1590,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/resolve-ternary.untouched.wat
+++ b/tests/compiler/resolve-ternary.untouched.wat
@@ -1178,7 +1178,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3063,7 +3063,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/retain-release-sanity.optimized.wat
+++ b/tests/compiler/retain-release-sanity.optimized.wat
@@ -875,7 +875,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1790,7 +1790,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2150,16 +2150,9 @@
   i32.const 708
   i32.ge_u
   if
-   local.get $1
-   local.get $4
-   i32.const 1
-   i32.or
-   i32.store
    local.get $0
    local.get $1
-   call $~lib/rt/tlsf/insertBlock
-   local.get $1
-   call $~lib/rt/rtrace/onfree
+   call $~lib/rt/tlsf/freeBlock
   end
   local.get $3
  )
@@ -2175,7 +2168,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 586
+   i32.const 582
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/retain-release-sanity.untouched.wat
+++ b/tests/compiler/retain-release-sanity.untouched.wat
@@ -1151,7 +1151,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3306,7 +3306,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3734,16 +3734,9 @@
   global.get $~lib/heap/__heap_base
   i32.ge_u
   if
-   local.get $1
-   local.get $4
-   i32.const 1
-   i32.or
-   i32.store
    local.get $0
    local.get $1
-   call $~lib/rt/tlsf/insertBlock
-   local.get $1
-   call $~lib/rt/rtrace/onfree
+   call $~lib/rt/tlsf/freeBlock
   end
   local.get $8
  )
@@ -3763,7 +3756,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 586
+   i32.const 582
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/retain-return.optimized.wat
+++ b/tests/compiler/retain-return.optimized.wat
@@ -865,7 +865,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1569,7 +1569,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/retain-return.untouched.wat
+++ b/tests/compiler/retain-return.untouched.wat
@@ -1149,7 +1149,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3050,7 +3050,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/runtime-full.optimized.wat
+++ b/tests/compiler/runtime-full.optimized.wat
@@ -866,7 +866,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1564,7 +1564,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/runtime-full.untouched.wat
+++ b/tests/compiler/runtime-full.untouched.wat
@@ -1142,7 +1142,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3027,7 +3027,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.optimized.wat
+++ b/tests/compiler/std/array-literal.optimized.wat
@@ -919,7 +919,7 @@
   if
    i32.const 0
    i32.const 384
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1661,7 +1661,7 @@
   if
    i32.const 0
    i32.const 384
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array-literal.untouched.wat
+++ b/tests/compiler/std/array-literal.untouched.wat
@@ -1225,7 +1225,7 @@
   if
    i32.const 0
    i32.const 384
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3186,7 +3186,7 @@
   if
    i32.const 0
    i32.const 384
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.optimized.wat
+++ b/tests/compiler/std/array.optimized.wat
@@ -1084,7 +1084,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2013,7 +2013,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2726,16 +2726,9 @@
   i32.const 8660
   i32.ge_u
   if
-   local.get $1
-   local.get $4
-   i32.const 1
-   i32.or
-   i32.store
    local.get $0
    local.get $1
-   call $~lib/rt/tlsf/insertBlock
-   local.get $1
-   call $~lib/rt/rtrace/onfree
+   call $~lib/rt/tlsf/freeBlock
   end
   local.get $3
  )
@@ -2751,7 +2744,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 586
+   i32.const 582
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -1362,7 +1362,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3517,7 +3517,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -4543,16 +4543,9 @@
   global.get $~lib/heap/__heap_base
   i32.ge_u
   if
-   local.get $1
-   local.get $4
-   i32.const 1
-   i32.or
-   i32.store
    local.get $0
    local.get $1
-   call $~lib/rt/tlsf/insertBlock
-   local.get $1
-   call $~lib/rt/rtrace/onfree
+   call $~lib/rt/tlsf/freeBlock
   end
   local.get $8
  )
@@ -4572,7 +4565,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 586
+   i32.const 582
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/arraybuffer.optimized.wat
+++ b/tests/compiler/std/arraybuffer.optimized.wat
@@ -873,7 +873,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1862,7 +1862,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/arraybuffer.untouched.wat
+++ b/tests/compiler/std/arraybuffer.untouched.wat
@@ -1150,7 +1150,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3418,7 +3418,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/dataview.optimized.wat
+++ b/tests/compiler/std/dataview.optimized.wat
@@ -880,7 +880,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1628,7 +1628,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/dataview.untouched.wat
+++ b/tests/compiler/std/dataview.untouched.wat
@@ -1157,7 +1157,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3312,7 +3312,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.optimized.wat
+++ b/tests/compiler/std/map.optimized.wat
@@ -894,7 +894,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1831,7 +1831,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2563,16 +2563,9 @@
   i32.const 868
   i32.ge_u
   if
-   local.get $1
-   local.get $4
-   i32.const 1
-   i32.or
-   i32.store
    local.get $0
    local.get $1
-   call $~lib/rt/tlsf/insertBlock
-   local.get $1
-   call $~lib/rt/rtrace/onfree
+   call $~lib/rt/tlsf/freeBlock
   end
   local.get $3
  )
@@ -2588,7 +2581,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 586
+   i32.const 582
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/map.untouched.wat
+++ b/tests/compiler/std/map.untouched.wat
@@ -1167,7 +1167,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3346,7 +3346,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -4223,16 +4223,9 @@
   global.get $~lib/heap/__heap_base
   i32.ge_u
   if
-   local.get $1
-   local.get $4
-   i32.const 1
-   i32.or
-   i32.store
    local.get $0
    local.get $1
-   call $~lib/rt/tlsf/insertBlock
-   local.get $1
-   call $~lib/rt/rtrace/onfree
+   call $~lib/rt/tlsf/freeBlock
   end
   local.get $8
  )
@@ -4252,7 +4245,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 586
+   i32.const 582
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.optimized.wat
+++ b/tests/compiler/std/set.optimized.wat
@@ -886,7 +886,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1823,7 +1823,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2521,16 +2521,9 @@
   i32.const 684
   i32.ge_u
   if
-   local.get $1
-   local.get $4
-   i32.const 1
-   i32.or
-   i32.store
    local.get $0
    local.get $1
-   call $~lib/rt/tlsf/insertBlock
-   local.get $1
-   call $~lib/rt/rtrace/onfree
+   call $~lib/rt/tlsf/freeBlock
   end
   local.get $3
  )
@@ -2546,7 +2539,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 586
+   i32.const 582
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/set.untouched.wat
+++ b/tests/compiler/std/set.untouched.wat
@@ -1162,7 +1162,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3341,7 +3341,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -4171,16 +4171,9 @@
   global.get $~lib/heap/__heap_base
   i32.ge_u
   if
-   local.get $1
-   local.get $4
-   i32.const 1
-   i32.or
-   i32.store
    local.get $0
    local.get $1
-   call $~lib/rt/tlsf/insertBlock
-   local.get $1
-   call $~lib/rt/rtrace/onfree
+   call $~lib/rt/tlsf/freeBlock
   end
   local.get $8
  )
@@ -4200,7 +4193,7 @@
   if
    i32.const 0
    i32.const 32
-   i32.const 586
+   i32.const 582
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-encoding.optimized.wat
+++ b/tests/compiler/std/string-encoding.optimized.wat
@@ -552,7 +552,7 @@
   if
    i32.const 0
    i32.const 112
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1583,7 +1583,7 @@
   if
    i32.const 0
    i32.const 112
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2492,16 +2492,9 @@
   i32.const 21196
   i32.ge_u
   if
-   local.get $1
-   local.get $4
-   i32.const 1
-   i32.or
-   i32.store
    local.get $0
    local.get $1
-   call $~lib/rt/tlsf/insertBlock
-   local.get $1
-   call $~lib/rt/rtrace/onfree
+   call $~lib/rt/tlsf/freeBlock
   end
   local.get $3
  )
@@ -2517,7 +2510,7 @@
   if
    i32.const 0
    i32.const 112
-   i32.const 586
+   i32.const 582
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string-encoding.untouched.wat
+++ b/tests/compiler/std/string-encoding.untouched.wat
@@ -677,7 +677,7 @@
   if
    i32.const 0
    i32.const 112
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3048,7 +3048,7 @@
   if
    i32.const 0
    i32.const 112
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -4188,16 +4188,9 @@
   global.get $~lib/heap/__heap_base
   i32.ge_u
   if
-   local.get $1
-   local.get $4
-   i32.const 1
-   i32.or
-   i32.store
    local.get $0
    local.get $1
-   call $~lib/rt/tlsf/insertBlock
-   local.get $1
-   call $~lib/rt/rtrace/onfree
+   call $~lib/rt/tlsf/freeBlock
   end
   local.get $8
  )
@@ -4217,7 +4210,7 @@
   if
    i32.const 0
    i32.const 112
-   i32.const 586
+   i32.const 582
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.optimized.wat
+++ b/tests/compiler/std/string.optimized.wat
@@ -1025,7 +1025,7 @@
   if
    i32.const 0
    i32.const 208
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -2056,7 +2056,7 @@
   if
    i32.const 0
    i32.const 208
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -5110,16 +5110,9 @@
   i32.const 27708
   i32.ge_u
   if
-   local.get $1
-   local.get $4
-   i32.const 1
-   i32.or
-   i32.store
    local.get $0
    local.get $1
-   call $~lib/rt/tlsf/insertBlock
-   local.get $1
-   call $~lib/rt/rtrace/onfree
+   call $~lib/rt/tlsf/freeBlock
   end
   local.get $3
  )
@@ -5135,7 +5128,7 @@
   if
    i32.const 0
    i32.const 208
-   i32.const 586
+   i32.const 582
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/string.untouched.wat
+++ b/tests/compiler/std/string.untouched.wat
@@ -1154,7 +1154,7 @@
   if
    i32.const 0
    i32.const 208
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3525,7 +3525,7 @@
   if
    i32.const 0
    i32.const 208
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -7855,16 +7855,9 @@
   global.get $~lib/heap/__heap_base
   i32.ge_u
   if
-   local.get $1
-   local.get $4
-   i32.const 1
-   i32.or
-   i32.store
    local.get $0
    local.get $1
-   call $~lib/rt/tlsf/insertBlock
-   local.get $1
-   call $~lib/rt/rtrace/onfree
+   call $~lib/rt/tlsf/freeBlock
   end
   local.get $8
  )
@@ -7884,7 +7877,7 @@
   if
    i32.const 0
    i32.const 208
-   i32.const 586
+   i32.const 582
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -1055,7 +1055,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1984,7 +1984,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -7433,16 +7433,9 @@
   i32.const 7732
   i32.ge_u
   if
-   local.get $1
-   local.get $4
-   i32.const 1
-   i32.or
-   i32.store
    local.get $0
    local.get $1
-   call $~lib/rt/tlsf/insertBlock
-   local.get $1
-   call $~lib/rt/rtrace/onfree
+   call $~lib/rt/tlsf/freeBlock
   end
   local.get $3
  )
@@ -7458,7 +7451,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 586
+   i32.const 582
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -1343,7 +1343,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3498,7 +3498,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -11132,16 +11132,9 @@
   global.get $~lib/heap/__heap_base
   i32.ge_u
   if
-   local.get $1
-   local.get $4
-   i32.const 1
-   i32.or
-   i32.store
    local.get $0
    local.get $1
-   call $~lib/rt/tlsf/insertBlock
-   local.get $1
-   call $~lib/rt/rtrace/onfree
+   call $~lib/rt/tlsf/freeBlock
   end
   local.get $8
  )
@@ -11161,7 +11154,7 @@
   if
    i32.const 0
    i32.const 144
-   i32.const 586
+   i32.const 582
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/while.optimized.wat
+++ b/tests/compiler/while.optimized.wat
@@ -1145,7 +1145,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -1853,7 +1853,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/while.untouched.wat
+++ b/tests/compiler/while.untouched.wat
@@ -1572,7 +1572,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 569
+   i32.const 565
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -3475,7 +3475,7 @@
   if
    i32.const 0
    i32.const 64
-   i32.const 593
+   i32.const 589
    i32.const 2
    call $~lib/builtins/abort
    unreachable


### PR DESCRIPTION
This should fix the issue reported in https://github.com/AssemblyScript/assemblyscript/issues/1042. Turned out that we were caching `blockInfo = block.mmInfo` within `reallocateBlock`, but when the block must be moved the cached value can become invalidated if the new and the old block are adjacent, leading to invalid flags caught by an assertion.