### PR TITLE
Fix wrong bound checks in TypedArray.wrap

### DIFF
--- a/std/assembly/typedarray.ts
+++ b/std/assembly/typedarray.ts
@@ -1737,7 +1737,8 @@ function WRAP<TArray extends ArrayBufferView, T>(buffer: ArrayBuffer, byteOffset
   const mask = <i32>(1 << alignof<T>() - 1);
   var byteLength: i32;
   var bufferByteLength = buffer.byteLength;
-  if (u32(<u32>byteOffset > <u32>bufferByteLength) | (byteOffset & mask)) {
+  // @ts-ignore: cast
+  if ((<u32>byteOffset > <u32>bufferByteLength) | (byteOffset & mask)) {
     throw new RangeError(E_INDEXOUTOFRANGE);
   }
   if (length < 0) {

--- a/std/assembly/typedarray.ts
+++ b/std/assembly/typedarray.ts
@@ -1734,7 +1734,7 @@ function REVERSE<TArray extends ArrayBufferView, T>(array: TArray): TArray {
 // @ts-ignore: decorator
 @inline
 function WRAP<TArray extends ArrayBufferView, T>(buffer: ArrayBuffer, byteOffset: i32 = 0, length: i32 = -1): TArray {
-  const mask = <i32>(1 << alignof<T>() - 1);
+  const mask = 1 << alignof<T>() - 1;
   var byteLength: i32;
   var bufferByteLength = buffer.byteLength;
   // @ts-ignore: cast

--- a/std/assembly/typedarray.ts
+++ b/std/assembly/typedarray.ts
@@ -1736,12 +1736,13 @@ function REVERSE<TArray extends ArrayBufferView, T>(array: TArray): TArray {
 function WRAP<TArray extends ArrayBufferView, T>(buffer: ArrayBuffer, byteOffset: i32 = 0, length: i32 = -1): TArray {
   var byteLength: i32;
   var bufferByteLength = buffer.byteLength;
-  if (i32(<u32>byteOffset > <u32>bufferByteLength) | (byteOffset & (sizeof<T>() - 1))) {
+  const mask = sizeof<T>() - 1;
+  if (i32(<u32>byteOffset > <u32>bufferByteLength) | (byteOffset & mask)) {
     throw new RangeError(E_INDEXOUTOFRANGE);
   }
   if (length < 0) {
     if (length == -1) {
-      if (bufferByteLength & (sizeof<T>() - 1)) {
+      if (bufferByteLength & mask) {
         throw new RangeError(E_INVALIDLENGTH);
       }
       byteLength = bufferByteLength - byteOffset;

--- a/std/assembly/typedarray.ts
+++ b/std/assembly/typedarray.ts
@@ -1735,7 +1735,7 @@ function REVERSE<TArray extends ArrayBufferView, T>(array: TArray): TArray {
 @inline
 function WRAP<TArray extends ArrayBufferView, T>(buffer: ArrayBuffer, byteOffset: i32 = 0, length: i32 = -1): TArray {
   var bufferByteLength = buffer.byteLength;
-  if (<u32>byteOffset >= <u32>bufferByteLength) {
+  if (<u32>byteOffset > <u32>bufferByteLength) {
     throw new RangeError(E_INDEXOUTOFRANGE);
   }
   var byteLength: i32;

--- a/std/assembly/typedarray.ts
+++ b/std/assembly/typedarray.ts
@@ -1734,7 +1734,7 @@ function REVERSE<TArray extends ArrayBufferView, T>(array: TArray): TArray {
 // @ts-ignore: decorator
 @inline
 function WRAP<TArray extends ArrayBufferView, T>(buffer: ArrayBuffer, byteOffset: i32 = 0, length: i32 = -1): TArray {
-  const mask = 1 << alignof<T>() - 1;
+  const mask = sizeof<T>() - 1;
   var byteLength: i32;
   var bufferByteLength = buffer.byteLength;
   // @ts-ignore: cast

--- a/std/assembly/typedarray.ts
+++ b/std/assembly/typedarray.ts
@@ -1744,9 +1744,8 @@ function WRAP<TArray extends ArrayBufferView, T>(buffer: ArrayBuffer, byteOffset
     if (length == -1) {
       if (bufferByteLength & (sizeof<T>() - 1)) {
         throw new RangeError(E_INVALIDLENGTH);
-      } else {
-        byteLength = bufferByteLength - byteOffset;
       }
+      byteLength = bufferByteLength - byteOffset;
     } else {
       throw new RangeError(E_INVALIDLENGTH);
     }

--- a/std/assembly/typedarray.ts
+++ b/std/assembly/typedarray.ts
@@ -1742,19 +1742,19 @@ function WRAP<TArray extends ArrayBufferView, T>(buffer: ArrayBuffer, byteOffset
   if (length < 0) {
     if (length == -1) {
       const mask = <i32>(1 << alignof<T>() - 1);
-      if (buffer.byteLength & mask) {
+      if (bufferByteLength & mask) {
         throw new RangeError(E_INVALIDLENGTH);
       } else {
-        byteLength = buffer.byteLength;
+        byteLength = bufferByteLength - byteOffset;
       }
     } else {
       throw new RangeError(E_INVALIDLENGTH);
     }
   } else {
     byteLength = length << alignof<T>();
-  }
-  if (byteOffset + byteLength > buffer.byteLength) {
-    throw new RangeError(E_INVALIDLENGTH);
+    if (byteOffset + byteLength > bufferByteLength) {
+      throw new RangeError(E_INVALIDLENGTH);
+    }
   }
   var out = __alloc(offsetof<TArray>(), idof<TArray>());
   store<usize>(out, __retain(changetype<usize>(buffer)), offsetof<TArray>("buffer"));

--- a/std/assembly/typedarray.ts
+++ b/std/assembly/typedarray.ts
@@ -1734,14 +1734,14 @@ function REVERSE<TArray extends ArrayBufferView, T>(array: TArray): TArray {
 // @ts-ignore: decorator
 @inline
 function WRAP<TArray extends ArrayBufferView, T>(buffer: ArrayBuffer, byteOffset: i32 = 0, length: i32 = -1): TArray {
+  const mask = <i32>(1 << alignof<T>() - 1);
+  var byteLength: i32;
   var bufferByteLength = buffer.byteLength;
-  if (<u32>byteOffset > <u32>bufferByteLength) {
+  if (u32(<u32>byteOffset > <u32>bufferByteLength) | (byteOffset & mask)) {
     throw new RangeError(E_INDEXOUTOFRANGE);
   }
-  var byteLength: i32;
   if (length < 0) {
     if (length == -1) {
-      const mask = <i32>(1 << alignof<T>() - 1);
       if (bufferByteLength & mask) {
         throw new RangeError(E_INVALIDLENGTH);
       } else {

--- a/std/assembly/typedarray.ts
+++ b/std/assembly/typedarray.ts
@@ -1734,16 +1734,15 @@ function REVERSE<TArray extends ArrayBufferView, T>(array: TArray): TArray {
 // @ts-ignore: decorator
 @inline
 function WRAP<TArray extends ArrayBufferView, T>(buffer: ArrayBuffer, byteOffset: i32 = 0, length: i32 = -1): TArray {
-  const mask = sizeof<T>() - 1;
   var byteLength: i32;
   var bufferByteLength = buffer.byteLength;
   // @ts-ignore: cast
-  if ((<u32>byteOffset > <u32>bufferByteLength) | (byteOffset & mask)) {
+  if ((<u32>byteOffset > <u32>bufferByteLength) | (byteOffset & (sizeof<T>() - 1))) {
     throw new RangeError(E_INDEXOUTOFRANGE);
   }
   if (length < 0) {
     if (length == -1) {
-      if (bufferByteLength & mask) {
+      if (bufferByteLength & (sizeof<T>() - 1)) {
         throw new RangeError(E_INVALIDLENGTH);
       } else {
         byteLength = bufferByteLength - byteOffset;

--- a/std/assembly/typedarray.ts
+++ b/std/assembly/typedarray.ts
@@ -1736,8 +1736,7 @@ function REVERSE<TArray extends ArrayBufferView, T>(array: TArray): TArray {
 function WRAP<TArray extends ArrayBufferView, T>(buffer: ArrayBuffer, byteOffset: i32 = 0, length: i32 = -1): TArray {
   var byteLength: i32;
   var bufferByteLength = buffer.byteLength;
-  // @ts-ignore: cast
-  if ((<u32>byteOffset > <u32>bufferByteLength) | (byteOffset & (sizeof<T>() - 1))) {
+  if (i32(<u32>byteOffset > <u32>bufferByteLength) | (byteOffset & (sizeof<T>() - 1))) {
     throw new RangeError(E_INDEXOUTOFRANGE);
   }
   if (length < 0) {

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -25321,7 +25321,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1740
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25340,7 +25340,7 @@
    else
     i32.const 32
     i32.const 480
-    i32.const 1749
+    i32.const 1750
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -25355,7 +25355,7 @@
    if
     i32.const 32
     i32.const 480
-    i32.const 1754
+    i32.const 1755
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -25482,7 +25482,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1740
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25683,7 +25683,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1740
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25798,7 +25798,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1740
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25809,7 +25809,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1745
+   i32.const 1746
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -25926,7 +25926,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1740
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25937,7 +25937,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1745
+   i32.const 1746
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26052,7 +26052,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1740
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26063,7 +26063,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1745
+   i32.const 1746
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26176,7 +26176,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1740
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26187,7 +26187,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1745
+   i32.const 1746
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26300,7 +26300,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1740
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26311,7 +26311,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1745
+   i32.const 1746
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26425,7 +26425,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1740
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26436,7 +26436,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1745
+   i32.const 1746
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26550,7 +26550,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1740
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26561,7 +26561,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1745
+   i32.const 1746
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26675,7 +26675,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1740
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26686,7 +26686,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1745
+   i32.const 1746
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26801,7 +26801,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -26915,7 +26915,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -26980,7 +26980,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27036,7 +27036,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27097,7 +27097,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27123,7 +27123,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27175,7 +27175,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27410,7 +27410,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27477,7 +27477,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27680,7 +27680,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27807,7 +27807,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27872,7 +27872,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -27887,7 +27887,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27960,7 +27960,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28025,7 +28025,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -28040,7 +28040,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28109,7 +28109,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28313,7 +28313,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28429,7 +28429,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28496,7 +28496,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28554,7 +28554,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28619,7 +28619,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28669,7 +28669,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28698,7 +28698,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28960,7 +28960,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29029,7 +29029,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29228,7 +29228,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -29243,7 +29243,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29336,7 +29336,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29402,7 +29402,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29460,7 +29460,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29525,7 +29525,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29577,7 +29577,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29634,7 +29634,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29891,7 +29891,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29959,7 +29959,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30165,7 +30165,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30281,7 +30281,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30346,7 +30346,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30377,7 +30377,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30441,7 +30441,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30493,7 +30493,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30550,7 +30550,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30804,7 +30804,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30874,7 +30874,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31078,7 +31078,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31200,7 +31200,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31255,7 +31255,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31308,7 +31308,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31366,7 +31366,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31547,7 +31547,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31669,7 +31669,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31727,7 +31727,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31781,7 +31781,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31834,7 +31834,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31892,7 +31892,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -32073,7 +32073,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -32143,7 +32143,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -32209,7 +32209,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -25321,7 +25321,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1740
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25340,7 +25340,7 @@
    else
     i32.const 32
     i32.const 480
-    i32.const 1750
+    i32.const 1749
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -25355,7 +25355,7 @@
    if
     i32.const 32
     i32.const 480
-    i32.const 1755
+    i32.const 1754
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -25482,7 +25482,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1740
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25683,7 +25683,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1740
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25798,7 +25798,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1740
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25809,7 +25809,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1746
+   i32.const 1745
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -25926,7 +25926,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1740
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25937,7 +25937,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1746
+   i32.const 1745
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26052,7 +26052,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1740
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26063,7 +26063,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1746
+   i32.const 1745
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26176,7 +26176,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1740
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26187,7 +26187,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1746
+   i32.const 1745
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26300,7 +26300,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1740
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26311,7 +26311,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1746
+   i32.const 1745
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26425,7 +26425,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1740
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26436,7 +26436,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1746
+   i32.const 1745
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26550,7 +26550,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1740
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26561,7 +26561,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1746
+   i32.const 1745
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26675,7 +26675,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1740
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26686,7 +26686,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1746
+   i32.const 1745
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26801,7 +26801,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -26915,7 +26915,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -26980,7 +26980,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27036,7 +27036,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27097,7 +27097,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27123,7 +27123,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27175,7 +27175,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27410,7 +27410,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27477,7 +27477,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27680,7 +27680,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27807,7 +27807,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27872,7 +27872,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -27887,7 +27887,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27960,7 +27960,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28025,7 +28025,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -28040,7 +28040,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28109,7 +28109,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28313,7 +28313,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28429,7 +28429,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28496,7 +28496,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28554,7 +28554,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28619,7 +28619,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28669,7 +28669,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28698,7 +28698,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28960,7 +28960,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29029,7 +29029,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29228,7 +29228,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -29243,7 +29243,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29336,7 +29336,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29402,7 +29402,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29460,7 +29460,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29525,7 +29525,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29577,7 +29577,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29634,7 +29634,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29891,7 +29891,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29959,7 +29959,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30165,7 +30165,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30281,7 +30281,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30346,7 +30346,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30377,7 +30377,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30441,7 +30441,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30493,7 +30493,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30550,7 +30550,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30804,7 +30804,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30874,7 +30874,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31078,7 +31078,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31200,7 +31200,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31255,7 +31255,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31308,7 +31308,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31366,7 +31366,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31547,7 +31547,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31669,7 +31669,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31727,7 +31727,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31781,7 +31781,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31834,7 +31834,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31892,7 +31892,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -32073,7 +32073,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -32143,7 +32143,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -32209,7 +32209,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -25340,7 +25340,7 @@
    else
     i32.const 32
     i32.const 480
-    i32.const 1751
+    i32.const 1750
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -25355,7 +25355,7 @@
    if
     i32.const 32
     i32.const 480
-    i32.const 1756
+    i32.const 1755
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -26801,7 +26801,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -26915,7 +26915,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -26980,7 +26980,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27036,7 +27036,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27097,7 +27097,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27123,7 +27123,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27175,7 +27175,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27410,7 +27410,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27477,7 +27477,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27680,7 +27680,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27807,7 +27807,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27872,7 +27872,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -27887,7 +27887,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27960,7 +27960,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28025,7 +28025,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -28040,7 +28040,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28109,7 +28109,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28313,7 +28313,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28429,7 +28429,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28496,7 +28496,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28554,7 +28554,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28619,7 +28619,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28669,7 +28669,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28698,7 +28698,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28960,7 +28960,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29029,7 +29029,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29228,7 +29228,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -29243,7 +29243,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29336,7 +29336,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29402,7 +29402,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29460,7 +29460,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29525,7 +29525,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29577,7 +29577,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29634,7 +29634,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29891,7 +29891,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29959,7 +29959,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30165,7 +30165,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30281,7 +30281,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30346,7 +30346,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30377,7 +30377,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30441,7 +30441,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30493,7 +30493,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30550,7 +30550,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30804,7 +30804,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30874,7 +30874,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31078,7 +31078,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31200,7 +31200,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31255,7 +31255,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31308,7 +31308,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31366,7 +31366,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31547,7 +31547,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31669,7 +31669,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31727,7 +31727,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31781,7 +31781,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31834,7 +31834,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31892,7 +31892,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -32073,7 +32073,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -32143,7 +32143,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -32209,7 +32209,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -25314,14 +25314,10 @@
  (func $~lib/typedarray/Uint8Array.wrap (; 421 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $1
-  i32.const -2147483648
-  i32.and
-  local.get $1
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   local.tee $3
   i32.gt_u
-  i32.or
   if
    i32.const 304
    i32.const 480
@@ -25339,20 +25335,8 @@
    i32.eq
    if (result i32)
     local.get $3
-    i32.const -2147483648
-    i32.and
-    if (result i32)
-     i32.const 32
-     i32.const 480
-     i32.const 1747
-     i32.const 8
-     call $~lib/builtins/abort
-     unreachable
-    else
-     local.get $3
-     local.get $1
-     i32.sub
-    end
+    local.get $1
+    i32.sub
    else
     i32.const 32
     i32.const 480
@@ -25500,17 +25484,6 @@
    i32.const 480
    i32.const 1742
    i32.const 4
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $2
-  i32.const -2147483648
-  i32.and
-  if
-   i32.const 32
-   i32.const 480
-   i32.const 1747
-   i32.const 8
    call $~lib/builtins/abort
    unreachable
   end
@@ -25712,17 +25685,6 @@
    i32.const 480
    i32.const 1742
    i32.const 4
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $2
-  i32.const -2147483648
-  i32.and
-  if
-   i32.const 32
-   i32.const 480
-   i32.const 1747
-   i32.const 8
    call $~lib/builtins/abort
    unreachable
   end
@@ -26096,7 +26058,7 @@
    unreachable
   end
   local.get $2
-  i32.const 2
+  i32.const 3
   i32.and
   if
    i32.const 32
@@ -26220,7 +26182,7 @@
    unreachable
   end
   local.get $2
-  i32.const 2
+  i32.const 3
   i32.and
   if
    i32.const 32
@@ -26344,7 +26306,7 @@
    unreachable
   end
   local.get $2
-  i32.const 4
+  i32.const 7
   i32.and
   if
    i32.const 32
@@ -26469,7 +26431,7 @@
    unreachable
   end
   local.get $2
-  i32.const 4
+  i32.const 7
   i32.and
   if
    i32.const 32
@@ -26594,7 +26556,7 @@
    unreachable
   end
   local.get $2
-  i32.const 2
+  i32.const 3
   i32.and
   if
    i32.const 32
@@ -26719,7 +26681,7 @@
    unreachable
   end
   local.get $2
-  i32.const 4
+  i32.const 7
   i32.and
   if
    i32.const 32
@@ -26892,7 +26854,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 712
+   i32.const 716
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -26925,7 +26887,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 718
+     i32.const 722
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -27387,7 +27349,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 712
+   i32.const 716
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -27420,7 +27382,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 718
+     i32.const 722
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -27784,7 +27746,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 712
+   i32.const 716
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -27817,7 +27779,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 718
+     i32.const 722
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -28406,7 +28368,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 712
+   i32.const 716
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -28439,7 +28401,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 718
+     i32.const 722
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -28930,7 +28892,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 712
+   i32.const 716
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -28970,7 +28932,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 718
+     i32.const 722
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -29312,7 +29274,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 712
+   i32.const 716
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -29345,7 +29307,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 718
+     i32.const 722
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -29867,7 +29829,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 712
+   i32.const 716
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -29900,7 +29862,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 718
+     i32.const 722
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -30258,7 +30220,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 712
+   i32.const 716
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -30291,7 +30253,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 718
+     i32.const 722
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -30781,7 +30743,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 712
+   i32.const 716
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -30814,7 +30776,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 718
+     i32.const 722
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -31172,7 +31134,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 712
+   i32.const 716
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -31212,7 +31174,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 718
+     i32.const 722
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -31642,7 +31604,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 712
+   i32.const 716
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -31680,7 +31642,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 718
+     i32.const 722
      i32.const 6
      call $~lib/builtins/abort
      unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -25282,13 +25282,140 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (; 419 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (; 419 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  local.get $0
+  i32.const 1073741808
+  i32.gt_u
+  if
+   i32.const 32
+   i32.const 80
+   i32.const 54
+   i32.const 42
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.tee $1
+  i32.const 0
+  local.get $0
+  call $~lib/memory/memory.fill
+  local.get $1
+  call $~lib/rt/pure/__retain
+ )
+ (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (; 420 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
   i32.load offset=12
  )
- (func $~lib/arraybuffer/ArrayBuffer#slice (; 420 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array.wrap (; 421 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  local.get $1
+  local.get $0
+  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  local.tee $3
+  i32.gt_u
+  if
+   i32.const 304
+   i32.const 480
+   i32.const 1739
+   i32.const 4
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
+  i32.const 0
+  i32.lt_s
+  if
+   local.get $2
+   i32.const -1
+   i32.eq
+   if (result i32)
+    local.get $3
+    i32.const -2147483648
+    i32.and
+    if (result i32)
+     i32.const 32
+     i32.const 480
+     i32.const 1746
+     i32.const 8
+     call $~lib/builtins/abort
+     unreachable
+    else
+     local.get $3
+     local.get $1
+     i32.sub
+    end
+   else
+    i32.const 32
+    i32.const 480
+    i32.const 1751
+    i32.const 6
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.set $2
+  else
+   local.get $1
+   local.get $2
+   i32.add
+   local.get $3
+   i32.gt_s
+   if
+    i32.const 32
+    i32.const 480
+    i32.const 1756
+    i32.const 6
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 12
+  i32.const 4
+  call $~lib/rt/tlsf/__alloc
+  local.tee $3
+  local.get $0
+  call $~lib/rt/pure/__retain
+  i32.store
+  local.get $3
+  local.get $2
+  i32.store offset=8
+  local.get $3
+  local.get $0
+  local.get $1
+  i32.add
+  i32.store offset=4
+  local.get $3
+  call $~lib/rt/pure/__retain
+ )
+ (func $~lib/typedarray/Uint8Array.wrap|trampoline (; 422 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  block $2of2
+   block $1of2
+    block $0of2
+     block $outOfRange
+      global.get $~argumentsLength
+      i32.const 1
+      i32.sub
+      br_table $0of2 $1of2 $2of2 $outOfRange
+     end
+     unreachable
+    end
+    i32.const 0
+    local.set $1
+   end
+   i32.const -1
+   local.set $2
+  end
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/typedarray/Uint8Array.wrap
+ )
+ (func $~lib/arraybuffer/ArrayBuffer#slice (; 423 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
@@ -25356,12 +25483,13 @@
   local.get $3
   call $~lib/rt/pure/__retain
  )
- (func $~lib/typedarray/Int8Array.wrap (; 421 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int8Array.wrap (; 424 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  local.tee $2
   i32.gt_u
   if
    i32.const 304
@@ -25371,30 +25499,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  local.get $2
   i32.const -2147483648
   i32.and
-  if (result i32)
+  if
    i32.const 32
    i32.const 480
    i32.const 1746
    i32.const 8
-   call $~lib/builtins/abort
-   unreachable
-  else
-   local.get $0
-   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  end
-  local.tee $2
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.gt_s
-  if
-   i32.const 32
-   i32.const 480
-   i32.const 1757
-   i32.const 4
    call $~lib/builtins/abort
    unreachable
   end
@@ -25414,7 +25526,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int8Array,i8> (; 422 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int8Array,i8> (; 425 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -25499,65 +25611,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array.wrap (; 423 ;) (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  i32.const 0
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.gt_u
-  if
-   i32.const 304
-   i32.const 480
-   i32.const 1739
-   i32.const 4
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.const -2147483648
-  i32.and
-  if (result i32)
-   i32.const 32
-   i32.const 480
-   i32.const 1746
-   i32.const 8
-   call $~lib/builtins/abort
-   unreachable
-  else
-   local.get $0
-   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  end
-  local.tee $2
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.gt_s
-  if
-   i32.const 32
-   i32.const 480
-   i32.const 1757
-   i32.const 4
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 12
-  i32.const 4
-  call $~lib/rt/tlsf/__alloc
-  local.tee $1
-  local.get $0
-  call $~lib/rt/pure/__retain
-  i32.store
-  local.get $1
-  local.get $2
-  i32.store offset=8
-  local.get $1
-  local.get $0
-  i32.store offset=4
-  local.get $1
-  call $~lib/rt/pure/__retain
- )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8Array,u8> (; 424 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8Array,u8> (; 426 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -25604,7 +25658,8 @@
   i32.const 1
   global.set $~argumentsLength
   local.get $0
-  call $~lib/typedarray/Uint8Array.wrap
+  i32.const 0
+  call $~lib/typedarray/Uint8Array.wrap|trampoline
   local.set $4
   loop $for-loop|1
    local.get $2
@@ -25640,12 +25695,13 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray.wrap (; 425 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray.wrap (; 427 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  local.tee $2
   i32.gt_u
   if
    i32.const 304
@@ -25655,30 +25711,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  local.get $2
   i32.const -2147483648
   i32.and
-  if (result i32)
+  if
    i32.const 32
    i32.const 480
    i32.const 1746
    i32.const 8
-   call $~lib/builtins/abort
-   unreachable
-  else
-   local.get $0
-   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  end
-  local.tee $2
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.gt_s
-  if
-   i32.const 32
-   i32.const 480
-   i32.const 1757
-   i32.const 4
    call $~lib/builtins/abort
    unreachable
   end
@@ -25698,7 +25738,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8ClampedArray,u8> (; 426 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8ClampedArray,u8> (; 428 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -25781,12 +25821,13 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array.wrap (; 427 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int16Array.wrap (; 429 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  local.tee $2
   i32.gt_u
   if
    i32.const 304
@@ -25796,30 +25837,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  local.get $2
   i32.const 1
   i32.and
-  if (result i32)
+  if
    i32.const 32
    i32.const 480
    i32.const 1746
    i32.const 8
-   call $~lib/builtins/abort
-   unreachable
-  else
-   local.get $0
-   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  end
-  local.tee $2
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.gt_s
-  if
-   i32.const 32
-   i32.const 480
-   i32.const 1757
-   i32.const 4
    call $~lib/builtins/abort
    unreachable
   end
@@ -25839,7 +25864,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int16Array,i16> (; 428 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int16Array,i16> (; 430 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -25924,12 +25949,13 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array.wrap (; 429 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array.wrap (; 431 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  local.tee $2
   i32.gt_u
   if
    i32.const 304
@@ -25939,30 +25965,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  local.get $2
   i32.const 1
   i32.and
-  if (result i32)
+  if
    i32.const 32
    i32.const 480
    i32.const 1746
    i32.const 8
-   call $~lib/builtins/abort
-   unreachable
-  else
-   local.get $0
-   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  end
-  local.tee $2
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.gt_s
-  if
-   i32.const 32
-   i32.const 480
-   i32.const 1757
-   i32.const 4
    call $~lib/builtins/abort
    unreachable
   end
@@ -25982,7 +25992,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint16Array,u16> (; 430 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint16Array,u16> (; 432 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -26065,12 +26075,13 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array.wrap (; 431 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int32Array.wrap (; 433 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  local.tee $2
   i32.gt_u
   if
    i32.const 304
@@ -26080,30 +26091,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  local.get $2
   i32.const 2
   i32.and
-  if (result i32)
+  if
    i32.const 32
    i32.const 480
    i32.const 1746
    i32.const 8
-   call $~lib/builtins/abort
-   unreachable
-  else
-   local.get $0
-   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  end
-  local.tee $2
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.gt_s
-  if
-   i32.const 32
-   i32.const 480
-   i32.const 1757
-   i32.const 4
    call $~lib/builtins/abort
    unreachable
   end
@@ -26123,7 +26118,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int32Array,i32> (; 432 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int32Array,i32> (; 434 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -26204,12 +26199,13 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array.wrap (; 433 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array.wrap (; 435 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  local.tee $2
   i32.gt_u
   if
    i32.const 304
@@ -26219,30 +26215,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  local.get $2
   i32.const 2
   i32.and
-  if (result i32)
+  if
    i32.const 32
    i32.const 480
    i32.const 1746
    i32.const 8
-   call $~lib/builtins/abort
-   unreachable
-  else
-   local.get $0
-   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  end
-  local.tee $2
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.gt_s
-  if
-   i32.const 32
-   i32.const 480
-   i32.const 1757
-   i32.const 4
    call $~lib/builtins/abort
    unreachable
   end
@@ -26262,7 +26242,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint32Array,u32> (; 434 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint32Array,u32> (; 436 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -26343,12 +26323,13 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array.wrap (; 435 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Int64Array.wrap (; 437 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  local.tee $2
   i32.gt_u
   if
    i32.const 304
@@ -26358,30 +26339,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  local.get $2
   i32.const 4
   i32.and
-  if (result i32)
+  if
    i32.const 32
    i32.const 480
    i32.const 1746
    i32.const 8
-   call $~lib/builtins/abort
-   unreachable
-  else
-   local.get $0
-   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  end
-  local.tee $2
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.gt_s
-  if
-   i32.const 32
-   i32.const 480
-   i32.const 1757
-   i32.const 4
    call $~lib/builtins/abort
    unreachable
   end
@@ -26401,7 +26366,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int64Array,i64> (; 436 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int64Array,i64> (; 438 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -26483,12 +26448,13 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array.wrap (; 437 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array.wrap (; 439 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  local.tee $2
   i32.gt_u
   if
    i32.const 304
@@ -26498,30 +26464,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  local.get $2
   i32.const 4
   i32.and
-  if (result i32)
+  if
    i32.const 32
    i32.const 480
    i32.const 1746
    i32.const 8
-   call $~lib/builtins/abort
-   unreachable
-  else
-   local.get $0
-   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  end
-  local.tee $2
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.gt_s
-  if
-   i32.const 32
-   i32.const 480
-   i32.const 1757
-   i32.const 4
    call $~lib/builtins/abort
    unreachable
   end
@@ -26541,7 +26491,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint64Array,u64> (; 438 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint64Array,u64> (; 440 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -26623,12 +26573,13 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array.wrap (; 439 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float32Array.wrap (; 441 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  local.tee $2
   i32.gt_u
   if
    i32.const 304
@@ -26638,30 +26589,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  local.get $2
   i32.const 2
   i32.and
-  if (result i32)
+  if
    i32.const 32
    i32.const 480
    i32.const 1746
    i32.const 8
-   call $~lib/builtins/abort
-   unreachable
-  else
-   local.get $0
-   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  end
-  local.tee $2
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.gt_s
-  if
-   i32.const 32
-   i32.const 480
-   i32.const 1757
-   i32.const 4
    call $~lib/builtins/abort
    unreachable
   end
@@ -26681,7 +26616,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Float32Array,f32> (; 440 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Float32Array,f32> (; 442 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -26763,12 +26698,13 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array.wrap (; 441 ;) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Float64Array.wrap (; 443 ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   i32.const 0
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  local.tee $2
   i32.gt_u
   if
    i32.const 304
@@ -26778,30 +26714,14 @@
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  local.get $2
   i32.const 4
   i32.and
-  if (result i32)
+  if
    i32.const 32
    i32.const 480
    i32.const 1746
    i32.const 8
-   call $~lib/builtins/abort
-   unreachable
-  else
-   local.get $0
-   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  end
-  local.tee $2
-  local.get $0
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.gt_s
-  if
-   i32.const 32
-   i32.const 480
-   i32.const 1757
-   i32.const 4
    call $~lib/builtins/abort
    unreachable
   end
@@ -26821,7 +26741,7 @@
   local.get $1
   call $~lib/rt/pure/__retain
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Float64Array,f64> (; 442 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Float64Array,f64> (; 444 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -26903,7 +26823,7 @@
   local.get $4
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i32>> (; 443 ;) (param $0 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i32>> (; 445 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -26954,7 +26874,7 @@
    end
   end
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int8Array> (; 444 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int8Array> (; 446 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -26968,7 +26888,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 702
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -27001,7 +26921,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 708
+     i32.const 718
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -27014,7 +26934,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int8Array#set<~lib/array/Array<f32>> (; 445 ;) (param $0 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/array/Array<f32>> (; 447 ;) (param $0 i32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -27081,7 +27001,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int64Array> (; 446 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int64Array> (; 448 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -27135,7 +27055,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int8Array#set<~lib/array/Array<f64>> (; 447 ;) (param $0 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/array/Array<f64>> (; 449 ;) (param $0 i32)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -27202,7 +27122,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Uint8Array> (; 448 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Uint8Array> (; 450 ;) (param $0 i32) (param $1 i32)
   local.get $1
   i32.load offset=8
   local.get $0
@@ -27224,7 +27144,7 @@
   i32.load offset=8
   call $~lib/memory/memory.copy
  )
- (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int16Array> (; 449 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int16Array> (; 451 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -27278,7 +27198,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i8>> (; 450 ;) (param $0 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i8>> (; 452 ;) (param $0 i32)
   i32.const 3724
   i32.load
   i32.const 7
@@ -27304,7 +27224,7 @@
   i32.load
   call $~lib/memory/memory.copy
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int8Array> (; 451 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int8Array> (; 453 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -27442,14 +27362,14 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<u8>#__unchecked_get (; 452 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__unchecked_get (; 454 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
   i32.add
   i32.load8_u
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array> (; 453 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array> (; 455 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -27463,7 +27383,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 702
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -27496,7 +27416,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 708
+     i32.const 718
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -27509,7 +27429,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<f32>> (; 454 ;) (param $0 i32)
+ (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<f32>> (; 456 ;) (param $0 i32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -27576,7 +27496,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<f64>> (; 455 ;) (param $0 i32)
+ (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<f64>> (; 457 ;) (param $0 i32)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -27643,7 +27563,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8Array> (; 456 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8Array> (; 458 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -27781,7 +27701,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i32>> (; 457 ;) (param $0 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i32>> (; 459 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -27846,7 +27766,7 @@
    end
   end
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray> (; 458 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray> (; 460 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -27860,7 +27780,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 702
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -27893,7 +27813,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 708
+     i32.const 718
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -27906,7 +27826,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f32>> (; 459 ;) (param $0 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f32>> (; 461 ;) (param $0 i32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -27977,7 +27897,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array> (; 460 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array> (; 462 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i64)
   (local $4 i32)
   local.get $2
@@ -28059,7 +27979,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f64>> (; 461 ;) (param $0 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f64>> (; 463 ;) (param $0 i32)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -28130,7 +28050,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array> (; 462 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array> (; 464 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   local.get $2
@@ -28208,7 +28128,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i8>> (; 463 ;) (param $0 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i8>> (; 465 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -28275,7 +28195,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8ClampedArray> (; 464 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8ClampedArray> (; 466 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -28415,7 +28335,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i32>> (; 465 ;) (param $0 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i32>> (; 467 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -28468,7 +28388,7 @@
    end
   end
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int16Array> (; 466 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int16Array> (; 468 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -28482,7 +28402,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 702
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -28515,7 +28435,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 708
+     i32.const 718
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -28528,7 +28448,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int16Array#set<~lib/array/Array<f32>> (; 467 ;) (param $0 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/array/Array<f32>> (; 469 ;) (param $0 i32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -28597,7 +28517,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int64Array> (; 468 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int64Array> (; 470 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -28653,7 +28573,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int16Array#set<~lib/array/Array<f64>> (; 469 ;) (param $0 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/array/Array<f64>> (; 471 ;) (param $0 i32)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -28722,7 +28642,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Uint8Array> (; 470 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Uint8Array> (; 472 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -28772,7 +28692,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int16Array> (; 471 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int16Array> (; 473 ;) (param $0 i32) (param $1 i32)
   local.get $1
   call $~lib/typedarray/Int16Array#get:length
   i32.const 4
@@ -28798,7 +28718,7 @@
   i32.load offset=8
   call $~lib/memory/memory.copy
  )
- (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i8>> (; 472 ;) (param $0 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i8>> (; 474 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -28853,7 +28773,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int16Array> (; 473 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int16Array> (; 475 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -28991,7 +28911,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array> (; 474 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array> (; 476 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -29006,7 +28926,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 702
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -29046,7 +28966,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 708
+     i32.const 718
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -29059,7 +28979,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<f32>> (; 475 ;) (param $0 i32)
+ (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<f32>> (; 477 ;) (param $0 i32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -29128,7 +29048,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<f64>> (; 476 ;) (param $0 i32)
+ (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<f64>> (; 478 ;) (param $0 i32)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -29197,7 +29117,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint16Array> (; 477 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint16Array> (; 479 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -29335,7 +29255,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i32>> (; 478 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i32>> (; 480 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $2
   i32.const 0
   i32.lt_s
@@ -29374,7 +29294,7 @@
   i32.load offset=8
   call $~lib/memory/memory.copy
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int32Array> (; 479 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int32Array> (; 481 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -29388,7 +29308,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 702
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -29421,7 +29341,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 708
+     i32.const 718
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -29434,7 +29354,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int32Array#set<~lib/array/Array<f32>> (; 480 ;) (param $0 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/array/Array<f32>> (; 482 ;) (param $0 i32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -29503,7 +29423,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int64Array> (; 481 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int64Array> (; 483 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -29559,7 +29479,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int32Array#set<~lib/array/Array<f64>> (; 482 ;) (param $0 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/array/Array<f64>> (; 484 ;) (param $0 i32)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -29628,7 +29548,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Uint8Array> (; 483 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Uint8Array> (; 485 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -29678,7 +29598,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int16Array> (; 484 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int16Array> (; 486 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -29734,7 +29654,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i8>> (; 485 ;) (param $0 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i8>> (; 487 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -29789,7 +29709,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int32Array> (; 486 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int32Array> (; 488 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -29929,7 +29849,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array> (; 487 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array> (; 489 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -29943,7 +29863,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 702
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -29976,7 +29896,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 708
+     i32.const 718
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -29989,7 +29909,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<f32>> (; 488 ;) (param $0 i32)
+ (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<f32>> (; 490 ;) (param $0 i32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -30058,7 +29978,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<f64>> (; 489 ;) (param $0 i32)
+ (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<f64>> (; 491 ;) (param $0 i32)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -30127,7 +30047,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint32Array> (; 490 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint32Array> (; 492 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -30267,7 +30187,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i32>> (; 491 ;) (param $0 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i32>> (; 493 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -30320,7 +30240,7 @@
    end
   end
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int64Array> (; 492 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int64Array> (; 494 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i64)
@@ -30334,7 +30254,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 702
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -30367,7 +30287,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 708
+     i32.const 718
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -30380,7 +30300,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int64Array#set<~lib/array/Array<f32>> (; 493 ;) (param $0 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/array/Array<f32>> (; 495 ;) (param $0 i32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -30449,7 +30369,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int64Array> (; 494 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int64Array> (; 496 ;) (param $0 i32) (param $1 i32)
   local.get $1
   call $~lib/typedarray/Int64Array#get:length
   i32.const 6
@@ -30475,7 +30395,7 @@
   i32.load offset=8
   call $~lib/memory/memory.copy
  )
- (func $~lib/typedarray/Int64Array#set<~lib/array/Array<f64>> (; 495 ;) (param $0 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/array/Array<f64>> (; 497 ;) (param $0 i32)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -30544,7 +30464,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Uint8Array> (; 496 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Uint8Array> (; 498 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -30594,7 +30514,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int16Array> (; 497 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int16Array> (; 499 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -30650,7 +30570,7 @@
    end
   end
  )
- (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i8>> (; 498 ;) (param $0 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i8>> (; 500 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -30705,7 +30625,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int64Array> (; 499 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int64Array> (; 501 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -30843,7 +30763,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array> (; 500 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array> (; 502 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i64)
@@ -30857,7 +30777,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 702
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -30890,7 +30810,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 708
+     i32.const 718
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -30903,7 +30823,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<f32>> (; 501 ;) (param $0 i32)
+ (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<f32>> (; 503 ;) (param $0 i32)
   (local $1 f32)
   (local $2 i32)
   (local $3 i32)
@@ -30972,7 +30892,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<f64>> (; 502 ;) (param $0 i32)
+ (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<f64>> (; 504 ;) (param $0 i32)
   (local $1 f64)
   (local $2 i32)
   (local $3 i32)
@@ -31041,7 +30961,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint64Array> (; 503 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint64Array> (; 505 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -31179,7 +31099,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#set<~lib/array/Array<i32>> (; 504 ;) (param $0 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/array/Array<i32>> (; 506 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -31233,7 +31153,7 @@
    end
   end
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Float32Array> (; 505 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Float32Array> (; 507 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 f32)
   (local $4 i32)
@@ -31248,7 +31168,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 702
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -31288,7 +31208,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 708
+     i32.const 718
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -31301,7 +31221,7 @@
    end
   end
  )
- (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Int64Array> (; 506 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Int64Array> (; 508 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -31358,7 +31278,7 @@
    end
   end
  )
- (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Uint8Array> (; 507 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Uint8Array> (; 509 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -31409,7 +31329,7 @@
    end
   end
  )
- (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Int16Array> (; 508 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Int16Array> (; 510 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -31466,7 +31386,7 @@
    end
   end
  )
- (func $~lib/typedarray/Float32Array#set<~lib/array/Array<i8>> (; 509 ;) (param $0 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/array/Array<i8>> (; 511 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -31522,7 +31442,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float32Array> (; 510 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float32Array> (; 512 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -31649,7 +31569,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#set<~lib/array/Array<i32>> (; 511 ;) (param $0 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/array/Array<i32>> (; 513 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -31703,7 +31623,7 @@
    end
   end
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Float64Array> (; 512 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Float64Array> (; 514 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 f64)
   (local $4 i32)
@@ -31718,7 +31638,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 702
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -31756,7 +31676,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 708
+     i32.const 718
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -31769,7 +31689,7 @@
    end
   end
  )
- (func $~lib/typedarray/Float64Array#set<~lib/array/Array<f32>> (; 513 ;) (param $0 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/array/Array<f32>> (; 515 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -31827,7 +31747,7 @@
    end
   end
  )
- (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Int64Array> (; 514 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Int64Array> (; 516 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -31884,7 +31804,7 @@
    end
   end
  )
- (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Uint8Array> (; 515 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Uint8Array> (; 517 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -31935,7 +31855,7 @@
    end
   end
  )
- (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Int16Array> (; 516 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Int16Array> (; 518 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $1
@@ -31992,7 +31912,7 @@
    end
   end
  )
- (func $~lib/typedarray/Float64Array#set<~lib/array/Array<i8>> (; 517 ;) (param $0 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/array/Array<i8>> (; 519 ;) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -32048,7 +31968,7 @@
    end
   end
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float64Array> (; 518 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float64Array> (; 520 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -32173,7 +32093,7 @@
   local.get $6
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Float32Array> (; 519 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Float32Array> (; 521 ;) (param $0 i32) (param $1 i32)
   (local $2 f32)
   (local $3 i32)
   (local $4 i32)
@@ -32243,7 +32163,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int32Array> (; 520 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int32Array> (; 522 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -32311,7 +32231,7 @@
    end
   end
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Uint32Array> (; 521 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Uint32Array> (; 523 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -32368,7 +32288,7 @@
    end
   end
  )
- (func $start:std/typedarray (; 522 ;)
+ (func $start:std/typedarray (; 524 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -34255,6 +34175,51 @@
   call $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint64Array,u64>
   call $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float32Array,f32>
   call $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float64Array,f64>
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $1
+  i32.const 2
+  global.set $~argumentsLength
+  local.get $1
+  i32.const 0
+  call $~lib/typedarray/Uint8Array.wrap|trampoline
+  local.tee $2
+  i32.load offset=8
+  if
+   i32.const 0
+   i32.const 416
+   i32.const 691
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $0
+  local.get $1
+  call $~lib/rt/pure/__release
+  i32.const 2
+  global.set $~argumentsLength
+  local.get $0
+  i32.const 2
+  call $~lib/typedarray/Uint8Array.wrap|trampoline
+  local.set $1
+  local.get $2
+  call $~lib/rt/pure/__release
+  local.get $1
+  i32.load offset=8
+  if
+   i32.const 0
+   i32.const 416
+   i32.const 695
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
   call $std/typedarray/testArrayWrap<~lib/typedarray/Int8Array,i8>
   call $std/typedarray/testArrayWrap<~lib/typedarray/Uint8Array,u8>
   call $std/typedarray/testArrayWrap<~lib/typedarray/Uint8ClampedArray,u8>
@@ -34410,7 +34375,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~start (; 523 ;)
+ (func $~start (; 525 ;)
   global.get $~started
   if
    return
@@ -34420,7 +34385,7 @@
   end
   call $start:std/typedarray
  )
- (func $~lib/rt/pure/__visit (; 524 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 526 ;) (param $0 i32) (param $1 i32)
   local.get $0
   i32.const 7732
   i32.lt_u
@@ -34523,7 +34488,7 @@
    unreachable
   end
  )
- (func $~lib/rt/__visit_members (; 525 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (; 527 ;) (param $0 i32) (param $1 i32)
   block $block$4$break
    block $switch$1$default
     block $switch$1$case$2

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -25325,7 +25325,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1742
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25344,7 +25344,7 @@
     if (result i32)
      i32.const 32
      i32.const 480
-     i32.const 1746
+     i32.const 1747
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -25356,7 +25356,7 @@
    else
     i32.const 32
     i32.const 480
-    i32.const 1751
+    i32.const 1752
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -25371,7 +25371,7 @@
    if
     i32.const 32
     i32.const 480
-    i32.const 1756
+    i32.const 1757
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -25498,7 +25498,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1742
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25509,7 +25509,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1746
+   i32.const 1747
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -25710,7 +25710,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1742
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25721,7 +25721,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1746
+   i32.const 1747
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -25836,7 +25836,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1742
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25847,7 +25847,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1746
+   i32.const 1747
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -25964,7 +25964,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1742
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25975,7 +25975,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1746
+   i32.const 1747
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26090,7 +26090,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1742
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26101,7 +26101,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1746
+   i32.const 1747
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26214,7 +26214,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1742
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26225,7 +26225,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1746
+   i32.const 1747
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26338,7 +26338,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1742
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26349,7 +26349,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1746
+   i32.const 1747
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26463,7 +26463,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1742
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26474,7 +26474,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1746
+   i32.const 1747
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26588,7 +26588,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1742
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26599,7 +26599,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1746
+   i32.const 1747
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26713,7 +26713,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1742
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26724,7 +26724,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1746
+   i32.const 1747
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26839,7 +26839,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -26953,7 +26953,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27018,7 +27018,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27074,7 +27074,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27135,7 +27135,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27161,7 +27161,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27213,7 +27213,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27448,7 +27448,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27515,7 +27515,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27718,7 +27718,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27845,7 +27845,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27910,7 +27910,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -27925,7 +27925,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27998,7 +27998,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28063,7 +28063,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -28078,7 +28078,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28147,7 +28147,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28351,7 +28351,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28467,7 +28467,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28534,7 +28534,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28592,7 +28592,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28657,7 +28657,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28707,7 +28707,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28736,7 +28736,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28998,7 +28998,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29067,7 +29067,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29266,7 +29266,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -29281,7 +29281,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29374,7 +29374,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29440,7 +29440,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29498,7 +29498,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29563,7 +29563,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29615,7 +29615,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29672,7 +29672,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29929,7 +29929,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29997,7 +29997,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30203,7 +30203,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30319,7 +30319,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30384,7 +30384,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30415,7 +30415,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30479,7 +30479,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30531,7 +30531,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30588,7 +30588,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30842,7 +30842,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30912,7 +30912,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31116,7 +31116,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31238,7 +31238,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31293,7 +31293,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31346,7 +31346,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31404,7 +31404,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31585,7 +31585,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31707,7 +31707,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31765,7 +31765,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31819,7 +31819,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31872,7 +31872,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31930,7 +31930,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -32111,7 +32111,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -32181,7 +32181,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -32247,7 +32247,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -25314,14 +25314,18 @@
  (func $~lib/typedarray/Uint8Array.wrap (; 421 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   local.get $1
+  i32.const -2147483648
+  i32.and
+  local.get $1
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   local.tee $3
   i32.gt_u
+  i32.or
   if
    i32.const 304
    i32.const 480
-   i32.const 1739
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25494,7 +25498,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1739
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25706,7 +25710,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1739
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25832,7 +25836,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1739
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25960,7 +25964,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1739
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26086,7 +26090,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1739
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26210,7 +26214,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1739
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26334,7 +26338,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1739
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26459,7 +26463,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1739
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26584,7 +26588,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1739
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26709,7 +26713,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1739
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -25321,7 +25321,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1742
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25340,7 +25340,7 @@
    else
     i32.const 32
     i32.const 480
-    i32.const 1752
+    i32.const 1751
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -25355,7 +25355,7 @@
    if
     i32.const 32
     i32.const 480
-    i32.const 1757
+    i32.const 1756
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -25482,7 +25482,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1742
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25683,7 +25683,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1742
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25798,7 +25798,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1742
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25809,7 +25809,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1747
+   i32.const 1746
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -25926,7 +25926,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1742
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -25937,7 +25937,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1747
+   i32.const 1746
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26052,7 +26052,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1742
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26063,7 +26063,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1747
+   i32.const 1746
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26176,7 +26176,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1742
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26187,7 +26187,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1747
+   i32.const 1746
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26300,7 +26300,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1742
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26311,7 +26311,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1747
+   i32.const 1746
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26425,7 +26425,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1742
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26436,7 +26436,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1747
+   i32.const 1746
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26550,7 +26550,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1742
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26561,7 +26561,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1747
+   i32.const 1746
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26675,7 +26675,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1742
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -26686,7 +26686,7 @@
   if
    i32.const 32
    i32.const 480
-   i32.const 1747
+   i32.const 1746
    i32.const 8
    call $~lib/builtins/abort
    unreachable
@@ -26801,7 +26801,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -26854,7 +26854,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 716
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -26887,7 +26887,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 722
+     i32.const 718
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -26915,7 +26915,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -26980,7 +26980,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27036,7 +27036,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27097,7 +27097,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27123,7 +27123,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27175,7 +27175,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27349,7 +27349,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 716
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -27382,7 +27382,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 722
+     i32.const 718
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -27410,7 +27410,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27477,7 +27477,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27680,7 +27680,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27746,7 +27746,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 716
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -27779,7 +27779,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 722
+     i32.const 718
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -27807,7 +27807,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27872,7 +27872,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -27887,7 +27887,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -27960,7 +27960,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28025,7 +28025,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -28040,7 +28040,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28109,7 +28109,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28313,7 +28313,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28368,7 +28368,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 716
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -28401,7 +28401,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 722
+     i32.const 718
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -28429,7 +28429,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28496,7 +28496,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28554,7 +28554,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28619,7 +28619,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28669,7 +28669,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28698,7 +28698,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -28892,7 +28892,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 716
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -28932,7 +28932,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 722
+     i32.const 718
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -28960,7 +28960,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29029,7 +29029,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29228,7 +29228,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -29243,7 +29243,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29274,7 +29274,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 716
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -29307,7 +29307,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 722
+     i32.const 718
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -29336,7 +29336,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29402,7 +29402,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29460,7 +29460,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29525,7 +29525,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29577,7 +29577,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29634,7 +29634,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29829,7 +29829,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 716
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -29862,7 +29862,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 722
+     i32.const 718
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -29891,7 +29891,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -29959,7 +29959,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30165,7 +30165,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30220,7 +30220,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 716
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -30253,7 +30253,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 722
+     i32.const 718
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -30281,7 +30281,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30346,7 +30346,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30377,7 +30377,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30441,7 +30441,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30493,7 +30493,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30550,7 +30550,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30743,7 +30743,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 716
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -30776,7 +30776,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 722
+     i32.const 718
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -30804,7 +30804,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -30874,7 +30874,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31078,7 +31078,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31134,7 +31134,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 716
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -31174,7 +31174,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 722
+     i32.const 718
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -31200,7 +31200,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31255,7 +31255,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31308,7 +31308,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31366,7 +31366,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31547,7 +31547,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31604,7 +31604,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 716
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -31642,7 +31642,7 @@
      call $~lib/builtins/trace
      i32.const 0
      i32.const 416
-     i32.const 722
+     i32.const 718
      i32.const 6
      call $~lib/builtins/abort
      unreachable
@@ -31669,7 +31669,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31727,7 +31727,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31781,7 +31781,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31834,7 +31834,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -31892,7 +31892,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -32073,7 +32073,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -32143,7 +32143,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -32209,7 +32209,7 @@
   if
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.optimized.wat
+++ b/tests/compiler/std/typedarray.optimized.wat
@@ -25362,7 +25362,7 @@
   i32.const 0
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.ge_u
+  i32.gt_u
   if
    i32.const 304
    i32.const 480
@@ -25505,7 +25505,7 @@
   i32.const 0
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.ge_u
+  i32.gt_u
   if
    i32.const 304
    i32.const 480
@@ -25646,7 +25646,7 @@
   i32.const 0
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.ge_u
+  i32.gt_u
   if
    i32.const 304
    i32.const 480
@@ -25787,7 +25787,7 @@
   i32.const 0
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.ge_u
+  i32.gt_u
   if
    i32.const 304
    i32.const 480
@@ -25930,7 +25930,7 @@
   i32.const 0
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.ge_u
+  i32.gt_u
   if
    i32.const 304
    i32.const 480
@@ -26071,7 +26071,7 @@
   i32.const 0
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.ge_u
+  i32.gt_u
   if
    i32.const 304
    i32.const 480
@@ -26210,7 +26210,7 @@
   i32.const 0
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.ge_u
+  i32.gt_u
   if
    i32.const 304
    i32.const 480
@@ -26349,7 +26349,7 @@
   i32.const 0
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.ge_u
+  i32.gt_u
   if
    i32.const 304
    i32.const 480
@@ -26489,7 +26489,7 @@
   i32.const 0
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.ge_u
+  i32.gt_u
   if
    i32.const 304
    i32.const 480
@@ -26629,7 +26629,7 @@
   i32.const 0
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.ge_u
+  i32.gt_u
   if
    i32.const 304
    i32.const 480
@@ -26769,7 +26769,7 @@
   i32.const 0
   local.get $0
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.ge_u
+  i32.gt_u
   if
    i32.const 304
    i32.const 480

--- a/tests/compiler/std/typedarray.ts
+++ b/tests/compiler/std/typedarray.ts
@@ -685,6 +685,16 @@ function testArrayWrap<TArray extends TypedArray<T>, T extends number>(): void {
   }
 }
 
+{
+  let buffer = new ArrayBuffer(0);
+  let array = Uint8Array.wrap(buffer, 0);
+  assert(array.length == 0);
+
+  buffer = new ArrayBuffer(2);
+  array = Uint8Array.wrap(buffer, 2);
+  assert(array.length == 0);
+}
+
 testArrayWrap<Int8Array, i8>();
 testArrayWrap<Uint8Array, u8>();
 testArrayWrap<Uint8ClampedArray, u8>();

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -37523,7 +37523,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1740
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -37544,7 +37544,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1745
+     i32.const 1746
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -37558,7 +37558,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1749
+    i32.const 1750
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -37578,7 +37578,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1754
+    i32.const 1755
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -37750,7 +37750,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1740
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -37771,7 +37771,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1745
+     i32.const 1746
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -37785,7 +37785,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1749
+    i32.const 1750
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -37805,7 +37805,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1754
+    i32.const 1755
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38120,7 +38120,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1740
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -38141,7 +38141,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1745
+     i32.const 1746
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -38155,7 +38155,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1749
+    i32.const 1750
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38175,7 +38175,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1754
+    i32.const 1755
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38376,7 +38376,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1740
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -38397,7 +38397,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1745
+     i32.const 1746
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -38411,7 +38411,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1749
+    i32.const 1750
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38431,7 +38431,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1754
+    i32.const 1755
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38634,7 +38634,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1740
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -38655,7 +38655,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1745
+     i32.const 1746
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -38669,7 +38669,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1749
+    i32.const 1750
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38689,7 +38689,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1754
+    i32.const 1755
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38890,7 +38890,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1740
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -38911,7 +38911,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1745
+     i32.const 1746
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -38925,7 +38925,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1749
+    i32.const 1750
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38945,7 +38945,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1754
+    i32.const 1755
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39144,7 +39144,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1740
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -39165,7 +39165,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1745
+     i32.const 1746
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -39179,7 +39179,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1749
+    i32.const 1750
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39199,7 +39199,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1754
+    i32.const 1755
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39398,7 +39398,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1740
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -39419,7 +39419,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1745
+     i32.const 1746
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -39433,7 +39433,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1749
+    i32.const 1750
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39453,7 +39453,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1754
+    i32.const 1755
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39653,7 +39653,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1740
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -39674,7 +39674,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1745
+     i32.const 1746
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -39688,7 +39688,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1749
+    i32.const 1750
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39708,7 +39708,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1754
+    i32.const 1755
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39908,7 +39908,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1740
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -39929,7 +39929,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1745
+     i32.const 1746
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -39943,7 +39943,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1749
+    i32.const 1750
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39963,7 +39963,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1754
+    i32.const 1755
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -40163,7 +40163,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1740
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -40184,7 +40184,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1745
+     i32.const 1746
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -40198,7 +40198,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1749
+    i32.const 1750
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -40218,7 +40218,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1754
+    i32.const 1755
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -40415,7 +40415,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40434,7 +40434,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40605,7 +40605,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40624,7 +40624,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40719,7 +40719,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40738,7 +40738,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40826,7 +40826,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40845,7 +40845,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40935,7 +40935,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40954,7 +40954,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41007,7 +41007,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41026,7 +41026,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41104,7 +41104,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41123,7 +41123,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41339,7 +41339,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41358,7 +41358,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41538,7 +41538,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41557,7 +41557,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41652,7 +41652,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41671,7 +41671,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41755,7 +41755,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41774,7 +41774,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41864,7 +41864,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41883,7 +41883,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41936,7 +41936,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41955,7 +41955,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42033,7 +42033,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42052,7 +42052,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42269,7 +42269,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42288,7 +42288,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42469,7 +42469,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42488,7 +42488,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42588,7 +42588,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42607,7 +42607,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42709,7 +42709,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42728,7 +42728,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42822,7 +42822,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42841,7 +42841,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42895,7 +42895,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42914,7 +42914,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43012,7 +43012,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43031,7 +43031,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43291,7 +43291,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43310,7 +43310,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43481,7 +43481,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43500,7 +43500,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43595,7 +43595,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43614,7 +43614,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43698,7 +43698,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43717,7 +43717,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43812,7 +43812,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43831,7 +43831,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43909,7 +43909,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43928,7 +43928,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43981,7 +43981,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44000,7 +44000,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44246,7 +44246,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44265,7 +44265,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44445,7 +44445,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44464,7 +44464,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44559,7 +44559,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44578,7 +44578,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44662,7 +44662,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44681,7 +44681,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44776,7 +44776,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44795,7 +44795,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44873,7 +44873,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44892,7 +44892,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44945,7 +44945,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44964,7 +44964,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45205,7 +45205,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45224,7 +45224,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45361,7 +45361,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45380,7 +45380,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45475,7 +45475,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45494,7 +45494,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45578,7 +45578,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45597,7 +45597,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45692,7 +45692,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45711,7 +45711,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45794,7 +45794,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45813,7 +45813,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45896,7 +45896,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45915,7 +45915,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46156,7 +46156,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46175,7 +46175,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46325,7 +46325,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46344,7 +46344,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46439,7 +46439,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46458,7 +46458,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46542,7 +46542,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46561,7 +46561,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46656,7 +46656,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46675,7 +46675,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46758,7 +46758,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46777,7 +46777,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46860,7 +46860,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46879,7 +46879,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47125,7 +47125,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47144,7 +47144,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47324,7 +47324,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47343,7 +47343,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47433,7 +47433,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47452,7 +47452,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47506,7 +47506,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47525,7 +47525,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47620,7 +47620,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47639,7 +47639,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47722,7 +47722,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47741,7 +47741,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47824,7 +47824,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47843,7 +47843,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48089,7 +48089,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48108,7 +48108,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48279,7 +48279,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48298,7 +48298,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48388,7 +48388,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48407,7 +48407,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48461,7 +48461,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48480,7 +48480,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48575,7 +48575,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48594,7 +48594,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48677,7 +48677,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48696,7 +48696,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48779,7 +48779,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48798,7 +48798,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49044,7 +49044,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49063,7 +49063,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49234,7 +49234,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49253,7 +49253,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49306,7 +49306,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49325,7 +49325,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49409,7 +49409,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49428,7 +49428,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49512,7 +49512,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49531,7 +49531,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49615,7 +49615,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49634,7 +49634,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49866,7 +49866,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49885,7 +49885,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50059,7 +50059,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50078,7 +50078,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50162,7 +50162,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50181,7 +50181,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50265,7 +50265,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50284,7 +50284,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50368,7 +50368,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50387,7 +50387,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50471,7 +50471,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50490,7 +50490,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50723,7 +50723,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50742,7 +50742,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50842,7 +50842,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50861,7 +50861,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50961,7 +50961,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1773
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50980,7 +50980,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -37510,16 +37510,20 @@
   local.set $3
   local.get $5
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $6
+  local.set $7
   local.get $4
-  local.get $6
+  local.get $7
   i32.gt_u
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.or
   if
    local.get $5
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1739
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -37532,7 +37536,7 @@
    i32.const -1
    i32.eq
    if
-    local.get $6
+    local.get $7
     i32.const -2147483648
     i32.and
     if
@@ -37545,10 +37549,10 @@
      call $~lib/builtins/abort
      unreachable
     else
-     local.get $6
+     local.get $7
      local.get $4
      i32.sub
-     local.set $7
+     local.set $6
     end
    else
     local.get $5
@@ -37564,11 +37568,11 @@
    local.get $3
    i32.const 0
    i32.shl
-   local.set $7
+   local.set $6
    local.get $4
-   local.get $7
-   i32.add
    local.get $6
+   i32.add
+   local.get $7
    i32.gt_s
    if
     local.get $5
@@ -37590,7 +37594,7 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $8
-  local.get $7
+  local.get $6
   i32.store offset=8
   local.get $8
   local.get $5
@@ -37734,16 +37738,20 @@
   local.set $3
   local.get $5
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $6
+  local.set $7
   local.get $4
-  local.get $6
+  local.get $7
   i32.gt_u
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.or
   if
    local.get $5
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1739
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -37756,7 +37764,7 @@
    i32.const -1
    i32.eq
    if
-    local.get $6
+    local.get $7
     i32.const -2147483648
     i32.and
     if
@@ -37769,10 +37777,10 @@
      call $~lib/builtins/abort
      unreachable
     else
-     local.get $6
+     local.get $7
      local.get $4
      i32.sub
-     local.set $7
+     local.set $6
     end
    else
     local.get $5
@@ -37788,11 +37796,11 @@
    local.get $3
    i32.const 0
    i32.shl
-   local.set $7
+   local.set $6
    local.get $4
-   local.get $7
-   i32.add
    local.get $6
+   i32.add
+   local.get $7
    i32.gt_s
    if
     local.get $5
@@ -37814,7 +37822,7 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $8
-  local.get $7
+  local.get $6
   i32.store offset=8
   local.get $8
   local.get $5
@@ -38101,16 +38109,20 @@
   local.set $3
   local.get $5
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $6
+  local.set $7
   local.get $4
-  local.get $6
+  local.get $7
   i32.gt_u
+  local.get $4
+  i32.const -2147483648
+  i32.and
+  i32.or
   if
    local.get $5
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1739
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -38123,7 +38135,7 @@
    i32.const -1
    i32.eq
    if
-    local.get $6
+    local.get $7
     i32.const -2147483648
     i32.and
     if
@@ -38136,10 +38148,10 @@
      call $~lib/builtins/abort
      unreachable
     else
-     local.get $6
+     local.get $7
      local.get $4
      i32.sub
-     local.set $7
+     local.set $6
     end
    else
     local.get $5
@@ -38155,11 +38167,11 @@
    local.get $3
    i32.const 0
    i32.shl
-   local.set $7
+   local.set $6
    local.get $4
-   local.get $7
-   i32.add
    local.get $6
+   i32.add
+   local.get $7
    i32.gt_s
    if
     local.get $5
@@ -38181,7 +38193,7 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $8
-  local.get $7
+  local.get $6
   i32.store offset=8
   local.get $8
   local.get $5
@@ -38354,16 +38366,20 @@
   local.set $3
   local.get $5
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $6
+  local.set $7
   local.get $4
-  local.get $6
+  local.get $7
   i32.gt_u
+  local.get $4
+  i32.const 1
+  i32.and
+  i32.or
   if
    local.get $5
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1739
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -38376,7 +38392,7 @@
    i32.const -1
    i32.eq
    if
-    local.get $6
+    local.get $7
     i32.const 1
     i32.and
     if
@@ -38389,10 +38405,10 @@
      call $~lib/builtins/abort
      unreachable
     else
-     local.get $6
+     local.get $7
      local.get $4
      i32.sub
-     local.set $7
+     local.set $6
     end
    else
     local.get $5
@@ -38408,11 +38424,11 @@
    local.get $3
    i32.const 1
    i32.shl
-   local.set $7
+   local.set $6
    local.get $4
-   local.get $7
-   i32.add
    local.get $6
+   i32.add
+   local.get $7
    i32.gt_s
    if
     local.get $5
@@ -38434,7 +38450,7 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $8
-  local.get $7
+  local.get $6
   i32.store offset=8
   local.get $8
   local.get $5
@@ -38609,16 +38625,20 @@
   local.set $3
   local.get $5
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $6
+  local.set $7
   local.get $4
-  local.get $6
+  local.get $7
   i32.gt_u
+  local.get $4
+  i32.const 1
+  i32.and
+  i32.or
   if
    local.get $5
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1739
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -38631,7 +38651,7 @@
    i32.const -1
    i32.eq
    if
-    local.get $6
+    local.get $7
     i32.const 1
     i32.and
     if
@@ -38644,10 +38664,10 @@
      call $~lib/builtins/abort
      unreachable
     else
-     local.get $6
+     local.get $7
      local.get $4
      i32.sub
-     local.set $7
+     local.set $6
     end
    else
     local.get $5
@@ -38663,11 +38683,11 @@
    local.get $3
    i32.const 1
    i32.shl
-   local.set $7
+   local.set $6
    local.get $4
-   local.get $7
-   i32.add
    local.get $6
+   i32.add
+   local.get $7
    i32.gt_s
    if
     local.get $5
@@ -38689,7 +38709,7 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $8
-  local.get $7
+  local.get $6
   i32.store offset=8
   local.get $8
   local.get $5
@@ -38862,16 +38882,20 @@
   local.set $3
   local.get $5
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $6
+  local.set $7
   local.get $4
-  local.get $6
+  local.get $7
   i32.gt_u
+  local.get $4
+  i32.const 2
+  i32.and
+  i32.or
   if
    local.get $5
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1739
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -38884,7 +38908,7 @@
    i32.const -1
    i32.eq
    if
-    local.get $6
+    local.get $7
     i32.const 2
     i32.and
     if
@@ -38897,10 +38921,10 @@
      call $~lib/builtins/abort
      unreachable
     else
-     local.get $6
+     local.get $7
      local.get $4
      i32.sub
-     local.set $7
+     local.set $6
     end
    else
     local.get $5
@@ -38916,11 +38940,11 @@
    local.get $3
    i32.const 2
    i32.shl
-   local.set $7
+   local.set $6
    local.get $4
-   local.get $7
-   i32.add
    local.get $6
+   i32.add
+   local.get $7
    i32.gt_s
    if
     local.get $5
@@ -38942,7 +38966,7 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $8
-  local.get $7
+  local.get $6
   i32.store offset=8
   local.get $8
   local.get $5
@@ -39113,16 +39137,20 @@
   local.set $3
   local.get $5
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $6
+  local.set $7
   local.get $4
-  local.get $6
+  local.get $7
   i32.gt_u
+  local.get $4
+  i32.const 2
+  i32.and
+  i32.or
   if
    local.get $5
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1739
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -39135,7 +39163,7 @@
    i32.const -1
    i32.eq
    if
-    local.get $6
+    local.get $7
     i32.const 2
     i32.and
     if
@@ -39148,10 +39176,10 @@
      call $~lib/builtins/abort
      unreachable
     else
-     local.get $6
+     local.get $7
      local.get $4
      i32.sub
-     local.set $7
+     local.set $6
     end
    else
     local.get $5
@@ -39167,11 +39195,11 @@
    local.get $3
    i32.const 2
    i32.shl
-   local.set $7
+   local.set $6
    local.get $4
-   local.get $7
-   i32.add
    local.get $6
+   i32.add
+   local.get $7
    i32.gt_s
    if
     local.get $5
@@ -39193,7 +39221,7 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $8
-  local.get $7
+  local.get $6
   i32.store offset=8
   local.get $8
   local.get $5
@@ -39364,16 +39392,20 @@
   local.set $3
   local.get $5
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $6
+  local.set $7
   local.get $4
-  local.get $6
+  local.get $7
   i32.gt_u
+  local.get $4
+  i32.const 4
+  i32.and
+  i32.or
   if
    local.get $5
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1739
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -39386,7 +39418,7 @@
    i32.const -1
    i32.eq
    if
-    local.get $6
+    local.get $7
     i32.const 4
     i32.and
     if
@@ -39399,10 +39431,10 @@
      call $~lib/builtins/abort
      unreachable
     else
-     local.get $6
+     local.get $7
      local.get $4
      i32.sub
-     local.set $7
+     local.set $6
     end
    else
     local.get $5
@@ -39418,11 +39450,11 @@
    local.get $3
    i32.const 3
    i32.shl
-   local.set $7
+   local.set $6
    local.get $4
-   local.get $7
-   i32.add
    local.get $6
+   i32.add
+   local.get $7
    i32.gt_s
    if
     local.get $5
@@ -39444,7 +39476,7 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $8
-  local.get $7
+  local.get $6
   i32.store offset=8
   local.get $8
   local.get $5
@@ -39616,16 +39648,20 @@
   local.set $3
   local.get $5
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $6
+  local.set $7
   local.get $4
-  local.get $6
+  local.get $7
   i32.gt_u
+  local.get $4
+  i32.const 4
+  i32.and
+  i32.or
   if
    local.get $5
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1739
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -39638,7 +39674,7 @@
    i32.const -1
    i32.eq
    if
-    local.get $6
+    local.get $7
     i32.const 4
     i32.and
     if
@@ -39651,10 +39687,10 @@
      call $~lib/builtins/abort
      unreachable
     else
-     local.get $6
+     local.get $7
      local.get $4
      i32.sub
-     local.set $7
+     local.set $6
     end
    else
     local.get $5
@@ -39670,11 +39706,11 @@
    local.get $3
    i32.const 3
    i32.shl
-   local.set $7
+   local.set $6
    local.get $4
-   local.get $7
-   i32.add
    local.get $6
+   i32.add
+   local.get $7
    i32.gt_s
    if
     local.get $5
@@ -39696,7 +39732,7 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $8
-  local.get $7
+  local.get $6
   i32.store offset=8
   local.get $8
   local.get $5
@@ -39868,16 +39904,20 @@
   local.set $3
   local.get $5
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $6
+  local.set $7
   local.get $4
-  local.get $6
+  local.get $7
   i32.gt_u
+  local.get $4
+  i32.const 2
+  i32.and
+  i32.or
   if
    local.get $5
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1739
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -39890,7 +39930,7 @@
    i32.const -1
    i32.eq
    if
-    local.get $6
+    local.get $7
     i32.const 2
     i32.and
     if
@@ -39903,10 +39943,10 @@
      call $~lib/builtins/abort
      unreachable
     else
-     local.get $6
+     local.get $7
      local.get $4
      i32.sub
-     local.set $7
+     local.set $6
     end
    else
     local.get $5
@@ -39922,11 +39962,11 @@
    local.get $3
    i32.const 2
    i32.shl
-   local.set $7
+   local.set $6
    local.get $4
-   local.get $7
-   i32.add
    local.get $6
+   i32.add
+   local.get $7
    i32.gt_s
    if
     local.get $5
@@ -39948,7 +39988,7 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $8
-  local.get $7
+  local.get $6
   i32.store offset=8
   local.get $8
   local.get $5
@@ -40120,16 +40160,20 @@
   local.set $3
   local.get $5
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $6
+  local.set $7
   local.get $4
-  local.get $6
+  local.get $7
   i32.gt_u
+  local.get $4
+  i32.const 4
+  i32.and
+  i32.or
   if
    local.get $5
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1739
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -40142,7 +40186,7 @@
    i32.const -1
    i32.eq
    if
-    local.get $6
+    local.get $7
     i32.const 4
     i32.and
     if
@@ -40155,10 +40199,10 @@
      call $~lib/builtins/abort
      unreachable
     else
-     local.get $6
+     local.get $7
      local.get $4
      i32.sub
-     local.set $7
+     local.set $6
     end
    else
     local.get $5
@@ -40174,11 +40218,11 @@
    local.get $3
    i32.const 3
    i32.shl
-   local.set $7
+   local.set $6
    local.get $4
-   local.get $7
-   i32.add
    local.get $6
+   i32.add
+   local.get $7
    i32.gt_s
    if
     local.get $5
@@ -40200,7 +40244,7 @@
   call $~lib/rt/pure/__retain
   i32.store
   local.get $8
-  local.get $7
+  local.get $6
   i32.store offset=8
   local.get $8
   local.get $5

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -37460,13 +37460,178 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (; 558 ;) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (; 558 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  i32.const 1073741808
+  i32.gt_u
+  if
+   i32.const 32
+   i32.const 80
+   i32.const 54
+   i32.const 42
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.set $2
+  local.get $2
+  i32.const 0
+  local.get $1
+  call $~lib/memory/memory.fill
+  local.get $2
+  call $~lib/rt/pure/__retain
+ )
+ (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (; 559 ;) (param $0 i32) (result i32)
   local.get $0
   i32.const 16
   i32.sub
   i32.load offset=12
  )
- (func $~lib/arraybuffer/ArrayBuffer#slice (; 559 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array.wrap (; 560 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $0
+  local.get $0
+  call $~lib/rt/pure/__retain
+  local.set $5
+  local.get $1
+  local.set $4
+  local.get $2
+  local.set $3
+  local.get $5
+  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  local.set $6
+  local.get $4
+  local.get $6
+  i32.gt_u
+  if
+   local.get $5
+   call $~lib/rt/pure/__release
+   i32.const 304
+   i32.const 480
+   i32.const 1739
+   i32.const 4
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  i32.const 0
+  i32.lt_s
+  if
+   local.get $3
+   i32.const -1
+   i32.eq
+   if
+    local.get $6
+    i32.const -2147483648
+    i32.and
+    if
+     local.get $5
+     call $~lib/rt/pure/__release
+     i32.const 32
+     i32.const 480
+     i32.const 1746
+     i32.const 8
+     call $~lib/builtins/abort
+     unreachable
+    else
+     local.get $6
+     local.get $4
+     i32.sub
+     local.set $7
+    end
+   else
+    local.get $5
+    call $~lib/rt/pure/__release
+    i32.const 32
+    i32.const 480
+    i32.const 1751
+    i32.const 6
+    call $~lib/builtins/abort
+    unreachable
+   end
+  else
+   local.get $3
+   i32.const 0
+   i32.shl
+   local.set $7
+   local.get $4
+   local.get $7
+   i32.add
+   local.get $6
+   i32.gt_s
+   if
+    local.get $5
+    call $~lib/rt/pure/__release
+    i32.const 32
+    i32.const 480
+    i32.const 1756
+    i32.const 6
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  i32.const 12
+  i32.const 4
+  call $~lib/rt/tlsf/__alloc
+  local.set $8
+  local.get $8
+  local.get $5
+  call $~lib/rt/pure/__retain
+  i32.store
+  local.get $8
+  local.get $7
+  i32.store offset=8
+  local.get $8
+  local.get $5
+  local.get $4
+  i32.add
+  i32.store offset=4
+  local.get $8
+  call $~lib/rt/pure/__retain
+  local.set $9
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $9
+  local.set $8
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $8
+ )
+ (func $~lib/typedarray/Uint8Array.wrap|trampoline (; 561 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  block $2of2
+   block $1of2
+    block $0of2
+     block $outOfRange
+      global.get $~argumentsLength
+      i32.const 1
+      i32.sub
+      br_table $0of2 $1of2 $2of2 $outOfRange
+     end
+     unreachable
+    end
+    i32.const 0
+    local.set $1
+   end
+   i32.const -1
+   local.set $2
+  end
+  local.get $0
+  local.get $1
+  local.get $2
+  call $~lib/typedarray/Uint8Array.wrap
+ )
+ (func $~lib/arraybuffer/ArrayBuffer#slice (; 562 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -37549,7 +37714,7 @@
   local.get $7
   call $~lib/rt/pure/__retain
  )
- (func $~lib/typedarray/Int8Array.wrap (; 560 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array.wrap (; 563 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -37591,8 +37756,7 @@
    i32.const -1
    i32.eq
    if
-    local.get $5
-    call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+    local.get $6
     i32.const -2147483648
     i32.and
     if
@@ -37605,8 +37769,9 @@
      call $~lib/builtins/abort
      unreachable
     else
-     local.get $5
-     call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+     local.get $6
+     local.get $4
+     i32.sub
      local.set $7
     end
    else
@@ -37624,22 +37789,21 @@
    i32.const 0
    i32.shl
    local.set $7
-  end
-  local.get $4
-  local.get $7
-  i32.add
-  local.get $5
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.gt_s
-  if
-   local.get $5
-   call $~lib/rt/pure/__release
-   i32.const 32
-   i32.const 480
-   i32.const 1757
-   i32.const 4
-   call $~lib/builtins/abort
-   unreachable
+   local.get $4
+   local.get $7
+   i32.add
+   local.get $6
+   i32.gt_s
+   if
+    local.get $5
+    call $~lib/rt/pure/__release
+    i32.const 32
+    i32.const 480
+    i32.const 1756
+    i32.const 6
+    call $~lib/builtins/abort
+    unreachable
+   end
   end
   i32.const 12
   i32.const 3
@@ -37668,7 +37832,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Int8Array.wrap|trampoline (; 561 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int8Array.wrap|trampoline (; 564 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -37691,7 +37855,7 @@
   local.get $2
   call $~lib/typedarray/Int8Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int8Array,i8> (; 562 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int8Array,i8> (; 565 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -37805,149 +37969,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array.wrap (; 563 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $0
-  local.get $0
-  call $~lib/rt/pure/__retain
-  local.set $5
-  local.get $1
-  local.set $4
-  local.get $2
-  local.set $3
-  local.get $5
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  local.set $6
-  local.get $4
-  local.get $6
-  i32.gt_u
-  if
-   local.get $5
-   call $~lib/rt/pure/__release
-   i32.const 304
-   i32.const 480
-   i32.const 1739
-   i32.const 4
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $3
-  i32.const 0
-  i32.lt_s
-  if
-   local.get $3
-   i32.const -1
-   i32.eq
-   if
-    local.get $5
-    call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-    i32.const -2147483648
-    i32.and
-    if
-     local.get $5
-     call $~lib/rt/pure/__release
-     i32.const 32
-     i32.const 480
-     i32.const 1746
-     i32.const 8
-     call $~lib/builtins/abort
-     unreachable
-    else
-     local.get $5
-     call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-     local.set $7
-    end
-   else
-    local.get $5
-    call $~lib/rt/pure/__release
-    i32.const 32
-    i32.const 480
-    i32.const 1751
-    i32.const 6
-    call $~lib/builtins/abort
-    unreachable
-   end
-  else
-   local.get $3
-   i32.const 0
-   i32.shl
-   local.set $7
-  end
-  local.get $4
-  local.get $7
-  i32.add
-  local.get $5
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.gt_s
-  if
-   local.get $5
-   call $~lib/rt/pure/__release
-   i32.const 32
-   i32.const 480
-   i32.const 1757
-   i32.const 4
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 12
-  i32.const 4
-  call $~lib/rt/tlsf/__alloc
-  local.set $8
-  local.get $8
-  local.get $5
-  call $~lib/rt/pure/__retain
-  i32.store
-  local.get $8
-  local.get $7
-  i32.store offset=8
-  local.get $8
-  local.get $5
-  local.get $4
-  i32.add
-  i32.store offset=4
-  local.get $8
-  call $~lib/rt/pure/__retain
-  local.set $9
-  local.get $5
-  call $~lib/rt/pure/__release
-  local.get $9
-  local.set $8
-  local.get $0
-  call $~lib/rt/pure/__release
-  local.get $8
- )
- (func $~lib/typedarray/Uint8Array.wrap|trampoline (; 564 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
-  block $2of2
-   block $1of2
-    block $0of2
-     block $outOfRange
-      global.get $~argumentsLength
-      i32.const 1
-      i32.sub
-      br_table $0of2 $1of2 $2of2 $outOfRange
-     end
-     unreachable
-    end
-    i32.const 0
-    local.set $1
-   end
-   i32.const -1
-   local.set $2
-  end
-  local.get $0
-  local.get $1
-  local.get $2
-  call $~lib/typedarray/Uint8Array.wrap
- )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8Array,u8> (; 565 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8Array,u8> (; 566 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -38059,7 +38081,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray.wrap (; 566 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray.wrap (; 567 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -38101,8 +38123,7 @@
    i32.const -1
    i32.eq
    if
-    local.get $5
-    call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+    local.get $6
     i32.const -2147483648
     i32.and
     if
@@ -38115,8 +38136,9 @@
      call $~lib/builtins/abort
      unreachable
     else
-     local.get $5
-     call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+     local.get $6
+     local.get $4
+     i32.sub
      local.set $7
     end
    else
@@ -38134,22 +38156,21 @@
    i32.const 0
    i32.shl
    local.set $7
-  end
-  local.get $4
-  local.get $7
-  i32.add
-  local.get $5
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.gt_s
-  if
-   local.get $5
-   call $~lib/rt/pure/__release
-   i32.const 32
-   i32.const 480
-   i32.const 1757
-   i32.const 4
-   call $~lib/builtins/abort
-   unreachable
+   local.get $4
+   local.get $7
+   i32.add
+   local.get $6
+   i32.gt_s
+   if
+    local.get $5
+    call $~lib/rt/pure/__release
+    i32.const 32
+    i32.const 480
+    i32.const 1756
+    i32.const 6
+    call $~lib/builtins/abort
+    unreachable
+   end
   end
   i32.const 12
   i32.const 5
@@ -38178,7 +38199,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Uint8ClampedArray.wrap|trampoline (; 567 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint8ClampedArray.wrap|trampoline (; 568 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -38201,7 +38222,7 @@
   local.get $2
   call $~lib/typedarray/Uint8ClampedArray.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8ClampedArray,u8> (; 568 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint8ClampedArray,u8> (; 569 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -38313,7 +38334,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array.wrap (; 569 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array.wrap (; 570 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -38355,8 +38376,7 @@
    i32.const -1
    i32.eq
    if
-    local.get $5
-    call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+    local.get $6
     i32.const 1
     i32.and
     if
@@ -38369,8 +38389,9 @@
      call $~lib/builtins/abort
      unreachable
     else
-     local.get $5
-     call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+     local.get $6
+     local.get $4
+     i32.sub
      local.set $7
     end
    else
@@ -38388,22 +38409,21 @@
    i32.const 1
    i32.shl
    local.set $7
-  end
-  local.get $4
-  local.get $7
-  i32.add
-  local.get $5
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.gt_s
-  if
-   local.get $5
-   call $~lib/rt/pure/__release
-   i32.const 32
-   i32.const 480
-   i32.const 1757
-   i32.const 4
-   call $~lib/builtins/abort
-   unreachable
+   local.get $4
+   local.get $7
+   i32.add
+   local.get $6
+   i32.gt_s
+   if
+    local.get $5
+    call $~lib/rt/pure/__release
+    i32.const 32
+    i32.const 480
+    i32.const 1756
+    i32.const 6
+    call $~lib/builtins/abort
+    unreachable
+   end
   end
   i32.const 12
   i32.const 6
@@ -38432,7 +38452,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Int16Array.wrap|trampoline (; 570 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int16Array.wrap|trampoline (; 571 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -38455,7 +38475,7 @@
   local.get $2
   call $~lib/typedarray/Int16Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int16Array,i16> (; 571 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int16Array,i16> (; 572 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -38569,7 +38589,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array.wrap (; 572 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array.wrap (; 573 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -38611,8 +38631,7 @@
    i32.const -1
    i32.eq
    if
-    local.get $5
-    call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+    local.get $6
     i32.const 1
     i32.and
     if
@@ -38625,8 +38644,9 @@
      call $~lib/builtins/abort
      unreachable
     else
-     local.get $5
-     call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+     local.get $6
+     local.get $4
+     i32.sub
      local.set $7
     end
    else
@@ -38644,22 +38664,21 @@
    i32.const 1
    i32.shl
    local.set $7
-  end
-  local.get $4
-  local.get $7
-  i32.add
-  local.get $5
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.gt_s
-  if
-   local.get $5
-   call $~lib/rt/pure/__release
-   i32.const 32
-   i32.const 480
-   i32.const 1757
-   i32.const 4
-   call $~lib/builtins/abort
-   unreachable
+   local.get $4
+   local.get $7
+   i32.add
+   local.get $6
+   i32.gt_s
+   if
+    local.get $5
+    call $~lib/rt/pure/__release
+    i32.const 32
+    i32.const 480
+    i32.const 1756
+    i32.const 6
+    call $~lib/builtins/abort
+    unreachable
+   end
   end
   i32.const 12
   i32.const 7
@@ -38688,7 +38707,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Uint16Array.wrap|trampoline (; 573 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint16Array.wrap|trampoline (; 574 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -38711,7 +38730,7 @@
   local.get $2
   call $~lib/typedarray/Uint16Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint16Array,u16> (; 574 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint16Array,u16> (; 575 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -38823,7 +38842,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array.wrap (; 575 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array.wrap (; 576 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -38865,8 +38884,7 @@
    i32.const -1
    i32.eq
    if
-    local.get $5
-    call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+    local.get $6
     i32.const 2
     i32.and
     if
@@ -38879,8 +38897,9 @@
      call $~lib/builtins/abort
      unreachable
     else
-     local.get $5
-     call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+     local.get $6
+     local.get $4
+     i32.sub
      local.set $7
     end
    else
@@ -38898,22 +38917,21 @@
    i32.const 2
    i32.shl
    local.set $7
-  end
-  local.get $4
-  local.get $7
-  i32.add
-  local.get $5
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.gt_s
-  if
-   local.get $5
-   call $~lib/rt/pure/__release
-   i32.const 32
-   i32.const 480
-   i32.const 1757
-   i32.const 4
-   call $~lib/builtins/abort
-   unreachable
+   local.get $4
+   local.get $7
+   i32.add
+   local.get $6
+   i32.gt_s
+   if
+    local.get $5
+    call $~lib/rt/pure/__release
+    i32.const 32
+    i32.const 480
+    i32.const 1756
+    i32.const 6
+    call $~lib/builtins/abort
+    unreachable
+   end
   end
   i32.const 12
   i32.const 8
@@ -38942,7 +38960,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Int32Array.wrap|trampoline (; 576 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int32Array.wrap|trampoline (; 577 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -38965,7 +38983,7 @@
   local.get $2
   call $~lib/typedarray/Int32Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int32Array,i32> (; 577 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int32Array,i32> (; 578 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -39075,7 +39093,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array.wrap (; 578 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array.wrap (; 579 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -39117,8 +39135,7 @@
    i32.const -1
    i32.eq
    if
-    local.get $5
-    call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+    local.get $6
     i32.const 2
     i32.and
     if
@@ -39131,8 +39148,9 @@
      call $~lib/builtins/abort
      unreachable
     else
-     local.get $5
-     call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+     local.get $6
+     local.get $4
+     i32.sub
      local.set $7
     end
    else
@@ -39150,22 +39168,21 @@
    i32.const 2
    i32.shl
    local.set $7
-  end
-  local.get $4
-  local.get $7
-  i32.add
-  local.get $5
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.gt_s
-  if
-   local.get $5
-   call $~lib/rt/pure/__release
-   i32.const 32
-   i32.const 480
-   i32.const 1757
-   i32.const 4
-   call $~lib/builtins/abort
-   unreachable
+   local.get $4
+   local.get $7
+   i32.add
+   local.get $6
+   i32.gt_s
+   if
+    local.get $5
+    call $~lib/rt/pure/__release
+    i32.const 32
+    i32.const 480
+    i32.const 1756
+    i32.const 6
+    call $~lib/builtins/abort
+    unreachable
+   end
   end
   i32.const 12
   i32.const 9
@@ -39194,7 +39211,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Uint32Array.wrap|trampoline (; 579 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint32Array.wrap|trampoline (; 580 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -39217,7 +39234,7 @@
   local.get $2
   call $~lib/typedarray/Uint32Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint32Array,u32> (; 580 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint32Array,u32> (; 581 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -39327,7 +39344,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array.wrap (; 581 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array.wrap (; 582 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -39369,8 +39386,7 @@
    i32.const -1
    i32.eq
    if
-    local.get $5
-    call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+    local.get $6
     i32.const 4
     i32.and
     if
@@ -39383,8 +39399,9 @@
      call $~lib/builtins/abort
      unreachable
     else
-     local.get $5
-     call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+     local.get $6
+     local.get $4
+     i32.sub
      local.set $7
     end
    else
@@ -39402,22 +39419,21 @@
    i32.const 3
    i32.shl
    local.set $7
-  end
-  local.get $4
-  local.get $7
-  i32.add
-  local.get $5
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.gt_s
-  if
-   local.get $5
-   call $~lib/rt/pure/__release
-   i32.const 32
-   i32.const 480
-   i32.const 1757
-   i32.const 4
-   call $~lib/builtins/abort
-   unreachable
+   local.get $4
+   local.get $7
+   i32.add
+   local.get $6
+   i32.gt_s
+   if
+    local.get $5
+    call $~lib/rt/pure/__release
+    i32.const 32
+    i32.const 480
+    i32.const 1756
+    i32.const 6
+    call $~lib/builtins/abort
+    unreachable
+   end
   end
   i32.const 12
   i32.const 10
@@ -39446,7 +39462,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Int64Array.wrap|trampoline (; 582 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Int64Array.wrap|trampoline (; 583 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -39469,7 +39485,7 @@
   local.get $2
   call $~lib/typedarray/Int64Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Int64Array,i64> (; 583 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Int64Array,i64> (; 584 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -39580,7 +39596,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array.wrap (; 584 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array.wrap (; 585 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -39622,8 +39638,7 @@
    i32.const -1
    i32.eq
    if
-    local.get $5
-    call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+    local.get $6
     i32.const 4
     i32.and
     if
@@ -39636,8 +39651,9 @@
      call $~lib/builtins/abort
      unreachable
     else
-     local.get $5
-     call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+     local.get $6
+     local.get $4
+     i32.sub
      local.set $7
     end
    else
@@ -39655,22 +39671,21 @@
    i32.const 3
    i32.shl
    local.set $7
-  end
-  local.get $4
-  local.get $7
-  i32.add
-  local.get $5
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.gt_s
-  if
-   local.get $5
-   call $~lib/rt/pure/__release
-   i32.const 32
-   i32.const 480
-   i32.const 1757
-   i32.const 4
-   call $~lib/builtins/abort
-   unreachable
+   local.get $4
+   local.get $7
+   i32.add
+   local.get $6
+   i32.gt_s
+   if
+    local.get $5
+    call $~lib/rt/pure/__release
+    i32.const 32
+    i32.const 480
+    i32.const 1756
+    i32.const 6
+    call $~lib/builtins/abort
+    unreachable
+   end
   end
   i32.const 12
   i32.const 11
@@ -39699,7 +39714,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Uint64Array.wrap|trampoline (; 585 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Uint64Array.wrap|trampoline (; 586 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -39722,7 +39737,7 @@
   local.get $2
   call $~lib/typedarray/Uint64Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint64Array,u64> (; 586 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Uint64Array,u64> (; 587 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -39833,7 +39848,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array.wrap (; 587 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array.wrap (; 588 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -39875,8 +39890,7 @@
    i32.const -1
    i32.eq
    if
-    local.get $5
-    call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+    local.get $6
     i32.const 2
     i32.and
     if
@@ -39889,8 +39903,9 @@
      call $~lib/builtins/abort
      unreachable
     else
-     local.get $5
-     call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+     local.get $6
+     local.get $4
+     i32.sub
      local.set $7
     end
    else
@@ -39908,22 +39923,21 @@
    i32.const 2
    i32.shl
    local.set $7
-  end
-  local.get $4
-  local.get $7
-  i32.add
-  local.get $5
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.gt_s
-  if
-   local.get $5
-   call $~lib/rt/pure/__release
-   i32.const 32
-   i32.const 480
-   i32.const 1757
-   i32.const 4
-   call $~lib/builtins/abort
-   unreachable
+   local.get $4
+   local.get $7
+   i32.add
+   local.get $6
+   i32.gt_s
+   if
+    local.get $5
+    call $~lib/rt/pure/__release
+    i32.const 32
+    i32.const 480
+    i32.const 1756
+    i32.const 6
+    call $~lib/builtins/abort
+    unreachable
+   end
   end
   i32.const 12
   i32.const 12
@@ -39952,7 +39966,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Float32Array.wrap|trampoline (; 588 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float32Array.wrap|trampoline (; 589 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -39975,7 +39989,7 @@
   local.get $2
   call $~lib/typedarray/Float32Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Float32Array,f32> (; 589 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Float32Array,f32> (; 590 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -40086,7 +40100,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array.wrap (; 590 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array.wrap (; 591 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -40128,8 +40142,7 @@
    i32.const -1
    i32.eq
    if
-    local.get $5
-    call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+    local.get $6
     i32.const 4
     i32.and
     if
@@ -40142,8 +40155,9 @@
      call $~lib/builtins/abort
      unreachable
     else
-     local.get $5
-     call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+     local.get $6
+     local.get $4
+     i32.sub
      local.set $7
     end
    else
@@ -40161,22 +40175,21 @@
    i32.const 3
    i32.shl
    local.set $7
-  end
-  local.get $4
-  local.get $7
-  i32.add
-  local.get $5
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  i32.gt_s
-  if
-   local.get $5
-   call $~lib/rt/pure/__release
-   i32.const 32
-   i32.const 480
-   i32.const 1757
-   i32.const 4
-   call $~lib/builtins/abort
-   unreachable
+   local.get $4
+   local.get $7
+   i32.add
+   local.get $6
+   i32.gt_s
+   if
+    local.get $5
+    call $~lib/rt/pure/__release
+    i32.const 32
+    i32.const 480
+    i32.const 1756
+    i32.const 6
+    call $~lib/builtins/abort
+    unreachable
+   end
   end
   i32.const 12
   i32.const 13
@@ -40205,7 +40218,7 @@
   call $~lib/rt/pure/__release
   local.get $8
  )
- (func $~lib/typedarray/Float64Array.wrap|trampoline (; 591 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/typedarray/Float64Array.wrap|trampoline (; 592 ;) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   block $2of2
    block $1of2
     block $0of2
@@ -40228,7 +40241,7 @@
   local.get $2
   call $~lib/typedarray/Float64Array.wrap
  )
- (func $std/typedarray/testArrayWrap<~lib/typedarray/Float64Array,f64> (; 592 ;)
+ (func $std/typedarray/testArrayWrap<~lib/typedarray/Float64Array,f64> (; 593 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -40339,7 +40352,7 @@
   local.get $7
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i32>> (; 593 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i32>> (; 594 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -40441,7 +40454,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int8Array> (; 594 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int8Array> (; 595 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -40464,7 +40477,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 702
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -40506,7 +40519,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 708
+      i32.const 718
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -40524,11 +40537,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<f32>#get:length (; 595 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f32>#get:length (; 596 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/typedarray/Int8Array#set<~lib/array/Array<f32>> (; 596 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/array/Array<f32>> (; 597 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -40643,7 +40656,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int64Array> (; 597 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int64Array> (; 598 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -40745,11 +40758,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<f64>#get:length (; 598 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<f64>#get:length (; 599 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/typedarray/Int8Array#set<~lib/array/Array<f64>> (; 599 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/array/Array<f64>> (; 600 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -40864,7 +40877,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Uint8Array> (; 600 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Uint8Array> (; 601 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -40931,7 +40944,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int16Array> (; 601 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/typedarray/Int16Array> (; 602 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -41033,7 +41046,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i8>> (; 602 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int8Array#set<~lib/array/Array<i8>> (; 603 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -41100,7 +41113,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int8Array> (; 603 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int8Array> (; 604 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -41263,7 +41276,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<i32>> (; 604 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<i32>> (; 605 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -41365,11 +41378,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<u8>#get:length (; 605 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u8>#get:length (; 606 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u8>#__unchecked_get (; 606 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u8>#__unchecked_get (; 607 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -41378,7 +41391,7 @@
   i32.add
   i32.load8_u
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array> (; 607 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8Array> (; 608 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -41401,7 +41414,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 702
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -41443,7 +41456,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 708
+      i32.const 718
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -41461,7 +41474,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<f32>> (; 608 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<f32>> (; 609 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -41576,7 +41589,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#set<~lib/typedarray/Int64Array> (; 609 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#set<~lib/typedarray/Int64Array> (; 610 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -41678,7 +41691,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<f64>> (; 610 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<f64>> (; 611 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -41793,7 +41806,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#set<~lib/typedarray/Uint8Array> (; 611 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#set<~lib/typedarray/Uint8Array> (; 612 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -41860,7 +41873,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#set<~lib/typedarray/Int16Array> (; 612 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#set<~lib/typedarray/Int16Array> (; 613 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -41962,7 +41975,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<i8>> (; 613 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8Array#set<~lib/array/Array<i8>> (; 614 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -42029,7 +42042,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8Array> (; 614 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8Array> (; 615 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -42192,7 +42205,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i32>> (; 615 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i32>> (; 616 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -42309,7 +42322,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray> (; 616 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray> (; 617 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -42332,7 +42345,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 702
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -42374,7 +42387,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 708
+      i32.const 718
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -42392,7 +42405,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f32>> (; 617 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f32>> (; 618 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -42511,7 +42524,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array> (; 618 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array> (; 619 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -42632,7 +42645,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f64>> (; 619 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<f64>> (; 620 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -42751,7 +42764,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Uint8Array> (; 620 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Uint8Array> (; 621 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -42818,7 +42831,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array> (; 621 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array> (; 622 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -42935,7 +42948,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i8>> (; 622 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/array/Array<i8>> (; 623 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -43052,7 +43065,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8ClampedArray> (; 623 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint8ClampedArray> (; 624 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -43215,7 +43228,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i32>> (; 624 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i32>> (; 625 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -43317,11 +43330,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<i16>#get:length (; 625 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i16>#get:length (; 626 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int16Array> (; 626 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int16Array> (; 627 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -43344,7 +43357,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 702
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -43386,7 +43399,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 708
+      i32.const 718
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -43404,7 +43417,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#set<~lib/array/Array<f32>> (; 627 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/array/Array<f32>> (; 628 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -43519,7 +43532,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int64Array> (; 628 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int64Array> (; 629 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -43621,7 +43634,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#set<~lib/array/Array<f64>> (; 629 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/array/Array<f64>> (; 630 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -43736,7 +43749,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Uint8Array> (; 630 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Uint8Array> (; 631 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -43838,7 +43851,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int16Array> (; 631 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/typedarray/Int16Array> (; 632 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -43905,7 +43918,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i8>> (; 632 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int16Array#set<~lib/array/Array<i8>> (; 633 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -44007,7 +44020,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int16Array> (; 633 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int16Array> (; 634 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -44170,7 +44183,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<i32>> (; 634 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<i32>> (; 635 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -44272,11 +44285,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<u16>#get:length (; 635 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u16>#get:length (; 636 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u16>#__unchecked_get (; 636 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u16>#__unchecked_get (; 637 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -44285,7 +44298,7 @@
   i32.add
   i32.load16_u
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array> (; 637 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint16Array> (; 638 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -44308,7 +44321,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 702
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -44350,7 +44363,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 708
+      i32.const 718
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -44368,7 +44381,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<f32>> (; 638 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<f32>> (; 639 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -44483,7 +44496,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#set<~lib/typedarray/Int64Array> (; 639 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint16Array#set<~lib/typedarray/Int64Array> (; 640 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -44585,7 +44598,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<f64>> (; 640 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<f64>> (; 641 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -44700,7 +44713,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#set<~lib/typedarray/Uint8Array> (; 641 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint16Array#set<~lib/typedarray/Uint8Array> (; 642 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -44802,7 +44815,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#set<~lib/typedarray/Int16Array> (; 642 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint16Array#set<~lib/typedarray/Int16Array> (; 643 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -44869,7 +44882,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<i8>> (; 643 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint16Array#set<~lib/array/Array<i8>> (; 644 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -44971,7 +44984,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint16Array> (; 644 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint16Array> (; 645 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -45134,7 +45147,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i32>> (; 645 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i32>> (; 646 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -45201,7 +45214,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int32Array> (; 646 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int32Array> (; 647 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -45224,7 +45237,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 702
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -45266,7 +45279,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 708
+      i32.const 718
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -45284,7 +45297,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#set<~lib/array/Array<f32>> (; 647 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/array/Array<f32>> (; 648 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -45399,7 +45412,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int64Array> (; 648 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int64Array> (; 649 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -45501,7 +45514,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#set<~lib/array/Array<f64>> (; 649 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/array/Array<f64>> (; 650 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -45616,7 +45629,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Uint8Array> (; 650 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Uint8Array> (; 651 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -45718,7 +45731,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int16Array> (; 651 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/typedarray/Int16Array> (; 652 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -45820,7 +45833,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i8>> (; 652 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int32Array#set<~lib/array/Array<i8>> (; 653 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -45922,7 +45935,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int32Array> (; 653 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int32Array> (; 654 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -46085,7 +46098,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<i32>> (; 654 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<i32>> (; 655 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -46152,11 +46165,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<u32>#get:length (; 655 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u32>#get:length (; 656 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<u32>#__unchecked_get (; 656 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/array/Array<u32>#__unchecked_get (; 657 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -46165,7 +46178,7 @@
   i32.add
   i32.load
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array> (; 657 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint32Array> (; 658 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -46188,7 +46201,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 702
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -46230,7 +46243,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 708
+      i32.const 718
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -46248,7 +46261,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<f32>> (; 658 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<f32>> (; 659 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -46363,7 +46376,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#set<~lib/typedarray/Int64Array> (; 659 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint32Array#set<~lib/typedarray/Int64Array> (; 660 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -46465,7 +46478,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<f64>> (; 660 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<f64>> (; 661 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -46580,7 +46593,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#set<~lib/typedarray/Uint8Array> (; 661 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint32Array#set<~lib/typedarray/Uint8Array> (; 662 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -46682,7 +46695,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#set<~lib/typedarray/Int16Array> (; 662 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint32Array#set<~lib/typedarray/Int16Array> (; 663 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -46784,7 +46797,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<i8>> (; 663 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint32Array#set<~lib/array/Array<i8>> (; 664 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -46886,7 +46899,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint32Array> (; 664 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint32Array> (; 665 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -47049,7 +47062,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i32>> (; 665 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i32>> (; 666 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -47151,11 +47164,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<i64>#get:length (; 666 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<i64>#get:length (; 667 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $~lib/array/Array<i64>#__unchecked_get (; 667 ;) (param $0 i32) (param $1 i32) (result i64)
+ (func $~lib/array/Array<i64>#__unchecked_get (; 668 ;) (param $0 i32) (param $1 i32) (result i64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -47164,7 +47177,7 @@
   i32.add
   i64.load
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Int64Array> (; 668 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Int64Array> (; 669 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -47187,7 +47200,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 702
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -47229,7 +47242,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 708
+      i32.const 718
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -47247,7 +47260,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#set<~lib/array/Array<f32>> (; 669 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/array/Array<f32>> (; 670 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -47362,7 +47375,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int64Array> (; 670 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int64Array> (; 671 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -47429,7 +47442,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#set<~lib/array/Array<f64>> (; 671 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/array/Array<f64>> (; 672 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -47544,7 +47557,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Uint8Array> (; 672 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Uint8Array> (; 673 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -47646,7 +47659,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int16Array> (; 673 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/typedarray/Int16Array> (; 674 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -47748,7 +47761,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i8>> (; 674 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Int64Array#set<~lib/array/Array<i8>> (; 675 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -47850,7 +47863,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int64Array> (; 675 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Int64Array> (; 676 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -48013,7 +48026,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<i32>> (; 676 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<i32>> (; 677 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -48115,11 +48128,11 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<u64>#get:length (; 677 ;) (param $0 i32) (result i32)
+ (func $~lib/array/Array<u64>#get:length (; 678 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=12
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array> (; 678 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Uint64Array> (; 679 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -48142,7 +48155,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 702
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -48184,7 +48197,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 708
+      i32.const 718
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -48202,7 +48215,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<f32>> (; 679 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<f32>> (; 680 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -48317,7 +48330,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#set<~lib/typedarray/Int64Array> (; 680 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint64Array#set<~lib/typedarray/Int64Array> (; 681 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -48384,7 +48397,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<f64>> (; 681 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<f64>> (; 682 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -48499,7 +48512,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#set<~lib/typedarray/Uint8Array> (; 682 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint64Array#set<~lib/typedarray/Uint8Array> (; 683 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -48601,7 +48614,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#set<~lib/typedarray/Int16Array> (; 683 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint64Array#set<~lib/typedarray/Int16Array> (; 684 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -48703,7 +48716,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<i8>> (; 684 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint64Array#set<~lib/array/Array<i8>> (; 685 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -48805,7 +48818,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint64Array> (; 685 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Uint64Array> (; 686 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -48968,7 +48981,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#set<~lib/array/Array<i32>> (; 686 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/array/Array<i32>> (; 687 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -49071,7 +49084,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<f32>#__unchecked_get (; 687 ;) (param $0 i32) (param $1 i32) (result f32)
+ (func $~lib/array/Array<f32>#__unchecked_get (; 688 ;) (param $0 i32) (param $1 i32) (result f32)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -49080,7 +49093,7 @@
   i32.add
   f32.load
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Float32Array> (; 688 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Float32Array> (; 689 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -49103,7 +49116,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 702
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -49145,7 +49158,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 708
+      i32.const 718
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -49163,7 +49176,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#set<~lib/array/Array<f32>> (; 689 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/array/Array<f32>> (; 690 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -49230,7 +49243,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Int64Array> (; 690 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Int64Array> (; 691 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -49333,7 +49346,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Uint8Array> (; 691 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Uint8Array> (; 692 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -49436,7 +49449,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Int16Array> (; 692 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/typedarray/Int16Array> (; 693 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -49539,7 +49552,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float32Array#set<~lib/array/Array<i8>> (; 693 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float32Array#set<~lib/array/Array<i8>> (; 694 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -49642,7 +49655,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float32Array> (; 694 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float32Array> (; 695 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -49790,7 +49803,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#set<~lib/array/Array<i32>> (; 695 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/array/Array<i32>> (; 696 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -49893,7 +49906,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/array/Array<f64>#__unchecked_get (; 696 ;) (param $0 i32) (param $1 i32) (result f64)
+ (func $~lib/array/Array<f64>#__unchecked_get (; 697 ;) (param $0 i32) (param $1 i32) (result f64)
   local.get $0
   i32.load offset=4
   local.get $1
@@ -49902,7 +49915,7 @@
   i32.add
   f64.load
  )
- (func $std/typedarray/valuesEqual<~lib/typedarray/Float64Array> (; 697 ;) (param $0 i32) (param $1 i32)
+ (func $std/typedarray/valuesEqual<~lib/typedarray/Float64Array> (; 698 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -49925,7 +49938,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 702
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -49965,7 +49978,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 708
+      i32.const 718
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -49983,7 +49996,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#set<~lib/array/Array<f32>> (; 698 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/array/Array<f32>> (; 699 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -50086,7 +50099,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Int64Array> (; 699 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Int64Array> (; 700 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -50189,7 +50202,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Uint8Array> (; 700 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Uint8Array> (; 701 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -50292,7 +50305,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Int16Array> (; 701 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/typedarray/Int16Array> (; 702 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -50395,7 +50408,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Float64Array#set<~lib/array/Array<i8>> (; 702 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Float64Array#set<~lib/array/Array<i8>> (; 703 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -50498,7 +50511,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float64Array> (; 703 ;)
+ (func $std/typedarray/testTypedArraySet<~lib/typedarray/Float64Array> (; 704 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -50646,7 +50659,7 @@
   local.get $8
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Float32Array> (; 704 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Float32Array> (; 705 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -50765,7 +50778,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int32Array> (; 705 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int32Array> (; 706 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -50882,7 +50895,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Uint32Array> (; 706 ;) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Uint32Array> (; 707 ;) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -50996,7 +51009,7 @@
   local.get $1
   call $~lib/rt/pure/__release
  )
- (func $start:std/typedarray (; 707 ;)
+ (func $start:std/typedarray (; 708 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -53016,6 +53029,66 @@
   call $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Uint64Array,u64>
   call $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float32Array,f32>
   call $std/typedarray/testArrayJoinAndToString<~lib/typedarray/Float64Array,f64>
+  i32.const 0
+  i32.const 0
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $21
+  i32.const 2
+  global.set $~argumentsLength
+  local.get $21
+  i32.const 0
+  i32.const 0
+  call $~lib/typedarray/Uint8Array.wrap|trampoline
+  local.set $22
+  local.get $22
+  call $~lib/typedarray/Uint8Array#get:length
+  i32.const 0
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 416
+   i32.const 691
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 0
+  i32.const 2
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  local.set $25
+  local.get $21
+  call $~lib/rt/pure/__release
+  local.get $25
+  local.set $21
+  i32.const 2
+  global.set $~argumentsLength
+  local.get $21
+  i32.const 2
+  i32.const 0
+  call $~lib/typedarray/Uint8Array.wrap|trampoline
+  local.set $3
+  local.get $22
+  call $~lib/rt/pure/__release
+  local.get $3
+  local.set $22
+  local.get $22
+  call $~lib/typedarray/Uint8Array#get:length
+  i32.const 0
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 416
+   i32.const 695
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $21
+  call $~lib/rt/pure/__release
+  local.get $22
+  call $~lib/rt/pure/__release
   call $std/typedarray/testArrayWrap<~lib/typedarray/Int8Array,i8>
   call $std/typedarray/testArrayWrap<~lib/typedarray/Uint8Array,u8>
   call $std/typedarray/testArrayWrap<~lib/typedarray/Uint8ClampedArray,u8>
@@ -53041,151 +53114,151 @@
   i32.const 0
   i32.const 10
   call $~lib/typedarray/Uint8ClampedArray#constructor
-  local.set $21
+  local.set $22
   i32.const 0
   i32.const 3
   call $~lib/typedarray/Float32Array#constructor
-  local.set $22
-  local.get $22
+  local.set $21
+  local.get $21
   i32.const 0
   f32.const 400
   call $~lib/typedarray/Float32Array#__set
-  local.get $22
+  local.get $21
   i32.const 1
   f32.const nan:0x400000
   call $~lib/typedarray/Float32Array#__set
-  local.get $22
+  local.get $21
   i32.const 2
   f32.const inf
   call $~lib/typedarray/Float32Array#__set
   i32.const 0
   i32.const 4
   call $~lib/typedarray/Int64Array#constructor
-  local.set $24
-  local.get $24
+  local.set $3
+  local.get $3
   i32.const 0
   i64.const -10
   call $~lib/typedarray/Int64Array#__set
-  local.get $24
+  local.get $3
   i32.const 1
   i64.const 100
   call $~lib/typedarray/Int64Array#__set
-  local.get $24
+  local.get $3
   i32.const 2
   i64.const 10
   call $~lib/typedarray/Int64Array#__set
-  local.get $24
+  local.get $3
   i32.const 3
   i64.const 300
   call $~lib/typedarray/Int64Array#__set
   i32.const 0
   i32.const 2
   call $~lib/typedarray/Int32Array#constructor
-  local.set $23
-  local.get $23
+  local.set $25
+  local.get $25
   i32.const 0
   i32.const 300
   call $~lib/typedarray/Int32Array#__set
-  local.get $23
+  local.get $25
   i32.const 1
   i32.const -1
   call $~lib/typedarray/Int32Array#__set
-  local.get $21
   local.get $22
+  local.get $21
   i32.const 1
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Float32Array>
-  local.get $21
-  local.get $24
+  local.get $22
+  local.get $3
   i32.const 4
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int64Array>
-  local.get $21
-  local.get $23
+  local.get $22
+  local.get $25
   i32.const 8
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int32Array>
-  local.get $21
+  local.get $22
   i32.const 10
   i32.const 0
   i32.const 21
   i32.const 7936
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $19
+  local.tee $23
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
   i32.const 0
   i32.const 4
   call $~lib/typedarray/Uint32Array#constructor
-  local.set $26
-  local.get $26
+  local.set $24
+  local.get $24
   i32.const 0
   i32.const 1
   call $~lib/typedarray/Uint32Array#__set
-  local.get $26
+  local.get $24
   i32.const 1
   i32.const 300
   call $~lib/typedarray/Uint32Array#__set
-  local.get $26
+  local.get $24
   i32.const 2
   i32.const 100
   call $~lib/typedarray/Uint32Array#__set
-  local.get $26
+  local.get $24
   i32.const 3
   i32.const -1
   call $~lib/typedarray/Uint32Array#__set
   i32.const 0
   i32.const 4
   call $~lib/typedarray/Int16Array#constructor
-  local.set $20
-  local.get $20
+  local.set $26
+  local.get $26
   i32.const 0
   i32.const -10
   call $~lib/typedarray/Int16Array#__set
-  local.get $20
+  local.get $26
   i32.const 1
   i32.const 100
   call $~lib/typedarray/Int16Array#__set
-  local.get $20
+  local.get $26
   i32.const 2
   i32.const 10
   call $~lib/typedarray/Int16Array#__set
-  local.get $20
+  local.get $26
   i32.const 3
   i32.const 300
   call $~lib/typedarray/Int16Array#__set
-  local.get $21
-  local.get $26
+  local.get $22
+  local.get $24
   i32.const 0
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Uint32Array>
-  local.get $21
-  local.get $20
+  local.get $22
+  local.get $26
   i32.const 5
   call $~lib/typedarray/Uint8ClampedArray#set<~lib/typedarray/Int16Array>
-  local.get $21
+  local.get $22
   i32.const 10
   i32.const 0
   i32.const 21
   i32.const 7968
   call $~lib/rt/__allocArray
   call $~lib/rt/pure/__retain
-  local.tee $18
+  local.tee $20
   call $std/typedarray/valuesEqual<~lib/typedarray/Uint8ClampedArray>
-  local.get $21
-  call $~lib/rt/pure/__release
   local.get $22
   call $~lib/rt/pure/__release
-  local.get $24
+  local.get $21
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $25
   call $~lib/rt/pure/__release
   local.get $23
   call $~lib/rt/pure/__release
-  local.get $19
+  local.get $24
   call $~lib/rt/pure/__release
   local.get $26
   call $~lib/rt/pure/__release
   local.get $20
   call $~lib/rt/pure/__release
-  local.get $18
-  call $~lib/rt/pure/__release
  )
- (func $~start (; 708 ;)
+ (func $~start (; 709 ;)
   global.get $~started
   if
    return
@@ -53195,37 +53268,37 @@
   end
   call $start:std/typedarray
  )
- (func $~lib/array/Array<i8>#__visit_impl (; 709 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i8>#__visit_impl (; 710 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<i32>#__visit_impl (; 710 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i32>#__visit_impl (; 711 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u32>#__visit_impl (; 711 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u32>#__visit_impl (; 712 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u64>#__visit_impl (; 712 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u64>#__visit_impl (; 713 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<i16>#__visit_impl (; 713 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i16>#__visit_impl (; 714 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<f32>#__visit_impl (; 714 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f32>#__visit_impl (; 715 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<f64>#__visit_impl (; 715 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<f64>#__visit_impl (; 716 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u8>#__visit_impl (; 716 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u8>#__visit_impl (; 717 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<u16>#__visit_impl (; 717 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u16>#__visit_impl (; 718 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/array/Array<i64>#__visit_impl (; 718 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<i64>#__visit_impl (; 719 ;) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/rt/pure/__visit (; 719 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 720 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -53355,7 +53428,7 @@
    end
   end
  )
- (func $~lib/rt/__visit_members (; 720 ;) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (; 721 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $block$4$break
    block $switch$1$default

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -37572,7 +37572,7 @@
   local.set $6
   local.get $4
   local.get $6
-  i32.ge_u
+  i32.gt_u
   if
    local.get $5
    call $~lib/rt/pure/__release
@@ -37828,7 +37828,7 @@
   local.set $6
   local.get $4
   local.get $6
-  i32.ge_u
+  i32.gt_u
   if
    local.get $5
    call $~lib/rt/pure/__release
@@ -38082,7 +38082,7 @@
   local.set $6
   local.get $4
   local.get $6
-  i32.ge_u
+  i32.gt_u
   if
    local.get $5
    call $~lib/rt/pure/__release
@@ -38336,7 +38336,7 @@
   local.set $6
   local.get $4
   local.get $6
-  i32.ge_u
+  i32.gt_u
   if
    local.get $5
    call $~lib/rt/pure/__release
@@ -38592,7 +38592,7 @@
   local.set $6
   local.get $4
   local.get $6
-  i32.ge_u
+  i32.gt_u
   if
    local.get $5
    call $~lib/rt/pure/__release
@@ -38846,7 +38846,7 @@
   local.set $6
   local.get $4
   local.get $6
-  i32.ge_u
+  i32.gt_u
   if
    local.get $5
    call $~lib/rt/pure/__release
@@ -39098,7 +39098,7 @@
   local.set $6
   local.get $4
   local.get $6
-  i32.ge_u
+  i32.gt_u
   if
    local.get $5
    call $~lib/rt/pure/__release
@@ -39350,7 +39350,7 @@
   local.set $6
   local.get $4
   local.get $6
-  i32.ge_u
+  i32.gt_u
   if
    local.get $5
    call $~lib/rt/pure/__release
@@ -39603,7 +39603,7 @@
   local.set $6
   local.get $4
   local.get $6
-  i32.ge_u
+  i32.gt_u
   if
    local.get $5
    call $~lib/rt/pure/__release
@@ -39856,7 +39856,7 @@
   local.set $6
   local.get $4
   local.get $6
-  i32.ge_u
+  i32.gt_u
   if
    local.get $5
    call $~lib/rt/pure/__release
@@ -40109,7 +40109,7 @@
   local.set $6
   local.get $4
   local.get $6
-  i32.ge_u
+  i32.gt_u
   if
    local.get $5
    call $~lib/rt/pure/__release

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -37523,7 +37523,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1742
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -37544,7 +37544,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1747
+     i32.const 1746
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -37559,7 +37559,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1752
+    i32.const 1751
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -37579,7 +37579,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1757
+    i32.const 1756
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -37751,7 +37751,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1742
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -37772,7 +37772,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1747
+     i32.const 1746
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -37787,7 +37787,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1752
+    i32.const 1751
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -37807,7 +37807,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1757
+    i32.const 1756
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38122,7 +38122,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1742
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -38143,7 +38143,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1747
+     i32.const 1746
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -38158,7 +38158,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1752
+    i32.const 1751
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38178,7 +38178,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1757
+    i32.const 1756
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38379,7 +38379,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1742
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -38400,7 +38400,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1747
+     i32.const 1746
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -38415,7 +38415,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1752
+    i32.const 1751
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38435,7 +38435,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1757
+    i32.const 1756
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38638,7 +38638,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1742
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -38659,7 +38659,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1747
+     i32.const 1746
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -38674,7 +38674,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1752
+    i32.const 1751
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38694,7 +38694,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1757
+    i32.const 1756
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38895,7 +38895,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1742
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -38916,7 +38916,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1747
+     i32.const 1746
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -38931,7 +38931,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1752
+    i32.const 1751
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38951,7 +38951,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1757
+    i32.const 1756
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39150,7 +39150,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1742
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -39171,7 +39171,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1747
+     i32.const 1746
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -39186,7 +39186,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1752
+    i32.const 1751
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39206,7 +39206,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1757
+    i32.const 1756
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39405,7 +39405,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1742
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -39426,7 +39426,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1747
+     i32.const 1746
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -39441,7 +39441,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1752
+    i32.const 1751
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39461,7 +39461,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1757
+    i32.const 1756
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39661,7 +39661,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1742
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -39682,7 +39682,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1747
+     i32.const 1746
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -39697,7 +39697,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1752
+    i32.const 1751
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39717,7 +39717,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1757
+    i32.const 1756
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39917,7 +39917,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1742
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -39938,7 +39938,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1747
+     i32.const 1746
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -39953,7 +39953,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1752
+    i32.const 1751
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39973,7 +39973,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1757
+    i32.const 1756
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -40173,7 +40173,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1742
+   i32.const 1741
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -40194,7 +40194,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1747
+     i32.const 1746
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -40209,7 +40209,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1752
+    i32.const 1751
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -40229,7 +40229,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1757
+    i32.const 1756
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -40426,7 +40426,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40445,7 +40445,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40521,7 +40521,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 716
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -40563,7 +40563,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 722
+      i32.const 718
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -40616,7 +40616,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40635,7 +40635,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40730,7 +40730,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40749,7 +40749,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40837,7 +40837,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40856,7 +40856,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40946,7 +40946,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40965,7 +40965,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41018,7 +41018,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41037,7 +41037,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41115,7 +41115,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41134,7 +41134,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41350,7 +41350,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41369,7 +41369,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41458,7 +41458,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 716
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -41500,7 +41500,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 722
+      i32.const 718
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -41549,7 +41549,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41568,7 +41568,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41663,7 +41663,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41682,7 +41682,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41766,7 +41766,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41785,7 +41785,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41875,7 +41875,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41894,7 +41894,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41947,7 +41947,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41966,7 +41966,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42044,7 +42044,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42063,7 +42063,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42280,7 +42280,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42299,7 +42299,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42389,7 +42389,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 716
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -42431,7 +42431,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 722
+      i32.const 718
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -42480,7 +42480,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42499,7 +42499,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42599,7 +42599,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42618,7 +42618,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42720,7 +42720,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42739,7 +42739,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42833,7 +42833,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42852,7 +42852,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42906,7 +42906,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42925,7 +42925,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43023,7 +43023,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43042,7 +43042,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43302,7 +43302,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43321,7 +43321,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43401,7 +43401,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 716
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -43443,7 +43443,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 722
+      i32.const 718
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -43492,7 +43492,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43511,7 +43511,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43606,7 +43606,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43625,7 +43625,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43709,7 +43709,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43728,7 +43728,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43823,7 +43823,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43842,7 +43842,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43920,7 +43920,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43939,7 +43939,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43992,7 +43992,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44011,7 +44011,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44257,7 +44257,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44276,7 +44276,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44365,7 +44365,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 716
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -44407,7 +44407,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 722
+      i32.const 718
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -44456,7 +44456,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44475,7 +44475,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44570,7 +44570,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44589,7 +44589,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44673,7 +44673,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44692,7 +44692,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44787,7 +44787,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44806,7 +44806,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44884,7 +44884,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44903,7 +44903,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44956,7 +44956,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44975,7 +44975,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45216,7 +45216,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45235,7 +45235,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45281,7 +45281,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 716
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -45323,7 +45323,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 722
+      i32.const 718
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -45372,7 +45372,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45391,7 +45391,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45486,7 +45486,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45505,7 +45505,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45589,7 +45589,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45608,7 +45608,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45703,7 +45703,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45722,7 +45722,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45805,7 +45805,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45824,7 +45824,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45907,7 +45907,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45926,7 +45926,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46167,7 +46167,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46186,7 +46186,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46245,7 +46245,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 716
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -46287,7 +46287,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 722
+      i32.const 718
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -46336,7 +46336,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46355,7 +46355,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46450,7 +46450,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46469,7 +46469,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46553,7 +46553,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46572,7 +46572,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46667,7 +46667,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46686,7 +46686,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46769,7 +46769,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46788,7 +46788,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46871,7 +46871,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46890,7 +46890,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47136,7 +47136,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47155,7 +47155,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47244,7 +47244,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 716
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -47286,7 +47286,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 722
+      i32.const 718
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -47335,7 +47335,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47354,7 +47354,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47444,7 +47444,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47463,7 +47463,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47517,7 +47517,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47536,7 +47536,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47631,7 +47631,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47650,7 +47650,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47733,7 +47733,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47752,7 +47752,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47835,7 +47835,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47854,7 +47854,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48100,7 +48100,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48119,7 +48119,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48199,7 +48199,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 716
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -48241,7 +48241,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 722
+      i32.const 718
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -48290,7 +48290,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48309,7 +48309,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48399,7 +48399,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48418,7 +48418,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48472,7 +48472,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48491,7 +48491,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48586,7 +48586,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48605,7 +48605,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48688,7 +48688,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48707,7 +48707,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48790,7 +48790,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48809,7 +48809,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49055,7 +49055,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49074,7 +49074,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49160,7 +49160,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 716
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -49202,7 +49202,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 722
+      i32.const 718
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -49245,7 +49245,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49264,7 +49264,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49317,7 +49317,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49336,7 +49336,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49420,7 +49420,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49439,7 +49439,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49523,7 +49523,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49542,7 +49542,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49626,7 +49626,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49645,7 +49645,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49877,7 +49877,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49896,7 +49896,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49982,7 +49982,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 716
+   i32.const 712
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -50022,7 +50022,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 722
+      i32.const 718
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -50070,7 +50070,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50089,7 +50089,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50173,7 +50173,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50192,7 +50192,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50276,7 +50276,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50295,7 +50295,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50379,7 +50379,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50398,7 +50398,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50482,7 +50482,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50501,7 +50501,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50734,7 +50734,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50753,7 +50753,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50853,7 +50853,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50872,7 +50872,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50972,7 +50972,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50991,7 +50991,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1777
+   i32.const 1776
    i32.const 46
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -37523,7 +37523,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1740
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -37544,7 +37544,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1746
+     i32.const 1745
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -37558,7 +37558,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1750
+    i32.const 1749
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -37578,7 +37578,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1755
+    i32.const 1754
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -37750,7 +37750,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1740
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -37771,7 +37771,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1746
+     i32.const 1745
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -37785,7 +37785,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1750
+    i32.const 1749
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -37805,7 +37805,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1755
+    i32.const 1754
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38120,7 +38120,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1740
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -38141,7 +38141,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1746
+     i32.const 1745
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -38155,7 +38155,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1750
+    i32.const 1749
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38175,7 +38175,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1755
+    i32.const 1754
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38376,7 +38376,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1740
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -38397,7 +38397,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1746
+     i32.const 1745
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -38411,7 +38411,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1750
+    i32.const 1749
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38431,7 +38431,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1755
+    i32.const 1754
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38634,7 +38634,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1740
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -38655,7 +38655,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1746
+     i32.const 1745
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -38669,7 +38669,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1750
+    i32.const 1749
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38689,7 +38689,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1755
+    i32.const 1754
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38890,7 +38890,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1740
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -38911,7 +38911,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1746
+     i32.const 1745
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -38925,7 +38925,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1750
+    i32.const 1749
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38945,7 +38945,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1755
+    i32.const 1754
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39144,7 +39144,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1740
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -39165,7 +39165,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1746
+     i32.const 1745
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -39179,7 +39179,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1750
+    i32.const 1749
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39199,7 +39199,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1755
+    i32.const 1754
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39398,7 +39398,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1740
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -39419,7 +39419,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1746
+     i32.const 1745
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -39433,7 +39433,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1750
+    i32.const 1749
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39453,7 +39453,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1755
+    i32.const 1754
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39653,7 +39653,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1740
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -39674,7 +39674,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1746
+     i32.const 1745
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -39688,7 +39688,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1750
+    i32.const 1749
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39708,7 +39708,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1755
+    i32.const 1754
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39908,7 +39908,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1740
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -39929,7 +39929,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1746
+     i32.const 1745
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -39943,7 +39943,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1750
+    i32.const 1749
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39963,7 +39963,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1755
+    i32.const 1754
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -40163,7 +40163,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1740
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -40184,7 +40184,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1746
+     i32.const 1745
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -40198,7 +40198,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1750
+    i32.const 1749
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -40218,7 +40218,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1755
+    i32.const 1754
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -40415,7 +40415,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40434,7 +40434,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40605,7 +40605,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40624,7 +40624,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40719,7 +40719,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40738,7 +40738,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40826,7 +40826,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40845,7 +40845,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40935,7 +40935,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40954,7 +40954,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41007,7 +41007,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41026,7 +41026,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41104,7 +41104,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41123,7 +41123,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41339,7 +41339,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41358,7 +41358,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41538,7 +41538,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41557,7 +41557,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41652,7 +41652,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41671,7 +41671,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41755,7 +41755,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41774,7 +41774,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41864,7 +41864,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41883,7 +41883,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41936,7 +41936,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41955,7 +41955,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42033,7 +42033,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42052,7 +42052,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42269,7 +42269,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42288,7 +42288,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42469,7 +42469,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42488,7 +42488,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42588,7 +42588,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42607,7 +42607,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42709,7 +42709,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42728,7 +42728,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42822,7 +42822,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42841,7 +42841,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42895,7 +42895,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42914,7 +42914,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43012,7 +43012,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43031,7 +43031,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43291,7 +43291,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43310,7 +43310,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43481,7 +43481,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43500,7 +43500,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43595,7 +43595,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43614,7 +43614,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43698,7 +43698,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43717,7 +43717,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43812,7 +43812,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43831,7 +43831,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43909,7 +43909,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43928,7 +43928,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43981,7 +43981,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44000,7 +44000,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44246,7 +44246,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44265,7 +44265,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44445,7 +44445,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44464,7 +44464,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44559,7 +44559,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44578,7 +44578,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44662,7 +44662,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44681,7 +44681,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44776,7 +44776,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44795,7 +44795,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44873,7 +44873,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44892,7 +44892,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44945,7 +44945,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44964,7 +44964,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45205,7 +45205,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45224,7 +45224,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45361,7 +45361,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45380,7 +45380,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45475,7 +45475,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45494,7 +45494,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45578,7 +45578,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45597,7 +45597,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45692,7 +45692,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45711,7 +45711,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45794,7 +45794,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45813,7 +45813,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45896,7 +45896,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45915,7 +45915,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46156,7 +46156,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46175,7 +46175,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46325,7 +46325,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46344,7 +46344,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46439,7 +46439,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46458,7 +46458,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46542,7 +46542,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46561,7 +46561,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46656,7 +46656,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46675,7 +46675,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46758,7 +46758,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46777,7 +46777,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46860,7 +46860,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46879,7 +46879,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47125,7 +47125,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47144,7 +47144,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47324,7 +47324,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47343,7 +47343,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47433,7 +47433,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47452,7 +47452,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47506,7 +47506,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47525,7 +47525,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47620,7 +47620,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47639,7 +47639,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47722,7 +47722,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47741,7 +47741,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47824,7 +47824,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47843,7 +47843,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48089,7 +48089,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48108,7 +48108,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48279,7 +48279,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48298,7 +48298,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48388,7 +48388,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48407,7 +48407,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48461,7 +48461,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48480,7 +48480,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48575,7 +48575,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48594,7 +48594,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48677,7 +48677,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48696,7 +48696,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48779,7 +48779,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48798,7 +48798,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49044,7 +49044,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49063,7 +49063,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49234,7 +49234,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49253,7 +49253,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49306,7 +49306,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49325,7 +49325,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49409,7 +49409,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49428,7 +49428,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49512,7 +49512,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49531,7 +49531,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49615,7 +49615,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49634,7 +49634,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49866,7 +49866,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49885,7 +49885,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50059,7 +50059,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50078,7 +50078,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50162,7 +50162,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50181,7 +50181,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50265,7 +50265,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50284,7 +50284,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50368,7 +50368,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50387,7 +50387,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50471,7 +50471,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50490,7 +50490,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50723,7 +50723,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50742,7 +50742,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50842,7 +50842,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50861,7 +50861,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50961,7 +50961,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1774
+   i32.const 1773
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50980,7 +50980,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 46
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -37548,18 +37548,17 @@
      i32.const 8
      call $~lib/builtins/abort
      unreachable
-    else
-     local.get $7
-     local.get $4
-     i32.sub
-     local.set $6
     end
+    local.get $7
+    local.get $4
+    i32.sub
+    local.set $6
    else
     local.get $5
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1751
+    i32.const 1750
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -37579,7 +37578,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1756
+    i32.const 1755
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -37776,18 +37775,17 @@
      i32.const 8
      call $~lib/builtins/abort
      unreachable
-    else
-     local.get $7
-     local.get $4
-     i32.sub
-     local.set $6
     end
+    local.get $7
+    local.get $4
+    i32.sub
+    local.set $6
    else
     local.get $5
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1751
+    i32.const 1750
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -37807,7 +37805,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1756
+    i32.const 1755
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38147,18 +38145,17 @@
      i32.const 8
      call $~lib/builtins/abort
      unreachable
-    else
-     local.get $7
-     local.get $4
-     i32.sub
-     local.set $6
     end
+    local.get $7
+    local.get $4
+    i32.sub
+    local.set $6
    else
     local.get $5
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1751
+    i32.const 1750
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38178,7 +38175,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1756
+    i32.const 1755
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38404,18 +38401,17 @@
      i32.const 8
      call $~lib/builtins/abort
      unreachable
-    else
-     local.get $7
-     local.get $4
-     i32.sub
-     local.set $6
     end
+    local.get $7
+    local.get $4
+    i32.sub
+    local.set $6
    else
     local.get $5
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1751
+    i32.const 1750
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38435,7 +38431,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1756
+    i32.const 1755
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38663,18 +38659,17 @@
      i32.const 8
      call $~lib/builtins/abort
      unreachable
-    else
-     local.get $7
-     local.get $4
-     i32.sub
-     local.set $6
     end
+    local.get $7
+    local.get $4
+    i32.sub
+    local.set $6
    else
     local.get $5
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1751
+    i32.const 1750
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38694,7 +38689,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1756
+    i32.const 1755
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38920,18 +38915,17 @@
      i32.const 8
      call $~lib/builtins/abort
      unreachable
-    else
-     local.get $7
-     local.get $4
-     i32.sub
-     local.set $6
     end
+    local.get $7
+    local.get $4
+    i32.sub
+    local.set $6
    else
     local.get $5
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1751
+    i32.const 1750
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38951,7 +38945,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1756
+    i32.const 1755
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39175,18 +39169,17 @@
      i32.const 8
      call $~lib/builtins/abort
      unreachable
-    else
-     local.get $7
-     local.get $4
-     i32.sub
-     local.set $6
     end
+    local.get $7
+    local.get $4
+    i32.sub
+    local.set $6
    else
     local.get $5
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1751
+    i32.const 1750
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39206,7 +39199,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1756
+    i32.const 1755
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39430,18 +39423,17 @@
      i32.const 8
      call $~lib/builtins/abort
      unreachable
-    else
-     local.get $7
-     local.get $4
-     i32.sub
-     local.set $6
     end
+    local.get $7
+    local.get $4
+    i32.sub
+    local.set $6
    else
     local.get $5
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1751
+    i32.const 1750
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39461,7 +39453,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1756
+    i32.const 1755
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39686,18 +39678,17 @@
      i32.const 8
      call $~lib/builtins/abort
      unreachable
-    else
-     local.get $7
-     local.get $4
-     i32.sub
-     local.set $6
     end
+    local.get $7
+    local.get $4
+    i32.sub
+    local.set $6
    else
     local.get $5
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1751
+    i32.const 1750
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39717,7 +39708,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1756
+    i32.const 1755
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39942,18 +39933,17 @@
      i32.const 8
      call $~lib/builtins/abort
      unreachable
-    else
-     local.get $7
-     local.get $4
-     i32.sub
-     local.set $6
     end
+    local.get $7
+    local.get $4
+    i32.sub
+    local.set $6
    else
     local.get $5
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1751
+    i32.const 1750
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39973,7 +39963,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1756
+    i32.const 1755
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -40198,18 +40188,17 @@
      i32.const 8
      call $~lib/builtins/abort
      unreachable
-    else
-     local.get $7
-     local.get $4
-     i32.sub
-     local.set $6
     end
+    local.get $7
+    local.get $4
+    i32.sub
+    local.set $6
    else
     local.get $5
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1751
+    i32.const 1750
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -40229,7 +40218,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1756
+    i32.const 1755
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -40426,7 +40415,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40445,7 +40434,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40616,7 +40605,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40635,7 +40624,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40730,7 +40719,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40749,7 +40738,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40837,7 +40826,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40856,7 +40845,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40946,7 +40935,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40965,7 +40954,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41018,7 +41007,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41037,7 +41026,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41115,7 +41104,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41134,7 +41123,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41350,7 +41339,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41369,7 +41358,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41549,7 +41538,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41568,7 +41557,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41663,7 +41652,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41682,7 +41671,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41766,7 +41755,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41785,7 +41774,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41875,7 +41864,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41894,7 +41883,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41947,7 +41936,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41966,7 +41955,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42044,7 +42033,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42063,7 +42052,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42280,7 +42269,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42299,7 +42288,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42480,7 +42469,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42499,7 +42488,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42599,7 +42588,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42618,7 +42607,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42720,7 +42709,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42739,7 +42728,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42833,7 +42822,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42852,7 +42841,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42906,7 +42895,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42925,7 +42914,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43023,7 +43012,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43042,7 +43031,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43302,7 +43291,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43321,7 +43310,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43492,7 +43481,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43511,7 +43500,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43606,7 +43595,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43625,7 +43614,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43709,7 +43698,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43728,7 +43717,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43823,7 +43812,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43842,7 +43831,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43920,7 +43909,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43939,7 +43928,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43992,7 +43981,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44011,7 +44000,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44257,7 +44246,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44276,7 +44265,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44456,7 +44445,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44475,7 +44464,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44570,7 +44559,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44589,7 +44578,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44673,7 +44662,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44692,7 +44681,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44787,7 +44776,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44806,7 +44795,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44884,7 +44873,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44903,7 +44892,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44956,7 +44945,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44975,7 +44964,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45216,7 +45205,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45235,7 +45224,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45372,7 +45361,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45391,7 +45380,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45486,7 +45475,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45505,7 +45494,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45589,7 +45578,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45608,7 +45597,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45703,7 +45692,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45722,7 +45711,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45805,7 +45794,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45824,7 +45813,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45907,7 +45896,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45926,7 +45915,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46167,7 +46156,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46186,7 +46175,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46336,7 +46325,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46355,7 +46344,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46450,7 +46439,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46469,7 +46458,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46553,7 +46542,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46572,7 +46561,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46667,7 +46656,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46686,7 +46675,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46769,7 +46758,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46788,7 +46777,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46871,7 +46860,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46890,7 +46879,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47136,7 +47125,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47155,7 +47144,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47335,7 +47324,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47354,7 +47343,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47444,7 +47433,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47463,7 +47452,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47517,7 +47506,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47536,7 +47525,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47631,7 +47620,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47650,7 +47639,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47733,7 +47722,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47752,7 +47741,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47835,7 +47824,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47854,7 +47843,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48100,7 +48089,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48119,7 +48108,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48290,7 +48279,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48309,7 +48298,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48399,7 +48388,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48418,7 +48407,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48472,7 +48461,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48491,7 +48480,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48586,7 +48575,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48605,7 +48594,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48688,7 +48677,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48707,7 +48696,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48790,7 +48779,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48809,7 +48798,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49055,7 +49044,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49074,7 +49063,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49245,7 +49234,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49264,7 +49253,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49317,7 +49306,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49336,7 +49325,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49420,7 +49409,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49439,7 +49428,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49523,7 +49512,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49542,7 +49531,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49626,7 +49615,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49645,7 +49634,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49877,7 +49866,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49896,7 +49885,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50070,7 +50059,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50089,7 +50078,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50173,7 +50162,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50192,7 +50181,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50276,7 +50265,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50295,7 +50284,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50379,7 +50368,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50398,7 +50387,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50482,7 +50471,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50501,7 +50490,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50734,7 +50723,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50753,7 +50742,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50853,7 +50842,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50872,7 +50861,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50972,7 +50961,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1774
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50991,7 +50980,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1775
    i32.const 46
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -37523,7 +37523,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1742
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -37544,7 +37544,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1746
+     i32.const 1747
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -37559,7 +37559,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1751
+    i32.const 1752
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -37579,7 +37579,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1756
+    i32.const 1757
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -37751,7 +37751,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1742
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -37772,7 +37772,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1746
+     i32.const 1747
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -37787,7 +37787,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1751
+    i32.const 1752
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -37807,7 +37807,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1756
+    i32.const 1757
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38122,7 +38122,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1742
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -38143,7 +38143,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1746
+     i32.const 1747
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -38158,7 +38158,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1751
+    i32.const 1752
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38178,7 +38178,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1756
+    i32.const 1757
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38379,7 +38379,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1742
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -38400,7 +38400,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1746
+     i32.const 1747
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -38415,7 +38415,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1751
+    i32.const 1752
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38435,7 +38435,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1756
+    i32.const 1757
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38638,7 +38638,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1742
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -38659,7 +38659,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1746
+     i32.const 1747
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -38674,7 +38674,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1751
+    i32.const 1752
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38694,7 +38694,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1756
+    i32.const 1757
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38895,7 +38895,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1742
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -38916,7 +38916,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1746
+     i32.const 1747
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -38931,7 +38931,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1751
+    i32.const 1752
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -38951,7 +38951,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1756
+    i32.const 1757
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39150,7 +39150,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1742
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -39171,7 +39171,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1746
+     i32.const 1747
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -39186,7 +39186,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1751
+    i32.const 1752
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39206,7 +39206,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1756
+    i32.const 1757
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39405,7 +39405,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1742
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -39426,7 +39426,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1746
+     i32.const 1747
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -39441,7 +39441,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1751
+    i32.const 1752
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39461,7 +39461,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1756
+    i32.const 1757
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39661,7 +39661,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1742
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -39682,7 +39682,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1746
+     i32.const 1747
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -39697,7 +39697,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1751
+    i32.const 1752
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39717,7 +39717,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1756
+    i32.const 1757
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39917,7 +39917,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1742
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -39938,7 +39938,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1746
+     i32.const 1747
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -39953,7 +39953,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1751
+    i32.const 1752
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -39973,7 +39973,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1756
+    i32.const 1757
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -40173,7 +40173,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1741
+   i32.const 1742
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -40194,7 +40194,7 @@
      call $~lib/rt/pure/__release
      i32.const 32
      i32.const 480
-     i32.const 1746
+     i32.const 1747
      i32.const 8
      call $~lib/builtins/abort
      unreachable
@@ -40209,7 +40209,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1751
+    i32.const 1752
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -40229,7 +40229,7 @@
     call $~lib/rt/pure/__release
     i32.const 32
     i32.const 480
-    i32.const 1756
+    i32.const 1757
     i32.const 6
     call $~lib/builtins/abort
     unreachable
@@ -40426,7 +40426,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40445,7 +40445,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40616,7 +40616,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40635,7 +40635,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40730,7 +40730,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40749,7 +40749,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40837,7 +40837,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40856,7 +40856,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -40946,7 +40946,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -40965,7 +40965,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41018,7 +41018,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41037,7 +41037,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41115,7 +41115,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41134,7 +41134,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41350,7 +41350,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41369,7 +41369,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41549,7 +41549,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41568,7 +41568,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41663,7 +41663,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41682,7 +41682,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41766,7 +41766,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41785,7 +41785,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41875,7 +41875,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41894,7 +41894,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -41947,7 +41947,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -41966,7 +41966,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42044,7 +42044,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42063,7 +42063,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42280,7 +42280,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42299,7 +42299,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42480,7 +42480,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42499,7 +42499,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42599,7 +42599,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42618,7 +42618,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42720,7 +42720,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42739,7 +42739,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42833,7 +42833,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42852,7 +42852,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -42906,7 +42906,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -42925,7 +42925,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43023,7 +43023,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43042,7 +43042,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43302,7 +43302,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43321,7 +43321,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43492,7 +43492,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43511,7 +43511,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43606,7 +43606,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43625,7 +43625,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43709,7 +43709,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43728,7 +43728,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43823,7 +43823,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43842,7 +43842,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43920,7 +43920,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -43939,7 +43939,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -43992,7 +43992,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44011,7 +44011,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44257,7 +44257,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44276,7 +44276,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44456,7 +44456,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44475,7 +44475,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44570,7 +44570,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44589,7 +44589,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44673,7 +44673,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44692,7 +44692,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44787,7 +44787,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44806,7 +44806,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44884,7 +44884,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44903,7 +44903,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -44956,7 +44956,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -44975,7 +44975,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45216,7 +45216,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45235,7 +45235,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45372,7 +45372,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45391,7 +45391,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45486,7 +45486,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45505,7 +45505,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45589,7 +45589,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45608,7 +45608,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45703,7 +45703,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45722,7 +45722,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45805,7 +45805,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45824,7 +45824,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -45907,7 +45907,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -45926,7 +45926,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46167,7 +46167,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46186,7 +46186,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46336,7 +46336,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46355,7 +46355,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46450,7 +46450,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46469,7 +46469,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46553,7 +46553,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46572,7 +46572,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46667,7 +46667,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46686,7 +46686,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46769,7 +46769,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46788,7 +46788,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -46871,7 +46871,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -46890,7 +46890,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47136,7 +47136,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47155,7 +47155,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47335,7 +47335,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47354,7 +47354,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47444,7 +47444,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47463,7 +47463,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47517,7 +47517,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47536,7 +47536,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47631,7 +47631,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47650,7 +47650,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47733,7 +47733,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47752,7 +47752,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -47835,7 +47835,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -47854,7 +47854,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48100,7 +48100,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48119,7 +48119,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48290,7 +48290,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48309,7 +48309,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48399,7 +48399,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48418,7 +48418,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48472,7 +48472,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48491,7 +48491,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48586,7 +48586,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48605,7 +48605,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48688,7 +48688,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48707,7 +48707,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -48790,7 +48790,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -48809,7 +48809,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49055,7 +49055,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49074,7 +49074,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49245,7 +49245,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49264,7 +49264,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49317,7 +49317,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49336,7 +49336,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49420,7 +49420,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49439,7 +49439,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49523,7 +49523,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49542,7 +49542,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49626,7 +49626,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49645,7 +49645,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -49877,7 +49877,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -49896,7 +49896,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50070,7 +50070,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50089,7 +50089,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50173,7 +50173,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50192,7 +50192,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50276,7 +50276,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50295,7 +50295,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50379,7 +50379,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50398,7 +50398,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50482,7 +50482,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50501,7 +50501,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50734,7 +50734,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50753,7 +50753,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50853,7 +50853,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50872,7 +50872,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable
@@ -50972,7 +50972,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1775
+   i32.const 1776
    i32.const 18
    call $~lib/builtins/abort
    unreachable
@@ -50991,7 +50991,7 @@
    call $~lib/rt/pure/__release
    i32.const 304
    i32.const 480
-   i32.const 1776
+   i32.const 1777
    i32.const 46
    call $~lib/builtins/abort
    unreachable

--- a/tests/compiler/std/typedarray.untouched.wat
+++ b/tests/compiler/std/typedarray.untouched.wat
@@ -37515,7 +37515,7 @@
   local.get $7
   i32.gt_u
   local.get $4
-  i32.const -2147483648
+  i32.const 0
   i32.and
   i32.or
   if
@@ -37537,7 +37537,7 @@
    i32.eq
    if
     local.get $7
-    i32.const -2147483648
+    i32.const 0
     i32.and
     if
      local.get $5
@@ -37743,7 +37743,7 @@
   local.get $7
   i32.gt_u
   local.get $4
-  i32.const -2147483648
+  i32.const 0
   i32.and
   i32.or
   if
@@ -37765,7 +37765,7 @@
    i32.eq
    if
     local.get $7
-    i32.const -2147483648
+    i32.const 0
     i32.and
     if
      local.get $5
@@ -38114,7 +38114,7 @@
   local.get $7
   i32.gt_u
   local.get $4
-  i32.const -2147483648
+  i32.const 0
   i32.and
   i32.or
   if
@@ -38136,7 +38136,7 @@
    i32.eq
    if
     local.get $7
-    i32.const -2147483648
+    i32.const 0
     i32.and
     if
      local.get $5
@@ -38887,7 +38887,7 @@
   local.get $7
   i32.gt_u
   local.get $4
-  i32.const 2
+  i32.const 3
   i32.and
   i32.or
   if
@@ -38909,7 +38909,7 @@
    i32.eq
    if
     local.get $7
-    i32.const 2
+    i32.const 3
     i32.and
     if
      local.get $5
@@ -39142,7 +39142,7 @@
   local.get $7
   i32.gt_u
   local.get $4
-  i32.const 2
+  i32.const 3
   i32.and
   i32.or
   if
@@ -39164,7 +39164,7 @@
    i32.eq
    if
     local.get $7
-    i32.const 2
+    i32.const 3
     i32.and
     if
      local.get $5
@@ -39397,7 +39397,7 @@
   local.get $7
   i32.gt_u
   local.get $4
-  i32.const 4
+  i32.const 7
   i32.and
   i32.or
   if
@@ -39419,7 +39419,7 @@
    i32.eq
    if
     local.get $7
-    i32.const 4
+    i32.const 7
     i32.and
     if
      local.get $5
@@ -39653,7 +39653,7 @@
   local.get $7
   i32.gt_u
   local.get $4
-  i32.const 4
+  i32.const 7
   i32.and
   i32.or
   if
@@ -39675,7 +39675,7 @@
    i32.eq
    if
     local.get $7
-    i32.const 4
+    i32.const 7
     i32.and
     if
      local.get $5
@@ -39909,7 +39909,7 @@
   local.get $7
   i32.gt_u
   local.get $4
-  i32.const 2
+  i32.const 3
   i32.and
   i32.or
   if
@@ -39931,7 +39931,7 @@
    i32.eq
    if
     local.get $7
-    i32.const 2
+    i32.const 3
     i32.and
     if
      local.get $5
@@ -40165,7 +40165,7 @@
   local.get $7
   i32.gt_u
   local.get $4
-  i32.const 4
+  i32.const 7
   i32.and
   i32.or
   if
@@ -40187,7 +40187,7 @@
    i32.eq
    if
     local.get $7
-    i32.const 4
+    i32.const 7
     i32.and
     if
      local.get $5
@@ -40521,7 +40521,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 712
+   i32.const 716
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -40563,7 +40563,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 718
+      i32.const 722
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -41458,7 +41458,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 712
+   i32.const 716
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -41500,7 +41500,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 718
+      i32.const 722
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -42389,7 +42389,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 712
+   i32.const 716
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -42431,7 +42431,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 718
+      i32.const 722
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -43401,7 +43401,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 712
+   i32.const 716
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -43443,7 +43443,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 718
+      i32.const 722
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -44365,7 +44365,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 712
+   i32.const 716
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -44407,7 +44407,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 718
+      i32.const 722
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -45281,7 +45281,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 712
+   i32.const 716
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -45323,7 +45323,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 718
+      i32.const 722
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -46245,7 +46245,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 712
+   i32.const 716
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -46287,7 +46287,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 718
+      i32.const 722
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -47244,7 +47244,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 712
+   i32.const 716
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -47286,7 +47286,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 718
+      i32.const 722
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -48199,7 +48199,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 712
+   i32.const 716
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -48241,7 +48241,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 718
+      i32.const 722
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -49160,7 +49160,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 712
+   i32.const 716
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -49202,7 +49202,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 718
+      i32.const 722
       i32.const 6
       call $~lib/builtins/abort
       unreachable
@@ -49982,7 +49982,7 @@
   if
    i32.const 0
    i32.const 416
-   i32.const 712
+   i32.const 716
    i32.const 2
    call $~lib/builtins/abort
    unreachable
@@ -50022,7 +50022,7 @@
      if
       i32.const 0
       i32.const 416
-      i32.const 718
+      i32.const 722
       i32.const 6
       call $~lib/builtins/abort
       unreachable


### PR DESCRIPTION
Relate to #1066