### PR TITLE
Slice version 0.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "assemblyscript",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -25,9 +25,9 @@
       }
     },
     "@types/node": {
-      "version": "13.5.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.1.tgz",
-      "integrity": "sha512-Jj2W7VWQ2uM83f8Ls5ON9adxN98MvyJsMSASYFuSvrov8RMRY64Ayay7KV35ph1TSGIJ2gG9ZVDdEq3c3zaydA==",
+      "version": "13.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.1.tgz",
+      "integrity": "sha512-Zq8gcQGmn4txQEJeiXo/KiLpon8TzAl0kmKH4zdWctPj05nWwp1ClMdAVEloqrQKfaC48PNLdgN/aVaLqUrluA==",
       "dev": true
     },
     "@webassemblyjs/ast": {
@@ -567,9 +567,9 @@
       "dev": true
     },
     "binaryen": {
-      "version": "90.0.0-nightly.20200208",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-90.0.0-nightly.20200208.tgz",
-      "integrity": "sha512-LwjT1+vp++uQKs6EU5oygCUFdP7WpuGpmuhk3Ov2sw/DZN0vusFDrkKpTGzzpscFZzSWz36vJKjFuWun1hhQ7A=="
+      "version": "90.0.0-nightly.20200214",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-90.0.0-nightly.20200214.tgz",
+      "integrity": "sha512-ZHajaPd2aP6kDrM9q77afnA402Ufsuw9yLUxtAfgmIglP1JMB2XSRmaXc5pgCELaX53PWJIdcH07LL8uNfTBRw=="
     },
     "bindings": {
       "version": "1.5.0",
@@ -876,9 +876,9 @@
       }
     },
     "chownr": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true
     },
     "chrome-trace-event": {
@@ -1249,9 +1249,9 @@
       "dev": true
     },
     "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"
@@ -2722,9 +2722,9 @@
       }
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
     "lcid": {
@@ -3172,9 +3172,9 @@
       "dev": true
     },
     "p-limit": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-      "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+      "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
       "dev": true,
       "requires": {
         "p-try": "^2.0.0"
@@ -3196,9 +3196,9 @@
       "dev": true
     },
     "pako": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
-      "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "dev": true
     },
     "parallel-transform": {
@@ -3915,12 +3915,12 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-resolve": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
       "dev": true,
       "requires": {
-        "atob": "^2.1.1",
+        "atob": "^2.1.2",
         "decode-uri-component": "^0.2.0",
         "resolve-url": "^0.2.1",
         "source-map-url": "^0.4.0",
@@ -4421,9 +4421,9 @@
       }
     },
     "webpack": {
-      "version": "4.41.5",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.5.tgz",
-      "integrity": "sha512-wp0Co4vpyumnp3KlkmpM5LWuzvZYayDwM2n17EHFr4qxBBbRokC7DJawPJC7TfSFZ9HZ6GsdH40EBj4UV0nmpw==",
+      "version": "4.41.6",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.6.tgz",
+      "integrity": "sha512-yxXfV0Zv9WMGRD+QexkZzmGIh54bsvEs+9aRWxnN8erLWEOehAKUTeNBoUbA6HPEZPlRo7KDi2ZcNveoZgK9MA==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -4557,9 +4557,9 @@
       }
     },
     "webpack-cli": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.10.tgz",
-      "integrity": "sha512-u1dgND9+MXaEt74sJR4PR7qkPxXUSQ0RXYq8x1L6Jg1MYVEmGPrH6Ah6C4arD4r0J1P5HKjRqpab36k0eIzPqg==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.11.tgz",
+      "integrity": "sha512-dXlfuml7xvAFwYUPsrtQAA9e4DOe58gnzSxhgrO/ZM/gyXTBowrsYeubyN4mqGhYdpXMFNyQ6emjJS9M7OBd4g==",
       "dev": true,
       "requires": {
         "chalk": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "assemblyscript",
     "wasm"
   ],
-  "version": "0.9.1",
+  "version": "0.9.2",
   "author": "Daniel Wirtz <dcode+assemblyscript@dcode.io>",
   "contributors": [],
   "license": "Apache-2.0",
@@ -21,13 +21,13 @@
     "url": "https://github.com/AssemblyScript/assemblyscript/issues"
   },
   "dependencies": {
-    "binaryen": "90.0.0-nightly.20200208",
+    "binaryen": "90.0.0-nightly.20200214",
     "long": "^4.0.0",
     "source-map-support": "^0.5.16",
     "ts-node": "^6.2.0"
   },
   "devDependencies": {
-    "@types/node": "^13.5.1",
+    "@types/node": "^13.7.1",
     "browser-process-hrtime": "^1.0.0",
     "diff": "^4.0.2",
     "glob": "^7.1.6",
@@ -37,8 +37,8 @@
     "ts-node": "^6.2.0",
     "tslint": "^5.20.1",
     "typescript": "^3.7.5",
-    "webpack": "^4.41.5",
-    "webpack-cli": "^3.3.10"
+    "webpack": "^4.41.6",
+    "webpack-cli": "^3.3.11"
   },
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/glue/binaryen.d.ts
+++ b/src/glue/binaryen.d.ts
@@ -804,5 +804,11 @@ export declare function _BinaryenSetLowMemoryUnused(on: bool): void;
 export declare function _BinaryenGetPassArgument(key: usize): usize;
 export declare function _BinaryenSetPassArgument(key: usize, value: usize): void;
 export declare function _BinaryenClearPassArguments(): void;
+export declare function _BinaryenGetAlwaysInlineMaxSize(): BinaryenIndex;
+export declare function _BinaryenSetAlwaysInlineMaxSize(size: BinaryenIndex): void;
+export declare function _BinaryenGetFlexibleInlineMaxSize(): BinaryenIndex;
+export declare function _BinaryenSetFlexibleInlineMaxSize(size: BinaryenIndex): void;
+export declare function _BinaryenGetOneCallerInlineMaxSize(): BinaryenIndex;
+export declare function _BinaryenSetOneCallerInlineMaxSize(size: BinaryenIndex): void;
 
 export declare function _BinaryenSetAPITracing(on: bool): void;

--- a/src/module.ts
+++ b/src/module.ts
@@ -1333,6 +1333,30 @@ export class Module {
     binaryen._BinaryenClearPassArguments();
   }
 
+  getAlwaysInlineMaxSize(): Index {
+    return binaryen._BinaryenGetAlwaysInlineMaxSize();
+  }
+
+  setAlwaysInlineMaxSize(size: Index): void {
+    binaryen._BinaryenSetAlwaysInlineMaxSize(size);
+  }
+
+  getFlexibleInlineMaxSize(): Index {
+    return binaryen._BinaryenGetFlexibleInlineMaxSize();
+  }
+
+  setFlexibleInlineMaxSize(size: Index): void {
+    binaryen._BinaryenSetFlexibleInlineMaxSize(size);
+  }
+
+  getOneCallerInlineMaxSize(): Index {
+    return binaryen._BinaryenGetOneCallerInlineMaxSize();
+  }
+
+  setOneCallerInlineMaxSize(size: Index): void {
+    binaryen._BinaryenSetOneCallerInlineMaxSize(size);
+  }
+
   // meta (module)
 
   getFeatures(): FeatureFlags {


### PR DESCRIPTION
## New features

* Added a `--tableBase` CLI option (like `--memoryBase`, but for tables)
* Support `x instanceof GenericClass`
* Update Binaryen to latest

## Relevant fixes

* Fixed `null` related edge cases when inferring array literals
* Fixed several code generation issues
* Align `Map#set` and `Set#add` with the spec, returning `this`
* Fixed WASI import scheme to use `wasi_snapshot_preview1`