### PR TITLE
Fix field export naming

### DIFF
--- a/src/program.ts
+++ b/src/program.ts
@@ -3071,6 +3071,16 @@ export class Field extends VariableLikeElement {
     this.setType(type);
     registerConcreteElement(this.program, this);
   }
+
+  /** Gets the internal name of the respective getter function. */
+  get internalGetterName(): string {
+    return this.parent.internalName + INSTANCE_DELIMITER + GETTER_PREFIX + this.name;
+  }
+
+  /** Gets the internal name of the respective setter function. */
+  get internalSetterName(): string {
+    return this.parent.internalName + INSTANCE_DELIMITER + SETTER_PREFIX + this.name;
+  }
 }
 
 /** A property comprised of a getter and a setter function. */

--- a/tests/compiler/exports.optimized.wat
+++ b/tests/compiler/exports.optimized.wat
@@ -28,20 +28,20 @@
  (export "animals.Animal.CAT" (global $exports/animals.Animal.CAT))
  (export "animals.Animal.DOG" (global $exports/animals.Animal.DOG))
  (export "Car" (global $exports/Car))
- (export "Car#get:doors" (func $exports/Car#get:numDoors))
- (export "Car#set:doors" (func $exports/Car#set:numDoors))
+ (export "Car#get:doors" (func $exports/Car#get:doors))
+ (export "Car#set:doors" (func $exports/Car#set:doors))
  (export "Car#constructor" (func $exports/Car#constructor|trampoline))
- (export "Car#get:numDoors" (func $exports/Car#get:numDoors))
- (export "Car#set:numDoors" (func $exports/Car#set:numDoors))
+ (export "Car#get:numDoors" (func $exports/Car#get:doors))
+ (export "Car#set:numDoors" (func $exports/Car#set:doors))
  (export "Car#openDoors" (func $exports/Car#openDoors))
  (export "Car.TIRES" (global $exports/Car.TIRES))
  (export "Car.getNumTires" (func $exports/Car.getNumTires))
  (export "vehicles.Car" (global $exports/vehicles.Car))
- (export "vehicles.Car#get:doors" (func $exports/Car#get:numDoors))
- (export "vehicles.Car#set:doors" (func $exports/Car#set:numDoors))
+ (export "vehicles.Car#get:doors" (func $exports/Car#get:doors))
+ (export "vehicles.Car#set:doors" (func $exports/Car#set:doors))
  (export "vehicles.Car#constructor" (func $exports/vehicles.Car#constructor|trampoline))
- (export "vehicles.Car#get:numDoors" (func $exports/Car#get:numDoors))
- (export "vehicles.Car#set:numDoors" (func $exports/Car#set:numDoors))
+ (export "vehicles.Car#get:numDoors" (func $exports/Car#get:doors))
+ (export "vehicles.Car#set:numDoors" (func $exports/Car#set:doors))
  (export "vehicles.Car#openDoors" (func $exports/Car#openDoors))
  (export "vehicles.Car.TIRES" (global $exports/vehicles.Car.TIRES))
  (export "vehicles.Car.getNumTires" (func $exports/Car.getNumTires))
@@ -129,11 +129,11 @@
   i32.store offset=12
   local.get $2
  )
- (func $exports/Car#get:numDoors (; 5 ;) (param $0 i32) (result i32)
+ (func $exports/Car#get:doors (; 5 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load
  )
- (func $exports/Car#set:numDoors (; 6 ;) (param $0 i32) (param $1 i32)
+ (func $exports/Car#set:doors (; 6 ;) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store

--- a/tests/compiler/exports.untouched.wat
+++ b/tests/compiler/exports.untouched.wat
@@ -30,8 +30,8 @@
  (export "animals.Animal.CAT" (global $exports/animals.Animal.CAT))
  (export "animals.Animal.DOG" (global $exports/animals.Animal.DOG))
  (export "Car" (global $exports/Car))
- (export "Car#get:doors" (func $Car#get:doors))
- (export "Car#set:doors" (func $Car#set:doors))
+ (export "Car#get:doors" (func $exports/Car#get:doors))
+ (export "Car#set:doors" (func $exports/Car#set:doors))
  (export "Car#constructor" (func $exports/Car#constructor|trampoline))
  (export "Car#get:numDoors" (func $exports/Car#get:numDoors))
  (export "Car#set:numDoors" (func $exports/Car#set:numDoors))
@@ -39,8 +39,8 @@
  (export "Car.TIRES" (global $exports/Car.TIRES))
  (export "Car.getNumTires" (func $exports/Car.getNumTires))
  (export "vehicles.Car" (global $exports/vehicles.Car))
- (export "vehicles.Car#get:doors" (func $vehicles.Car#get:doors))
- (export "vehicles.Car#set:doors" (func $vehicles.Car#set:doors))
+ (export "vehicles.Car#get:doors" (func $exports/vehicles.Car#get:doors))
+ (export "vehicles.Car#set:doors" (func $exports/vehicles.Car#set:doors))
  (export "vehicles.Car#constructor" (func $exports/vehicles.Car#constructor|trampoline))
  (export "vehicles.Car#get:numDoors" (func $exports/vehicles.Car#get:numDoors))
  (export "vehicles.Car#set:numDoors" (func $exports/vehicles.Car#set:numDoors))
@@ -195,22 +195,31 @@
   i32.store
   local.get $0
  )
- (func $exports/Car#get:numDoors (; 8 ;) (param $0 i32) (result i32)
+ (func $exports/Car#get:doors (; 8 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load
  )
- (func $exports/Car#set:numDoors (; 9 ;) (param $0 i32) (param $1 i32)
+ (func $exports/Car#set:doors (; 9 ;) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
  )
- (func $exports/Car#openDoors (; 10 ;) (param $0 i32)
+ (func $exports/Car#get:numDoors (; 10 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load
+ )
+ (func $exports/Car#set:numDoors (; 11 ;) (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  i32.store
+ )
+ (func $exports/Car#openDoors (; 12 ;) (param $0 i32)
   nop
  )
- (func $exports/vehicles.Car.getNumTires (; 11 ;) (result i32)
+ (func $exports/vehicles.Car.getNumTires (; 13 ;) (result i32)
   global.get $exports/vehicles.Car.TIRES
  )
- (func $exports/vehicles.Car#constructor (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/vehicles.Car#constructor (; 14 ;) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   i32.eqz
   if
@@ -228,19 +237,28 @@
   i32.store
   local.get $0
  )
- (func $exports/vehicles.Car#get:numDoors (; 13 ;) (param $0 i32) (result i32)
+ (func $exports/vehicles.Car#get:doors (; 15 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load
  )
- (func $exports/vehicles.Car#set:numDoors (; 14 ;) (param $0 i32) (param $1 i32)
+ (func $exports/vehicles.Car#set:doors (; 16 ;) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
  )
- (func $exports/vehicles.Car#openDoors (; 15 ;) (param $0 i32)
+ (func $exports/vehicles.Car#get:numDoors (; 17 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.load
+ )
+ (func $exports/vehicles.Car#set:numDoors (; 18 ;) (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  i32.store
+ )
+ (func $exports/vehicles.Car#openDoors (; 19 ;) (param $0 i32)
   nop
  )
- (func $~start (; 16 ;)
+ (func $~start (; 20 ;)
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -252,7 +270,7 @@
   global.get $~lib/rt/stub/startOffset
   global.set $~lib/rt/stub/offset
  )
- (func $exports/subOpt|trampoline (; 17 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/subOpt|trampoline (; 21 ;) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -270,16 +288,7 @@
   local.get $1
   call $exports/subOpt
  )
- (func $Car#get:doors (; 18 ;) (param $0 i32) (result i32)
-  local.get $0
-  i32.load
- )
- (func $Car#set:doors (; 19 ;) (param $0 i32) (param $1 i32)
-  local.get $0
-  local.get $1
-  i32.store
- )
- (func $exports/Car#constructor|trampoline (; 20 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $exports/Car#constructor|trampoline (; 22 ;) (param $0 i32) (param $1 i32) (result i32)
   block $1of1
    block $0of1
     block $outOfRange
@@ -294,15 +303,6 @@
   local.get $0
   local.get $1
   call $exports/Car#constructor
- )
- (func $vehicles.Car#get:doors (; 21 ;) (param $0 i32) (result i32)
-  local.get $0
-  i32.load
- )
- (func $vehicles.Car#set:doors (; 22 ;) (param $0 i32) (param $1 i32)
-  local.get $0
-  local.get $1
-  i32.store
  )
  (func $exports/vehicles.Car#constructor|trampoline (; 23 ;) (param $0 i32) (param $1 i32) (result i32)
   block $1of1

--- a/tests/compiler/extends-recursive.optimized.wat
+++ b/tests/compiler/extends-recursive.optimized.wat
@@ -5,13 +5,13 @@
  (global $extends-recursive/Child i32 (i32.const 3))
  (export "memory" (memory $0))
  (export "Child" (global $extends-recursive/Child))
- (export "Child#get:child" (func $Child#get:child))
- (export "Child#set:child" (func $Child#set:child))
- (func $Child#get:child (; 0 ;) (param $0 i32) (result i32)
+ (export "Child#get:child" (func $extends-recursive/Parent#get:child))
+ (export "Child#set:child" (func $extends-recursive/Parent#set:child))
+ (func $extends-recursive/Parent#get:child (; 0 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load
  )
- (func $Child#set:child (; 1 ;) (param $0 i32) (param $1 i32)
+ (func $extends-recursive/Parent#set:child (; 1 ;) (param $0 i32) (param $1 i32)
   (local $2 i32)
   local.get $0
   local.get $1

--- a/tests/compiler/extends-recursive.untouched.wat
+++ b/tests/compiler/extends-recursive.untouched.wat
@@ -7,12 +7,12 @@
  (global $extends-recursive/Child i32 (i32.const 3))
  (export "memory" (memory $0))
  (export "Child" (global $extends-recursive/Child))
- (export "Child#get:child" (func $Child#get:child))
- (export "Child#set:child" (func $Child#set:child))
+ (export "Child#get:child" (func $extends-recursive/Parent#get:child))
+ (export "Child#set:child" (func $extends-recursive/Parent#set:child))
  (func $~lib/rt/stub/__retain (; 0 ;) (param $0 i32) (result i32)
   local.get $0
  )
- (func $Child#get:child (; 1 ;) (param $0 i32) (result i32)
+ (func $extends-recursive/Parent#get:child (; 1 ;) (param $0 i32) (result i32)
   local.get $0
   i32.load
   call $~lib/rt/stub/__retain
@@ -20,7 +20,7 @@
  (func $~lib/rt/stub/__release (; 2 ;) (param $0 i32)
   nop
  )
- (func $Child#set:child (; 3 ;) (param $0 i32) (param $1 i32)
+ (func $extends-recursive/Parent#set:child (; 3 ;) (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   local.tee $0


### PR DESCRIPTION
This fixes a naming issue only present for instance fields of explicitly exported classes. These were added with truncated internal names.