### PR TITLE
Slice version 0.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "assemblyscript",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -25,9 +25,9 @@
       }
     },
     "@types/node": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.0.tgz",
-      "integrity": "sha512-Onhn+z72D2O2Pb2ql2xukJ55rglumsVo1H6Fmyi8mlU9SvKdBk/pUSUAiBY/d9bAOF7VVWajX3sths/+g6ZiAQ==",
+      "version": "13.5.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.1.tgz",
+      "integrity": "sha512-Jj2W7VWQ2uM83f8Ls5ON9adxN98MvyJsMSASYFuSvrov8RMRY64Ayay7KV35ph1TSGIJ2gG9ZVDdEq3c3zaydA==",
       "dev": true
     },
     "@webassemblyjs/ast": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "assemblyscript",
     "wasm"
   ],
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": "Daniel Wirtz <dcode+assemblyscript@dcode.io>",
   "contributors": [],
   "license": "Apache-2.0",
@@ -27,7 +27,7 @@
     "ts-node": "^6.2.0"
   },
   "devDependencies": {
-    "@types/node": "^13.5.0",
+    "@types/node": "^13.5.1",
     "browser-process-hrtime": "^1.0.0",
     "diff": "^4.0.2",
     "glob": "^7.1.6",


### PR DESCRIPTION
This is a minor release we knew was coming by updating Binaryen after 0.9, which turned out to be not so dramatic, yet is good to do. Also fixes a couple things, with the last one potentially unbreaking some users.

* Fix truncated field export naming
* Fix `asc.compileString` definitions
* Update Binaryen
* Add a fallback for argumentsLength without mutable-globals