### PR TITLE
Be more careful on invalid tokens

### DIFF
--- a/src/diagnosticMessages.generated.ts
+++ b/src/diagnosticMessages.generated.ts
@@ -65,6 +65,7 @@ export enum DiagnosticCode {
   An_accessor_cannot_have_type_parameters = 1094,
   A_set_accessor_cannot_have_a_return_type_annotation = 1095,
   Type_parameter_list_cannot_be_empty = 1098,
+  Type_argument_list_cannot_be_empty = 1099,
   A_continue_statement_can_only_be_used_within_an_enclosing_iteration_statement = 1104,
   A_break_statement_can_only_be_used_within_an_enclosing_iteration_or_switch_statement = 1105,
   A_return_statement_can_only_be_used_within_a_function_body = 1108,
@@ -214,6 +215,7 @@ export function diagnosticCodeToString(code: DiagnosticCode): string {
     case 1094: return "An accessor cannot have type parameters.";
     case 1095: return "A 'set' accessor cannot have a return type annotation.";
     case 1098: return "Type parameter list cannot be empty.";
+    case 1099: return "Type argument list cannot be empty.";
     case 1104: return "A 'continue' statement can only be used within an enclosing iteration statement.";
     case 1105: return "A 'break' statement can only be used within an enclosing iteration or switch statement.";
     case 1108: return "A 'return' statement can only be used within a function body.";

--- a/src/diagnosticMessages.json
+++ b/src/diagnosticMessages.json
@@ -60,6 +60,7 @@
   "An accessor cannot have type parameters.": 1094,
   "A 'set' accessor cannot have a return type annotation.": 1095,
   "Type parameter list cannot be empty.": 1098,
+  "Type argument list cannot be empty.": 1099,
   "A 'continue' statement can only be used within an enclosing iteration statement.": 1104,
   "A 'break' statement can only be used within an enclosing iteration or switch statement.": 1105,
   "A 'return' statement can only be used within a function body.": 1108,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3618,7 +3618,8 @@ export class Parser extends DiagnosticEmitter {
 
     var state = tn.mark();
     if (!tn.skip(Token.LESSTHAN)) return null;
-    var typeArguments: TypeNode[] | null = null;
+    var start = tn.tokenPos;
+    var typeArguments = new Array<TypeNode>();
     do {
       if (tn.peek() === Token.GREATERTHAN) {
         break;
@@ -3628,11 +3629,19 @@ export class Parser extends DiagnosticEmitter {
         tn.reset(state);
         return null;
       }
-      if (!typeArguments) typeArguments = [ type ];
-      else typeArguments.push(type);
+      typeArguments.push(type);
     } while (tn.skip(Token.COMMA));
-    if (tn.skip(Token.GREATERTHAN) && tn.skip(Token.OPENPAREN)) {
-      return typeArguments;
+    if (tn.skip(Token.GREATERTHAN)) {
+      let end = tn.pos;
+      if (tn.skip(Token.OPENPAREN)) {
+        if (!typeArguments.length) {
+          this.error(
+            DiagnosticCode.Type_argument_list_cannot_be_empty,
+            tn.range(start, end)
+          );
+        }
+        return typeArguments;
+      }
     }
     tn.reset(state);
     return null;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1043,8 +1043,9 @@ export class Parser extends DiagnosticEmitter {
 
     // at '<': TypeParameter (',' TypeParameter)* '>'
 
-    var typeParameters: TypeParameterNode[] | null = null;
+    var typeParameters = new Array<TypeParameterNode>();
     var seenOptional = false;
+    var start = tn.tokenPos;
     while (!tn.skip(Token.GREATERTHAN)) {
       let typeParameter = this.parseTypeParameter(tn);
       if (!typeParameter) return null;
@@ -1057,8 +1058,7 @@ export class Parser extends DiagnosticEmitter {
         );
         typeParameter.defaultType = null;
       }
-      if (!typeParameters) typeParameters = [ typeParameter ];
-      else typeParameters.push(typeParameter);
+      typeParameters.push(typeParameter);
       if (!tn.skip(Token.COMMA)) {
         if (tn.skip(Token.GREATERTHAN)) {
           break;
@@ -1071,10 +1071,10 @@ export class Parser extends DiagnosticEmitter {
         }
       }
     }
-    if (!(typeParameters && typeParameters.length)) {
+    if (!typeParameters.length) {
       this.error(
         DiagnosticCode.Type_parameter_list_cannot_be_empty,
-        tn.range()
+        tn.range(start, tn.pos)
       ); // recoverable
     }
     return typeParameters;


### PR DESCRIPTION
This fixes quite a bit of unnecessary diagnostic noise related to `INVALID` tokens, based on the example given by @MaxGraey :

```ts
export function getSpooky<👻>(): string {
    return "boo";
}
```

In particular, if an `INVALID` token is seen and is part of a surrogate pair, the entire pair will be skipped instead of emitting two diagnostics. Also, the tokenizer now implicitly skips over invalid tokens aiding the parser. There's already a diagnostic anyway. Also fixes a bug in the parser emitting `null` on empty type parameter lists, which sometimes resulted in reparsing something that already emitted a diagnostic.

In the example above, this now results in 2 errors (invalid character, empty type parameter list) instead of spooky 13.