### PR TITLE
Handle instanceof of entire classes

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1094,6 +1094,11 @@ export class NamedTypeNode extends TypeNode {
   name: TypeName;
   /** Type argument references. */
   typeArguments: TypeNode[] | null;
+
+  get hasTypeArguments(): bool {
+    var typeArguments = this.typeArguments;
+    return typeArguments !== null && typeArguments.length > 0;
+  }
 }
 
 /** Represents a function type. */

--- a/tests/compiler/instanceof-class.json
+++ b/tests/compiler/instanceof-class.json
@@ -1,0 +1,5 @@
+{
+  "asc_flags": [
+    "--runtime none"
+  ]
+}

--- a/tests/compiler/instanceof-class.optimized.wat
+++ b/tests/compiler/instanceof-class.optimized.wat
@@ -1,0 +1,182 @@
+(module
+ (type $none_=>_none (func))
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $i32_=>_none (func (param i32)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
+ (memory $0 1)
+ (data (i32.const 16) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00i\00n\00s\00t\00a\00n\00c\00e\00o\00f\00-\00c\00l\00a\00s\00s\00.\00t\00s")
+ (data (i32.const 80) "\07\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\04\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\05")
+ (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
+ (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
+ (global $instanceof-class/a (mut i32) (i32.const 0))
+ (global $instanceof-class/b (mut i32) (i32.const 0))
+ (export "memory" (memory $0))
+ (start $~start)
+ (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  memory.size
+  local.tee $2
+  i32.const 16
+  i32.shl
+  local.tee $1
+  i32.gt_u
+  if
+   local.get $2
+   local.get $0
+   local.get $1
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const -65536
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.tee $1
+   local.get $2
+   local.get $1
+   i32.gt_s
+   select
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $1
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 2 ;) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  global.get $~lib/rt/stub/offset
+  i32.const 16
+  i32.add
+  local.tee $2
+  i32.const 16
+  i32.add
+  call $~lib/rt/stub/maybeGrowMemory
+  local.get $2
+  i32.const 16
+  i32.sub
+  local.tee $1
+  i32.const 16
+  i32.store
+  local.get $1
+  i32.const 1
+  i32.store offset=4
+  local.get $1
+  local.get $0
+  i32.store offset=8
+  local.get $1
+  i32.const 0
+  i32.store offset=12
+  local.get $2
+ )
+ (func $start:instanceof-class (; 3 ;)
+  (local $0 i32)
+  i32.const 144
+  global.set $~lib/rt/stub/startOffset
+  i32.const 144
+  global.set $~lib/rt/stub/offset
+  i32.const 3
+  call $~lib/rt/stub/__alloc
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 4
+   call $~lib/rt/stub/__alloc
+   local.set $0
+  end
+  local.get $0
+  global.set $instanceof-class/a
+  i32.const 6
+  call $~lib/rt/stub/__alloc
+  local.tee $0
+  i32.eqz
+  if
+   i32.const 5
+   call $~lib/rt/stub/__alloc
+   local.set $0
+  end
+  local.get $0
+  global.set $instanceof-class/b
+  global.get $instanceof-class/b
+  call $instanceof-class/Child~instanceof
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 17
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $~start (; 4 ;)
+  call $start:instanceof-class
+ )
+ (func $~lib/rt/__instanceof (; 5 ;) (param $0 i32) (param $1 i32) (result i32)
+  local.get $0
+  i32.const 16
+  i32.sub
+  i32.load offset=8
+  local.tee $0
+  i32.const 80
+  i32.load
+  i32.le_u
+  if
+   loop $do-continue|0
+    local.get $0
+    local.get $1
+    i32.eq
+    if
+     i32.const 1
+     return
+    end
+    local.get $0
+    i32.const 3
+    i32.shl
+    i32.const 84
+    i32.add
+    i32.load offset=4
+    local.tee $0
+    br_if $do-continue|0
+   end
+  end
+  i32.const 0
+ )
+ (func $instanceof-class/Child~instanceof (; 6 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 0
+   return
+  end
+  local.get $0
+  i32.const 3
+  call $~lib/rt/__instanceof
+  if
+   i32.const 1
+   return
+  end
+  local.get $0
+  i32.const 6
+  call $~lib/rt/__instanceof
+  if
+   i32.const 1
+   return
+  end
+  i32.const 0
+ )
+)

--- a/tests/compiler/instanceof-class.ts
+++ b/tests/compiler/instanceof-class.ts
@@ -1,0 +1,18 @@
+class Parent<T> {
+}
+
+class Child<T> extends Parent<T> {
+}
+
+class SomethingElse<T> {
+}
+
+var a: Child<i32> = new Child<i32>();
+assert(a instanceof Child);            // static true
+assert(a instanceof Parent);           // static true
+assert(!(a instanceof SomethingElse)); // static false
+
+var b: Parent<f32> = new Child<f32>();
+assert(b instanceof Parent);           // static true
+assert(b instanceof Child);            // dynamic true (checks Child<i32>, Child<f32>)
+assert(!(b instanceof SomethingElse)); // static false

--- a/tests/compiler/instanceof-class.untouched.wat
+++ b/tests/compiler/instanceof-class.untouched.wat
@@ -1,0 +1,280 @@
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (type $none_=>_none (func))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_=>_none (func (param i32)))
+ (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
+ (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
+ (memory $0 1)
+ (data (i32.const 16) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00i\00n\00s\00t\00a\00n\00c\00e\00o\00f\00-\00c\00l\00a\00s\00s\00.\00t\00s\00")
+ (data (i32.const 80) "\07\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\04\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\05\00\00\00")
+ (table $0 1 funcref)
+ (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
+ (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
+ (global $instanceof-class/a (mut i32) (i32.const 0))
+ (global $instanceof-class/b (mut i32) (i32.const 0))
+ (global $~lib/rt/__rtti_base i32 (i32.const 80))
+ (global $~lib/heap/__heap_base i32 (i32.const 140))
+ (export "memory" (memory $0))
+ (start $~start)
+ (func $~lib/rt/stub/maybeGrowMemory (; 1 ;) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  memory.size
+  local.set $1
+  local.get $1
+  i32.const 16
+  i32.shl
+  local.set $2
+  local.get $0
+  local.get $2
+  i32.gt_u
+  if
+   local.get $0
+   local.get $2
+   i32.sub
+   i32.const 65535
+   i32.add
+   i32.const 65535
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.set $3
+   local.get $1
+   local.tee $4
+   local.get $3
+   local.tee $5
+   local.get $4
+   local.get $5
+   i32.gt_s
+   select
+   local.set $4
+   local.get $4
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $3
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+  end
+  local.get $0
+  global.set $~lib/rt/stub/offset
+ )
+ (func $~lib/rt/stub/__alloc (; 2 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.const 1073741808
+  i32.gt_u
+  if
+   unreachable
+  end
+  global.get $~lib/rt/stub/offset
+  i32.const 16
+  i32.add
+  local.set $2
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  local.tee $3
+  i32.const 16
+  local.tee $4
+  local.get $3
+  local.get $4
+  i32.gt_u
+  select
+  local.set $5
+  local.get $2
+  local.get $5
+  i32.add
+  call $~lib/rt/stub/maybeGrowMemory
+  local.get $2
+  i32.const 16
+  i32.sub
+  local.set $6
+  local.get $6
+  local.get $5
+  i32.store
+  local.get $6
+  i32.const 1
+  i32.store offset=4
+  local.get $6
+  local.get $1
+  i32.store offset=8
+  local.get $6
+  local.get $0
+  i32.store offset=12
+  local.get $2
+ )
+ (func $~lib/rt/stub/__retain (; 3 ;) (param $0 i32) (result i32)
+  local.get $0
+ )
+ (func $instanceof-class/Parent<i32>#constructor (; 4 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 4
+   call $~lib/rt/stub/__alloc
+   call $~lib/rt/stub/__retain
+   local.set $0
+  end
+  local.get $0
+ )
+ (func $instanceof-class/Child<i32>#constructor (; 5 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 3
+   call $~lib/rt/stub/__alloc
+   call $~lib/rt/stub/__retain
+   local.set $0
+  end
+  local.get $0
+  call $instanceof-class/Parent<i32>#constructor
+  local.set $0
+  local.get $0
+ )
+ (func $instanceof-class/Parent<f32>#constructor (; 6 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 5
+   call $~lib/rt/stub/__alloc
+   call $~lib/rt/stub/__retain
+   local.set $0
+  end
+  local.get $0
+ )
+ (func $instanceof-class/Child<f32>#constructor (; 7 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 6
+   call $~lib/rt/stub/__alloc
+   call $~lib/rt/stub/__retain
+   local.set $0
+  end
+  local.get $0
+  call $instanceof-class/Parent<f32>#constructor
+  local.set $0
+  local.get $0
+ )
+ (func $start:instanceof-class (; 8 ;)
+  global.get $~lib/heap/__heap_base
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  global.set $~lib/rt/stub/startOffset
+  global.get $~lib/rt/stub/startOffset
+  global.set $~lib/rt/stub/offset
+  i32.const 0
+  call $instanceof-class/Child<i32>#constructor
+  global.set $instanceof-class/a
+  i32.const 0
+  call $instanceof-class/Child<f32>#constructor
+  global.set $instanceof-class/b
+  global.get $instanceof-class/b
+  call $instanceof-class/Child~instanceof
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 32
+   i32.const 17
+   i32.const 0
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $~start (; 9 ;)
+  call $start:instanceof-class
+ )
+ (func $~lib/rt/__instanceof (; 10 ;) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  local.get $0
+  i32.const 16
+  i32.sub
+  i32.load offset=8
+  local.set $2
+  global.get $~lib/rt/__rtti_base
+  local.set $3
+  local.get $2
+  local.get $3
+  i32.load
+  i32.le_u
+  if
+   loop $do-continue|0
+    local.get $2
+    local.get $1
+    i32.eq
+    if
+     i32.const 1
+     return
+    end
+    local.get $3
+    i32.const 4
+    i32.add
+    local.get $2
+    i32.const 8
+    i32.mul
+    i32.add
+    i32.load offset=4
+    local.tee $2
+    local.set $4
+    local.get $4
+    br_if $do-continue|0
+   end
+  end
+  i32.const 0
+ )
+ (func $instanceof-class/Child~instanceof (; 11 ;) (param $0 i32) (result i32)
+  local.get $0
+  i32.eqz
+  if
+   i32.const 0
+   return
+  end
+  local.get $0
+  i32.const 3
+  call $~lib/rt/__instanceof
+  if
+   i32.const 1
+   return
+  end
+  local.get $0
+  i32.const 6
+  call $~lib/rt/__instanceof
+  if
+   i32.const 1
+   return
+  end
+  i32.const 0
+  return
+ )
+)


### PR DESCRIPTION
This is an initial implementation of `instanceof CLASS` checks like

```ts
a instanceof Array
a instanceof Map
a instanceof Set
```

Does static checks where possible, except in upcast cases like

```ts
class Parent<T> {}
class Child<T> extends Parent<T> {}

var a: Parent<i32> = new Child<i32>();
if (a instanceof Child) {
  ...
}
```

where an internal helper, here named `Child~instanceof`, is generated and called, that checks against all possible concrete instance ids. For example, if there's a `Child<i32>` and a `Child<f32>` present in the module, both are valid according to the dynamic check. Dynamic checks are potentially costly if there are lots of instances of a generic class.