### PR TITLE
Fix special 'null' cases when inferring array literals

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -7855,16 +7855,17 @@ export class Compiler extends DiagnosticEmitter {
     constraints: Constraints
   ): ExpressionRef {
     var module = this.module;
+    var flow = this.currentFlow;
+
+    var arrayInstance = this.resolver.lookupExpression(expression, flow, this.currentType);
+    if (!arrayInstance) return module.unreachable();
+
     var program = this.program;
     var arrayBufferInstance = assert(program.arrayBufferInstance);
-    var flow = this.currentFlow;
 
     // block those here so compiling expressions doesn't conflict
     var tempThis = flow.getTempLocal(this.options.usizeType);
     var tempDataStart = flow.getTempLocal(arrayBufferInstance.type);
-
-    var arrayInstance = this.resolver.lookupExpression(expression, this.currentFlow, this.currentType);
-    if (!arrayInstance) return module.unreachable();
 
     assert(arrayInstance.kind == ElementKind.CLASS);
     var arrayType = (<Class>arrayInstance).type;

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -7441,13 +7441,11 @@ export class Compiler extends DiagnosticEmitter {
           }
           return module.ref_null();
         }
-        // TODO: this would be a breaking change
-        // this.error(
-        //   DiagnosticCode.Type_0_is_not_assignable_to_type_1,
-        //   expression.range, "null", contextualType.toString()
-        // );
-        // return module.unreachable();
         this.currentType = options.usizeType;
+        this.warning(
+          DiagnosticCode.Expression_resolves_to_unusual_type_0,
+          expression.range, this.currentType.toString()
+        );
         return options.isWasm64
           ? module.i64(0)
           : module.i32(0);

--- a/src/diagnosticMessages.generated.ts
+++ b/src/diagnosticMessages.generated.ts
@@ -37,6 +37,7 @@ export enum DiagnosticCode {
   _0_must_be_a_power_of_two = 223,
   _0_is_not_a_valid_operator = 224,
   Expression_cannot_be_represented_by_a_type = 225,
+  Expression_resolves_to_unusual_type_0 = 226,
   Type_0_is_cyclic_Module_will_include_deferred_garbage_collection = 900,
   Importing_the_table_disables_some_indirect_call_optimizations = 901,
   Exporting_the_table_disables_some_indirect_call_optimizations = 902,
@@ -186,6 +187,7 @@ export function diagnosticCodeToString(code: DiagnosticCode): string {
     case 223: return "'{0}' must be a power of two.";
     case 224: return "'{0}' is not a valid operator.";
     case 225: return "Expression cannot be represented by a type.";
+    case 226: return "Expression resolves to unusual type '{0}'.";
     case 900: return "Type '{0}' is cyclic. Module will include deferred garbage collection.";
     case 901: return "Importing the table disables some indirect call optimizations.";
     case 902: return "Exporting the table disables some indirect call optimizations.";

--- a/src/diagnosticMessages.json
+++ b/src/diagnosticMessages.json
@@ -30,6 +30,7 @@
   "'{0}' must be a power of two.": 223,
   "'{0}' is not a valid operator.": 224,
   "Expression cannot be represented by a type.": 225,
+  "Expression resolves to unusual type '{0}'.": 226,
 
   "Type '{0}' is cyclic. Module will include deferred garbage collection.": 900,
   "Importing the table disables some indirect call optimizations.": 901,

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -65,7 +65,8 @@ import {
   TernaryExpression,
   isTypeOmitted,
   FunctionExpression,
-  NewExpression
+  NewExpression,
+  ArrayLiteralExpression
 } from "./ast";
 
 import {
@@ -2160,10 +2161,10 @@ export class Resolver extends DiagnosticEmitter {
     /** How to proceed with eventual diagnostics. */
     reportMode: ReportMode = ReportMode.REPORT
   ): Element | null {
+    this.currentThisExpression = node;
+    this.currentElementExpression = null;
     switch (node.literalKind) {
       case LiteralKind.INTEGER: {
-        this.currentThisExpression = node;
-        this.currentElementExpression = null;
         let intType = this.determineIntegerLiteralType(
           (<IntegerLiteralExpression>node).value,
           ctxType
@@ -2173,20 +2174,56 @@ export class Resolver extends DiagnosticEmitter {
         return wrapperClasses.get(intType)!;
       }
       case LiteralKind.FLOAT: {
-        this.currentThisExpression = node;
-        this.currentElementExpression = null;
         let fltType = ctxType == Type.f32 ? Type.f32 : Type.f64;
         let wrapperClasses = this.program.wrapperClasses;
         assert(wrapperClasses.has(fltType));
         return wrapperClasses.get(fltType)!;
       }
       case LiteralKind.STRING: {
-        this.currentThisExpression = node;
-        this.currentElementExpression = null;
         return this.program.stringInstance;
       }
-      // TODO
-      // case LiteralKind.ARRAY:
+      case LiteralKind.ARRAY: {
+        let classReference = ctxType.classReference;
+        if (ctxType.is(TypeFlags.REFERENCE) && classReference !== null && classReference.prototype == this.program.arrayPrototype) {
+          return this.getElementOfType(ctxType);
+        }
+        // otherwise infer, ignoring ctxType
+        let expressions = (<ArrayLiteralExpression>node).elementExpressions;
+        let elementType = Type.auto;
+        let literallyNullable = false;
+        for (let i = 0, k = expressions.length; i < k; ++i) {
+          let expression = expressions[i];
+          if (expression) {
+            if (expression.kind == NodeKind.NULL) {
+              literallyNullable = true;
+            } else {
+              let currentType = this.resolveExpression(expression, ctxFlow, elementType);
+              if (!currentType) return null;
+              if (elementType == Type.auto) elementType = currentType;
+              else if (currentType != elementType) {
+                let commonType = Type.commonDenominator(elementType, currentType, false);
+                if (commonType) elementType = commonType;
+                // otherwise triggers error on compilation
+              }
+            }
+          }
+        }
+        if (elementType /* still */ == Type.auto) {
+          this.error(
+            DiagnosticCode.The_type_argument_for_type_parameter_0_cannot_be_inferred_from_the_usage_Consider_specifying_the_type_arguments_explicitly,
+            node.range, "T"
+          );
+          return null;
+        }
+        if (
+          literallyNullable &&
+          elementType.is(TypeFlags.REFERENCE) &&
+          !elementType.is(TypeFlags.HOST) // TODO: anyref isn't nullable as-is
+        ) {
+          elementType = elementType.asNullable();
+        }
+        return assert(this.resolveClass(this.program.arrayPrototype, [ elementType ]));
+      }
     }
     if (reportMode == ReportMode.REPORT) {
       this.error(

--- a/std/assembly/array.ts
+++ b/std/assembly/array.ts
@@ -38,7 +38,7 @@ export class Array<T> extends ArrayBufferView {
   private length_: i32;
 
   static isArray<U>(value: U): bool {
-    return builtin_isArray(value) && value !== null;
+    return isReference<U>() ? builtin_isArray(value) && value !== null : false;
   }
 
   static create<T>(capacity: i32 = 0): Array<T> {
@@ -355,10 +355,7 @@ export class Array<T> extends ArrayBufferView {
       base + sizeof<T>(),
       <usize>lastIndex << alignof<T>()
     );
-    store<T>(base + (<usize>lastIndex << alignof<T>()),
-      // @ts-ignore: cast
-      <T>null
-    );
+    store<T>(base + (<usize>lastIndex << alignof<T>()), isReference<T>() ? null : 0);
     this.length_ = lastIndex;
     return element; // no need to retain -> is moved
   }

--- a/tests/compiler/builtins.ts
+++ b/tests/compiler/builtins.ts
@@ -24,20 +24,20 @@ assert(isInteger(<i32>1));
 assert(!isInteger(<f32>1));
 assert(isFloat(<f32>1));
 assert(!isFloat(<i32>1));
-assert(isReference(changetype<string>(null)));
-assert(!isReference(changetype<usize>(null)));
+assert(isReference(changetype<string>(0)));
+assert(!isReference(changetype<usize>(0)));
 assert(isString(""));
 assert(isString("abc"));
 assert(!isString(1));
-assert(isArray(changetype<i32[]>(null)));
-assert(isArrayLike(changetype<i32[]>(null)));
-assert(isArrayLike(changetype<string>(null)));
-assert(isArrayLike(changetype<Uint8Array>(null)));
-assert(!isArray(changetype<usize>(null)));
-assert(isFunction(changetype<() => void>(null)));
-assert(!isFunction(changetype<u32>(null)));
-assert(isNullable(changetype<C | null>(null)));
-assert(!isNullable(changetype<C>(null)));
+assert(isArray(changetype<i32[]>(0)));
+assert(isArrayLike(changetype<i32[]>(0)));
+assert(isArrayLike(changetype<string>(0)));
+assert(isArrayLike(changetype<Uint8Array>(0)));
+assert(!isArray(changetype<usize>(0)));
+assert(isFunction(changetype<() => void>(0)));
+assert(!isFunction(changetype<u32>(0)));
+assert(isNullable(changetype<C | null>(0)));
+assert(!isNullable(changetype<C>(0)));
 
 // evaluation
 

--- a/tests/compiler/infer-array.optimized.wat
+++ b/tests/compiler/infer-array.optimized.wat
@@ -19,6 +19,15 @@
  (data (i32.const 288) "\18\00\00\00\01\00\00\00\00\00\00\00\18")
  (data (i32.const 310) "\f0?\00\00\00\00\00\00\00@\00\00\00\00\00\00\08@")
  (data (i32.const 336) "\0c\00\00\00\01\00\00\00\00\00\00\00\0c\00\00\00\00\00\80?\00\00\00@\00\00@@")
+ (data (i32.const 368) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\00a")
+ (data (i32.const 400) "\08\00\00\00\01\00\00\00\00\00\00\00\08\00\00\00\00\00\00\00\80\01")
+ (data (i32.const 432) "\04\00\00\00\01\00\00\00\00\00\00\00\04")
+ (data (i32.const 464) "\08\00\00\00\01\00\00\00\00\00\00\00\08")
+ (data (i32.const 496) "\08\00\00\00\01\00\00\00\00\00\00\00\08\00\00\00\01")
+ (data (i32.const 528) "\08\00\00\00\01\00\00\00\00\00\00\00\08\00\00\00\00\00\00\00\01")
+ (data (i32.const 560) "\04\00\00\00\01\00\00\00\00\00\00\00\04\00\00\00\01")
+ (data (i32.const 592) "\04\00\00\00\01\00\00\00\00\00\00\00\04\00\00\00\02")
+ (data (i32.const 624) "^\00\00\00\01\00\00\00\01\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y")
  (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (export "memory" (memory $0))
@@ -363,9 +372,9 @@
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  i32.const 368
+  i32.const 736
   global.set $~lib/rt/stub/startOffset
-  i32.const 368
+  i32.const 736
   global.set $~lib/rt/stub/offset
   i32.const 3
   i32.const 2
@@ -452,6 +461,56 @@
   i32.store
   local.get $1
   i32.const 0
+  i32.store offset=4
+  i32.const 2
+  i32.const 2
+  i32.const 9
+  i32.const 416
+  call $~lib/rt/__allocArray
+  drop
+  i32.const 1
+  i32.const 2
+  i32.const 10
+  i32.const 448
+  call $~lib/rt/__allocArray
+  drop
+  i32.const 2
+  i32.const 2
+  i32.const 10
+  i32.const 480
+  call $~lib/rt/__allocArray
+  drop
+  i32.const 2
+  i32.const 2
+  i32.const 3
+  i32.const 512
+  call $~lib/rt/__allocArray
+  drop
+  i32.const 2
+  i32.const 2
+  i32.const 3
+  i32.const 544
+  call $~lib/rt/__allocArray
+  drop
+  i32.const 2
+  i32.const 2
+  i32.const 11
+  i32.const 0
+  call $~lib/rt/__allocArray
+  i32.load offset=4
+  local.tee $0
+  i32.const 1
+  i32.const 2
+  i32.const 3
+  i32.const 576
+  call $~lib/rt/__allocArray
+  i32.store
+  local.get $0
+  i32.const 1
+  i32.const 2
+  i32.const 3
+  i32.const 608
+  call $~lib/rt/__allocArray
   i32.store offset=4
  )
  (func $~start (; 9 ;)

--- a/tests/compiler/infer-array.ts
+++ b/tests/compiler/infer-array.ts
@@ -40,3 +40,28 @@ class Ref {}
   let arr = [a, null];
   assert(isNullable(arr[0]));
 }
+{ // leading null literals are deferred
+  let arr = [null, "a"];
+  assert(isNullable(arr[0]));
+}
+{ // only nulls infers as usize[]
+  let arr1 = [null];
+  assert(isInteger(arr1[0]));
+  assert(!isNullable(arr1[0]));
+  let arr2 = [null, null];
+  assert(isInteger(arr2[0]));
+  assert(!isNullable(arr2[0]));
+}
+{ // null in integer contexts infers as usize
+  let arr1 = [1, null];
+  assert(isInteger(arr1[0]));
+  assert(!isNullable(arr1[0]));
+  let arr2 = [null, 1];
+  assert(isInteger(arr2[0]));
+  assert(!isNullable(arr2[0]));
+}
+{ // nesting works as well
+  let arr = [[1], [2]];
+  assert(isArray(arr[0]));
+  assert(!isNullable(arr));
+}

--- a/tests/compiler/infer-array.untouched.wat
+++ b/tests/compiler/infer-array.untouched.wat
@@ -18,11 +18,20 @@
  (data (i32.const 240) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00i\00n\00f\00e\00r\00-\00a\00r\00r\00a\00y\00.\00t\00s\00")
  (data (i32.const 288) "\18\00\00\00\01\00\00\00\00\00\00\00\18\00\00\00\00\00\00\00\00\00\f0?\00\00\00\00\00\00\00@\00\00\00\00\00\00\08@")
  (data (i32.const 336) "\0c\00\00\00\01\00\00\00\00\00\00\00\0c\00\00\00\00\00\80?\00\00\00@\00\00@@")
+ (data (i32.const 368) "\02\00\00\00\01\00\00\00\01\00\00\00\02\00\00\00a\00")
+ (data (i32.const 400) "\08\00\00\00\01\00\00\00\00\00\00\00\08\00\00\00\00\00\00\00\80\01\00\00")
+ (data (i32.const 432) "\04\00\00\00\01\00\00\00\00\00\00\00\04\00\00\00\00\00\00\00")
+ (data (i32.const 464) "\08\00\00\00\01\00\00\00\00\00\00\00\08\00\00\00\00\00\00\00\00\00\00\00")
+ (data (i32.const 496) "\08\00\00\00\01\00\00\00\00\00\00\00\08\00\00\00\01\00\00\00\00\00\00\00")
+ (data (i32.const 528) "\08\00\00\00\01\00\00\00\00\00\00\00\08\00\00\00\00\00\00\00\01\00\00\00")
+ (data (i32.const 560) "\04\00\00\00\01\00\00\00\00\00\00\00\04\00\00\00\01\00\00\00")
+ (data (i32.const 592) "\04\00\00\00\01\00\00\00\00\00\00\00\04\00\00\00\02\00\00\00")
+ (data (i32.const 624) "^\00\00\00\01\00\00\00\01\00\00\00^\00\00\00E\00l\00e\00m\00e\00n\00t\00 \00t\00y\00p\00e\00 \00m\00u\00s\00t\00 \00b\00e\00 \00n\00u\00l\00l\00a\00b\00l\00e\00 \00i\00f\00 \00a\00r\00r\00a\00y\00 \00i\00s\00 \00h\00o\00l\00e\00y\00")
  (table $0 1 funcref)
  (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
  (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
  (global $~lib/ASC_SHRINK_LEVEL i32 (i32.const 0))
- (global $~lib/heap/__heap_base i32 (i32.const 364))
+ (global $~lib/heap/__heap_base i32 (i32.const 736))
  (export "memory" (memory $0))
  (start $~start)
  (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (param $0 i32)
@@ -1578,12 +1587,114 @@
   local.set $2
   local.get $2
  )
- (func $start:infer-array (; 19 ;)
+ (func $~lib/array/Array<~lib/string/String | null>#__unchecked_get (; 19 ;) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
+  call $~lib/rt/stub/__retain
+ )
+ (func $~lib/array/Array<~lib/string/String | null>#__get (; 20 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 64
+   i32.const 128
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<~lib/string/String | null>#__unchecked_get
+  local.set $2
+  local.get $2
+ )
+ (func $~lib/array/Array<usize>#__unchecked_get (; 21 ;) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
+ )
+ (func $~lib/array/Array<usize>#__get (; 22 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 64
+   i32.const 128
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<usize>#__unchecked_get
+  local.set $2
+  local.get $2
+ )
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_get (; 23 ;) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.load offset=4
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
+  call $~lib/rt/stub/__retain
+ )
+ (func $~lib/array/Array<~lib/array/Array<i32>>#__get (; 24 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  local.get $0
+  i32.load offset=12
+  i32.ge_u
+  if
+   i32.const 64
+   i32.const 128
+   i32.const 93
+   i32.const 41
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<~lib/array/Array<i32>>#__unchecked_get
+  local.set $2
+  local.get $2
+  i32.eqz
+  if
+   local.get $2
+   call $~lib/rt/stub/__release
+   i32.const 640
+   i32.const 128
+   i32.const 97
+   i32.const 39
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
+ )
+ (func $start:infer-array (; 25 ;)
   (local $0 i32)
   (local $1 i32)
   (local $2 f32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
   global.get $~lib/heap/__heap_base
   i32.const 15
   i32.add
@@ -1754,8 +1865,95 @@
   call $~lib/rt/stub/__release
   local.get $1
   call $~lib/rt/stub/__release
+  i32.const 2
+  i32.const 2
+  i32.const 9
+  i32.const 416
+  call $~lib/rt/__allocArray
+  call $~lib/rt/stub/__retain
+  local.set $4
+  local.get $4
+  call $~lib/rt/stub/__release
+  local.get $1
+  call $~lib/rt/stub/__release
+  i32.const 1
+  i32.const 2
+  i32.const 10
+  i32.const 448
+  call $~lib/rt/__allocArray
+  call $~lib/rt/stub/__retain
+  local.set $4
+  i32.const 2
+  i32.const 2
+  i32.const 10
+  i32.const 480
+  call $~lib/rt/__allocArray
+  call $~lib/rt/stub/__retain
+  local.set $0
+  local.get $4
+  call $~lib/rt/stub/__release
+  local.get $0
+  call $~lib/rt/stub/__release
+  i32.const 2
+  i32.const 2
+  i32.const 3
+  i32.const 512
+  call $~lib/rt/__allocArray
+  call $~lib/rt/stub/__retain
+  local.set $4
+  i32.const 2
+  i32.const 2
+  i32.const 3
+  i32.const 544
+  call $~lib/rt/__allocArray
+  call $~lib/rt/stub/__retain
+  local.set $1
+  local.get $4
+  call $~lib/rt/stub/__release
+  local.get $1
+  call $~lib/rt/stub/__release
+  i32.const 2
+  i32.const 2
+  i32.const 11
+  i32.const 0
+  call $~lib/rt/__allocArray
+  call $~lib/rt/stub/__retain
+  local.set $1
+  local.get $1
+  i32.load offset=4
+  local.set $4
+  local.get $4
+  i32.const 1
+  i32.const 2
+  i32.const 3
+  i32.const 576
+  call $~lib/rt/__allocArray
+  call $~lib/rt/stub/__retain
+  local.tee $3
+  call $~lib/rt/stub/__retain
+  i32.store
+  local.get $4
+  i32.const 1
+  i32.const 2
+  i32.const 3
+  i32.const 608
+  call $~lib/rt/__allocArray
+  call $~lib/rt/stub/__retain
+  local.tee $5
+  call $~lib/rt/stub/__retain
+  i32.store offset=4
+  local.get $1
+  local.set $4
+  local.get $3
+  call $~lib/rt/stub/__release
+  local.get $5
+  call $~lib/rt/stub/__release
+  local.get $4
+  call $~lib/rt/stub/__release
+  local.get $1
+  call $~lib/rt/stub/__release
  )
- (func $~start (; 20 ;)
+ (func $~start (; 26 ;)
   call $start:infer-array
  )
 )

--- a/tests/compiler/std/array.untouched.wat
+++ b/tests/compiler/std/array.untouched.wat
@@ -2128,13 +2128,6 @@
  )
  (func $~lib/array/Array.isArray<i32> (; 28 ;) (param $0 i32) (result i32)
   i32.const 0
-  if (result i32)
-   local.get $0
-   i32.const 0
-   i32.ne
-  else
-   i32.const 0
-  end
  )
  (func $~lib/array/Array.isArray<~lib/string/String> (; 29 ;) (param $0 i32) (result i32)
   (local $1 i32)

--- a/tests/compiler/std/object.optimized.wat
+++ b/tests/compiler/std/object.optimized.wat
@@ -630,7 +630,7 @@
   end
   i32.const 0
   i32.const 0
-  call $~lib/object/Object.is<i32>
+  call $~lib/object/Object.is<~lib/string/String>
   i32.const 1
   i32.ne
   if

--- a/tests/compiler/std/object.ts
+++ b/tests/compiler/std/object.ts
@@ -46,6 +46,6 @@ assert(Object.is("a", "a") == true);
 assert(Object.is("a", "b") == false);
 assert(Object.is("a", "ab") == false);
 
-assert(Object.is(null, null) == true);
+assert(Object.is<string | null>(null, null) == true);
 assert(Object.is<string | null>("", null) == false);
 assert(Object.is<string | null>(null, "") == false);

--- a/tests/compiler/std/object.untouched.wat
+++ b/tests/compiler/std/object.untouched.wat
@@ -301,12 +301,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $~lib/object/Object.is<usize> (; 11 ;) (param $0 i32) (param $1 i32) (result i32)
-  local.get $0
-  local.get $1
-  i32.eq
- )
- (func $~lib/object/Object.is<~lib/string/String | null> (; 12 ;) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/object/Object.is<~lib/string/String | null> (; 11 ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   local.get $0
   call $~lib/rt/stub/__retain
@@ -324,7 +319,7 @@
   call $~lib/rt/stub/__release
   local.get $2
  )
- (func $start:std/object (; 13 ;)
+ (func $start:std/object (; 12 ;)
   f64.const 0
   f64.const 0
   call $~lib/object/Object.is<f64>
@@ -845,7 +840,7 @@
   end
   i32.const 0
   i32.const 0
-  call $~lib/object/Object.is<usize>
+  call $~lib/object/Object.is<~lib/string/String | null>
   i32.const 1
   i32.eq
   i32.eqz
@@ -886,7 +881,7 @@
    unreachable
   end
  )
- (func $~start (; 14 ;)
+ (func $~start (; 13 ;)
   call $start:std/object
  )
 )


### PR DESCRIPTION
This PR addresses the issues reported in https://github.com/AssemblyScript/assemblyscript/issues/1083, except that it doesn't yet disallow inferring `null` to `usize` if the contextual type is not a reference type as this would be a breaking change I'm not sure about yet.

Referencing the snippets of the original issue:

```ts
let arr1 = [null, "a"]; // should compile but produce error
```

This now compiles due to inferring logic skipping null literals, and applying the nullable flag afterwards.

```ts
let arr2 = [null];      // should produce error but compile
```

This now produces an error because `null` has been skipped and the final element type is `auto`. More of a side-effect that would play well with disallowing `null` in non-reference contexts, if we decide to go for that.

```ts
let arr3 = [1, null];   // should produce error but compile for now
```

This still compiles. While the `null` literal is skipped, `i32` is not nullable so remains `i32` so `null` behaves like it's in an `i32` context. In 32-bit, its `usize` type is implicitly convertible to `i32`. Disallowing `null`, as mentioned above, would result in an error here.

```ts
let arr4 = [[1], [2]];  // currently produce compiler error
```

This now compiles since the inference logic has been moved to the resolver. Infers `i32[], i32[]`, then `i32[][]`.