### PR TITLE
Update Binaryen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -567,9 +567,9 @@
       "dev": true
     },
     "binaryen": {
-      "version": "90.0.0-nightly.20200128",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-90.0.0-nightly.20200128.tgz",
-      "integrity": "sha512-f64O/OpAtS39zcocpqjMtskUgAkUAv2fBlY9/hu2Ly4m0Xd/waaTrPRLSaAsEDzFcn+MebOdCN8ASjej1jc0uA=="
+      "version": "90.0.0-nightly.20200208",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-90.0.0-nightly.20200208.tgz",
+      "integrity": "sha512-LwjT1+vp++uQKs6EU5oygCUFdP7WpuGpmuhk3Ov2sw/DZN0vusFDrkKpTGzzpscFZzSWz36vJKjFuWun1hhQ7A=="
     },
     "bindings": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/AssemblyScript/assemblyscript/issues"
   },
   "dependencies": {
-    "binaryen": "90.0.0-nightly.20200128",
+    "binaryen": "90.0.0-nightly.20200208",
     "long": "^4.0.0",
     "source-map-support": "^0.5.16",
     "ts-node": "^6.2.0"

--- a/src/glue/binaryen.d.ts
+++ b/src/glue/binaryen.d.ts
@@ -781,7 +781,7 @@ export declare function _BinaryenSideEffectImplicitTrap(): BinaryenSideEffects;
 export declare function _BinaryenSideEffectIsAtomic(): BinaryenSideEffects;
 export declare function _BinaryenSideEffectAny(): BinaryenSideEffects;
 
-export declare function _BinaryenExpressionGetSideEffects(expr: BinaryenExpressionRef): BinaryenSideEffects;
+export declare function _BinaryenExpressionGetSideEffects(expr: BinaryenExpressionRef, features: BinaryenFeatureFlags): BinaryenSideEffects;
 
 type BinaryenRelooperRef = usize;
 type BinaryenRelooperBlockRef = usize;
@@ -799,5 +799,10 @@ export declare function _BinaryenGetShrinkLevel(): i32;
 export declare function _BinaryenSetShrinkLevel(level: i32): void;
 export declare function _BinaryenGetDebugInfo(): bool;
 export declare function _BinaryenSetDebugInfo(on: bool): void;
+export declare function _BinaryenGetLowMemoryUnused(): bool;
+export declare function _BinaryenSetLowMemoryUnused(on: bool): void;
+export declare function _BinaryenGetPassArgument(key: usize): usize;
+export declare function _BinaryenSetPassArgument(key: usize, value: usize): void;
+export declare function _BinaryenClearPassArguments(): void;
 
 export declare function _BinaryenSetAPITracing(on: bool): void;

--- a/src/module.ts
+++ b/src/module.ts
@@ -1283,13 +1283,13 @@ export class Module {
     binaryen._free(cArr);
   }
 
-  // meta
+  // meta (global)
 
   getOptimizeLevel(): i32 {
     return binaryen._BinaryenGetOptimizeLevel();
   }
 
-  setOptimizeLevel(level: i32 = 2): void {
+  setOptimizeLevel(level: i32): void {
     binaryen._BinaryenSetOptimizeLevel(level);
   }
 
@@ -1297,13 +1297,43 @@ export class Module {
     return binaryen._BinaryenGetShrinkLevel();
   }
 
-  setShrinkLevel(level: i32 = 1): void {
+  setShrinkLevel(level: i32): void {
     binaryen._BinaryenSetShrinkLevel(level);
   }
 
-  setDebugInfo(on: bool = false): void {
+  getDebugInfo(): boolean {
+    return binaryen._BinaryenGetDebugInfo();
+  }
+
+  setDebugInfo(on: bool): void {
     binaryen._BinaryenSetDebugInfo(on);
   }
+
+  getLowMemoryUnused(): bool {
+    return binaryen._BinaryenGetLowMemoryUnused();
+  }
+
+  setLowMemoryUnused(on: bool): void {
+    binaryen._BinaryenSetLowMemoryUnused(on);
+  }
+
+  getPassArgument(key: string): string | null {
+    var cStr = this.allocStringCached(key);
+    var ptr = binaryen._BinaryenGetPassArgument(cStr);
+    return ptr ? readString(ptr) : null;
+  }
+
+  setPassArgument(key: string, value: string | null): void {
+    var cStr1 = this.allocStringCached(key);
+    var cStr2 = this.allocStringCached(value);
+    binaryen._BinaryenSetPassArgument(cStr1, cStr2);
+  }
+
+  clearPassArguments(): void {
+    binaryen._BinaryenClearPassArguments();
+  }
+
+  // meta (module)
 
   getFeatures(): FeatureFlags {
     return binaryen._BinaryenModuleGetFeatures(this.ref);
@@ -1897,15 +1927,16 @@ export enum SideEffects {
   WritesMemory = 128 /* _BinaryenSideEffectWritesMemory */,
   ImplicitTrap = 256 /* _BinaryenSideEffectImplicitTrap */,
   IsAtomic = 512 /* _BinaryenSideEffectIsAtomic */,
-  Any = 1023 /* _BinaryenSideEffectAny */,
+  Throws = 1024 /* _BinaryenSideEffectThrows */,
+  Any = 2047 /* _BinaryenSideEffectAny */,
 }
 
-export function getSideEffects(expr: ExpressionRef): SideEffects {
-  return binaryen._BinaryenExpressionGetSideEffects(expr);
+export function getSideEffects(expr: ExpressionRef, features: FeatureFlags = FeatureFlags.All): SideEffects {
+  return binaryen._BinaryenExpressionGetSideEffects(expr, features);
 }
 
-export function hasSideEffects(expr: ExpressionRef): bool {
-  return getSideEffects(expr) != SideEffects.None;
+export function hasSideEffects(expr: ExpressionRef, features: FeatureFlags = FeatureFlags.All): bool {
+  return getSideEffects(expr, features) != SideEffects.None;
 }
 
 // helpers


### PR DESCRIPTION
Not much this time, but it might be interesting to investigate `lowMemoryUnused`, doing optimizations like

```wat
(i32.load
 (i32.add
  (local.get $0
  (i32.const 128)
 )
)
```

to

```wat
(i32.load offset=128
 (local.get $0)
)
```

if not prevented by options like `--memoryBase`.